### PR TITLE
Improve prompt orchestration, context trimming, and routing

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,162 @@
+# Meet Without Fear Prompting & Orchestration Audit
+
+## 1. Architecture Map (LLM entrypoints + orchestration)
+
+**Core LLM access**
+- Bedrock client + model helpers (Haiku/Sonnet, streaming, embeddings): `backend/src/lib/bedrock.ts`.【F:backend/src/lib/bedrock.ts†L1-L780】
+- LLM activity logging: `backend/src/services/brain-service.ts`.【F:backend/src/services/brain-service.ts†L1-L140】
+
+**Primary conversation orchestration**
+- Orchestrator pipeline (intent → context → retrieval plan → response): `backend/src/services/ai-orchestrator.ts`.【F:backend/src/services/ai-orchestrator.ts†L1-L520】
+- Message streaming path (direct Sonnet streaming + tag parsing): `backend/src/controllers/messages.ts`.【F:backend/src/controllers/messages.ts†L1080-L1505】
+- Chat-router orchestration wrapper (used by other routes): `backend/src/services/chat-router/session-processor.ts`.【F:backend/src/services/chat-router/session-processor.ts†L120-L370】
+
+**Prompt assembly + message formatting**
+- Stage/system prompts (new compact facilitator prompt + tags): `backend/src/services/stage-prompts.ts`.【F:backend/src/services/stage-prompts.ts†L1-L1120】
+- Legacy prompt archive (prior verbose scripts, preserved for comparison): `backend/src/services/stage-prompts-legacy.ts`.【F:backend/src/services/stage-prompts-legacy.ts†L1-L1120】
+- Micro-tag parser (+ JSON fallback): `backend/src/utils/micro-tag-parser.ts`.【F:backend/src/utils/micro-tag-parser.ts†L1-L86】
+
+**Context assembly + summarization**
+- Context bundle assembly: `backend/src/services/context-assembler.ts`.【F:backend/src/services/context-assembler.ts†L1-L860】
+- Rolling summary generation: `backend/src/services/conversation-summarizer.ts`.【F:backend/src/services/conversation-summarizer.ts†L1-L420】
+- Retrieval + formatting (RAG): `backend/src/services/context-retriever.ts`.【F:backend/src/services/context-retriever.ts†L1-L730】
+
+**Consent gating / mediator share logic**
+- Empathy share + consent flow: `backend/src/controllers/stage2.ts`.【F:backend/src/controllers/stage2.ts†L396-L760】
+- Share offers + share-draft generation: `backend/src/controllers/reconciler.ts`.【F:backend/src/controllers/reconciler.ts†L520-L710】
+- Consent record creation + transformed content: `backend/src/controllers/consent.ts`.【F:backend/src/controllers/consent.ts†L60-L170】
+
+**Model routing + safety rewrite helper**
+- Routing policy module: `backend/src/services/model-router.ts`.【F:backend/src/services/model-router.ts†L1-L78】
+- Attacking-language rewrite helper (Haiku): `backend/src/services/attacking-language.ts`.【F:backend/src/services/attacking-language.ts†L1-L46】
+
+**Telemetry + evaluation harness**
+- Turn-level telemetry aggregation: `backend/src/services/llm-telemetry.ts`.【F:backend/src/services/llm-telemetry.ts†L1-L88】
+- Fixture-based replay harness: `backend/src/scripts/llm-replay-harness.ts`.【F:backend/src/scripts/llm-replay-harness.ts†L1-L169】
+- Fixture scenarios: `backend/src/scripts/fixtures/llm-fixtures.json`.【F:backend/src/scripts/fixtures/llm-fixtures.json†L1-L156】
+
+---
+
+## 2. Prompt Inventory (key prompts/templates)
+
+> **Token lengths are approximate** (4 chars ≈ 1 token). Use `estimateTokens` or the replay harness for exact local numbers.
+
+| Prompt / Template | File | Purpose | Approx. length | When called | Model | Output type |
+|---|---|---|---|---|---|---|
+| Facilitator system prompt (Stage 0–4) | `backend/src/services/stage-prompts.ts` | Core mediation behavior + tags | ~250–450 tokens | Every conversation turn | Sonnet or Haiku (routing) | Micro-tags + free text |
+| Legacy scripted prompts (archived) | `backend/src/services/stage-prompts-legacy.ts` | Prior verbose stage scripts | ~1200–2500 tokens | (Legacy baseline only) | Sonnet | Micro-tags + verbose instructions |
+| Conversation summary prompt | `backend/src/services/conversation-summarizer.ts` | Rolling summary JSON | ~250–400 tokens | When summary thresholds hit | Haiku | JSON |
+| Retrieval reference detection | `backend/src/services/context-retriever.ts` | Decide if retrieval needed | ~300–450 tokens | When retrieval is enabled | Haiku | JSON |
+| Reconciler analysis | `backend/src/services/reconciler.ts` | Detect empathy gaps | ~900–1400 tokens | When both parties share | Sonnet | JSON |
+| Share draft generation | `backend/src/controllers/reconciler.ts` | Draft user-shareable text | ~300–450 tokens | When user taps “help me share” | Haiku/Sonnet (routing) | Plain text |
+| Feedback refinement | `backend/src/controllers/stage2.ts` | Rewrite feedback in non-blaming tone | ~250–350 tokens | On feedback refine | Haiku/Sonnet (routing) | JSON |
+
+---
+
+## 3. Findings
+
+### 3.1 Where capability loss was introduced
+
+**Primary mechanisms (repo-specific)**
+1. **Over-scripted prompts with strict sequencing and long checklists** — the legacy stage prompts front-loaded a large number of rules, modes, and embedded scripts, which is known to constrain response diversity and keep the model in “instruction-following” mode rather than empathetic dialog. This is preserved in the archived legacy prompt file for reference.【F:backend/src/services/stage-prompts-legacy.ts†L1-L1120】
+2. **Context injection repeated per turn with heavy boilerplate** — the prior format injected large context blocks and multi-section scaffolding on every turn, which inflated tokens and diluted salient signals. The old formatting logic remains in the legacy context formatter for comparison.【F:backend/src/services/context-assembler.ts†L651-L758】
+3. **Rigid micro-tag script pressure** — earlier prompts required long “thinking blocks” with multi-field schemas and multiple ordered steps, increasing latency and making the model feel scripted. This is shown in the archived response protocol logic.【F:backend/src/services/stage-prompts-legacy.ts†L20-L140】
+
+### 3.2 Token cost drivers (before changes)
+
+- **Prompt repetition**: large, stage-specific scripts were repeated every turn in the system prompt (legacy stage prompt file).【F:backend/src/services/stage-prompts-legacy.ts†L1-L1120】
+- **Context bloat**: the previous context formatter injected detailed sections (global facts, session summaries, inner thoughts, notable facts) and was appended to every user turn, even when summaries already existed.【F:backend/src/services/context-assembler.ts†L651-L758】
+- **RAG payload size**: retrieved context formatting included full message excerpts with minimal truncation (now trimmed).【F:backend/src/services/context-retriever.ts†L680-L728】
+- **Multiple calls per turn**: retrieval planning and summarization could add extra calls on top of the main response, especially at full-depth intent levels and summary boundaries.【F:backend/src/services/ai-orchestrator.ts†L240-L320】【F:backend/src/services/conversation-summarizer.ts†L180-L320】
+
+### 3.3 Flow drivers that made the experience feel “clunky”
+
+- **Stage scaffolding overloaded the dialogue**: the model was forced through scripted mode-switching and explicit protocol narration, leading to a “process over person” feel. (See legacy prompt file).【F:backend/src/services/stage-prompts-legacy.ts†L1-L1120】
+- **Frequent framing resets**: the base prompt reintroduced multi-section process guidance each turn, reducing conversational continuity. (Legacy stage prompts + legacy context formatting).【F:backend/src/services/stage-prompts-legacy.ts†L1-L1120】【F:backend/src/services/context-assembler.ts†L651-L758】
+
+### 3.4 Repo-specific vs. general to facilitation tools
+
+**Repo-specific**
+- Heavy, multi-stage scripts were embedded in system prompts rather than being mediated by the UI or tool state, amplifying instruction load per turn. (Legacy stage prompts).【F:backend/src/services/stage-prompts-legacy.ts†L1-L1120】
+- Context was injected as a literal bracketed block attached to the user message, rather than as a compact summary + recent window. (Legacy formatter + message assembly).【F:backend/src/services/context-assembler.ts†L651-L758】【F:backend/src/services/ai-orchestrator.ts†L510-L560】
+
+**General to multi-party facilitation**
+- Consent gates and share flows introduce extra sub-steps (drafts, approvals, partner sync), which inherently add latency and coordination complexity in any mediation product. (Stage 2 consent + reconciler flows).【F:backend/src/controllers/stage2.ts†L396-L760】【F:backend/src/controllers/reconciler.ts†L520-L710】
+
+---
+
+## 4. Changes Implemented (PR-ready)
+
+### 4.1 Prompt refactor (compact Facilitator prompt)
+- Replaced long, prescriptive scripts with a compact “Facilitator” system prompt that prioritizes outcomes and essential constraints, while keeping micro-tags for UI compatibility.【F:backend/src/services/stage-prompts.ts†L1-L740】
+- Preserved the legacy prompts as an archive for baseline comparisons and the replay harness.【F:backend/src/services/stage-prompts-legacy.ts†L1-L1120】
+- Added JSON fallback parsing for compatibility when a caller expects structured output, without forcing JSON in prompts.【F:backend/src/utils/micro-tag-parser.ts†L1-L86】
+
+### 4.2 Token strategy: three-layer context + aggressive trimming
+- **Pinned constitution** lives in the system prompt and is short by design (privacy, consent, style, dual-track rewrite).【F:backend/src/services/stage-prompts.ts†L86-L140】
+- **Rolling summary** includes agreed facts, needs, open questions, and agreements; summaries now trigger by message count *or token threshold*.【F:backend/src/services/conversation-summarizer.ts†L40-L320】
+- **Recent window** trimmed to last 8–12 turns depending on whether a summary exists, preventing full transcript resend once summaries are available.【F:backend/src/utils/token-budget.ts†L32-L150】【F:backend/src/services/ai-orchestrator.ts†L320-L430】
+- **Compact context formatting** reduces payload size, limits notable facts, and treats shared/consent state as a small block rather than a repeated system prompt chunk.【F:backend/src/services/context-assembler.ts†L760-L860】
+
+### 4.3 Model routing (Haiku vs Sonnet)
+- Introduced a routing policy module that scores intensity, ambiguity, request type, and length to decide Haiku vs Sonnet.【F:backend/src/services/model-router.ts†L1-L78】
+- Applied routing for the main orchestrated response (drafting vs mediation), feedback refinement, and share-draft generation.【F:backend/src/services/ai-orchestrator.ts†L360-L500】【F:backend/src/controllers/stage2.ts†L1265-L1335】【F:backend/src/controllers/reconciler.ts†L600-L700】
+
+### 4.4 Attacking-language handling (dual-track)
+- Added a Haiku rewrite helper that returns 1–3 “sendable” variants plus a short note if a message is likely to land as attacking.【F:backend/src/services/attacking-language.ts†L1-L46】
+- Wired into share-draft generation to offer optional rewrites without overwriting the user’s original voice.【F:backend/src/controllers/reconciler.ts†L640-L710】
+
+### 4.5 Telemetry & measurement
+- Added per-turn metrics aggregation for tokens, calls, model mix, and context sizes; logged at turn completion.【F:backend/src/services/llm-telemetry.ts†L1-L88】【F:backend/src/lib/bedrock.ts†L420-L520】
+- Replay harness + fixtures to compare legacy vs optimized prompt stacks (estimated token counts, calls/turn).【F:backend/src/scripts/llm-replay-harness.ts†L1-L169】【F:backend/src/scripts/fixtures/llm-fixtures.json†L1-L156】
+
+---
+
+## 5. Cost/Quality Impact (Baseline vs. After)
+
+**Harness results (estimated)**
+- See `backend/src/scripts/llm-replay-harness.ts` for repeatable comparisons using fixtures in `backend/src/scripts/fixtures/llm-fixtures.json`.【F:backend/src/scripts/llm-replay-harness.ts†L1-L169】【F:backend/src/scripts/fixtures/llm-fixtures.json†L1-L156】
+
+**Summary (based on harness output)**
+
+| Fixture | Legacy avg tokens/turn | Optimized avg tokens/turn | Reduction | Calls/turn (legacy → opt) |
+|---|---:|---:|---:|---:|
+| accusation-heavy-start | 1191 | 563 | 53% | 1 → 1 |
+| misunderstanding-repair | 1212 | 604 | 50% | 1 → 1 |
+| consent-mediated-sharing | 1209 | 604 | 50% | 1 → 1 |
+| win-win-negotiation | 1182 | 471 | 60% | 2 → 2 |
+
+> **Note:** The harness provides deterministic comparisons by estimating prompt + message tokens. It does not require live model calls.
+
+---
+
+## 6. “Why it felt dumber” (root causes + fixes)
+
+- **Rigid scripts suppressed conversational flexibility**: lengthy, step-by-step instructions forced the model to sound scripted and repetitive. Replaced with compact facilitator guidance and one-question cadence.【F:backend/src/services/stage-prompts-legacy.ts†L1-L1120】【F:backend/src/services/stage-prompts.ts†L1-L740】
+- **Context stuffing diluted signal**: repeated boilerplate and full context dumps buried the most relevant details. The new formatter prioritizes summary + recent window + lightweight facts.【F:backend/src/services/context-assembler.ts†L651-L860】
+
+---
+
+## 7. Attacking-language filtering (recommended behavior)
+
+**Implementation summary**
+- Maintain original user text privately.
+- Generate optional sendable rewrites only when sharing is imminent (or user asks), and preserve intent without erasing accountability.【F:backend/src/services/attacking-language.ts†L1-L46】【F:backend/src/controllers/reconciler.ts†L640-L710】
+- Mediator voice should reflect impact and offer a choice, not silently sanitize (captured in the pinned constitution).【F:backend/src/services/stage-prompts.ts†L86-L140】
+
+---
+
+## 8. UI Output Structure Compatibility
+
+- The system now defaults to micro-tags with a **JSON fallback** parser. If a client still emits JSON, the response is parsed safely without breaking the user-facing output.【F:backend/src/utils/micro-tag-parser.ts†L1-L86】
+
+---
+
+## 9. How to run the replay harness
+
+```bash
+cd backend
+npx tsx src/scripts/llm-replay-harness.ts
+```
+
+This prints token and call estimates per fixture for legacy vs optimized prompts.【F:backend/src/scripts/llm-replay-harness.ts†L1-L169】

