### PR TITLE
Add MCP profile and relationship planning document

### DIFF
--- a/docs/model-context-profile-plan.md
+++ b/docs/model-context-profile-plan.md
@@ -1,0 +1,80 @@
+# Model Context Protocol Plan: User, Relationship, and Network Profiles
+
+## Goal
+Create a Model Context Protocol (MCP)-powered system that builds rich, evolving profiles for individuals, their relationships, and the broader network of people they are connected to. These profiles should capture key milestones, challenges, traumas, progress, and win-wins achieved, then use the shared context to support inner work and conflict resolution through a dedicated profile communicator.
+
+## Guiding Principles
+- **Consent-first data sharing:** Users explicitly grant permissions for sharing relationship context between profiles.
+- **Minimal but meaningful data:** Store only the context required for support, with clear provenance and timestamps.
+- **Bias-aware summaries:** Use structured, factual summaries to prevent misinterpretation.
+- **Human-centered outputs:** Provide outputs that are actionable, compassionate, and supportive of growth.
+
+## Core Data Model
+### Individual Profile
+- Identity and preferences (name, pronouns, communication style, boundaries).
+- Emotional and relational baseline (common triggers, conflict patterns, strengths).
+- Milestones and wins (personal achievements, breakthroughs).
+- Challenges and traumas (flagged with sensitivity, consent, and visibility rules).
+- Current goals (inner work objectives, relational intentions).
+
+### Relationship Profile
+- Relationship type (partner, family, friend, colleague, mentor).
+- Key milestones (moving in, reconciliations, agreements made).
+- Challenges and conflicts (themes, unresolved topics).
+- Win-wins achieved (agreements, improved practices).
+- Shared commitments and intentions.
+
+### Network Profile
+- Map of relationships to understand context across multiple connections.
+- Cluster insights (recurring dynamics across relationships).
+- Safeguards to avoid cross-contamination of sensitive details.
+
+## MCP-Based Context Architecture
+### MCP Servers
+- **Profile Server:** Stores and retrieves individual profiles with permissions.
+- **Relationship Server:** Stores relationship-specific histories and agreements.
+- **Milestone Server:** Dedicated log for milestones, traumas, and progress markers.
+- **Insight Server:** Generates summaries, risk flags, and recommended actions.
+
+### MCP Clients
+- **Coaching Client:** Uses profiles for personalized inner-work reflections.
+- **Conflict Resolution Client:** Uses shared relationship context to propose de-escalation steps.
+- **Progress Tracker Client:** Surfaces growth trends and recurring patterns.
+
+## Profile Communicator (Cross-Profile Mediator)
+A specialized MCP client/service that:
+1. **Aggregates consented data** from two or more profiles.
+2. **Normalizes language** to neutral, non-blaming summaries.
+3. **Highlights shared goals** and win-win outcomes.
+4. **Surfaces unresolved themes** without disclosing sensitive trauma details.
+5. **Provides tailored prompts** to encourage empathy and accountability.
+
+## Milestone & Trauma Handling
+- Store entries with **confidence levels**, **source**, and **visibility scope**.
+- Create “safe summaries” for sensitive events (e.g., “past boundary violation” rather than explicit details).
+- Allow **time-bound visibility** (e.g., only for active conflict resolution sessions).
+
+## Inner Work & Conflict Resolution Flow
+1. **Session start:** Pull summarized individual + relationship context.
+2. **Shared intent:** Identify overlapping goals and desired outcomes.
+3. **Pattern detection:** Highlight repeated triggers or escalations.
+4. **Guided dialogue:** Offer neutral prompts aligned with both users’ stated needs.
+5. **Resolution tracking:** Log agreements and actions as new milestones.
+
+## Implementation Steps
+1. **Define schemas** for individual, relationship, and milestone records.
+2. **Build MCP servers** for profile, relationship, and milestone data.
+3. **Implement permission model** (consent flags, visibility rules, audit logs).
+4. **Create communicator client** for shared-context mediation.
+5. **Integrate progress tracker** to visualize changes over time.
+6. **Test with anonymized scenarios** and bias/consent edge cases.
+
+## Risks & Mitigations
+- **Privacy leakage:** Strict consent checks and scoped context retrieval.
+- **Over-sharing trauma context:** Use safe summaries and redaction rules.
+- **Bias in summaries:** Standardized templates and human-in-the-loop review.
+
+## Next Steps
+- Prototype schemas and API contracts.
+- Run internal design review focused on ethics and consent.
+- Pilot with a small set of opt-in relationship scenarios.