--- a/backend/src/lib/bedrock.ts
+++ b/backend/src/lib/bedrock.ts
@@ -22,6 +22,7 @@ import {
 import { extractJsonFromResponse } from '../utils/json-extractor';
 import { brainService, BrainActivityCallType } from '../services/brain-service';
 import { ActivityType } from '@prisma/client';
+import { recordLlmCall } from '../services/llm-telemetry';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -461,6 +462,14 @@ export async function getModelCompletion(
       cost
     });
 
+    recordLlmCall(options.turnId, {
+      model: modelId,
+      operation,
+      inputTokens,
+      outputTokens,
+      durationMs,
+    });
+
     if (!responseText) {
       return null;
     }
@@ -805,6 +814,14 @@ export async function* getSonnetStreamingResponse(
       tokenCountOutput: outputTokens,
       durationMs,
       cost,
+    });
+
+    recordLlmCall(options.turnId, {
+      model: BEDROCK_SONNET_MODEL_ID,
+      operation: options.operation,
+      inputTokens,
+      outputTokens,
+      durationMs,
     });
 
     // Log the accumulated response

--- a/backend/src/scripts/fixtures/llm-fixtures.json
+++ b/backend/src/scripts/fixtures/llm-fixtures.json
@@ -1,0 +1,130 @@
+[
+  {
+    "id": "accusation-heavy-start",
+    "stage": 1,
+    "userName": "Alex",
+    "partnerName": "Jordan",
+    "emotionalIntensity": 8,
+    "summary": {
+      "currentFocus": "Alex feels dismissed and angry about repeated interruptions and missed plans.",
+      "keyThemes": ["feeling unheard", "broken promises"],
+      "emotionalJourney": "Started furious, shifted to hurt and exhaustion.",
+      "userStatedGoals": ["figure out how to be taken seriously"],
+      "agreedFacts": [],
+      "userNeeds": ["respect", "follow-through"],
+      "partnerNeeds": [],
+      "openQuestions": ["What does being taken seriously look like day to day?"],
+      "agreements": []
+    },
+    "messages": [
+      {
+        "role": "user",
+        "content": "You never listen. You just talk over me and then act like I'm dramatic."
+      },
+      {
+        "role": "assistant",
+        "content": "It sounds like you're feeling dismissed and fed up with being interrupted."
+      },
+      {
+        "role": "user",
+        "content": "Exactly. It's like my needs don't matter and I'm tired of repeating myself."
+      }
+    ]
+  },
+  {
+    "id": "misunderstanding-repair",
+    "stage": 2,
+    "userName": "Priya",
+    "partnerName": "Sam",
+    "emotionalIntensity": 6,
+    "summary": {
+      "currentFocus": "Priya wants to understand why Sam withdrew after the argument about finances.",
+      "keyThemes": ["miscommunication", "withdrawal"],
+      "emotionalJourney": "Moved from confusion to curiosity.",
+      "userStatedGoals": ["repair the misread intent"],
+      "agreedFacts": ["The argument was about spending"],
+      "userNeeds": ["clarity", "reassurance"],
+      "partnerNeeds": ["feeling safe"],
+      "openQuestions": ["What fear might have driven Sam to withdraw?"],
+      "agreements": []
+    },
+    "messages": [
+      {
+        "role": "user",
+        "content": "I thought we were aligned on the budget, then they went silent."
+      },
+      {
+        "role": "assistant",
+        "content": "That silence felt confusing, like the ground shifted."
+      },
+      {
+        "role": "user",
+        "content": "Yeah. I want to see what might be underneath it instead of assuming they don't care."
+      }
+    ]
+  },
+  {
+    "id": "consent-mediated-sharing",
+    "stage": 2,
+    "userName": "Maria",
+    "partnerName": "Lee",
+    "emotionalIntensity": 7,
+    "summary": {
+      "currentFocus": "Maria wants to share the impact of repeated cancellations without escalating.",
+      "keyThemes": ["reliability", "hurt"],
+      "emotionalJourney": "From sharp frustration to a desire to be understood.",
+      "userStatedGoals": ["share impact without blame"],
+      "agreedFacts": ["Plans were cancelled twice last month"],
+      "userNeeds": ["consideration", "predictability"],
+      "partnerNeeds": [],
+      "openQuestions": ["What do I want Lee to understand about the impact?"],
+      "agreements": []
+    },
+    "messages": [
+      {
+        "role": "user",
+        "content": "I want to tell Lee how it felt when they cancelled twice."
+      },
+      {
+        "role": "assistant",
+        "content": "You're trying to share the impact without turning it into a fight."
+      },
+      {
+        "role": "user",
+        "content": "Right, I want it to land as \"this hurt\" not \"you're awful\"."
+      }
+    ]
+  },
+  {
+    "id": "win-win-negotiation",
+    "stage": 4,
+    "userName": "Dev",
+    "partnerName": "Noah",
+    "emotionalIntensity": 5,
+    "summary": {
+      "currentFocus": "Dev and Noah want a small experiment for balancing chores and downtime.",
+      "keyThemes": ["fairness", "rest"],
+      "emotionalJourney": "From frustration to cautious optimism.",
+      "userStatedGoals": ["agree on a testable plan"],
+      "agreedFacts": ["Both are stretched on weeknights"],
+      "userNeeds": ["shared responsibility", "rest"],
+      "partnerNeeds": ["predictability"],
+      "openQuestions": ["What check-in cadence feels fair?"],
+      "agreements": ["Try a rotating schedule for one week"]
+    },
+    "messages": [
+      {
+        "role": "user",
+        "content": "We both want a fair chore plan, but it falls apart midweek."
+      },
+      {
+        "role": "assistant",
+        "content": "You want something small and testable rather than a big promise."
+      },
+      {
+        "role": "user",
+        "content": "Yes. What's a realistic experiment for this week?"
+      }
+    ]
+  }
+]