--- a/docs/model-context-profile-plan.md
+++ b/docs/model-context-profile-plan.md
@@ -1,5 +1,41 @@
 # Model Context Protocol Plan: User, Relationship, and Network Profiles
 
+## What is MCP and why it matters here
+Model Context Protocol (MCP) is a standard that lets applications expose data and tools to language models through well-defined interfaces. Instead of hard-coding every data source into the app, MCP provides a structured way to ask for context (like a user profile, a relationship history, or a milestone log) and receive a governed response with clear permissions and provenance.
+
+For Meet Without Fear, MCP is relevant because the product requires **safe, consistent access to sensitive context** (individual, relationship, and network) while enforcing consent and visibility rules. MCP can act as the glue between profile storage, milestone logs, and insight generation while keeping those services separate and permissioned. This makes it easier to:
+- enforce consent-first sharing in a central place,
+- audit what context was used in a session, and
+- swap or evolve services without rebuilding the entire context layer.
+
+## Is MCP necessary?
+MCP is **not strictly necessary** to deliver the first version of the plan. The core needs (profile storage, relationship records, and consent checks) can be built with traditional APIs and a monolith service. MCP becomes valuable when you want:
+- multiple services (profile, relationship, milestone, insight) to work together,
+- multiple clients (coaching, conflict resolution, progress tracker) to access shared, permissioned context, and
+- a clear interface for expanding or integrating future tools.
+
+In short, MCP is **useful but not required** for an initial MVP. It becomes more valuable as the system grows in complexity and number of data sources.
+
+## Pros and Cons for Meet Without Fear
+### Pros
+- **Separation of concerns:** Profile, relationship, and milestone data can live in distinct services with clean boundaries.
+- **Consent enforcement:** MCP servers can enforce scope-based permissions before data reaches a client.
+- **Auditability:** MCP requests can be logged for compliance and safety review.
+- **Extensibility:** New insight or analysis services can be added without reworking core apps.
+
+### Cons
+- **Complexity overhead:** MCP adds an extra layer that can slow early development.
+- **Operational cost:** Multiple servers and permission checks mean more infrastructure and monitoring.
+- **Integration effort:** Engineering time is needed to align data schemas and permission logic across services.
+
+## Recommendation
+Move forward with the plan, but **phase MCP adoption**:
+1. **Phase 1 (MVP):** Build the schemas, permission model, and a simple profile + relationship service. Use direct APIs initially for speed.
+2. **Phase 2 (Expansion):** Introduce MCP for profile/relationship/milestone context once multiple clients (coaching, conflict resolution, progress tracking) need consistent, governed access.
+3. **Phase 3 (Scale):** Expand MCP servers for insight generation and cross-profile mediation with stronger audit and consent controls.
+
+This phased approach balances speed with long-term safety and extensibility, keeping MCP as a strategic enabler rather than an upfront blocker.
+
 ## Goal
 Create a Model Context Protocol (MCP)-powered system that builds rich, evolving profiles for individuals, their relationships, and the broader network of people they are connected to. These profiles should capture key milestones, challenges, traumas, progress, and win-wins achieved, then use the shared context to support inner work and conflict resolution through a dedicated profile communicator.
 


### PR DESCRIPTION
### Motivation
- Introduce a Model Context Protocol (MCP) plan to build evolving profiles for individuals, their relationships, and networked connections to capture milestones, challenges, traumas, progress, and win‑wins for improved inner work and conflict resolution. 
- Emphasize consent-first sharing, minimal/safe summaries, bias-aware outputs, and a dedicated cross-profile communicator to mediate shared context and reduce harm.

### Description
- Add a new planning document at `docs/model-context-profile-plan.md` that defines goals, guiding principles, and the core data models for `Individual`, `Relationship`, and `Network` profiles. 
- Describe an MCP-based architecture including `Profile`, `Relationship`, `Milestone`, and `Insight` servers and client roles such as Coaching, Conflict Resolution, and Progress Tracker, plus a `Profile Communicator` for aggregated mediation. 
- Specify milestone and trauma handling approaches, an inner-work and conflict-resolution flow, implementation steps, risk mitigations, and recommended next steps.

### Testing
- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697537c96bc8832d91b3ee3ae1ab05a2)