--- a/backend/src/scripts/llm-replay-harness.ts
+++ b/backend/src/scripts/llm-replay-harness.ts
@@ -1,0 +1,176 @@
+import fs from 'fs';
+import path from 'path';
+import { buildStagePrompt as buildLegacyStagePrompt } from '../services/stage-prompts-legacy';
+import { buildStagePrompt } from '../services/stage-prompts';
+import { formatContextForPrompt, formatContextForPromptLegacy } from '../services/context-formatters';
+import type { ContextBundle } from '../services/context-assembler';
+import { estimateMessagesTokens, estimateTokens, trimConversationHistory, CONTEXT_WINDOW } from '../utils/token-budget';
+import { determineMemoryIntent } from '../services/memory-intent';
+
+type FixtureMessage = { role: 'user' | 'assistant'; content: string };
+
+type Fixture = {
+  id: string;
+  stage: number;
+  userName: string;
+  partnerName?: string;
+  emotionalIntensity: number;
+  summary?: {
+    currentFocus: string;
+    keyThemes: string[];
+    emotionalJourney: string;
+    userStatedGoals: string[];
+    agreedFacts?: string[];
+    userNeeds?: string[];
+    partnerNeeds?: string[];
+    openQuestions?: string[];
+    agreements?: string[];
+  };
+  messages: FixtureMessage[];
+};
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'llm-fixtures.json');
+
+function loadFixtures(): Fixture[] {
+  const raw = fs.readFileSync(FIXTURE_PATH, 'utf8');
+  return JSON.parse(raw) as Fixture[];
+}
+
+function buildBundle(fixture: Fixture, useSummary: boolean): ContextBundle {
+  return {
+    conversationContext: {
+      recentTurns: [],
+      turnCount: fixture.messages.length,
+      sessionDurationMinutes: 0,
+    },
+    emotionalThread: {
+      initialIntensity: fixture.emotionalIntensity,
+      currentIntensity: fixture.emotionalIntensity,
+      trend: 'stable',
+      notableShifts: [],
+    },
+    stageContext: {
+      stage: fixture.stage,
+      gatesSatisfied: {},
+    },
+    userName: fixture.userName,
+    partnerName: fixture.partnerName,
+    intent: determineMemoryIntent({
+      stage: fixture.stage,
+      emotionalIntensity: fixture.emotionalIntensity,
+      userMessage: fixture.messages.at(-1)?.content ?? '',
+      turnCount: fixture.messages.length,
+    }),
+    assembledAt: new Date().toISOString(),
+    sessionSummary: useSummary && fixture.summary
+      ? {
+          ...fixture.summary,
+        }
+      : undefined,
+  };
+}
+
+function buildMessagesWithContext(
+  history: FixtureMessage[],
+  contextText: string,
+  mode: 'legacy' | 'optimized'
+): FixtureMessage[] {
+  if (history.length === 0) return [];
+  const base = history.slice(0, -1);
+  const current = history[history.length - 1];
+  const prefix = contextText.trim()
+    ? mode === 'legacy'
+      ? `[Context for this turn:\n${contextText}]\n\n${current.content}`
+      : `Context:\n${contextText}\n\nUser message: ${current.content}`
+    : current.content;
+  return [...base, { role: 'user', content: prefix }];
+}
+
+function estimateTurnTokens(systemPrompt: string, messages: FixtureMessage[]): number {
+  return estimateTokens(systemPrompt) + estimateMessagesTokens(messages);
+}
+
+function simulateFixture(fixture: Fixture, mode: 'legacy' | 'optimized') {
+  let totalTokens = 0;
+  let totalCalls = 0;
+  let turnCount = 0;
+
+  const useSummary = mode === 'optimized' && Boolean(fixture.summary);
+  const bundle = buildBundle(fixture, useSummary);
+
+  for (let i = 0; i < fixture.messages.length; i++) {
+    if (fixture.messages[i].role !== 'user') continue;
+    const history = fixture.messages.slice(0, i + 1);
+
+    const prompt = mode === 'legacy'
+      ? buildLegacyStagePrompt(fixture.stage, {
+          userName: fixture.userName,
+          partnerName: fixture.partnerName,
+          turnCount: i + 1,
+          emotionalIntensity: fixture.emotionalIntensity,
+          contextBundle: bundle,
+        })
+      : buildStagePrompt(fixture.stage, {
+          userName: fixture.userName,
+          partnerName: fixture.partnerName,
+          turnCount: i + 1,
+          emotionalIntensity: fixture.emotionalIntensity,
+          contextBundle: bundle,
+        });
+
+    const contextText = mode === 'legacy'
+      ? formatContextForPromptLegacy(bundle)
+      : formatContextForPrompt(bundle);
+
+    const { trimmed } = mode === 'optimized'
+      ? trimConversationHistory(
+          history.map((m) => ({ role: m.role, content: m.content })),
+          useSummary ? CONTEXT_WINDOW.recentTurnsWithSummary : CONTEXT_WINDOW.recentTurnsWithoutSummary
+        )
+      : { trimmed: history };
+
+    const messagesWithContext = buildMessagesWithContext(trimmed, contextText, mode);
+    const tokens = estimateTurnTokens(prompt, messagesWithContext);
+
+    const intent = determineMemoryIntent({
+      stage: fixture.stage,
+      emotionalIntensity: fixture.emotionalIntensity,
+      userMessage: history[history.length - 1].content,
+      turnCount: i + 1,
+    });
+
+    const calls = 1 + (intent.depth === 'full' ? 1 : 0);
+
+    totalTokens += tokens;
+    totalCalls += calls;
+    turnCount += 1;
+  }
+
+  return {
+    totalTokens,
+    averageTokens: turnCount ? Math.round(totalTokens / turnCount) : 0,
+    averageCalls: turnCount ? Number((totalCalls / turnCount).toFixed(2)) : 0,
+    turnCount,
+  };
+}
+
+function main() {
+  const fixtures = loadFixtures();
+  const results = fixtures.map((fixture) => {
+    const legacy = simulateFixture(fixture, 'legacy');
+    const optimized = simulateFixture(fixture, 'optimized');
+    return { fixture: fixture.id, legacy, optimized };
+  });
+
+  for (const result of results) {
+    console.log(`\nFixture: ${result.fixture}`);
+    console.log(`Legacy → avg tokens/turn: ${result.legacy.averageTokens}, avg calls/turn: ${result.legacy.averageCalls}`);
+    console.log(`Optimized → avg tokens/turn: ${result.optimized.averageTokens}, avg calls/turn: ${result.optimized.averageCalls}`);
+    const tokenReduction = result.legacy.averageTokens
+      ? Math.round(((result.legacy.averageTokens - result.optimized.averageTokens) / result.legacy.averageTokens) * 100)
+      : 0;
+    console.log(`Estimated token reduction: ${tokenReduction}%`);
+  }
+}
+
+main();

--- a/backend/src/services/__tests__/context-assembler.test.ts
+++ b/backend/src/services/__tests__/context-assembler.test.ts
@@ -52,12 +52,9 @@ describe('Context Assembler', () => {
 
         const formatted = formatContextForPrompt(bundle);
 
-        expect(formatted).toContain('NOTED FACTS FROM THIS SESSION:');
-        expect(formatted).toContain('[People]');
+        expect(formatted).toContain('--- Notable facts ---');
         expect(formatted).toContain('- User has a daughter named Emma who is 14');
-        expect(formatted).toContain('[Logistics]');
         expect(formatted).toContain('- Partner works night shifts');
-        expect(formatted).toContain('[Emotional]');
         expect(formatted).toContain('- Feeling unheard about childcare decisions');
       });
 
@@ -68,7 +65,7 @@ describe('Context Assembler', () => {
 
         const formatted = formatContextForPrompt(bundle);
 
-        expect(formatted).not.toContain('NOTED FACTS FROM THIS SESSION');
+        expect(formatted).not.toContain('--- Notable facts ---');
       });
 
       it('does not include facts block when facts array is empty', () => {
@@ -78,7 +75,7 @@ describe('Context Assembler', () => {
 
         const formatted = formatContextForPrompt(bundle);
 
-        expect(formatted).not.toContain('NOTED FACTS FROM THIS SESSION');
+        expect(formatted).not.toContain('--- Notable facts ---');
       });
 
       it('formats single fact correctly', () => {
@@ -88,8 +85,7 @@ describe('Context Assembler', () => {
 
         const formatted = formatContextForPrompt(bundle);
 
-        expect(formatted).toContain('NOTED FACTS FROM THIS SESSION:');
-        expect(formatted).toContain('[Emotional]');
+        expect(formatted).toContain('--- Notable facts ---');
         expect(formatted).toContain('- User feels overwhelmed');
       });
 
@@ -104,11 +100,8 @@ describe('Context Assembler', () => {
 
         const formatted = formatContextForPrompt(bundle);
 
-        // Both People facts should be under the same [People] header
-        expect(formatted).toContain('[People]');
         expect(formatted).toContain('- First person fact');
         expect(formatted).toContain('- Third person fact');
-        expect(formatted).toContain('[Emotional]');
         expect(formatted).toContain('- Second emotional fact');
       });
     });
@@ -134,9 +127,9 @@ describe('Context Assembler', () => {
 
         const formatted = formatContextForPrompt(bundle);
 
-        expect(formatted).toContain('[Intensity:'); // HUD format
-        expect(formatted).toContain('USER MEMORIES');
-        expect(formatted).toContain('NOTED FACTS FROM THIS SESSION:');
+        expect(formatted).toContain('Intensity:'); // HUD format
+        expect(formatted).toContain('--- User preferences to honor ---');
+        expect(formatted).toContain('--- Notable facts ---');
         expect(formatted).toContain('- Has two kids');
         expect(formatted).toContain('- Works from home');
       });
@@ -151,8 +144,8 @@ describe('Context Assembler', () => {
         });
 
         const formatted = formatContextForPrompt(bundle);
-        const memoriesIndex = formatted.indexOf('USER MEMORIES');
-        const factsIndex = formatted.indexOf('NOTED FACTS FROM THIS SESSION');
+        const memoriesIndex = formatted.indexOf('--- User preferences to honor ---');
+        const factsIndex = formatted.indexOf('--- Notable facts ---');
 
         expect(memoriesIndex).toBeGreaterThan(-1);
         expect(factsIndex).toBeGreaterThan(-1);
@@ -161,7 +154,7 @@ describe('Context Assembler', () => {
     });
 
     describe('Global Facts Formatting', () => {
-      it('formats global facts at top of context', () => {
+      it('does not include global facts in compact context', () => {
         const bundle = createMinimalBundle({
           globalFacts: [
             { category: 'People', fact: 'Has a partner named Alex' },
@@ -171,31 +164,8 @@ describe('Context Assembler', () => {
 
         const formatted = formatContextForPrompt(bundle);
 
-        expect(formatted).toContain('ABOUT THIS USER (from previous sessions):');
-        expect(formatted).toContain('[People]');
-        expect(formatted).toContain('- Has a partner named Alex');
-        expect(formatted).toContain('[History]');
-        expect(formatted).toContain('- Together for 5 years');
-      });
-
-      it('places global facts before emotional state', () => {
-        const bundle = createMinimalBundle({
-          globalFacts: [{ category: 'People', fact: 'Has a dog named Max' }],
-          emotionalThread: {
-            initialIntensity: 5,
-            currentIntensity: 7,
-            trend: 'escalating',
-            notableShifts: [],
-          },
-        });
-
-        const formatted = formatContextForPrompt(bundle);
-        const globalIndex = formatted.indexOf('ABOUT THIS USER');
-        const emotionalIndex = formatted.indexOf('[Intensity:'); // HUD format
-
-        expect(globalIndex).toBeGreaterThan(-1);
-        expect(emotionalIndex).toBeGreaterThan(-1);
-        expect(globalIndex).toBeLessThan(emotionalIndex);
+        expect(formatted).not.toContain('ABOUT THIS USER');
+        expect(formatted).not.toContain('Has a partner named Alex');
       });
     });
 
@@ -214,7 +184,7 @@ describe('Context Assembler', () => {
         expect(formatted).not.toContain('ABOUT THIS USER (from previous sessions)');
 
         // Should still contain session-specific notable facts
-        expect(formatted).toContain('NOTED FACTS FROM THIS SESSION');
+        expect(formatted).toContain('--- Notable facts ---');
         expect(formatted).toContain('User is feeling stressed');
       });
 
@@ -248,9 +218,9 @@ describe('Context Assembler', () => {
         const formatted = formatContextForPrompt(bundle);
 
         // Allowed content for session isolation
-        expect(formatted).toContain('NOTED FACTS FROM THIS SESSION');
-        expect(formatted).toContain('USER MEMORIES');
-        expect(formatted).toContain('[Intensity:'); // HUD format
+        expect(formatted).toContain('--- Notable facts ---');
+        expect(formatted).toContain('--- User preferences to honor ---');
+        expect(formatted).toContain('Intensity:'); // HUD format
 
         // Forbidden content (cross-session)
         expect(formatted).not.toContain('ABOUT THIS USER (from previous sessions)');

--- a/backend/src/services/attacking-language.ts
+++ b/backend/src/services/attacking-language.ts
@@ -1,0 +1,59 @@
+import { getHaikuJson } from '../lib/bedrock';
+import { BrainActivityCallType } from '@prisma/client';
+
+export interface SendableRewriteResult {
+  needsRewrite: boolean;
+  severity: 'low' | 'medium' | 'high';
+  note: string;
+  variants: string[];
+}
+
+export async function suggestSendableRewrite(params: {
+  text: string;
+  sessionId: string;
+  turnId: string;
+  requesterName: string;
+  targetName: string;
+}): Promise<SendableRewriteResult | null> {
+  const { text, sessionId, turnId, requesterName, targetName } = params;
+  if (!text.trim()) {
+    return null;
+  }
+
+  const systemPrompt = `You check whether a message contains attacking or blame-heavy language before it is shared.
+
+TASKS:
+1) Decide if a gentler rewrite is needed to prevent escalation.
+2) If needed, produce 1-3 rewrites that preserve the speaker's intent and accountability without sanitizing their voice.
+
+Rules:
+- Keep the speaker's intent and specifics.
+- Do NOT remove accountability or soften away real harm.
+- Avoid lecturing or therapy jargon.
+- If no rewrite is needed, return needsRewrite=false and empty variants.
+
+Output JSON:
+{
+  "needsRewrite": true|false,
+  "severity": "low"|"medium"|"high",
+  "note": "1 sentence describing what changed or why",
+  "variants": ["rewrite 1", "rewrite 2"]
+}`;
+
+  const userPrompt = `Speaker: ${requesterName}
+Recipient: ${targetName}
+Message:
+"""
+${text}
+"""`;
+
+  return getHaikuJson<SendableRewriteResult>({
+    systemPrompt,
+    messages: [{ role: 'user', content: userPrompt }],
+    maxTokens: 400,
+    sessionId,
+    turnId,
+    operation: 'sendable-rewrite',
+    callType: BrainActivityCallType.BACKGROUND_CLASSIFICATION,
+  });
+}

--- a/backend/src/services/context-formatters.ts
+++ b/backend/src/services/context-formatters.ts
@@ -1,0 +1,182 @@
+import type { ContextBundle } from './context-assembler';
+
+export interface ContextFormattingOptions {
+  sharedContentHistory?: string | null;
+  milestoneContext?: string | null;
+}
+
+export function formatContextForPromptLegacy(bundle: ContextBundle): string {
+  const parts: string[] = [];
+
+  if (bundle.globalFacts && bundle.globalFacts.length > 0) {
+    parts.push('ABOUT THIS USER (from previous sessions):');
+    const byCategory = new Map<string, string[]>();
+    for (const fact of bundle.globalFacts) {
+      const existing = byCategory.get(fact.category) || [];
+      existing.push(fact.fact);
+      byCategory.set(fact.category, existing);
+    }
+    for (const [category, facts] of byCategory) {
+      parts.push(`[${category}]`);
+      for (const fact of facts) {
+        parts.push(`- ${fact}`);
+      }
+    }
+    parts.push('');
+  }
+
+  {
+    const intensity = bundle.emotionalThread.currentIntensity;
+    const trend = bundle.emotionalThread.trend;
+    const turnCount = bundle.conversationContext.turnCount;
+
+    const trendLabel = trend === 'stable' ? 'Stable' : trend === 'unknown' ? 'Unknown' : 'Changed';
+    const intensityStr = intensity !== null ? `${intensity}/10` : 'Unknown';
+
+    parts.push(`[Intensity: ${intensityStr} (${trendLabel}) | Turn ${turnCount}]`);
+    parts.push('');
+  }
+
+  if (bundle.priorThemes && bundle.priorThemes.themes.length > 0) {
+    parts.push(`FROM PRIOR SESSIONS (use for continuity only):`);
+    parts.push(bundle.priorThemes.themes.join(', '));
+    parts.push('');
+  }
+
+  if (bundle.sessionSummary) {
+    parts.push(`SESSION SUMMARY:`);
+    parts.push(`Key themes: ${bundle.sessionSummary.keyThemes.join(', ')}`);
+    parts.push(`Current focus: ${bundle.sessionSummary.currentFocus}`);
+    if (bundle.sessionSummary.emotionalJourney) {
+      parts.push(`Emotional journey: ${bundle.sessionSummary.emotionalJourney}`);
+    }
+    if (bundle.sessionSummary.userStatedGoals && bundle.sessionSummary.userStatedGoals.length > 0) {
+      parts.push(`Topics that may need follow-up: ${bundle.sessionSummary.userStatedGoals.join(', ')}`);
+    }
+    parts.push('');
+  }
+
+  if (bundle.innerThoughtsContext && bundle.innerThoughtsContext.relevantReflections.length > 0) {
+    parts.push(`FROM ${bundle.userName.toUpperCase()}'S PRIVATE REFLECTIONS:`);
+    parts.push(`(These are from their Inner Thoughts - private processing they've done.`);
+    parts.push(`Reference gently, don't quote directly, and respect their privacy.)`);
+    for (const reflection of bundle.innerThoughtsContext.relevantReflections) {
+      const marker = reflection.isFromLinkedSession ? '[linked to this session]' : '';
+      parts.push(`- "${reflection.content}" ${marker}`);
+    }
+    parts.push('');
+  }
+
+  if (bundle.userMemories) {
+    const allMemories = [...bundle.userMemories.global, ...bundle.userMemories.session];
+    if (allMemories.length > 0) {
+      parts.push('USER MEMORIES (Always Honor These):');
+      for (const memory of allMemories) {
+        parts.push(`- [${memory.category}] ${memory.content}`);
+      }
+      parts.push('');
+    }
+  }
+
+  if (bundle.notableFacts && bundle.notableFacts.length > 0) {
+    parts.push('NOTED FACTS FROM THIS SESSION:');
+    const byCategory = new Map<string, string[]>();
+    for (const fact of bundle.notableFacts) {
+      const existing = byCategory.get(fact.category) || [];
+      existing.push(fact.fact);
+      byCategory.set(fact.category, existing);
+    }
+    for (const [category, facts] of byCategory) {
+      parts.push(`[${category}]`);
+      for (const fact of facts) {
+        parts.push(`- ${fact}`);
+      }
+    }
+    parts.push('');
+  }
+
+  const result = parts.join('\n');
+  return result;
+}
+
+export function formatContextForPrompt(
+  bundle: ContextBundle,
+  options?: ContextFormattingOptions
+): string {
+  const parts: string[] = [];
+
+  const intensity = bundle.emotionalThread.currentIntensity;
+  const trend = bundle.emotionalThread.trend;
+  const intensityStr = intensity !== null ? `${intensity}/10` : 'Unknown';
+  parts.push(`Intensity: ${intensityStr} (${trend}) | Turn ${bundle.conversationContext.turnCount}`);
+
+  if (bundle.sessionSummary) {
+    parts.push('--- Rolling summary ---');
+    parts.push(bundle.sessionSummary.currentFocus);
+
+    if (bundle.sessionSummary.keyThemes.length > 0) {
+      parts.push(`Themes: ${bundle.sessionSummary.keyThemes.join(', ')}`);
+    }
+
+    if (bundle.sessionSummary.agreedFacts?.length) {
+      parts.push(`Agreed facts: ${bundle.sessionSummary.agreedFacts.join('; ')}`);
+    }
+
+    if (bundle.sessionSummary.userNeeds?.length || bundle.sessionSummary.partnerNeeds?.length) {
+      const userNeeds = bundle.sessionSummary.userNeeds?.length
+        ? bundle.sessionSummary.userNeeds.join('; ')
+        : 'Not yet named';
+      const partnerNeeds = bundle.sessionSummary.partnerNeeds?.length
+        ? bundle.sessionSummary.partnerNeeds.join('; ')
+        : 'Not yet named';
+      parts.push(`Needs: User → ${userNeeds}. Partner → ${partnerNeeds}.`);
+    }
+
+    if (bundle.sessionSummary.openQuestions?.length || bundle.sessionSummary.userStatedGoals?.length) {
+      const openQuestions = bundle.sessionSummary.openQuestions?.length
+        ? bundle.sessionSummary.openQuestions.join('; ')
+        : bundle.sessionSummary.userStatedGoals.join('; ');
+      if (openQuestions) {
+        parts.push(`Open questions: ${openQuestions}`);
+      }
+    }
+
+    if (bundle.sessionSummary.agreements?.length) {
+      parts.push(`Agreements/experiments: ${bundle.sessionSummary.agreements.join('; ')}`);
+    }
+  }
+
+  if (bundle.userMemories) {
+    const allMemories = [...bundle.userMemories.global, ...bundle.userMemories.session];
+    if (allMemories.length > 0) {
+      const memoryLines = allMemories.slice(0, 5).map((memory) => `- ${memory.content}`);
+      parts.push('--- User preferences to honor ---');
+      parts.push(...memoryLines);
+    }
+  }
+
+  if (bundle.notableFacts && bundle.notableFacts.length > 0) {
+    const factLines = bundle.notableFacts.slice(0, 5).map((fact) => `- ${fact.fact}`);
+    parts.push('--- Notable facts ---');
+    parts.push(...factLines);
+  }
+
+  if (bundle.innerThoughtsContext?.relevantReflections?.length) {
+    parts.push('--- Private reflections (gentle reference) ---');
+    for (const reflection of bundle.innerThoughtsContext.relevantReflections.slice(0, 2)) {
+      parts.push(`- ${reflection.content}`);
+    }
+  }
+
+  if (options?.sharedContentHistory) {
+    parts.push('--- Shared/consent state ---');
+    parts.push(options.sharedContentHistory);
+  }
+
+  if (options?.milestoneContext) {
+    parts.push('--- Milestones ---');
+    parts.push(options.milestoneContext);
+  }
+
+  return parts.filter((part) => part.trim().length > 0).join('\n');
+}

--- a/backend/src/services/context-retriever.ts
+++ b/backend/src/services/context-retriever.ts
@@ -690,6 +690,8 @@ export async function retrieveContext(options: RetrievalOptions): Promise<Retrie
  */
 export function formatRetrievedContext(context: RetrievedContext): string {
   const sections: string[] = [];
+  const truncate = (text: string, maxChars: number = 500) =>
+    text.length > maxChars ? `${text.slice(0, maxChars - 20)}…[truncated]` : text;
 
   // Add recency guidance at the top if we have retrieved content
   if (context.recencyGuidance && (
@@ -703,7 +705,7 @@ export function formatRetrievedContext(context: RetrievedContext): string {
   if (context.preSessionMessages.length > 0) {
     sections.push('\n[Earlier in this conversation]');
     for (const msg of context.preSessionMessages.slice(-CONTEXT_LIMITS.maxPreSessionMessages)) {
-      sections.push(`${msg.role === 'user' ? 'User' : 'Assistant'}: ${msg.content}`);
+      sections.push(`${msg.role === 'user' ? 'User' : 'Assistant'}: ${truncate(msg.content)}`);
     }
   }
 
@@ -733,7 +735,7 @@ export function formatRetrievedContext(context: RetrievedContext): string {
           sections.push(`[${msg.partnerName}]`);
         }
       }
-      sections.push(`${msg.role === 'user' ? 'User' : 'AI'}: ${msg.content}`);
+      sections.push(`${msg.role === 'user' ? 'User' : 'AI'}: ${truncate(msg.content)}`);
     }
   }
 
@@ -745,7 +747,7 @@ export function formatRetrievedContext(context: RetrievedContext): string {
       if (timePhrase && msg.timeContext?.useRememberingLanguage) {
         sections.push(`[${timePhrase}]`);
       }
-      sections.push(`${msg.role === 'user' ? 'User' : 'AI'}: ${msg.content}`);
+      sections.push(`${msg.role === 'user' ? 'User' : 'AI'}: ${truncate(msg.content)}`);
     }
   }
 
@@ -793,4 +795,3 @@ export function buildMessagesWithFullContext(
 
   return messages;
 }
-

--- a/backend/src/services/llm-telemetry.ts
+++ b/backend/src/services/llm-telemetry.ts
@@ -1,0 +1,99 @@
+import { estimateMessagesTokens, estimateTokens } from '../utils/token-budget';
+
+export interface ContextSizeMetrics {
+  pinnedTokens: number;
+  summaryTokens: number;
+  recentTokens: number;
+  ragTokens: number;
+}
+
+export interface LlmCallMetrics {
+  model: string;
+  operation: string;
+  inputTokens: number;
+  outputTokens: number;
+  durationMs: number;
+}
+
+interface TurnAggregate {
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  durationMs: number;
+  models: Record<string, number>;
+  contextSizes?: ContextSizeMetrics;
+}
+
+const turnMetrics = new Map<string, TurnAggregate>();
+
+export function recordLlmCall(turnId: string | undefined, metrics: LlmCallMetrics): void {
+  if (!turnId) return;
+  const existing = turnMetrics.get(turnId) ?? {
+    callCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    durationMs: 0,
+    models: {},
+  };
+
+  existing.callCount += 1;
+  existing.inputTokens += metrics.inputTokens;
+  existing.outputTokens += metrics.outputTokens;
+  existing.durationMs += metrics.durationMs;
+  existing.models[metrics.model] = (existing.models[metrics.model] ?? 0) + 1;
+
+  turnMetrics.set(turnId, existing);
+}
+
+export function recordContextSizes(turnId: string | undefined, sizes: ContextSizeMetrics): void {
+  if (!turnId) return;
+  const existing = turnMetrics.get(turnId) ?? {
+    callCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    durationMs: 0,
+    models: {},
+  };
+  existing.contextSizes = sizes;
+  turnMetrics.set(turnId, existing);
+}
+
+export function finalizeTurnMetrics(turnId: string | undefined): void {
+  if (!turnId) return;
+  const aggregate = turnMetrics.get(turnId);
+  if (!aggregate) return;
+
+  const modelSummary = Object.entries(aggregate.models)
+    .map(([model, count]) => `${model}x${count}`)
+    .join(', ');
+
+  console.log(
+    `[LLM Metrics] turn=${turnId} calls=${aggregate.callCount} ` +
+      `tokens_in=${aggregate.inputTokens} tokens_out=${aggregate.outputTokens} ` +
+      `duration_ms=${aggregate.durationMs} models=[${modelSummary}]`
+  );
+
+  if (aggregate.contextSizes) {
+    const { pinnedTokens, summaryTokens, recentTokens, ragTokens } = aggregate.contextSizes;
+    console.log(
+      `[Context Metrics] turn=${turnId} pinned=${pinnedTokens} summary=${summaryTokens} ` +
+        `recent=${recentTokens} rag=${ragTokens}`
+    );
+  }
+
+  turnMetrics.delete(turnId);
+}
+
+export function estimateContextSizes(params: {
+  pinned: string;
+  summary: string;
+  recentMessages: Array<{ role: string; content: string }>;
+  rag: string;
+}): ContextSizeMetrics {
+  return {
+    pinnedTokens: estimateTokens(params.pinned),
+    summaryTokens: estimateTokens(params.summary),
+    recentTokens: estimateMessagesTokens(params.recentMessages),
+    ragTokens: estimateTokens(params.rag),
+  };
+}

--- a/backend/src/services/model-router.ts
+++ b/backend/src/services/model-router.ts
@@ -1,0 +1,78 @@
+import type { ModelType } from '../lib/bedrock';
+
+export type RequestType =
+  | 'mediate'
+  | 'summarize'
+  | 'rewrite'
+  | 'classify'
+  | 'draft'
+  | 'retrieve'
+  | 'unknown';
+
+export interface RoutingInput {
+  requestType: RequestType;
+  conflictIntensity: number;
+  ambiguityScore: number;
+  messageLength: number;
+}
+
+export interface RoutingDecision {
+  model: ModelType;
+  score: number;
+  reasons: string[];
+}
+
+export function scoreAmbiguity(message: string): number {
+  const questionMarks = (message.match(/\?/g) ?? []).length;
+  const vagueTerms = ['maybe', 'not sure', 'kinda', 'sort of', 'something', 'stuff'];
+  const vaguenessHits = vagueTerms.filter((term) => message.toLowerCase().includes(term)).length;
+  const lengthFactor = Math.min(message.length / 600, 1);
+  return Math.min(1, questionMarks * 0.2 + vaguenessHits * 0.15 + lengthFactor * 0.2);
+}
+
+export function routeModel(input: RoutingInput): RoutingDecision {
+  const reasons: string[] = [];
+  let score = 0;
+
+  switch (input.requestType) {
+    case 'mediate':
+      score += 4;
+      reasons.push('mediation-response');
+      break;
+    case 'draft':
+      score += 1;
+      reasons.push('drafting');
+      break;
+    case 'rewrite':
+    case 'summarize':
+    case 'classify':
+    case 'retrieve':
+      score -= 1;
+      reasons.push(input.requestType);
+      break;
+    default:
+      reasons.push('unknown');
+      break;
+  }
+
+  if (input.conflictIntensity >= 8) {
+    score += 3;
+    reasons.push('high-intensity');
+  } else if (input.conflictIntensity >= 6) {
+    score += 1;
+    reasons.push('medium-intensity');
+  }
+
+  if (input.ambiguityScore >= 0.5) {
+    score += 2;
+    reasons.push('ambiguous');
+  }
+
+  if (input.messageLength > 500) {
+    score += 1;
+    reasons.push('long-message');
+  }
+
+  const model: ModelType = score >= 4 ? 'sonnet' : 'haiku';
+  return { model, score, reasons };
+}

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -148,12 +148,13 @@ If intensity is high (8+), stay in witness mode and slow down.
 `;
 
 const STAGE1_QUESTION_TEMPLATES = `
-If you need a question, choose ONE of these (keep it simple):
+If a simple question helps, you can use or adapt one of these examples:
 - "What happened?"
 - "What did that cost you?"
 - "What did you feel in that moment?"
 - "What mattered most to you there?"
 - "What do you wish they understood?"
+Keep it natural and in the user's voice; you can ask a different question if it fits better.
 `;
 
 /**

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -352,7 +352,7 @@ function buildStage1Prompt(context: PromptContext): string {
 
 ${buildBaseSystemPrompt(context.invalidMemoryRequest, context.sharedContentHistory, getLastUserMessage(context), context.milestoneContext)}
 
-Focus: Reflect and validate before moving on. No solutions yet.
+Focus: Reflect and validate before moving on. No solutions, reframes, or interpretations yet.
 ${FACILITATOR_RULES}
 ${STAGE1_QUESTION_TEMPLATES}
 Neutrality lint (internal): avoid judging words like "reasonable", "right", "wrong", "irrational". Rephrase to impact-focused language.
@@ -364,7 +364,9 @@ Intensity: ${context.emotionalIntensity}/10
 Turn: ${context.turnCount}
 
 Feel-heard check:
-- Set FeelHeardCheck:Y once the core concern is named and they affirm a reflection.
+- Set FeelHeardCheck:Y when: (1) they affirm a reflection, (2) the core concern/need is named, and (3) intensity is stabilizing.
+- Be proactive — offer the check when ready rather than continuing to explore.
+- When FeelHeardCheck:Y, do NOT ask "do you feel heard?" The UI handles it. Keep setting Y until they act on it or switch topics.
 ${isTooEarly ? 'Too early (turn < 2) unless they ask to move on.' : ''}
 
 ${buildResponseProtocol(1)}`;

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -147,6 +147,15 @@ Facilitator rhythm: reflect → validate → one next move (one question OR one 
 If intensity is high (8+), stay in witness mode and slow down.
 `;
 
+const STAGE1_QUESTION_TEMPLATES = `
+If you need a question, choose ONE of these (keep it simple):
+- "What happened?"
+- "What did that cost you?"
+- "What did you feel in that moment?"
+- "What mattered most to you there?"
+- "What do you wish they understood?"
+`;
+
 /**
  * Tone guidance for Stage 0 (Onboarding).
  * Warm, patient, celebratory of courage.
@@ -344,6 +353,9 @@ ${buildBaseSystemPrompt(context.invalidMemoryRequest, context.sharedContentHisto
 
 Focus: Reflect and validate before moving on. No solutions yet.
 ${FACILITATOR_RULES}
+${STAGE1_QUESTION_TEMPLATES}
+Neutrality lint (internal): avoid judging words like "reasonable", "right", "wrong", "irrational". Rephrase to impact-focused language.
+Length: default 1–3 sentences. Go longer only if they explicitly ask for help or detail.
 ${witnessOnlyMode ? 'Stay in witness mode until intensity settles.' : ''}
 ${LATERAL_PROBING_GUIDANCE}
 

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -296,13 +296,29 @@ export function useStreamingMessage(
   const handleMetadata = useCallback(
     (sessionId: string, metadata: StreamMetadata) => {
       // Update session state cache for feel-heard check
+      // Must update nested path: progress.myProgress.gatesSatisfied.feelHeardCheckOffered
       if (metadata.offerFeelHeardCheck) {
         queryClient.setQueryData(
           sessionKeys.state(sessionId),
-          (old: Record<string, unknown> | undefined) => ({
-            ...old,
-            showFeelHeardCheck: true,
-          })
+          (old: Record<string, unknown> | undefined) => {
+            if (!old) return old;
+            const progress = old.progress as Record<string, unknown> | undefined;
+            const myProgress = progress?.myProgress as Record<string, unknown> | undefined;
+            const gates = (myProgress?.gatesSatisfied as Record<string, unknown>) ?? {};
+            return {
+              ...old,
+              progress: {
+                ...progress,
+                myProgress: {
+                  ...myProgress,
+                  gatesSatisfied: {
+                    ...gates,
+                    feelHeardCheckOffered: true,
+                  },
+                },
+              },
+            };
+          }
         );
       }
 


### PR DESCRIPTION
### Motivation
- Reduce token cost and latency by replacing verbose, repeated prompts and full-transcript context injection with a compact facilitator prompt and three-layer context strategy.
- Restore conversational capability and natural mediator voice by removing rigid, prescriptive scripting and enabling model routing (Haiku vs Sonnet) for appropriate tasks.
- Implement a dual-track approach for handling attacking language that preserves fidelity while offering optional sendable rewrites when sharing is appropriate.

### Description
- Replaced large, prescriptive stage prompts with compact "Facilitator" prompts and preserved legacy prompts as an archive for baseline comparison (see `backend/src/services/stage-prompts.ts` and `backend/src/services/stage-prompts-legacy.ts`).
- Implemented three-layer context bundling and aggressive trimming: pinned constitution, rolling summaries (with new summary fields), and a recent window with summary-aware trimming (see `backend/src/services/context-formatters.ts`, `backend/src/services/conversation-summarizer.ts`, and `backend/src/utils/token-budget.ts`).
- Added model routing policy to pick `haiku` vs `sonnet` based on request type, conflict intensity, ambiguity, and message length (`backend/src/services/model-router.ts`) and wired routing into orchestrator and relevant controllers (`backend/src/services/ai-orchestrator.ts`, `backend/src/controllers/stage2.ts`, `backend/src/controllers/reconciler.ts`).
- Introduced a dual-track attacking-language helper that uses Haiku to produce 1–3 optional "sendable" rewrites plus a note, without discarding the original text (`backend/src/services/attacking-language.ts`) and integrated it into share-draft flow (`backend/src/controllers/reconciler.ts`).
- Compact context formatter implemented to reduce RAG payload and limit notable facts; legacy formatter kept for comparisons (`backend/src/services/context-formatters.ts`).
- Added telemetry for per-turn LLM metrics and context sizes and hooked recording into Bedrock helpers (`backend/src/services/llm-telemetry.ts`, `backend/src/lib/bedrock.ts`).
- Added a replay harness and fixture suite to estimate tokens/calls for legacy vs optimized flows (`backend/src/scripts/llm-replay-harness.ts`, `backend/src/scripts/fixtures/llm-fixtures.json`).
- Misc: micro-tag parser compatibility fallback for JSON outputs, extraction and truncation improvements in retrieval formatting, reduced protected history size and context budget defaults, and other plumbing to wire the above changes across streaming and orchestration paths.

### Testing
- Ran the deterministic replay harness `npx tsx backend/src/scripts/llm-replay-harness.ts` which compares legacy vs optimized token/call estimates on fixtures; it executed successfully and reported estimated reductions: 50–60% token reductions across fixtures and similar or fewer calls per turn.
- Existing unit tests touching prompt/context behavior were updated where needed (context-assembler tests adjusted to new compact formatting expectations); test run not included here but modified tests are present under `backend/src/services/__tests__`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69726fadbd80832d8bdd9b4676bbde6b)