### PR TITLE
Redesign Stage 1 & 2 prompts based on user feedback

### DIFF
--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -44,16 +44,16 @@ describe('Stage Prompts Service', () => {
       const context = createContext();
       const prompt = buildStagePrompt(1, context);
 
-      expect(prompt).toContain('Witness');
+      expect(prompt).toContain('listen to Test User');
       expect(prompt).toContain('Test User');
-      expect(prompt).toContain('feel fully heard');
+      expect(prompt).toContain('GATHERING PHASE');
     });
 
     it('returns Stage 2 prompt for stage 2', () => {
       const context = createContext();
       const prompt = buildStagePrompt(2, context);
 
-      expect(prompt).toContain('Perspective Stretch');
+      expect(prompt).toContain('exploring what Partner might be going through');
       expect(prompt).toContain('Partner');
     });
 
@@ -62,7 +62,7 @@ describe('Stage Prompts Service', () => {
       const prompt = buildStagePrompt(3, context);
 
       expect(prompt).toContain('Need Mapping');
-      expect(prompt).toContain('underlying needs');
+      expect(prompt).toContain('needs underneath');
     });
 
     it('returns Stage 4 prompt for stage 4', () => {
@@ -97,8 +97,8 @@ describe('Stage Prompts Service', () => {
       expect(prompt).toContain('just sent their invitation');
       expect(prompt).toContain('Partner');
       // Should also contain the regular Stage 1 prompt (not replaced)
-      expect(prompt).toContain('Witness stage');
-      expect(prompt).toContain('feel fully heard');
+      expect(prompt).toContain('listen to Test User');
+      expect(prompt).toContain('GATHERING PHASE');
       // Should NOT explicitly name stages
       expect(prompt).not.toContain('"Stage 1"');
       expect(prompt).not.toContain('"witness stage"');
@@ -115,10 +115,9 @@ describe('Stage Prompts Service', () => {
       // Transition injection content
       expect(prompt).toContain('TRANSITION:');
       expect(prompt).toContain('feeling heard');
-      expect(prompt).toContain('curiosity');
       expect(prompt).toContain('Partner');
       // Regular Stage 2 prompt content
-      expect(prompt).toContain('Perspective Stretch');
+      expect(prompt).toContain('exploring what Partner might be going through');
       expect(prompt).toContain('FOUR MODES');
     });
 
@@ -167,8 +166,8 @@ describe('Stage Prompts Service', () => {
 
       // Should be regular Stage 1 prompt without transition injection
       expect(prompt).not.toContain('TRANSITION:');
-      expect(prompt).toContain('Witness stage');
-      expect(prompt).toContain('feel fully heard');
+      expect(prompt).toContain('listen to Test User');
+      expect(prompt).toContain('GATHERING PHASE');
     });
 
     it('includes user and partner names in transition prompts', () => {
@@ -234,9 +233,9 @@ describe('Stage Prompts Service', () => {
       };
       const prompt = buildStagePrompt(1, context, options);
 
-      // Should be regular witness prompt, not transition
-      expect(prompt).toContain('Witness stage');
-      expect(prompt).toContain('Reflect and validate');
+      // Should be regular listening prompt, not transition
+      expect(prompt).toContain('listen to Test User');
+      expect(prompt).toContain('ONE SIDE OF THE STORY');
     });
 
     it('uses regular Stage 2 prompt when not transitioning', () => {

--- a/docs/devils-advocate-review.md
+++ b/docs/devils-advocate-review.md
@@ -1,0 +1,451 @@
+# Devil's Advocate Review: Proposed Prompt Redesign
+
+> Critical review of Stage 1 and Stage 2 prompt proposals. For every problem identified, a concrete fix is suggested.
+
+---
+
+## Overall Assessment
+
+The proposals are a genuine improvement. They solve the most egregious issues (parroting, therapy-speak, missing Stage 2 rationale). But they also introduce new risks. The most serious: **the pendulum may swing from "too therapeutic" to "too interrogative,"** and the safety net for high-intensity users has been thinned in ways that could hurt real people.
+
+Below I go section by section.
+
+---
+
+## 1. The Gathering Phase May Feel Cold (Stage 1 — `FACILITATOR_RULES`)
+
+### The Problem
+
+The new `FACILITATOR_RULES` says:
+
+> "GATHERING PHASE (early in the conversation — roughly the first 4-5 exchanges): ...Acknowledge briefly (one short sentence, or even just start with the question)... Do NOT reflect back, paraphrase, or summarize yet — you don't know enough"
+
+And the `buildStage1Prompt` phaseGuidance for gathering:
+
+> "Keep responses short — acknowledge briefly, then ask a question. Don't reflect or summarize yet."
+
+**What happens when a user opens with:** *"My husband hit me last night and I don't know what to do"*?
+
+Under the current prompt, the AI would reflect and validate — maybe too much, but at least it would acknowledge the gravity. Under the new prompt, the gathering phase instruction says: acknowledge briefly, ask a question. The AI might say: "That sounds really serious. What happened leading up to it?"
+
+That's... fine? But it's also a scenario where a one-sentence acknowledgment feels callously insufficient. The instruction "Do NOT reflect back" is too absolute for high-stakes disclosures.
+
+### The High-Intensity Override Is Insufficient
+
+The proposal does have a high-intensity carve-out:
+
+> "AT ANY POINT: If emotional intensity is high (8+), slow way down. Just be present."
+
+And in `buildStage1Prompt`:
+
+> "`isHighIntensity` → 'really activated right now. Don't try to move the conversation forward. Just be steady and present.'"
+
+But this only triggers at intensity 8+. **The EmotionSlider defaults to some starting value.** On turn 1, if someone types a devastating message but hasn't adjusted the slider, intensity could read as 5. The gathering phase instruction ("don't reflect, just ask") applies. The AI asks a follow-up question to someone who just disclosed domestic violence.
+
+### Fix
+
+Add a **severity-aware exception** to the gathering phase — not based solely on the slider value, but instructed as behavioral guidance:
+
+```
+GATHERING PHASE exception: If someone shares something devastating (violence,
+abuse, loss, betrayal), do NOT rush to a question. Acknowledge the weight of
+what they said first. You can still be brief — "That's a huge thing to share.
+I'm glad you told me." — but don't skip straight to a question. Let them
+breathe. THEN ask.
+```
+
+This preserves the gathering intent while preventing the AI from sounding callous on disclosures that deserve more than "Got it."
+
+---
+
+## 2. "Don't Agree" vs. "Acknowledge Pain" — The Neutrality Razor Is Too Sharp (Stage 1 — `NEUTRALITY_GUIDANCE`)
+
+### The Problem
+
+The new `NEUTRALITY_GUIDANCE` says:
+
+> "Never say 'that's understandable' about the other person's behavior."
+> "Never use words that take sides: 'reasonable', 'right', 'wrong', 'unfair', 'irrational', 'toxic'."
+
+Consider: a user says *"He screamed at me in front of the kids and I felt humiliated."*
+
+The AI can't say "that's understandable" about feeling humiliated? It literally IS understandable. The instruction conflates acknowledging **the user's reaction** with validating **the partner's guilt**.
+
+Also: the word "unfair" is banned. But sometimes a user is describing their feeling: "It felt really unfair." If the AI can't even reflect that word back, it'll feel like the AI is dodging their emotional reality.
+
+### Fix
+
+Rewrite the neutrality guidance to distinguish three layers:
+
+```
+NEUTRALITY — THREE LAYERS:
+1. Their FEELINGS: Always acknowledge. "Of course you'd feel humiliated" is fine.
+   You're validating their emotional experience, not the events.
+2. Their INTERPRETATION of what happened: Don't confirm or deny. If they say
+   "He's gaslighting me," don't agree or disagree. Ask what happened that made
+   them feel that way.
+3. Their CHARACTERIZATION of the partner: Never agree. If they say "She's toxic,"
+   don't validate the label. Acknowledge the pain: "Sounds like you're really
+   hurt by how she's been acting."
+
+You CAN use "understandable" about FEELINGS ("It's understandable you'd feel that way").
+You CANNOT use "understandable" about BEHAVIOR ("It's understandable that you'd want to leave him" — this takes a side).
+```
+
+The current proposal's flat ban on "that's understandable" will cause the AI to sound evasive when people describe genuine suffering.
+
+---
+
+## 3. Will Rapid-Fire Questions Feel Like an Intake Form? (Stage 1 — `STAGE1_QUESTION_TEMPLATES`)
+
+### The Problem
+
+The question templates are good individually:
+
+> "What happened?" / "What did that feel like?" / "What mattered most to you in that moment?" / "What do you wish they understood?"
+
+But there's no instruction about **variety and conversational flow**. If the AI cycles through these in order, turns 1-5 become:
+
+1. "What happened?"
+2. "Got it. What did that feel like?"
+3. "Thanks for sharing. How long has this been going on?"
+4. "Makes sense. What's at stake for you here?"
+5. "What do you wish they understood?"
+
+That reads like an intake questionnaire, not a conversation. The old prompt had the same risk but buried it under reflection. The new prompt, by stripping away reflection in early turns, makes the question-barrage pattern the *only* thing happening.
+
+### Fix
+
+Add explicit anti-pattern guidance:
+
+```
+DON'T just cycle through questions. A good conversation has rhythm:
+- Sometimes respond to what they just said before asking something new
+- Sometimes you don't need a question at all — a short acknowledgment lets them
+  keep going on their own
+- If they're on a roll, get out of the way. "Tell me more" or even just silence
+  (no question) works.
+- The worst version of this is five questions in a row with one-sentence
+  acknowledgments. That's an interview, not a conversation.
+```
+
+---
+
+## 4. The Turn 5 Cliff: Gathering → Reflecting Transition Is Too Rigid (Stage 1 — `buildStage1Prompt`)
+
+### The Problem
+
+```typescript
+const isGathering = context.turnCount < 5 && context.emotionalIntensity < 8;
+```
+
+And the phaseGuidance:
+
+> gathering: "You're still building the picture..."
+> reflecting: "You have a solid picture now..."
+
+Turn 4: "Don't reflect yet." Turn 5: "Now reflect." There's no gradient. In reality, some users share everything in two long messages. Others take ten turns of one-liners. A hard cutoff at turn 5 means:
+
+- **Verbose user**: By turn 3, the AI has a complete picture but is instructed to keep asking questions for two more turns. They'll feel unheard: "I already told you everything, why do you keep asking?"
+- **Guarded user**: At turn 5, the AI switches to reflection mode but barely knows anything. It'll produce hollow reflections based on minimal information.
+
+### Fix
+
+Make the transition instruction softer and judgment-based rather than turn-count-based:
+
+```typescript
+const phaseGuidance = isHighIntensity
+  ? `... (keep as-is)`
+  : isGathering
+    ? `You're still early in the conversation. Default to asking questions,
+       but if they've already shared a lot, it's okay to reflect earlier than
+       turn 5. Use your judgment — the goal is to have enough context that
+       your reflection adds value, not just parrots.`
+    : `You've been listening for a while. If you have a good picture,
+       reflect back what you've heard. If you still feel lost, keep asking
+       — there's no shame in needing more.`;
+```
+
+The turn count should be a **signal**, not a **gate**. The prompt should say "roughly" and "by default" rather than presenting it as a phase boundary.
+
+---
+
+## 5. Stage 2 Purpose Explanation — Risk of Condescension (Stage 2 — `STAGE2_PURPOSE_CONTEXT` and Transition)
+
+### The Problem
+
+The transition now says:
+
+> "Then explain what comes next — naturally, not like reading instructions. Cover these points in your own words: - Both are talking to the AI separately... - This next step is about trying to understand... - It's not a test... - At the end, write a short statement..."
+
+That's **four bullet points** the AI must cover in a transition message. Plus "keep the whole thing to 3-5 sentences." Plus "then ask an opening question."
+
+This is asking the AI to deliver a mini-lecture in 3-5 sentences. That's a lot of ground to cover. Two risks:
+
+1. **Over-explaining to users who already get it**: If someone intuitively grasps perspective-taking, hearing "it's not a test, getting it wrong is fine, research shows..." will feel patronizing.
+2. **The explanation itself becomes the verbose problem we're trying to fix**: The old transition was 1-2 sentences. The new one is 3-5 sentences of explanation + a question. We just made the transition *longer*.
+
+### Fix
+
+Make the explanation **adaptive**:
+
+```
+Then naturally introduce what comes next. The key point is that both of you are
+doing this for each other. You don't need to cover every detail upfront — if
+they seem to get it, move on quickly. If they seem confused or resistant,
+explain more (both sides are doing this separately, it's a guess not a test,
+the effort matters more than accuracy).
+
+Keep it brief — 2-3 sentences is plenty for most people. More only if they
+need it.
+```
+
+This lets the AI calibrate. Some users need the full rationale. Others just need "Now let's think about what [partner] might be going through."
+
+---
+
+## 6. The Dispatch Off-Ramp for "Why Am I Guessing?" — Is It Over-Engineered? (Stage 2 — `EXPLAIN_EMPATHY_PURPOSE`)
+
+### The Problem
+
+The proposal creates a new dispatch type (`EXPLAIN_EMPATHY_PURPOSE`), a new handler function, a new prompt builder, and a fallback — all to handle "Why am I doing this?"
+
+Let's be honest: how often will a user explicitly ask "Why am I guessing?" vs. how often will they show confusion through behavior (low effort, "I don't know," resistance)?
+
+The **inline** handling for implicit disengagement (Section 6 of the Stage 2 proposal — "HANDLING 'I DON'T KNOW' OR LOW EFFORT") is where 80% of the real confusion will surface. The dispatch off-ramp handles the other 20%.
+
+But the dispatch introduces complexity:
+- A separate AI call (Sonnet) for what could be a 3-sentence inline response
+- A fallback function for when the dispatch call fails
+- A new type to maintain in `dispatch-handler.ts`
+- The pattern of "output ONLY `<thinking>` + `<dispatch>` (no visible text)" means the user sees nothing while the secondary call happens — creating a delay
+
+### My Take
+
+This isn't *wrong*, but it is over-engineered for the problem size. The existing inline handling (the "I DON'T KNOW" section) could absorb this case.
+
+### Fix (if keeping the dispatch)
+
+If you keep the dispatch, make the trigger conditions more specific to avoid false positives:
+
+```
+WHEN TO USE <dispatch>EXPLAIN_EMPATHY_PURPOSE</dispatch>:
+- ONLY for direct, explicit process questions: "Why am I guessing?" / "What's
+  the point?" / "Shouldn't they talk to you?"
+- NOT for resistance like "I don't care what they think" — handle that inline
+- NOT for confusion like "I'm not sure what to say" — that's a BRIDGING moment
+```
+
+Without this specificity, the AI might over-dispatch and interrupt conversational flow.
+
+---
+
+## 7. Stage 2 — "No Opinions" May Neuter Helpful Prompts (Stage 2 — `WHAT NOT TO DO`)
+
+### The Problem
+
+> "Don't state psychological principles as facts ('People act from fear' / 'This is probably driven by their attachment style')."
+
+The original: *"People usually act from fear — what might [partner] be afraid of?"* — this was actually a useful reframe. It gave users a mental model for depersonalizing their partner's behavior. The new version removes it entirely from the MIRROR mode:
+
+> "What do you think was happening for [partner] that led them to do that?"
+
+This is good but it's *harder* for the user. The old version gave them a foothold ("fear") to start imagining. The new version is completely open-ended. For someone who is stuck in blame, an open-ended question with no scaffolding may get "I don't know, they're just an asshole."
+
+### Fix
+
+Don't state principles as facts, but DO offer tentative framing as a *question*:
+
+```
+MIRROR mode: Don't state psychological principles as facts. But you CAN
+offer tentative framings as questions:
+- Instead of: "People usually act from fear"
+- Try: "Sometimes when people act like that, there's something they're
+  scared of underneath. Does that ring true for [partner]?"
+
+The difference: a statement tells them what to think. A question invites them
+to consider a possibility.
+```
+
+---
+
+## 8. `FACILITATOR_RULES` Shared Across Stages — Collision Risk (Stage 1 → Stages 3 & 4)
+
+### The Problem
+
+The Stage 1 proposal notes (Integration Notes, item 9):
+
+> "`FACILITATOR_RULES` is also used by Stages 2, 3, and 4 (lines 410, 448, 489). The new version works for all stages since the gathering/reflecting phases are defined by turn count which resets per stage."
+
+But the new `FACILITATOR_RULES` contains:
+
+> "GATHERING PHASE (early in the conversation — roughly the first 4-5 exchanges): Your job is to understand the situation. You don't have enough information to reflect yet."
+
+This makes sense for Stage 1 (first conversation with the user). It does NOT make sense for Stage 3 (Need Mapping) or Stage 4 (Strategic Repair), where the AI already has context from previous stages. At Stage 3, turn 1, the AI "doesn't have enough information to reflect yet"? It has the entire prior conversation. Yet the new rules would tell it to be in gathering mode.
+
+The Stage 2 proposal wisely **does not use the new `FACILITATOR_RULES`** — it inlines its own approach instructions. But Stages 3 and 4 still reference it (lines 448, 489 in the current code).
+
+### Fix
+
+Either:
+
+**A)** Create a Stage 1-specific version and keep the old `FACILITATOR_RULES` for Stages 3/4:
+```typescript
+const STAGE1_LISTENING_RULES = `...`; // New gathering/reflecting phases
+const FACILITATOR_RULES = `...`;       // Keep original for 3/4 (or lightly edit)
+```
+
+**B)** Add a stage-awareness clause to the new rules:
+```
+GATHERING PHASE applies when you're first meeting this person's story
+(Stage 1). In later stages, you already have context — skip to reflecting
+and respond to where they are now.
+```
+
+Option A is cleaner. The gathering/reflecting concept is Stage 1-specific and shouldn't leak into other stages.
+
+---
+
+## 9. Are the Proposals Actually Shorter? (Both Stages)
+
+### Character Count Comparison
+
+| Component | Current (approx) | Proposed Stage 1 (approx) | Change |
+|-----------|------------------|--------------------------|--------|
+| `SIMPLE_LANGUAGE_PROMPT` | ~50 chars | ~600 chars | +1100% |
+| `PINNED_CONSTITUTION` | ~300 chars | ~350 chars | +17% |
+| `FACILITATOR_RULES` | ~250 chars | ~1100 chars | +340% |
+| `NEUTRALITY_GUIDANCE` | 0 (didn't exist) | ~550 chars | New |
+| `buildStage1Prompt` body | ~1200 chars | ~1500 chars | +25% |
+
+The proposals are **significantly longer** than the originals. That's not automatically bad — the originals were under-specified, causing the AI to fill gaps with therapy-speak. But the feedback said "bot talks too much." If we're adding ~2000 chars to the system prompt, we need to be sure that translates to *shorter AI responses*, not just more instructions the AI might selectively follow.
+
+The Stage 2 proposal adds `STAGE2_PURPOSE_CONTEXT` (~550 chars), a longer transition (~500 chars vs ~200 chars), and a longer initial message prompt. Plus an entirely new dispatch handler.
+
+### Fix
+
+This isn't a problem *per se* — longer prompts that produce shorter, better responses are fine. But **test it**. Run the same user inputs through both prompt versions and compare actual AI output length and quality. Don't assume more instructions = better behavior. LLMs sometimes ignore longer prompts more than shorter ones.
+
+---
+
+## 10. Missing: What Does the AI Say When the Slider Isn't Adjusted? (Both Stages)
+
+### The Problem
+
+Both proposals reference `context.emotionalIntensity` extensively for branching behavior. But neither addresses what happens when the user hasn't interacted with the slider and intensity is at its default value.
+
+The UI agent (Task #7) is adding a slider hint, which helps. But there's a prompt-level gap: if intensity reads as 5 (default) but the user's TEXT clearly signals 9+ distress, the AI should NOT be in gathering mode asking questions.
+
+### Fix
+
+Add a text-based intensity override instruction:
+
+```
+If the user's words clearly signal extreme distress (descriptions of violence,
+self-harm, desperate language) but their slider intensity is moderate or low,
+treat them as high-intensity regardless. The slider may not be updated.
+Trust the words over the number.
+```
+
+---
+
+## 11. Stage 2 — The "I Don't Know" Handler Repeats the Rationale Too Literally
+
+### The Problem
+
+The "HANDLING 'I DON'T KNOW'" section says:
+
+> Re-explain why this matters in plain language: "The reason we do this is that when each person genuinely tries to see the other side, it's one of the biggest things that predicts whether you'll actually work things out."
+
+This is a **literal script**. If the user says "I don't know" twice, the AI will re-explain with nearly identical language both times. The second time, it'll feel like the AI is stuck on a loop.
+
+### Fix
+
+```
+If they disengage again after you've already explained the purpose, don't
+repeat the rationale. Instead, try a concrete, grounded approach:
+- "Okay, forget what they might be 'feeling' for a sec. If [partner] were
+  sitting here right now, what do you think they'd say happened?"
+- "What do you think [partner] would say if I asked them the same question
+  I asked you?"
+
+Meet them where they are. If empathy-as-a-concept isn't landing, try
+empathy-as-perspective-taking instead.
+```
+
+---
+
+## 12. The Word "Activated" Is Still in the Proposals
+
+### The Problem
+
+The research analysis (Feedback #2) correctly identifies "activated" as clinical language:
+
+> "'activated' is clinical language"
+
+The Stage 1 proposal uses it in `buildStage1Prompt` phaseGuidance:
+
+> "really activated right now"
+
+And Stage 2:
+
+> "how upset/activated they are"
+
+### Fix
+
+Replace all instances of "activated" with plain language: "upset", "worked up", "overwhelmed", "in a rough place." The word "activated" is a dead giveaway that a therapist wrote these prompts.
+
+---
+
+## 13. `buildResponseProtocol` Modification — Backward Compatibility (Stage 2)
+
+### The Problem
+
+The Stage 2 proposal modifies `buildResponseProtocol()` to add the empathy off-ramp conditionally:
+
+```typescript
+const empathyOffRamp = stage === 2
+  ? `\n- If asked why they're doing this...: <dispatch>EXPLAIN_EMPATHY_PURPOSE</dispatch>`
+  : '';
+```
+
+This changes a function that ALL stages use. If the dispatch handler for `EXPLAIN_EMPATHY_PURPOSE` doesn't exist yet (because it hasn't been implemented in `dispatch-handler.ts`), and the AI emits `<dispatch>EXPLAIN_EMPATHY_PURPOSE</dispatch>` during Stage 2, the parsing code in `dispatch-handler.ts` will hit the `default` or `unknown` case.
+
+### Fix
+
+Implement the dispatch handler BEFORE deploying the prompt change, or add a guard:
+
+```typescript
+// In dispatch-handler.ts
+case 'EXPLAIN_EMPATHY_PURPOSE':
+  // If handler not yet implemented, fall through to inline handling
+  if (!handleEmpathyPurposeExplanation) {
+    return null; // Let the main prompt handle it
+  }
+  return handleEmpathyPurposeExplanation(context);
+```
+
+Or better: deploy the dispatch handler and the prompt change atomically.
+
+---
+
+## Summary: Top 5 Issues by Severity
+
+| # | Issue | Severity | Section |
+|---|-------|----------|---------|
+| 1 | High-intensity/crisis disclosures get insufficient acknowledgment in gathering phase | **Critical** | Section 1 |
+| 2 | Neutrality guidance bans acknowledging feelings ("that's understandable" about feelings) | **High** | Section 2 |
+| 3 | `FACILITATOR_RULES` gathering phase leaks into Stages 3/4 where it doesn't apply | **High** | Section 8 |
+| 4 | Turn 5 hard cutoff doesn't account for verbose vs. guarded users | **Medium** | Section 4 |
+| 5 | Stage 2 purpose explanation risks being a mini-lecture for users who don't need it | **Medium** | Section 5 |
+
+---
+
+## What's Good (I Should Say This Too)
+
+- **The `SIMPLE_LANGUAGE_PROMPT` before/after table** (Section 1 of Stage 1 proposal) is excellent. Concrete examples of what to say instead are exactly how you change LLM tone.
+- **`NEUTRALITY_GUIDANCE` as a first-class concept** is overdue. The old "internal lint" was too weak.
+- **Stage 2 purpose explanation existing at all** — this was a real gap. Users genuinely didn't understand why they were being asked to do empathy work.
+- **The "I DON'T KNOW" handler** — this scenario was completely unhandled before. Having explicit guidance is a big win.
+- **Removing `FACILITATOR_RULES` from Stage 2** and replacing with inline approach instructions — this is the right architecture. Stage 2 has fundamentally different needs.
+- **The fallback response** for the empathy dispatch handler is well-written and could honestly be the primary handler (skip the extra AI call).

--- a/docs/freshness-review.md
+++ b/docs/freshness-review.md
@@ -1,0 +1,268 @@
+# Freshness Review: Proposed Prompt Redesigns
+
+> Reviewed by Freshness Guard. The gold standard question: "If you were writing instructions for a naturally empathetic, incredible listener who'd never done this specific process before — what would you tell them?"
+
+---
+
+## Overall Verdict
+
+**Stage 1: Mostly fresh.** The gathering-then-reflecting redesign is genuinely new thinking, not a patch job. A few areas need trimming.
+
+**Stage 2: Mixed.** The purpose explanation (`STAGE2_PURPOSE_CONTEXT`) is excellent. But the prompt as a whole is over-engineered — too many mechanisms solving the same problem, too many example phrases, and some sections that feel like direct responses to complaints.
+
+---
+
+## 1. PATCHING (Does it look like the old prompt was edited?)
+
+### Stage 1 — Mostly Clean
+
+The core redesign (gathering → reflecting phases) is genuinely new architecture. It doesn't feel like someone took the old "reflect → validate → one next move" and added disclaimers.
+
+**One concern:** The `FORBIDDEN` list in `buildStage1Prompt` is carried almost verbatim from the old prompt:
+
+> Old: `FORBIDDEN in Stage 1: "next step", "what might help", "what you could try", "moving forward", "first small step"`
+> New: `FORBIDDEN in this stage: "next step", "what might help", "what you could try", "moving forward", "first small step", "have you considered"`
+
+Same list, same structure, one addition. This is literal carryover, not fresh writing. A from-scratch prompt would give a principle ("You're here to listen, not fix") and trust the model to apply it — which the new prompt already does in the same line! The principle makes the word list redundant.
+
+### Stage 2 — Borderline
+
+The `WHAT NOT TO DO` section maps almost 1:1 to feedback items:
+
+| Feedback | WHAT NOT TO DO rule |
+|----------|-------------------|
+| "Adding too much of its own opinion" | "Don't state psychological principles as facts" |
+| "Sounds like a technical therapist" | "Don't be a therapist. Be a person." |
+| "Don't just agree with the person" | "Don't agree if user characterizes partner negatively" |
+
+A truly from-scratch prompt wouldn't have a "WHAT NOT TO DO" section at all — it would define the identity clearly enough that these behaviors are naturally avoided. The `YOUR ROLE` line already does this well: "Help X step into Y's shoes — not by telling them what Y feels, but by asking questions." If you nail the identity, you don't need the prohibitions.
+
+---
+
+## 2. OVER-ENGINEERING (Too many rules?)
+
+### Stage 1 — Acceptable, Right on the Edge
+
+Distinct rule clusters: ~9 (gathering phase, reflecting phase, high intensity, brief/guarded, pace matching, neutrality, forbidden words, length constraint, feel-heard check). This is at the upper limit but each piece arguably earns its place.
+
+### Stage 2 — Over-Engineered
+
+Distinct rule clusters: **~12** (role description, purpose context, four modes, early stage behavior, high intensity, "I don't know" handling, "what not to do" list, draft context, ready-share criteria, length constraint, lateral probing, dispatch off-ramp).
+
+**Three separate mechanisms for explaining the same concept (purpose of Stage 2):**
+1. `STAGE2_PURPOSE_CONTEXT` constant — tells the AI what to share
+2. "On the first message of this stage, briefly explain why you're asking them to do this" — inline instruction
+3. `EXPLAIN_EMPATHY_PURPOSE` dispatch off-ramp — for explicit questions
+4. `HANDLING "I DON'T KNOW"` section — re-explains the value again
+
+That's **four** paths to the same explanation. A naturally skilled person would just... explain it when it needed explaining. They wouldn't need four separate protocols for "if they ask", "if they seem unsure", "if they disengage", and "the first time you talk to them."
+
+**Recommendation:** Keep `STAGE2_PURPOSE_CONTEXT` as the AI's understanding of the purpose. Keep the dispatch off-ramp for explicit "why?" questions. Remove the inline "first message" instruction and the scripted re-explanation in the "I don't know" handler. Trust the AI to use the purpose context when needed.
+
+---
+
+## 3. CONTRADICTIONS
+
+### Stage 2 — One Significant Tension
+
+The `WHAT NOT TO DO` section says:
+> "Don't state psychological principles as facts ('People act from fear' / 'This is probably driven by their attachment style')"
+
+But `STAGE2_PURPOSE_CONTEXT` says:
+> "Research on conflict resolution consistently shows that the single strongest predictor of working things out is each person genuinely trying to see the other's perspective."
+
+One instruction says "don't cite research/principles" while the purpose explanation *is* citing research. The AI will need to thread this needle: it can cite research when explaining *why we're doing this*, but not when analyzing the partner's behavior. That distinction is clear to us but may confuse the model. Worth clarifying.
+
+**Fix:** Add a brief note: "You can explain the research behind this step (it's what makes the purpose credible) — just don't use psychological frameworks to interpret the partner's behavior."
+
+---
+
+## 4. PROMPT BLOAT
+
+This is the biggest concern across both proposals.
+
+### Stage 1: Significantly Longer
+
+| Component | Old | New |
+|-----------|-----|-----|
+| `SIMPLE_LANGUAGE_PROMPT` | 1 line | ~15 lines |
+| `PINNED_CONSTITUTION` | 4 lines | 5 lines |
+| `FACILITATOR_RULES` | 3 lines | 20 lines |
+| `NEUTRALITY_GUIDANCE` | Didn't exist | 10 lines |
+| `STAGE1_QUESTION_TEMPLATES` | 8 lines | 9 lines |
+| `buildStage1Prompt()` body | ~20 lines | ~30 lines |
+
+The old prompt was compact because it used dense concepts ("witness mode", "facilitator rhythm"). The new prompt unpacks those into plain language, which inherently takes more words. That's a legitimate tradeoff. But some sections can be trimmed:
+
+- **`SIMPLE_LANGUAGE_PROMPT`** — 7 substitution examples is too many. Pick 3-4. The AI gets the pattern after 3 examples; 7 is over-teaching.
+- **`FACILITATOR_RULES`** — The "Good" and "Bad" examples are useful, but there are 2 good examples and 1 bad example. One of each would suffice.
+- **`NEUTRALITY_GUIDANCE`** — This is 5 specific rules. Could be 3. Rules like "Never use words that take sides: 'reasonable', 'right', 'wrong', 'unfair', 'irrational', 'toxic'" overlap with "never confirm or deny what HAPPENED."
+
+### Stage 2: Significantly Longer
+
+The new `buildStage2Prompt` body is ~80 lines vs the old ~54 lines, plus a new `STAGE2_PURPOSE_CONTEXT` (~8 lines), plus a new dispatch handler (~70 lines of code/prompt). The increase is justified for the purpose explanation and dispatch handler. But the inline bloat — "I don't know" handling, "what not to do", mode descriptions with multiple example phrases — can be trimmed.
+
+**Specific cuts for Stage 2:**
+- Remove the scripted re-explanation in "HANDLING I DON'T KNOW": `"The reason we do this is that when each person genuinely tries to see the other side, it's one of the biggest things that predicts whether you'll actually work things out. It's not about being right — it's about showing you tried."` This word-for-word script will be repeated verbatim by the AI. Let it use `STAGE2_PURPOSE_CONTEXT` in its own words.
+- Remove the "WHAT NOT TO DO" section entirely. The `YOUR ROLE` definition and `NEUTRALITY_GUIDANCE` (from Stage 1's proposal, which Stage 2 could also use) already cover this.
+
+---
+
+## 5. JARGON LEAKAGE
+
+### "Activated" — Therapy Term
+
+Both proposals use "activated" to describe high emotional states:
+
+Stage 1 `phaseGuidance`:
+> "${userName} is really activated right now."
+
+Stage 2:
+> "Don't push toward perspective-taking when they're activated."
+
+"Activated" is somatic/therapy jargon. Normal people say "upset," "worked up," "emotional," or "really going through it." The Stage 1 high-intensity line should be:
+> "${userName} is really upset right now."
+
+### "Perspective-taking" — Academic
+
+Stage 2 uses "perspective-taking" in several places:
+> "Don't push toward perspective-taking when they're activated."
+> "Give space before inviting perspective-taking."
+
+This is psychology terminology. Say "seeing things from the other side" or "thinking about what they're going through."
+
+### "Stage" as a concept
+
+The Stage 2 prompt says:
+> "On the first message of this stage..."
+> "EARLY STAGE 2..."
+
+A from-scratch prompt written for a person wouldn't say "stage." It would say "this step" or "this part." Small thing, but it leaks process internals into the AI's thinking.
+
+### What's Clean
+
+- `PINNED_CONSTITUTION` — no "mediator," no "consent-based space." Clean.
+- `SIMPLE_LANGUAGE_PROMPT` — the before/after examples are genuinely de-therapized.
+- Stage 2 `YOUR ROLE` line — "a thoughtful friend helping them see things from the other side" — excellent.
+- `NEUTRALITY_GUIDANCE` opening — "You only know what this person is telling you. You don't know what actually happened. You weren't there." — this is outstanding. Real, direct, human.
+
+---
+
+## 6. SCRIPTED FEELING
+
+This is the second biggest concern after bloat.
+
+### Stage 1 — Too Many Example Phrases
+
+Total canned phrases the AI could rotate through:
+
+**`SIMPLE_LANGUAGE_PROMPT`** (7 replacement phrases):
+- "That sounds rough."
+- "You've mentioned that a few times."
+- "Makes sense you'd feel that way."
+- "Yeah, that's a lot."
+- "Thanks for telling me that."
+- "Tell me more about that."
+- "So basically..."
+
+**`STAGE1_QUESTION_TEMPLATES`** (7 questions):
+- "What happened?"
+- "What did that feel like?"
+- "What mattered most to you in that moment?"
+- "What do you wish they understood?"
+- "How long has this been going on?"
+- "What's at stake for you here?"
+- "What was the last straw?"
+
+**`FACILITATOR_RULES`** (2 good examples):
+- "Got it. What happened next?"
+- "Thanks for sharing that. How did that make you feel?"
+
+That's **16 canned phrases** the AI could draw from. After 3-4 exchanges, users will start recognizing the rotation. A naturally great listener doesn't have a menu of 16 phrases — they respond to what's actually in front of them.
+
+**Fix:** Cut `SIMPLE_LANGUAGE_PROMPT` examples to 3 (keep the most illustrative ones: "That sounds rough", "Makes sense you'd feel that way", "Tell me more about that"). Cut question templates to 4-5. Remove the good/bad examples from `FACILITATOR_RULES` — the gathering/reflecting concept is clear enough without them.
+
+### Stage 2 — Scripted Re-Explanation
+
+The "I don't know" handler includes this word-for-word script:
+> "The reason we do this is that when each person genuinely tries to see the other side, it's one of the biggest things that predicts whether you'll actually work things out. It's not about being right — it's about showing you tried."
+
+Every time a user says "I don't know," the AI will produce nearly this exact paragraph. It will feel robotic by the second occurrence. The AI has `STAGE2_PURPOSE_CONTEXT` — let it paraphrase.
+
+Mode descriptions also have embedded example phrases (BRIDGING has 2, BUILDING has 2, MIRROR has 1, "I don't know" has 2). That's 7 more canned phrases on top of Stage 1's 16. Less severe here since modes are mutually exclusive, but worth watching.
+
+---
+
+## Gold Standard Test
+
+> "Imagine you're writing instructions for a person who is naturally empathetic, an incredible listener, and skilled at mediation — but who has never done this specific process before. What would you tell them?"
+
+### Stage 1: Mostly Passes
+
+You'd tell them:
+- "Start by just listening. Ask questions. Don't try to reflect back or summarize until you've heard enough." **Covered well.**
+- "You only have one side of the story. Acknowledge how they feel, but don't agree about what happened." **Covered well.**
+- "When you've heard enough, mirror back what they said in their own words." **Covered well.**
+- "Keep it short." **Covered well.**
+
+You would NOT:
+- Give them 7 things to say instead of 7 other things. You'd trust their language.
+- Give them 7 template questions. They know how to ask questions.
+- Give them a forbidden words list. They'd know not to jump to solutions.
+
+**Verdict: Stage 1 passes the test in spirit but is over-specified in detail.** Trim the examples and it's genuinely fresh.
+
+### Stage 2: Partially Passes
+
+You'd tell them:
+- "Now we need them to try seeing things from the other person's side. Explain why — both people are doing this, research shows it's the biggest predictor of resolution, it's a guess not a test." **Covered excellently.**
+- "Ask them questions that help them think about what the other person might be going through." **Covered well.**
+- "If they're still upset, give them space first." **Covered.**
+- "If they say 'I don't know,' don't push. Re-explain why it matters and try a different angle." **Covered, but over-specified.**
+
+You would NOT:
+- Give them a 3-step protocol for "I don't know" with a scripted re-explanation.
+- Give them four named modes with example phrases for each.
+- Give them a "WHAT NOT TO DO" list of 4 items.
+- Create three separate mechanisms for the same explanation.
+
+**Verdict: Stage 2 has the right ideas but wraps them in too much structure.** The four modes are probably necessary (they were in the original), but the I-don't-know handler, what-not-to-do list, and triple-explanation mechanism are over-engineering.
+
+---
+
+## Summary of Recommendations
+
+### Must Fix (Will Cause Problems)
+
+1. **Cut example phrases** in `SIMPLE_LANGUAGE_PROMPT` from 7 to 3. Scripting risk is real.
+2. **Remove scripted re-explanation** in Stage 2 "I don't know" handler. Let the AI use `STAGE2_PURPOSE_CONTEXT` in its own words.
+3. **Replace "activated"** with "upset" or "worked up" everywhere.
+4. **Resolve the research contradiction** in Stage 2 (can cite research for purpose, not for partner analysis).
+
+### Should Fix (Will Improve Quality)
+
+5. **Remove `WHAT NOT TO DO` section** from Stage 2. The identity/role definition already covers it.
+6. **Consolidate purpose-explanation paths** in Stage 2 from 4 to 2 (constant + dispatch).
+7. **Replace "perspective-taking"** with plain language.
+8. **Remove `FORBIDDEN` word list** from Stage 1. The principle "You're here to listen, not fix" is sufficient.
+9. **Cut question templates** from 7 to 4-5.
+
+### Nice to Have (Polish)
+
+10. Replace "stage" with "step" or "part" in AI-facing instructions.
+11. Remove "Good/Bad" examples from `FACILITATOR_RULES` — the concept is clear without them.
+12. Consider whether `NEUTRALITY_GUIDANCE` can be 3 rules instead of 5 (some overlap).
+
+---
+
+## What's Genuinely Well Done
+
+Credit where it's due — these things are excellent:
+
+- **`NEUTRALITY_GUIDANCE` opening**: "You only know what this person is telling you. You don't know what actually happened. You weren't there." — Brilliant. Direct. Human. Best single line in either proposal.
+- **Gathering → Reflecting phase split** in Stage 1 — genuinely new architecture, not a patch.
+- **`STAGE2_PURPOSE_CONTEXT`** — clear, natural explanation of why the step exists. Addresses the core feedback perfectly.
+- **`YOUR ROLE` in Stage 2** — "a thoughtful friend helping them see things from the other side." Perfect identity framing.
+- **Dispatch off-ramp for `EXPLAIN_EMPATHY_PURPOSE`** — smart architectural decision. Keeps the main prompt lean and handles explicit questions separately.
+- **Transition injection (1→2)** — properly explains both sides are doing this. Addresses the "why am I guessing?" confusion at the right moment.
+- **De-therapized language overall** — "witness mode" is gone, "facilitator rhythm" is gone, "validate" is mostly gone. Real improvement.

--- a/docs/prompt-analysis.md
+++ b/docs/prompt-analysis.md
@@ -1,0 +1,339 @@
+# Prompt Architecture Analysis & Feedback Mapping
+
+> Research document for the prompt redesign team. Maps user feedback to specific code, identifies root causes, and catalogs features that must be preserved.
+
+---
+
+## 1. Architecture Overview
+
+### File Map
+
+| File | Purpose | Lines |
+|------|---------|-------|
+| `backend/src/services/stage-prompts.ts` | Main prompt builder for all stages (0-4), transitions, inner work, reconciler | ~1535 |
+| `backend/src/services/needs-prompts.ts` | Needs assessment prompts (Stage 3 support) | ~260 |
+| `mobile/src/components/EmotionSlider.tsx` | In-chat emotion barometer slider | ~203 |
+| `mobile/src/components/SessionEntryMoodCheck.tsx` | Session-entry mood modal (separate from slider) | ~233 |
+
+### Prompt Flow
+
+1. `ai-orchestrator.ts` receives user message with context (stage, intensity, turn count, etc.)
+2. Calls `buildStagePrompt(stage, context, options)` from `stage-prompts.ts`
+3. The stage prompt includes: base system prompt + stage-specific instructions + response protocol
+4. Base system prompt = `SIMPLE_LANGUAGE_PROMPT` + `PINNED_CONSTITUTION` + `PRIVACY_GUIDANCE` + `INVALID_MEMORY_GUIDANCE` + (optional) `PROCESS_OVERVIEW`
+5. Response uses semantic `<thinking>` tags for metadata (not visible to user)
+
+### Response Protocol (Semantic Router)
+
+All stages use `buildResponseProtocol()` which outputs:
+
+```
+<thinking>
+Mode: [WITNESS|PERSPECTIVE|NEEDS|REPAIR|ONBOARDING|DISPATCH]
+UserIntensity: [1-10]
+FeelHeardCheck: [Y/N]    (Stage 1 only)
+ReadyShare: [Y/N]         (Stage 2 only)
+Strategy: [brief]
+</thinking>
+```
+
+Then plain text response. Off-ramps via `<dispatch>` tags. **This format must be preserved.**
+
+---
+
+## 2. Feedback-to-Code Mapping
+
+### Feedback #1: "Bot talks too much in beginning stage"
+
+**Root Cause**: Stage 1 (`buildStage1Prompt`, line 348-376) has a `FACILITATOR_RULES` constant (line 146-149) that says:
+
+```
+Facilitator rhythm: reflect → validate → one next move
+```
+
+This instructs the AI to **reflect and validate on every turn**, even before it has information to reflect on. Combined with `LATERAL_PROBING_GUIDANCE` (line 138-140) and `STAGE1_QUESTION_TEMPLATES` (lines 151-159), the AI gets conflicting signals: reflect first, but also ask questions.
+
+**Specific lines causing verbosity**:
+- **Line 147**: `Facilitator rhythm: reflect → validate → one next move` — This rhythm is applied from turn 1, before the AI has anything substantive to reflect on. The AI fills space with generic validation.
+- **Line 356-357**: `Focus: Reflect and validate before moving on. No solutions, reframes, or interpretations yet.` — "Reflect and validate" as the primary focus makes the AI parrot back what the user just said before asking anything.
+- **Line 361**: `Length: default 1–3 sentences.` — This is good but gets overridden by the reflect+validate+question pattern which pushes responses to 3+ sentences every time.
+- **Line 349**: `witnessOnlyMode = context.turnCount < 3 || context.emotionalIntensity >= 8` — For the first 3 turns, the AI is locked into "witness only" which means pure reflection with no forward movement.
+
+**Fix direction**: In early turns (turnCount < 4-5), the AI should **primarily ask questions to gather information**. Reflection and validation should happen *after* the user has shared enough substance to reflect on. The "reflect → validate → question" rhythm should become "acknowledge briefly → ask" in early turns.
+
+---
+
+### Feedback #2: "Sounds like a technical therapist"
+
+**Root Cause**: Multiple constants use clinical framing despite the `SIMPLE_LANGUAGE_PROMPT` (line 103-105):
+
+```
+STYLE: Warm, clear, direct. No jargon. One question max.
+```
+
+This is too brief to counteract the therapy-coded language throughout:
+
+- **Line 107-112**: `PINNED_CONSTITUTION` — Uses terms like "mediator", "consent-based space", "dual-track sharing", "de-escalate". This frames the AI as a clinical professional.
+- **Line 147**: `Facilitator rhythm: reflect → validate → one next move` — "Facilitator rhythm" is therapy jargon. A normal person doesn't think in terms of "reflect → validate".
+- **Line 352**: `You are Meet Without Fear in the Witness stage. Help ${userName} feel fully heard.` — "Witness stage" and "feel fully heard" are therapy concepts. A real friend would just listen.
+- **Lines 413-417**: Stage 2 modes — `LISTENING`, `BRIDGING`, `BUILDING`, `MIRROR` — These are named like therapy techniques, and their instructions read like a therapy manual.
+- **Line 147-148**: `If the user's emotional intensity is high (8+), they are very activated/distressed — stay in witness mode` — "Activated" is clinical language.
+- **Lines 845-855**: Inner work "TECHNIQUES" section literally lists therapy techniques: "Reflection", "Curiosity", "Gentle probing", "Pattern noticing", "Holding space".
+
+**Fix direction**: Replace the AI's self-concept from "mediator/facilitator in a therapeutic process" to something like "a really good friend who happens to be great at listening." The mode names are internal (in `<thinking>`) so they can stay clinical, but the behavioral instructions should use natural language. Instead of "reflect → validate → one next move", describe what a natural, caring person would do.
+
+---
+
+### Feedback #3: "Adding too much of its own opinion"
+
+**Root Cause**: Several prompt instructions encourage interpretation and pattern-surfacing:
+
+- **Line 147**: `Facilitator rhythm: reflect → validate → one next move` — "Validate" can be interpreted by the LLM as agreeing with the user's perspective, adding the AI's own assessment.
+- **Line 409**: `Help ${userName} see the fear, hurt, and unmet needs driving ${partnerName}'s behavior` — "See the fear, hurt, and unmet needs" instructs the AI to interpret the partner's behavior, which comes across as the AI injecting its own psychological analysis.
+- **Line 417**: `"People usually act from fear - what might ${partnerName} be afraid of?"` — This is the AI stating a psychological principle as fact, which is "adding its own opinion."
+- **Line 452**: Stage 3 EXCAVATING mode: `Reframe to underlying need: "They never help" → need for partnership/teamwork` — The AI is instructed to reframe the user's words, which can feel like the AI is telling them what they "really" mean.
+- **Line 360**: `Neutrality lint (internal): avoid judging words like "reasonable", "right", "wrong", "irrational". Rephrase to impact-focused language.` — Good intent but the AI still interprets when it "rephrases."
+
+**Fix direction**: Stage 1 should be almost purely "ask and understand." The AI should ask questions, mirror the user's own words, and avoid interpreting meaning. When it reflects, it should use the user's exact language ("You said X" not "It sounds like you're feeling Y because of Z"). Save interpretation for later stages when the user has invited deeper exploration.
+
+---
+
+### Feedback #4: "Empathy section: 'Why am I guessing?'"
+
+**Root Cause**: Stage 2 never explains the *purpose* of perspective-taking. The user is suddenly asked to imagine their partner's feelings with no explanation of why this helps.
+
+- **Line 405**: `Help ${userName} imagine what ${partnerName} might be feeling or afraid of.` — This is the AI's instruction but the user never hears WHY they're doing this.
+- **Lines 540-541**: Transition from Stage 1 → 2: `TRANSITION: ${userName} just confirmed feeling heard. Acknowledge this warmly (1-2 sentences), then gently invite curiosity about what ${partnerName} might be feeling or afraid of.` — Jumps straight to the empathy task without explaining the rationale.
+- **Lines 667-676**: Stage 2 initial message: `Generate an opening message (1-2 sentences) that gently introduces the perspective-taking work ahead. Be encouraging without being pushy.` — Says "introduce" but doesn't tell the AI to explain the *purpose* or *benefit*.
+- **Line 431**: ReadyShare instruction mentions drafting an empathy statement, but the user gets no context on what this statement will be used for or why it matters.
+
+**Fix direction**: The Stage 1→2 transition AND the Stage 2 opening must explain:
+1. **What** they'll be doing (imagining their partner's experience)
+2. **Why** it helps (research shows understanding the other person's fears/feelings is the single biggest predictor of resolution; it's not about being right or wrong)
+3. **How** it works (they'll explore, then write a short statement that gets shared — their partner does the same for them)
+4. **That it's a guess** (they're not expected to get it right — the act of trying is what matters)
+
+---
+
+### Feedback #5: "Reflect/empathize AFTER gathering info"
+
+**Root Cause**: Same as #1 but deserves its own callout. The `FACILITATOR_RULES` (line 147) make reflection the **first** action on every turn:
+
+```
+Facilitator rhythm: reflect → validate → one next move
+```
+
+This means:
+- Turn 1: User says "I'm having trouble with my wife" → AI reflects that back ("It sounds like things have been difficult with your wife") → validates ("That must be hard") → asks a question. That's 3 parts when 1 would do.
+- Turn 2: User shares one detail → AI reflects, validates, asks. Still mostly repeating what the user said.
+- Turn 3: User shares more → AI reflects, validates, asks. NOW there might be enough to reflect meaningfully, but the user has already experienced 2 turns of parroting.
+
+**Specific code**:
+- **Line 356**: `Focus: Reflect and validate before moving on.` — Literally says "reflect before moving on."
+- **Line 147**: `reflect → validate → one next move` — Reflection as step 1.
+- **Line 349**: `witnessOnlyMode = context.turnCount < 3` — First 3 turns locked into reflection mode.
+
+**Fix direction**: Create two distinct phases within Stage 1:
+- **Gathering phase** (turns 1-4ish): Acknowledge briefly (1 short sentence max), ask a question. No substantive reflection yet. The AI is building understanding.
+- **Reflection phase** (turns 5+): Now the AI has enough context to reflect meaningfully. Do the reflect → validate → question rhythm here.
+
+The `witnessOnlyMode` flag at line 349 should control the opposite behavior — early turns should be in "gather mode" not "witness only mode."
+
+---
+
+### Feedback #6: "Don't just agree with the person"
+
+**Root Cause**: The prompt instructions lean heavily toward validation without balancing neutrality:
+
+- **Line 147**: `Facilitator rhythm: reflect → validate → one next move` — "Validate" as a core step means the AI affirms the user's perspective every turn.
+- **Line 356**: `Focus: Reflect and validate before moving on.` — "Validate" again as primary instruction.
+- **Line 148**: `If the user's emotional intensity is high (8+)... Prioritize space and validation over progress.` — At high intensity, validation becomes the ONLY move.
+- **Line 360**: Neutrality lint exists (`avoid judging words like "reasonable", "right", "wrong"`) but is labeled "internal" — it's easily outweighed by the multiple "validate" instructions.
+- **Line 109-110**: `PINNED_CONSTITUTION`: `de-escalate when language is attacking or unsafe; stay non-shaming` — De-escalation is good, but the prompt never says "stay neutral about the facts of the situation."
+
+**What's missing**: An explicit instruction like: "You don't know what actually happened between these people. You only have one side of the story. Your job is to understand their experience, not to confirm their version of events. Validate feelings (how they feel), not facts (what happened)."
+
+**Fix direction**: Replace "validate" with "acknowledge" in the facilitator rules. Add an explicit neutrality instruction: "You have one side of the story. Acknowledge how they feel without confirming or denying what happened. Never use words that take sides like 'that's understandable' about the partner's behavior."
+
+---
+
+### Feedback #7: "No instruction to slide to change emotion"
+
+**Root Cause**: The `EmotionSlider` component (`mobile/src/components/EmotionSlider.tsx`) has no onboarding hint, no explanatory text, and no first-time guidance.
+
+**Current state**:
+- **Line 125**: Header text is just `"How are you feeling?"` — No instruction that this is a slider you can interact with.
+- **Lines 149-153**: Labels "Calm" / "Elevated" / "Intense" are below the slider but hidden in compact mode (`display: compact ? 'none' : 'flex'` at line 195).
+- **Compact mode**: In the chat view (`ChatInterface.tsx`), the slider is rendered with `compact={compactEmotionSlider}` — in compact mode the bottom labels are hidden, so the user just sees a tiny slider with no context.
+- **`SessionEntryMoodCheck.tsx`**: This modal appears on session entry with a full-screen slider and "How are you feeling right now?" title + "Continue" button. But this is a **separate component** from the in-chat `EmotionSlider`. After the mood check modal, the user sees the compact slider in the chat with no explanation that they can continue adjusting it.
+
+**Fix direction**: Add a first-time hint to the `EmotionSlider` component. Something like "Slide to update how you're feeling" that appears once (stored in AsyncStorage) and fades away after the first interaction. The hint needs to work in compact mode since that's the primary use case in chat.
+
+---
+
+## 3. Features That MUST Be Preserved
+
+Any redesign must keep these working:
+
+### 3.1 Response Protocol (Semantic Router)
+- `<thinking>` block with Mode, UserIntensity, Strategy
+- `FeelHeardCheck: [Y/N]` in Stage 1 (drives UI panel)
+- `ReadyShare: [Y/N]` in Stage 2 (drives empathy draft UI)
+- `<draft>` tag for invitation and empathy statement drafts
+- `<dispatch>` for off-ramps (EXPLAIN_PROCESS, HANDLE_MEMORY_REQUEST)
+- **Plain text after thinking block** — no tags/brackets in user-visible text
+
+### 3.2 Stage 1: Feel-Heard Check Logic
+- Lines 368-373: FeelHeardCheck:Y triggers when: (1) user affirms a reflection, (2) core concern/need is named, (3) intensity is stabilizing
+- The UI handles the "do you feel heard?" question — AI must NOT ask it
+- Even when FeelHeardCheck:Y, AI stays in witness mode
+- Turn < 2 is too early (line 373)
+
+### 3.3 Stage 2: Empathy Draft & ReadyShare
+- Lines 430-434: ReadyShare:Y when user articulates partner's feelings without blame
+- Turn < 4 is too early for draft (line 384, 431)
+- Draft format: 2-4 sentences in `<draft>` tag, written as user speaking to partner
+- Empathy refinement mode (lines 392-402): when `isRefiningEmpathy`, AI must update the draft
+- Shared context from partner integration (lines 397-401)
+
+### 3.4 Stage Transitions
+- Lines 530-555: Transition injections prepend to stage prompt
+- Each transition is 1-2 sentences acknowledging the previous stage
+- Must NOT lose stage modes/rules/readiness signals
+
+### 3.5 Emotional Intensity Handling
+- `emotionalIntensity` (1-10) from EmotionSlider drives behavior
+- 8+ = high intensity → witness/listening mode, slow down, validate
+- AI must NOT mirror intensity in its tone (stated in multiple places)
+- `witnessOnlyMode` at line 349 for turnCount < 3 OR intensity >= 8
+
+### 3.6 Invitation Prompt
+- Lines 313-342: `buildInvitationPrompt` for crafting partner invitation
+- Inner thoughts context integration (lines 317-321)
+- Refinement mode (line 323-325)
+- Draft in `<draft>` tag
+
+### 3.7 Privacy & Constitution
+- `PINNED_CONSTITUTION` (lines 107-112): Never claim partner's thoughts
+- `PRIVACY_GUIDANCE` (lines 88-91): Only use what user shared
+- These are non-negotiable safety guardrails
+
+### 3.8 Lateral Probing
+- Line 138-140: When users are brief/guarded, widen the lens instead of drilling
+- This is good design — preserve it
+
+### 3.9 Length Constraint
+- `Length: default 1–3 sentences` (appears in Stages 1, 3, 4)
+- `Go longer only if they explicitly ask for help or detail`
+- This is correct but needs to be reinforced more strongly
+
+### 3.10 Forbidden Actions Per Stage
+- Stage 1 (line 357): No "next step", "what might help", "moving forward"
+- Stage 3 (line 461): No "try this", "experiment with", solutions
+- Stage 3 (line 462): No introducing needs user hasn't expressed
+- Stage 4 (line 510): No criticizing partner's proposals
+- These boundaries are good and must be kept
+
+---
+
+## 4. Constants Catalog
+
+| Constant | Lines | Purpose | Change? |
+|----------|-------|---------|---------|
+| `SIMPLE_LANGUAGE_PROMPT` | 103-105 | Style directive | Expand significantly — currently too brief to drive behavior |
+| `PINNED_CONSTITUTION` | 107-112 | Core safety/privacy rules | Keep but de-therapize language |
+| `PRIVACY_GUIDANCE` | 88-91 | Cross-user information boundary | Keep as-is |
+| `INVALID_MEMORY_GUIDANCE` | 96-98 | Redirect memory requests | Keep as-is |
+| `PROCESS_OVERVIEW` | 75-81 | Only shown if user asks about process | Keep as-is |
+| `FACILITATOR_RULES` | 146-149 | reflect→validate→one next move | **REWRITE** — root cause of multiple issues |
+| `STAGE1_QUESTION_TEMPLATES` | 151-159 | Example questions for Stage 1 | Good, keep or expand |
+| `LATERAL_PROBING_GUIDANCE` | 138-140 | Widen lens when user is guarded | Keep as-is |
+| `ONBOARDING_TONE` | 165-167 | Warm, practical for Stage 0 | Keep as-is |
+| `NEED_MAPPING_APPROACH` | 173-175 | Validate before reframe in Stage 3 | Keep as-is |
+| `INNER_WORK_GUIDANCE` | 721-732 | Solo reflection session guidance | Keep as-is |
+
+---
+
+## 5. Redesign Priorities (Ordered by Impact)
+
+### P0: Critical (Directly breaks user experience)
+
+1. **Rewrite `FACILITATOR_RULES`** — This single constant is the root cause of feedback #1, #3, #5, and partially #6. It needs to become phase-aware (gather first, reflect later) and stop defaulting to validation.
+
+2. **Add Stage 2 purpose explanation** — Users are confused about why they're doing empathy work. The Stage 1→2 transition (line 541) and Stage 2 intro (line 667-676) need to explain the why, not just the what.
+
+3. **Replace validation-first with acknowledgment-first** — Every instance of "validate" in the prompt text should be reviewed. Validate *feelings*, not *interpretations*.
+
+### P1: High (Noticeably affects tone)
+
+4. **De-therapize the AI's self-concept** — Replace "Witness stage", "mediator", "consent-based space", "facilitator rhythm" with natural language. The AI should think of itself as a caring, smart friend.
+
+5. **Add explicit neutrality instruction** — A new constant alongside `PRIVACY_GUIDANCE` that says "You have one side of the story. Never take sides."
+
+6. **Expand `SIMPLE_LANGUAGE_PROMPT`** — Currently 1 line. Needs specific examples of what natural vs. clinical language looks like.
+
+### P2: Medium (Quality of life)
+
+7. **Add EmotionSlider onboarding hint** — UI change, handled by the UI agent separately.
+
+8. **Differentiate early vs. late Stage 1 behavior** — `witnessOnlyMode` at line 349 should be inverted: early = gathering, late = witnessing.
+
+---
+
+## 6. Specific Rewrite Targets
+
+### For Task #2 (Stage 1 + Base Prompts Redesign)
+
+**Files to modify**: `stage-prompts.ts`
+
+**Constants to rewrite**:
+- `FACILITATOR_RULES` (line 146-149) → Phase-aware: gather first, reflect after 4+ turns
+- `SIMPLE_LANGUAGE_PROMPT` (line 103-105) → Expand with examples and anti-patterns
+- `PINNED_CONSTITUTION` (line 107-112) → Keep safety, de-therapize framing
+
+**Functions to modify**:
+- `buildStage1Prompt()` (line 348-376):
+  - Add explicit "gathering phase" for early turns
+  - Change `witnessOnlyMode` logic at line 349
+  - Add neutrality instruction ("you have one side of the story")
+  - Remove or soften "Reflect and validate before moving on" at line 356
+- `buildBaseSystemPrompt()` (line 198-221):
+  - Add new neutrality constant
+  - Expand style guidance
+
+**New constant needed**:
+- `NEUTRALITY_GUIDANCE` — "You only have one person's perspective. Acknowledge their feelings without confirming their version of events."
+
+### For Task #3 (Stage 2 Empathy Prompts Redesign)
+
+**Files to modify**: `stage-prompts.ts`
+
+**Functions to modify**:
+- `buildTransitionInjection()` (line 530-555):
+  - Stage 1→2 transition (line 540-542) must explain WHY empathy work matters
+  - Add: purpose, what happens (both sides do this), it's a guess not a test
+- `buildStage2Prompt()` (line 382-436):
+  - Add purpose explanation in the prompt body
+  - De-therapize mode names in behavioral descriptions (LISTENING/BRIDGING/BUILDING/MIRROR descriptions at lines 413-417 are too clinical in their *instructions*)
+  - Add reassurance: "You're not expected to get this right. The act of trying to understand is what matters."
+- `buildInitialMessagePrompt()` case 2 (line 667-676):
+  - Tell the AI to explain what they'll be doing and why
+  - Not just "gently introduces the perspective-taking work" but explains the benefit
+
+**Preserve**:
+- `ReadyShare` flag logic (line 430-434)
+- Draft format and refinement mode
+- Turn-gating (turn < 4 too early)
+- FOUR MODES structure (internal behavior, can stay as-is)
+- Shared context integration
+
+---
+
+## 7. Anti-Patterns to Avoid in Redesign
+
+1. **Don't just add more text to prompts** — The prompts are already 1535 lines. Rewrite, don't append.
+2. **Don't remove safety guardrails** — Privacy, constitution, and stage-forbidden actions are critical.
+3. **Don't change the response protocol format** — The semantic router (`<thinking>`, `<draft>`, `<dispatch>`) is deeply integrated.
+4. **Don't break stage gating** — Turn count checks and intensity thresholds exist for good reasons.
+5. **Don't over-prescribe natural language** — Giving the AI 20 example phrases will make it sound scripted. Give it a character and let it improvise.
+6. **Don't conflate the AI's internal instructions with user-facing tone** — Mode names (WITNESS, PERSPECTIVE, etc.) are in `<thinking>` blocks. They can be clinical. The behavioral *instructions* that shape user-facing text are what need to change.

--- a/docs/proposed-stage1.md
+++ b/docs/proposed-stage1.md
@@ -1,0 +1,294 @@
+# Proposed Stage 1 & Base Prompt Redesign
+
+> Redesigned from scratch based on user feedback analysis. These are TypeScript constants and functions that replace existing code in `stage-prompts.ts`.
+
+---
+
+## Design Philosophy
+
+The AI is **not a therapist, facilitator, or mediator**. It's someone who is naturally great at listening — the person everyone goes to when they're having a hard time. It asks good questions, doesn't rush to interpret, and when it does reflect back what it's heard, it uses the person's own words.
+
+**Two phases within Stage 1:**
+- **Gathering** (early turns): Short acknowledgment + focused question. Building a picture.
+- **Reflecting** (later turns): Now there's enough to work with. Mirror back what you've heard using their words. Check understanding.
+
+---
+
+## 1. `SIMPLE_LANGUAGE_PROMPT` (replaces lines 102-104)
+
+```typescript
+const SIMPLE_LANGUAGE_PROMPT = `
+VOICE & STYLE:
+You sound like a person — warm, direct, and real. Not a therapist, not a chatbot, not a self-help book.
+
+Rules:
+- Short sentences. Plain words. Say it like you'd say it to a friend.
+- One question per response, max. Sometimes zero.
+- 1-3 sentences by default. Go longer only if they ask for more detail.
+
+Instead of this:                        Say something like this:
+"I hear that you're experiencing..."  → "That sounds rough."
+"I want to validate your feelings..." → "Makes sense you'd feel that way."
+"Let's explore that further..."      → "Tell me more about that."
+`;
+```
+
+---
+
+## 2. `PINNED_CONSTITUTION` (replaces lines 106-111)
+
+```typescript
+const PINNED_CONSTITUTION = `
+You are Meet Without Fear — here to help two people understand each other better.
+
+Ground rules:
+- Privacy: Never claim to know what the other person said or feels unless it was explicitly shared with consent.
+- Safety: If someone's language becomes attacking or unsafe, calmly de-escalate. Never shame.
+- Boundaries: Keep the user's raw words private. Only suggest optional "sendable" rewrites when sharing is about to happen or they ask for one.
+`;
+```
+
+**What changed:** Removed "mediator", "consent-based space", "dual-track sharing". Same safety rules, human language.
+
+---
+
+## 3. `NEUTRALITY_GUIDANCE` (new constant)
+
+```typescript
+const NEUTRALITY_GUIDANCE = `
+ONE SIDE OF THE STORY:
+You only know what this person is telling you. You don't know what actually happened. You weren't there.
+
+Three layers of neutrality:
+
+1. THEIR FEELINGS — always acknowledge.
+   OK: "It makes sense you'd feel humiliated." / "That sounds painful."
+   You're not agreeing with their version of events — you're acknowledging what they're going through.
+
+2. THEIR INTERPRETATIONS — don't confirm or deny.
+   They say: "She did it on purpose to hurt me."
+   Bad: "That's understandable." (confirms their interpretation)
+   Good: "What makes you think it was intentional?" (explores without agreeing)
+
+3. PARTNER CHARACTERIZATIONS — never agree.
+   They say: "He's always been selfish."
+   Bad: "That sounds really unfair." (takes their side)
+   Good: "What happened most recently?" (stays with specifics)
+
+When you reflect, use their words: "You said X" — not "It sounds like they were being Y."
+`;
+```
+
+---
+
+## 4. `STAGE1_LISTENING_RULES` (new constant, replaces `FACILITATOR_RULES` for Stage 1)
+
+The old `FACILITATOR_RULES` was shared across Stages 1-4. The gathering/reflecting phases are Stage 1 specific, so this becomes its own constant. Stages 2-4 should keep the old `FACILITATOR_RULES` or get their own variants (see integration notes).
+
+```typescript
+const STAGE1_LISTENING_RULES = `
+HOW TO LISTEN:
+
+GATHERING PHASE (early in the conversation — roughly the first 4-5 exchanges, but use your judgment):
+Your job is to understand the situation. You probably don't have enough information to reflect meaningfully yet.
+- Acknowledge briefly (one short sentence, or even just start with the question)
+- Ask one focused question to learn more
+- Don't reflect back or summarize yet — you're still learning what happened
+- But don't just fire questions either. If they say something heavy, sit with it for a beat before asking. Sometimes "Yeah, that's a lot" is all you need before moving on.
+- If they share something devastating (violence, betrayal, loss), acknowledge the weight of it first — "That's serious" or "I'm glad you're telling me this" — before asking anything.
+- Good: "Got it. What happened next?"  Bad: "It sounds like you're really struggling with trust in this relationship. That must be so hard. What happened next?"
+
+REFLECTING PHASE (after you have a real picture — usually turn 5+, but earlier if they've shared a lot):
+Now you know enough to be useful. Reflect using THEIR words, not your interpretation.
+- Mirror what they've told you: "You said [their words]. That's what's eating at you."
+- Check if you've got it right: "Am I getting that right?"
+- Still ask questions, but now they come from understanding, not just information-gathering
+- Keep it short. One reflection + one question max.
+
+AT ANY POINT:
+- If emotional intensity is high (8+), slow way down. Just be present. Short sentences. No questions unless they're ready.
+- If they're brief or guarded, try a different angle — ask about something adjacent (timeline, what matters to them, what's at stake) instead of pushing deeper on the same thread.
+- Match their pace. If they're pouring out, let them. If they're measured, be measured.
+- Don't just cycle through questions. Sometimes respond to what they said before asking something new. Sometimes don't ask a question at all — just let them keep going.
+`;
+```
+
+---
+
+## 5. `STAGE1_QUESTION_TEMPLATES` (replaces lines 150-158)
+
+```typescript
+const STAGE1_QUESTION_TEMPLATES = `
+EXAMPLE QUESTIONS (adapt to context — ask whatever fits):
+- "What happened?"
+- "What did that feel like?"
+- "What do you wish they understood?"
+- "How long has this been going on?"
+- "What's at stake for you here?"
+`;
+```
+
+---
+
+## 6. `buildStage1Prompt()` (replaces lines 347-375)
+
+```typescript
+function buildStage1Prompt(context: PromptContext): string {
+  const userName = context.userName || 'there';
+  // Soft default: gathering for ~first 5 turns. The STAGE1_LISTENING_RULES
+  // tell the AI to use judgment (verbose users may share everything by turn 2,
+  // guarded users may need 8+ turns). This flag sets the default guidance.
+  const isGathering = context.turnCount < 5 && context.emotionalIntensity < 8;
+  const isHighIntensity = context.emotionalIntensity >= 8;
+  const isTooEarlyForFeelHeard = context.turnCount < 3;
+
+  const phaseGuidance = isHighIntensity
+    ? `${userName} is in a really intense place right now. Don't try to move the conversation forward. Just be steady and present. Short responses. Acknowledge what they're feeling without adding your take. Let them lead.`
+    : isGathering
+      ? `You're still building the picture. Keep responses short — acknowledge briefly, then ask a question. Don't reflect or summarize yet unless they've shared something really heavy that deserves more than a one-liner. You need more before you can reflect well.`
+      : `You have a solid picture now. When it feels right, reflect back what you've heard using ${userName}'s own words. Check if you've understood correctly. You can still ask questions, but they should come from understanding, not just gathering.`;
+
+  return `You're here to listen to ${userName} and really understand what's going on for them.
+
+${buildBaseSystemPrompt(context.invalidMemoryRequest, context.sharedContentHistory, getLastUserMessage(context), context.milestoneContext)}
+
+${NEUTRALITY_GUIDANCE}
+${STAGE1_LISTENING_RULES}
+${STAGE1_QUESTION_TEMPLATES}
+
+RIGHT NOW: ${phaseGuidance}
+
+You're here to listen, not fix. No advice, no solutions, no "have you considered" — those belong in later stages.
+
+Length: 1-3 sentences. Seriously — keep it short. The user is here to talk, not to read.
+
+Emotional intensity: ${context.emotionalIntensity}/10 (do NOT match their intensity in your tone — stay steady regardless)
+${isHighIntensity ? 'HIGH INTENSITY — be calm and present. Short responses. Give them space.' : ''}
+Turn: ${context.turnCount}
+
+Feel-heard check:
+- Set FeelHeardCheck:Y when ALL of these are true: (1) they've affirmed something you reflected back, (2) you can name their core concern, and (3) their intensity is stabilizing or steady.
+- Be proactive — when the moment feels right, set it. Don't wait for a perfect signal.
+- When FeelHeardCheck:Y, do NOT ask "do you feel heard?" — the UI handles that. Keep setting Y until they act on the prompt.
+- Even when FeelHeardCheck:Y, stay in listening mode. Do NOT pivot to advice, action, or next steps.
+${isTooEarlyForFeelHeard ? '- Too early (turn < 3) — you haven\'t heard enough yet.' : ''}
+
+${buildResponseProtocol(1)}`;
+}
+```
+
+**Key changes from current:**
+1. Opening line: "You're here to listen" instead of "You are Meet Without Fear in the Witness stage. Help X feel fully heard."
+2. Phase-aware guidance: `isGathering` drives soft default, not `witnessOnlyMode`
+3. `NEUTRALITY_GUIDANCE` injected at Stage 1 level
+4. No more "Reflect and validate before moving on" as primary focus
+5. Explicit "don't reflect yet" instruction for early turns, with crisis exception
+6. Natural language throughout — no "witness mode", no "facilitator rhythm"
+7. `STAGE1_LISTENING_RULES` is Stage 1 only — doesn't leak into Stages 2-4
+
+---
+
+## 7. Updated `buildBaseSystemPrompt()` (replaces lines 197-220)
+
+```typescript
+function buildBaseSystemPrompt(
+  invalidMemoryRequest?: { requestedContent: string; rejectionReason: string },
+  _sharedContentHistory?: string | null,
+  userMessage?: string,
+  _milestoneContext?: string | null
+): string {
+  const invalidMemorySection = invalidMemoryRequest
+    ? `\n\n⚠️ INVALID REQUEST DETECTED:
+The user has requested: "${invalidMemoryRequest.requestedContent}"
+This conflicts with how we work. Rejection reason: ${invalidMemoryRequest.rejectionReason}
+
+Acknowledge their request warmly, explain why that approach won't work here, and offer an alternative. Be direct, not clinical.`
+    : '';
+
+  const processOverviewSection = userMessage && isProcessQuestion(userMessage)
+    ? PROCESS_OVERVIEW
+    : '';
+
+  return `${SIMPLE_LANGUAGE_PROMPT}
+${PINNED_CONSTITUTION}
+${PRIVACY_GUIDANCE}
+${INVALID_MEMORY_GUIDANCE}${processOverviewSection}${invalidMemorySection}`;
+}
+```
+
+**What changed:** Only the invalid memory request language was de-therapized ("therapeutic values" → "how we work", removed "therapeutic integrity"). The structure is identical — `NEUTRALITY_GUIDANCE` is injected at the stage level, not the base level, because Stages 3 and 4 have different neutrality needs.
+
+---
+
+## 8. Updated Stage 1 Initial Message Prompt (replaces lines 655-664)
+
+```typescript
+    case 1: // Witness
+      return `You are Meet Without Fear. ${context.userName} is ready to share what's going on between them and ${partnerName}.
+
+${SIMPLE_LANGUAGE_PROMPT}
+${PRIVACY_GUIDANCE}
+
+YOUR TASK:
+Generate an opening message (1-2 sentences) that invites them to share what's on their mind. Be warm and curious — like a friend asking "so what happened?" Don't be formal.
+
+${buildResponseProtocol(-1)}`;
+```
+
+---
+
+## 9. What's Preserved (unchanged)
+
+These existing pieces are **not modified** by this proposal:
+
+| Component | Why it stays |
+|-----------|-------------|
+| `buildResponseProtocol()` | Semantic router format is deeply integrated |
+| `PRIVACY_GUIDANCE` | Already clean and correct |
+| `INVALID_MEMORY_GUIDANCE` | Already clean and correct |
+| `PROCESS_OVERVIEW` | Only shown when asked, already fine |
+| `LATERAL_PROBING_GUIDANCE` | Good design, integrated into `STAGE1_LISTENING_RULES` for Stage 1; kept as-is for Stages 2-4 |
+| `FeelHeardCheck` logic | Criteria and turn-gating preserved exactly |
+| `isProcessQuestion()` | Utility function, no changes needed |
+| Forbidden actions list | Good boundaries, kept as-is |
+| Emotional intensity handling | 8+ behavior preserved, language updated |
+| All Stage 2/3/4 prompts | Out of scope (Stage 2 handled by Task #3) |
+| Inner work prompts | Already has good natural tone |
+| Reconciler prompts | Separate system, no changes |
+| Invitation prompt | Already clean |
+
+---
+
+## 10. Summary of Changes
+
+| Item | Before | After |
+|------|--------|-------|
+| `SIMPLE_LANGUAGE_PROMPT` | 1 line, too brief to drive behavior | Expanded with voice rules + 3 before/after examples |
+| `PINNED_CONSTITUTION` | "mediator in a consent-based space" | "here to help two people understand each other" |
+| `FACILITATOR_RULES` → `STAGE1_LISTENING_RULES` | "reflect → validate → one next move" on every turn, shared across all stages | Stage 1 gets its own constant with phase-aware listening. Old constant kept for Stages 2-4. |
+| `NEUTRALITY_GUIDANCE` | Didn't exist | Three-layer neutrality: feelings (acknowledge), interpretations (explore), characterizations (never agree) |
+| `buildStage1Prompt` opening | "Witness stage. Help X feel fully heard." | "You're here to listen to X." |
+| Early turn behavior | `witnessOnlyMode` = pure reflection | `isGathering` = acknowledge briefly + ask question (soft default, with crisis exception) |
+| Late turn behavior | Same as early (reflect → validate → question) | Reflect using their words, check understanding |
+| "Validate" instruction | Core action on every turn | Replaced with "acknowledge" — feelings, not facts |
+| High intensity | "activated/distressed — stay in witness mode" | "in a really intense place — be steady and present" |
+| Neutrality lint | Internal note, easily outweighed | First-class constant with specific examples |
+
+---
+
+## 11. Integration Notes
+
+**To apply these changes to `stage-prompts.ts`:**
+
+1. Replace `SIMPLE_LANGUAGE_PROMPT` constant (lines 102-104)
+2. Replace `PINNED_CONSTITUTION` constant (lines 106-111)
+3. Add `NEUTRALITY_GUIDANCE` constant after `PINNED_CONSTITUTION`
+4. Add `STAGE1_LISTENING_RULES` constant (new — Stage 1 specific)
+5. **Keep the old `FACILITATOR_RULES`** constant (lines 145-148) for Stages 2, 3, and 4 (lines 410, 448, 489). Stage 1 no longer references it.
+6. Replace `STAGE1_QUESTION_TEMPLATES` constant (lines 150-158)
+7. Replace `buildStage1Prompt()` function (lines 347-375) — now references `STAGE1_LISTENING_RULES` instead of `FACILITATOR_RULES`
+8. Update the invalid memory section in `buildBaseSystemPrompt()` (lines 203-208)
+9. Update Stage 1 initial message case in `buildInitialMessagePrompt()` (lines 655-664)
+10. `LATERAL_PROBING_GUIDANCE` constant (lines 137-139) can be kept for Stage 2/3/4 use, but is no longer referenced in Stage 1 — its behavior is integrated into `STAGE1_LISTENING_RULES`
+
+**Stages 2-4 strategy:** The old `FACILITATOR_RULES` ("reflect → validate → one next move") stays for Stages 2-4 in this proposal. Those stages start with full context, so the gathering/reflecting phase split doesn't apply. The Stage 2 writer (Task #3) may choose to replace `FACILITATOR_RULES` for Stage 2 as well, and Stages 3-4 can be addressed later if needed.

--- a/docs/proposed-stage2.md
+++ b/docs/proposed-stage2.md
@@ -1,0 +1,352 @@
+# Proposed Stage 2 (Perspective Stretch / Empathy) Prompts
+
+> Redesigned from scratch based on user feedback analysis. Drop-in replacement for the Stage 2 sections of `stage-prompts.ts`, plus a new dispatch handler in `dispatch-handler.ts`.
+
+---
+
+## Design Philosophy
+
+The core problem: users don't understand **why** they're being asked to guess their partner's feelings. They feel confused ("Why am I guessing? Shouldn't he be talking to the AI too?") and the AI sounds like a therapy manual walking them through clinical exercises.
+
+The fix: explain the purpose clearly and naturally, treat this as a **conversation** (not an exercise), and sound like a smart friend helping them see things differently — not a therapist running a protocol.
+
+### Two Layers of "Why" Handling
+
+User confusion about Stage 2 shows up in two distinct ways, and each needs a different response:
+
+1. **Explicit questions** ("Why am I guessing?" / "Shouldn't he be talking to the AI too?" / "What's the point of this?") — These are direct process questions. They trigger a **new dispatch off-ramp** (`EXPLAIN_EMPATHY_PURPOSE`) that hands off to a specialized prompt in `dispatch-handler.ts`. This gives a thorough, focused explanation without bloating the main conversational prompt.
+
+2. **Implicit disengagement** ("I don't know" / "I don't care what they think" / one-word answers) — The user isn't asking a question, they're pulling away. This is handled **inline** within `buildStage2Prompt()`. The AI acknowledges the difficulty, briefly re-explains the value, and tries a different angle.
+
+### Key Changes from Current Code
+
+1. **Purpose explanation via two paths** — `STAGE2_PURPOSE_CONTEXT` constant gives the AI understanding of why this step exists (used organically). `EXPLAIN_EMPATHY_PURPOSE` dispatch handles explicit "why?" questions with a specialized prompt.
+2. **Natural voice** — Mode descriptions use plain language. No "Reflect, validate" rhythm. Instead: be curious, help them think it through.
+3. **Identity-driven, not rule-driven** — YOUR ROLE line defines who the AI is (thoughtful friend, one side of the story). No separate "WHAT NOT TO DO" list — the identity handles it.
+4. **"I don't know" handling** — When the user disengages, the AI uses the purpose context in its own words and tries different angles. No scripted re-explanation.
+
+---
+
+## 1. New `STAGE2_PURPOSE_CONTEXT` Constant
+
+```typescript
+/**
+ * Explains WHY this step (seeing things from the other side) exists.
+ * Used in Stage 2 prompt body so the AI can explain it to the user naturally.
+ * Also guides the AI when handling resistance or confusion.
+ */
+const STAGE2_PURPOSE_CONTEXT = `
+WHY THIS STEP EXISTS (share this with the user when they seem unsure, resistant, or ask why):
+- Their partner is also talking to the AI separately, working through their own side of things.
+- Both people independently try to understand the other person — that's what makes this work.
+- Research on conflict resolution consistently shows that the single strongest predictor of working things out is each person genuinely trying to see the other's perspective.
+- This is a guess, not a test. Nobody expects them to read minds. The act of honestly trying to imagine what the other person might be going through is what matters.
+- At the end, they'll write a short statement about what they think their partner might be feeling. That statement gets shared so each person can see how the other sees them.
+- Getting it "wrong" is completely fine — it still shows their partner they made the effort.
+
+NOTE: You can cite the research behind this step (it's what makes the purpose credible). But don't use psychological frameworks to analyze the partner's behavior — no "this is probably driven by attachment" or "people act from fear." Help the user discover things through their own thinking.
+`;
+```
+
+---
+
+## 2. New `buildStage2Prompt()` Function
+
+```typescript
+function buildStage2Prompt(context: PromptContext): string {
+  const earlyStage2 = context.turnCount <= 3;
+  const tooEarlyForDraft = context.turnCount < 4;
+  const partnerName = context.partnerName || 'your partner';
+  const userName = context.userName;
+
+  // Build empathy draft context (for refinement flow)
+  const draftContext = context.empathyDraft
+    ? `
+CURRENT EMPATHY DRAFT (user's working version):
+"${context.empathyDraft}"
+
+This is the user's current draft. When they want changes, update this text — don't start over. Keep their voice unless they ask you to change it.
+${context.isRefiningEmpathy ? `
+REFINEMENT MODE:
+${userName} is actively refining their empathy statement. You MUST:
+1. Set ReadyShare:Y
+2. Generate an updated draft in <draft> tags that incorporates their latest reflections
+3. Even if they're just thinking out loud about what they learned, use that to improve the draft${context.sharedContextFromPartner ? `
+
+PARTNER'S SHARED CONTEXT (to help with refinement):
+"${context.sharedContextFromPartner}"
+
+${partnerName} shared this so ${userName} can understand them better. Use it to guide the draft, but let ${userName} put it in their own words.` : ''}` : ''}`
+    : '';
+
+  return `You are Meet Without Fear. ${userName} has been heard and is now exploring what ${partnerName} might be going through on their side.
+
+${buildBaseSystemPrompt(context.invalidMemoryRequest, context.sharedContentHistory, getLastUserMessage(context), context.milestoneContext)}
+
+YOUR ROLE: Help ${userName} step into ${partnerName}'s shoes — not by telling them what ${partnerName} feels, but by asking questions that help ${userName} figure it out themselves. You're a thoughtful friend helping them see things from the other side. You only have one side of the story — acknowledge ${userName}'s feelings without confirming or denying what ${partnerName} did.
+
+${STAGE2_PURPOSE_CONTEXT}
+
+WHEN THEY EXPLICITLY ASK WHY (e.g., "Why am I guessing?" / "Shouldn't he be talking to the AI too?" / "What's the point?"):
+Use <dispatch>EXPLAIN_EMPATHY_PURPOSE</dispatch>. Only for direct process questions — not resistance, confusion, or low effort.
+
+FOUR MODES (pick based on where the user is):
+- LISTENING: They're still upset or need to vent more. Give them space. Acknowledge what they're feeling, then gently circle back when they're ready.
+- BRIDGING: The venting is settling. Start inviting curiosity: "What do you think was going on for ${partnerName} in that moment?" or "How do you think ${partnerName} might describe what happened?"
+- BUILDING: They're engaging with ${partnerName}'s perspective. Go deeper: "What might ${partnerName} be worried about?" / "What do you think ${partnerName} needs here?" Acknowledge genuine insight.
+- MIRROR: They're slipping into blame or judgment. Acknowledge the hurt behind it, then redirect with curiosity. You can offer tentative framings as questions — not stating principles as fact, but inviting them to consider a possibility: "Sometimes when people act like that, there's something they're scared of underneath — does that ring true for ${partnerName}?"
+
+${earlyStage2 ? `EARLY IN THIS STEP: ${userName} may still have leftover feelings. Start in LISTENING mode. Give space before trying to shift their focus.` : ''}
+${context.emotionalIntensity >= 8 ? `HIGH INTENSITY: ${userName} is really upset right now. Stay in LISTENING mode. Be calm and steady — don't match their intensity. Let them settle first.` : ''}
+
+IF THEY SAY "I DON'T KNOW" OR DISENGAGE:
+Don't push harder and don't skip ahead. Acknowledge it's hard, use the purpose context above to re-explain why this matters in your own words, and try a different angle. If they disengage again, pivot: "If ${partnerName} were sitting here right now, what do you think they'd say happened?"
+
+${draftContext}
+
+Stay with ${partnerName}'s perspective — let ${userName} discover it through their own curiosity. Follow their pace.
+
+${LATERAL_PROBING_GUIDANCE}
+
+Length: default 1-3 sentences. Go longer only if explaining the purpose of this step or if they ask for more detail.
+
+User's emotional intensity: ${context.emotionalIntensity}/10 (how upset they are — high means slow down and give space; do NOT match their intensity in your tone)
+Turn: ${context.turnCount}
+
+READY TO SHARE (ReadyShare:Y):
+${tooEarlyForDraft ? `TOO EARLY (Turn < 4): Keep exploring through conversation. Don't rush to a draft.` : `Set ReadyShare:Y when ${userName} can describe what ${partnerName} might be feeling or going through without blame — curiosity over defensiveness, "they might feel" over "they always."`}
+
+When ReadyShare:Y, include a 2-4 sentence empathy statement in <draft> tags — what ${userName} imagines ${partnerName} is experiencing, written as ${userName} speaking to ${partnerName} (e.g., "I think you might be feeling..."). Focus purely on ${partnerName}'s inner experience — their feelings, fears, or needs.
+
+${buildResponseProtocol(2, { includesDraft: true, draftPurpose: 'empathy' })}`;
+}
+```
+
+---
+
+## 3. Updated Stage 1→2 Transition in `buildTransitionInjection()`
+
+Replace the existing `toStage === 2 && fromStage === 1` block:
+
+```typescript
+  // Stage 1 → Stage 2: Feel heard confirmed, shift to perspective stretch
+  if (toStage === 2 && fromStage === 1) {
+    return `TRANSITION: ${userName} just confirmed feeling heard. Acknowledge this warmly (1-2 sentences).
+
+Then naturally introduce what comes next. The key point is that both ${userName} and ${partnerName} are each doing this for the other. You don't need to cover every detail upfront — if they seem to get it, move on quickly. If they seem confused or resistant, explain more (both sides are doing this separately with the AI, it's a guess not a test, the effort matters more than accuracy, they'll each write a short statement that gets shared).
+
+Keep it brief — 2-3 sentences is enough for most people. More only if they need it. Then ask an opening question to get them thinking about ${partnerName}'s experience.\n\n`;
+  }
+```
+
+---
+
+## 4. Updated Stage 2 Initial Message in `buildInitialMessagePrompt()` case 2
+
+Replace the existing `case 2` block:
+
+```typescript
+    case 2: // Perspective Stretch
+      return `You are Meet Without Fear. ${context.userName} has been heard and is ready to explore ${partnerName}'s perspective.
+
+${SIMPLE_LANGUAGE_PROMPT}
+${PRIVACY_GUIDANCE}
+
+CONTEXT: Both ${context.userName} and ${partnerName} are each going through this process separately with the AI. This step is where each person tries to understand the other's experience.
+
+YOUR TASK:
+Generate an opening message (2-4 sentences) that:
+1. Acknowledges they've been heard and that took something real.
+2. Naturally introduces what comes next: trying to see things from ${partnerName}'s side. The key point is that both of them are doing this for each other. You don't need to cover every detail — keep it brief. If they need more explanation, they'll ask (and the conversation prompt handles that).
+3. Asks an opening question to get them thinking — something like "How do you think ${partnerName} might describe what's been going on?" or "What do you think ${partnerName} is feeling about all this?"
+
+Sound like a warm, smart person — not a therapist introducing an exercise. This is a conversation, not a clinical protocol. Don't over-explain.
+
+${buildResponseProtocol(-1)}`;
+```
+
+---
+
+## 5. New Dispatch Off-Ramp: `EXPLAIN_EMPATHY_PURPOSE`
+
+### 5a. Update `buildResponseProtocol()` in `stage-prompts.ts`
+
+Add the new off-ramp for Stage 2. The existing function builds off-ramps as static text — add a stage-conditional line:
+
+```typescript
+function buildResponseProtocol(stage: number, options?: {
+  includesDraft?: boolean;
+  draftPurpose?: 'invitation' | 'empathy';
+}): string {
+  const flags: string[] = ['UserIntensity: [1-10]'];
+  if (stage === 1) {
+    flags.push('FeelHeardCheck: [Y/N]');
+  } else if (stage === 2) {
+    flags.push('ReadyShare: [Y/N]');
+  }
+
+  const draftSection = options?.includesDraft
+    ? `
+If you prepared a ${options.draftPurpose} draft, include:
+<draft>
+${options.draftPurpose} text
+</draft>`
+    : '';
+
+  // Stage 2 gets an extra off-ramp for empathy purpose questions
+  const empathyOffRamp = stage === 2
+    ? `\n- If asked why they're doing this / why guess partner's feelings / what's the point: <dispatch>EXPLAIN_EMPATHY_PURPOSE</dispatch>`
+    : '';
+
+  return `
+OUTPUT FORMAT:
+<thinking>
+Mode: [WITNESS|PERSPECTIVE|NEEDS|REPAIR|ONBOARDING|DISPATCH]
+${flags.join('\n')}
+Strategy: [brief]
+</thinking>${draftSection}
+
+Then write the user-facing response (plain text, no tags).
+
+OFF-RAMPS (only when needed):
+- If asked how this works / process: <dispatch>EXPLAIN_PROCESS</dispatch>
+- If asked to remember something: <dispatch>HANDLE_MEMORY_REQUEST</dispatch>${empathyOffRamp}
+
+If you use <dispatch>, output ONLY <thinking> + <dispatch> (no visible text).`;
+}
+```
+
+### 5b. Deployment Note
+
+The `buildResponseProtocol()` change and `dispatch-handler.ts` changes MUST be deployed atomically. If the prompt advertises `EXPLAIN_EMPATHY_PURPOSE` but the handler doesn't exist yet, the dispatch will hit the `default` unknown-tag path and return a generic "I'm here to help" response. Deploy both in the same commit/release.
+
+### 5c. Update `DispatchTag` type in `dispatch-handler.ts`
+
+```typescript
+export type DispatchTag =
+  | 'EXPLAIN_PROCESS'
+  | 'EXPLAIN_EMPATHY_PURPOSE'
+  | 'HANDLE_MEMORY_REQUEST'
+  | string; // Allow unknown tags
+```
+
+### 5d. Add handler case in `handleDispatch()` switch in `dispatch-handler.ts`
+
+```typescript
+    case 'EXPLAIN_EMPATHY_PURPOSE':
+      return handleEmpathyPurposeExplanation(context);
+```
+
+### 5e. New handler function and prompt builder in `dispatch-handler.ts`
+
+```typescript
+/**
+ * Build system prompt for explaining why the empathy step exists.
+ * Triggered when user explicitly asks "Why am I guessing?" or similar.
+ */
+function buildEmpathyPurposePrompt(context: DispatchContext): string {
+  const { userName, partnerName } = context;
+  const user = userName || 'you';
+  const partner = partnerName || 'your partner';
+
+  return `You are Meet Without Fear, explaining to ${user} why this step matters — seeing things from the other side.
+
+${user} has been exploring ${partner}'s perspective and has asked something like "Why am I guessing at what ${partner} feels?" or "Shouldn't ${partner} be talking to the AI too?" or "What's the point of this?"
+
+WHAT TO EXPLAIN (in your own words, naturally — not as a bulleted list):
+
+1. Yes, ${partner} IS also going through this process separately. Both people talk to the AI on their own, working through their own side.
+
+2. This step is where each person tries to understand what the other might be going through. Both ${user} and ${partner} do this for each other.
+
+3. Why it works: Research on conflict resolution consistently shows that the single strongest predictor of working things out is each person genuinely trying to see the other's perspective. It doesn't matter if the guess is accurate — the act of honestly trying is what matters.
+
+4. It's a guess, not a test. Nobody expects ${user} to read ${partner}'s mind. Getting it "wrong" is completely fine. What matters is that ${partner} will see ${user} made the effort.
+
+5. What happens next: ${user} will write a short statement about what they think ${partner} might be feeling. That statement gets shared (with consent) so ${partner} can see how ${user} sees them. ${partner} does the same thing for ${user}.
+
+STYLE:
+- Sound like a warm, smart person explaining something that genuinely helps — not a therapist reading a protocol.
+- Keep it to 3-5 sentences. Don't over-explain.
+- End by gently inviting them back into the conversation: ask an opening question about ${partner}'s perspective.
+- Match their energy. If they seem frustrated, acknowledge that before explaining.`;
+}
+
+/**
+ * Handle empathy purpose explanation with full AI conversation capability.
+ */
+async function handleEmpathyPurposeExplanation(context: DispatchContext): Promise<string> {
+  const { userMessage, conversationHistory, sessionId, turnId } = context;
+
+  try {
+    const messages = [
+      ...conversationHistory.slice(-6),
+      { role: 'user' as const, content: userMessage },
+    ];
+
+    const response = await getSonnetResponse({
+      systemPrompt: buildEmpathyPurposePrompt(context),
+      messages,
+      maxTokens: 512,
+      sessionId,
+      turnId,
+      operation: 'dispatch-empathy-purpose',
+      callType: BrainActivityCallType.ORCHESTRATED_RESPONSE,
+    });
+
+    if (response) {
+      return response.trim();
+    }
+
+    return getFallbackEmpathyPurposeResponse(context);
+  } catch (error) {
+    console.error('[Dispatch Handler] Empathy purpose explanation failed:', error);
+    return getFallbackEmpathyPurposeResponse(context);
+  }
+}
+
+/**
+ * Fallback if AI call fails for empathy purpose explanation.
+ */
+function getFallbackEmpathyPurposeResponse(context: DispatchContext): string {
+  const partner = context.partnerName || 'your partner';
+  return `Good question. ${partner} is actually going through this same process on their side — you're both independently trying to understand each other. Research shows that genuinely trying to see the other person's perspective is one of the biggest things that helps people work things out. It's not a test — it's about the effort. You'll each write a short statement that gets shared, so ${partner} can see you tried to understand them, and you'll see the same from them.
+
+What do you think might be going on for ${partner} in all this?`;
+}
+```
+
+---
+
+## Summary of What Changed vs. What's Preserved
+
+### Changed
+| Element | Old | New |
+|---------|-----|-----|
+| AI self-concept | "You are Meet Without Fear in Perspective Stretch" (clinical exercise) | "You are Meet Without Fear" helping them explore (conversation) |
+| Opening line | "Help X imagine what Y might be feeling or afraid of" | "X has been heard and is now exploring what Y might be going through" |
+| Focus instruction | "See the fear, hurt, and unmet needs driving Y's behavior" (AI interprets) | "Help X step into Y's shoes — not by telling them, but by asking questions" |
+| Mode: MIRROR | "People usually act from fear — what might Y be afraid of?" (AI states principle as fact) | Tentative framing as question: "Sometimes when people act like that, there's something underneath — does that ring true?" (invites consideration, doesn't state facts) |
+| FACILITATOR_RULES | Imported directly: "reflect → validate → one next move" | Removed — replaced with natural approach instructions |
+| "I don't know" handling | None | Inline: acknowledge, use purpose context in own words, try different angle; on repeated disengagement pivot to "what would they say happened?" |
+| "Why am I doing this?" handling | Falls through to generic `EXPLAIN_PROCESS` dispatch | New `EXPLAIN_EMPATHY_PURPOSE` dispatch (explicit process questions ONLY — resistance/confusion handled inline) |
+| Purpose explanation | None | `STAGE2_PURPOSE_CONTEXT` constant (AI's understanding) + dispatch for explicit questions — 2 paths, not 4 |
+| Transition (1→2) | "Acknowledge warmly, then gently invite curiosity" (2 sentences) | Adaptive: brief intro (2-3 sentences) by default, expand only if user needs it |
+| Initial message (case 2) | "Gently introduces the perspective-taking work" (1-2 sentences) | Brief intro + opening question (2-4 sentences), doesn't over-explain |
+
+### Preserved (Unchanged)
+| Element | Details |
+|---------|---------|
+| Four modes | LISTENING, BRIDGING, BUILDING, MIRROR — internal names and behavioral structure intact |
+| ReadyShare:Y/N | Same turn gating (< 4 too early), same criteria (curiosity over defensiveness) |
+| `<draft>` tags | 2-4 sentence empathy statement, user speaking to partner |
+| Draft refinement | `isRefiningEmpathy` flow with shared context from partner |
+| Emotional intensity | 8+ = LISTENING mode, calm tone, don't match intensity |
+| Response protocol | `buildResponseProtocol(2, ...)` with ReadyShare flag |
+| `<thinking>` format | Mode, UserIntensity, ReadyShare, Strategy |
+| Turn count tracking | `context.turnCount` drives early-stage behavior |
+| Lateral probing | `LATERAL_PROBING_GUIDANCE` still included |
+| Privacy/constitution | `buildBaseSystemPrompt()` still called with all guards |
+| Length constraint | "1-3 sentences" default maintained |
+| Off-ramps | Existing `EXPLAIN_PROCESS` and `HANDLE_MEMORY_REQUEST` preserved; new `EXPLAIN_EMPATHY_PURPOSE` added for Stage 2 |
+| Dispatch mechanism | Same pattern: `<thinking>` + `<dispatch>` with no visible text; handler calls Sonnet with specialized prompt |

--- a/docs/regression-check.md
+++ b/docs/regression-check.md
@@ -1,0 +1,483 @@
+# Regression Check: Proposed Prompt Redesign
+
+> Systematic verification that every functional feature of the current prompts is preserved in the proposals.
+> Checked against: `backend/src/services/stage-prompts.ts` (current), `docs/proposed-stage1.md`, `docs/proposed-stage2.md`
+
+---
+
+## STAGE 1 FEATURES
+
+### 1. Response protocol format (`<thinking>` block with Mode, UserIntensity, FeelHeardCheck, Strategy)
+
+**Status: PRESERVED**
+
+The proposed `buildStage1Prompt()` calls `buildResponseProtocol(1)` at the end, same as current. The Stage 2 proposal modifies `buildResponseProtocol()` to add a conditional off-ramp for Stage 2 only — for Stage 1 calls, the output is identical:
+
+```
+<thinking>
+Mode: [WITNESS|PERSPECTIVE|NEEDS|REPAIR|ONBOARDING|DISPATCH]
+UserIntensity: [1-10]
+FeelHeardCheck: [Y/N]
+Strategy: [brief]
+</thinking>
+```
+
+---
+
+### 2. FeelHeardCheck: Y/N flag with conditions
+
+**Status: PRESERVED**
+
+Current conditions (line 368):
+1. They affirm a reflection
+2. Core concern/need is named
+3. Intensity is stabilizing
+
+Proposed conditions:
+1. "they've affirmed something you reflected back"
+2. "you can name their core concern"
+3. "their intensity is stabilizing or steady"
+
+All three conditions preserved. Additional behavioral rules also preserved:
+- Be proactive about setting it
+- Do NOT ask "do you feel heard?" (UI handles it)
+- Keep setting Y until they act on it
+- Stay in listening mode even when Y (no pivot to action/next steps)
+
+---
+
+### 3. FeelHeardCheck too early guard
+
+**Status: MODIFIED**
+
+| | Current | Proposed |
+|---|---------|----------|
+| Threshold | `turnCount < 2` | `turnCount < 3` |
+| Text | "Too early (turn < 2) unless they ask to move on." | "Too early (turn < 3) — you haven't heard enough yet." |
+
+**Assessment: SAFE.** The threshold is raised by 1 turn, which aligns with the "gather first" redesign philosophy. The "unless they ask to move on" escape hatch is removed, but at turn 2 there's almost never enough context for a meaningful FeelHeardCheck anyway. Low risk.
+
+---
+
+### 4. WitnessOnlyMode or equivalent for high intensity (8+)
+
+**Status: PRESERVED**
+
+Current: `witnessOnlyMode = context.turnCount < 3 || context.emotionalIntensity >= 8` → "stay in witness mode until intensity settles"
+
+Proposed: `isHighIntensity = context.emotionalIntensity >= 8` → Phase guidance says: "Don't try to move the conversation forward. Just be steady and present. Short responses. Acknowledge what they're feeling without adding your take. Let them lead."
+
+The 8+ threshold is maintained. The "stay in witness mode" behavior is preserved in natural language. Additionally, `FACILITATOR_RULES` contains: "If emotional intensity is high (8+), slow way down. Just be present. Short sentences."
+
+---
+
+### 5. Emotional intensity parameter (1-10) included in prompt
+
+**Status: PRESERVED**
+
+Current: `User's emotional intensity: ${context.emotionalIntensity}/10 (how activated/distressed...)`
+Proposed: `Emotional intensity: ${context.emotionalIntensity}/10`
+
+**Minor note:** The current version always includes "(do NOT mirror this intensity in your tone)" in the intensity line regardless of level. The proposed only includes the "Do NOT match their intensity" instruction when `isHighIntensity` is true. For medium intensity (5-7), this instruction is lost. However, the `FACILITATOR_RULES` says "Match their pace" (which is about conversational pace, not emotional intensity), and the overall prompt voice is calm by design. **Low risk but worth noting.**
+
+---
+
+### 6. High intensity behavior (slow down, prioritize space)
+
+**Status: PRESERVED**
+
+Same threshold (8+), same behavioral instruction (slow down, be present, don't push forward, short responses). Language updated from clinical ("activated/distressed — stay in witness mode") to natural ("really activated right now — be steady and present").
+
+---
+
+### 7. Length constraint (1-3 sentences default)
+
+**Status: PRESERVED (STRENGTHENED)**
+
+Current: `Length: default 1–3 sentences. Go longer only if they explicitly ask for help or detail.`
+Proposed: `Length: 1-3 sentences. Seriously — keep it short. The user is here to talk, not to read.`
+
+Same constraint with stronger emphasis.
+
+---
+
+### 8. Forbidden phrases (no solutions/next steps language)
+
+**Status: PRESERVED (EXPANDED)**
+
+Current forbidden list: "next step", "what might help", "what you could try", "moving forward", "first small step"
+Proposed: All of the above **plus** "have you considered"
+
+No removals, one addition. Safe.
+
+---
+
+### 9. Neutrality lint (no judging words)
+
+**Status: MODIFIED (UPGRADED)**
+
+Current: Single internal note — `Neutrality lint (internal): avoid judging words like "reasonable", "right", "wrong", "irrational". Rephrase to impact-focused language.`
+
+Proposed: Full `NEUTRALITY_GUIDANCE` constant with:
+- Same prohibited words ("reasonable", "right", "wrong", "irrational") plus "unfair", "toxic"
+- Explicit "one side of the story" framing
+- Specific behavioral instructions ("If they say 'They always do X' — don't agree. Ask what happened this time.")
+- "Use their words" instruction
+
+**Assessment: SAFE.** This is a strict upgrade. The original intent is preserved and significantly strengthened.
+
+---
+
+### 10. Lateral probing for brief/guarded users
+
+**Status: MODIFIED (ABSORBED)**
+
+Current: `${LATERAL_PROBING_GUIDANCE}` injected as a separate constant.
+
+Proposed: The behavior is absorbed into `FACILITATOR_RULES`: "If they're brief or guarded, try a different angle — ask about something adjacent (timeline, what matters to them, what's at stake) instead of pushing deeper on the same thread."
+
+The `LATERAL_PROBING_GUIDANCE` constant is preserved for Stage 2/3/4 use but no longer referenced in Stage 1.
+
+**Assessment: SAFE.** Same guidance, different delivery mechanism.
+
+---
+
+### 11. Turn count parameter
+
+**Status: PRESERVED**
+
+`Turn: ${context.turnCount}` — identical in both.
+
+---
+
+### 12. `<dispatch>` off-ramps preserved
+
+**Status: PRESERVED**
+
+Both `EXPLAIN_PROCESS` and `HANDLE_MEMORY_REQUEST` are preserved in the response protocol. No Stage 1 off-ramps were removed.
+
+---
+
+## STAGE 2 FEATURES
+
+### 1. Response protocol format (`<thinking>` block with Mode, UserIntensity, ReadyShare, Strategy)
+
+**Status: PRESERVED**
+
+`buildResponseProtocol(2, { includesDraft: true, draftPurpose: 'empathy' })` is called at the end of the proposed function. The modified `buildResponseProtocol()` adds a conditional `EXPLAIN_EMPATHY_PURPOSE` off-ramp for Stage 2 but the `<thinking>` format is identical.
+
+---
+
+### 2. Four modes: LISTENING, BRIDGING, BUILDING, MIRROR
+
+**Status: PRESERVED**
+
+All four modes present with equivalent behavioral descriptions:
+
+| Mode | Current | Proposed |
+|------|---------|----------|
+| LISTENING | "Still venting? Give full space. Reflect, validate." | "They're still upset or need to vent more. Give them space." |
+| BRIDGING | "Venting subsides? Invite curiosity" | "The venting is settling. Start inviting curiosity" |
+| BUILDING | "Help them imagine partner's experience" | "They're engaging with partner's perspective. Keep going deeper" |
+| MIRROR | "Judgment detected? Acknowledge hurt, redirect: 'People usually act from fear'" | "Slipping into blame? Acknowledge the hurt behind the judgment, redirect with curiosity" |
+
+The MIRROR mode change is notable: the current version states a psychological principle ("People usually act from fear — what might Y be afraid of?"). The proposed uses a neutral question ("What do you think was happening for Y that led them to do that?"). This is intentional — feedback #3 was about the AI adding its own opinions.
+
+**Assessment: SAFE.** Modes preserved, behavioral descriptions updated per redesign goals.
+
+---
+
+### 3. ReadyShare: Y/N flag with conditions
+
+**Status: PRESERVED**
+
+Same criteria: user can describe partner's feelings without blame, curiosity over defensiveness, "they might feel" over "they always." Same turn gating. Same Y/N flag in `<thinking>` block.
+
+---
+
+### 4. Turn < 4 too early for draft
+
+**Status: PRESERVED**
+
+`const tooEarlyForDraft = context.turnCount < 4;` — identical in both.
+
+---
+
+### 5. Draft generation in `<draft>` tags (2-4 sentences, user -> partner voice)
+
+**Status: PRESERVED**
+
+Current: "2-4 sentence empathy statement in `<draft>` — what X imagines Y is feeling, written as X speaking to Y (e.g., 'I imagine you might be feeling...'). Purely about Y's inner experience."
+
+Proposed: "2-4 sentence empathy statement in `<draft>` tags — what X imagines Y is experiencing, written as X speaking to Y (e.g., 'I think you might be feeling...'). Focus purely on Y's inner experience — their feelings, fears, or needs."
+
+Functionally identical. Example phrasing changed slightly.
+
+---
+
+### 6. Empathy draft refinement context (isRefiningEmpathy)
+
+**Status: MODIFIED (IMPROVED)**
+
+Current instructions reference old JSON field names:
+- `Set "offerReadyToShare": true`
+- `Generate a "proposedEmpathyStatement"`
+
+Proposed corrects to semantic tag format:
+- `Set ReadyShare:Y`
+- `Generate an updated draft in <draft> tags`
+
+**Assessment: SAFE (improvement).** The proposed version correctly references the actual response protocol format rather than legacy JSON fields.
+
+---
+
+### 7. Shared context from partner handling (sharedContextFromPartner)
+
+**Status: PRESERVED**
+
+Same conditional logic: if `context.sharedContextFromPartner` exists, inject it with instructions to use for refinement. The label changed from "use this to help them refine" to "to help with refinement" and adds "let X put it in their own words." Functionally identical.
+
+---
+
+### 8. Early Stage 2 handling (turnCount <= 3)
+
+**Status: PRESERVED**
+
+`const earlyStage2 = context.turnCount <= 3;` — identical threshold. Same behavior: start in LISTENING mode, give space before inviting perspective-taking.
+
+---
+
+### 9. High intensity handling (8+ = listening mode)
+
+**Status: PRESERVED**
+
+Same threshold (>=8), same mode (LISTENING), same de-escalation behavior.
+
+Current: "Stay in LISTENING mode. Validate heavily. Not the moment for perspective-taking. Your tone should be calm and grounding, not matching their intensity."
+
+Proposed: "Stay in LISTENING mode. Be calm and steady — don't match their intensity. This isn't the moment to push perspective-taking."
+
+Additionally, the intensity line preserves "do NOT match their intensity in your tone" for ALL intensity levels (unlike Stage 1 where it's conditional).
+
+---
+
+### 10. Partner name variable usage throughout
+
+**Status: PRESERVED**
+
+`${partnerName}` used extensively in both. Partner name defaults to `'your partner'` in both.
+
+---
+
+### 11. Lateral probing guidance
+
+**Status: PRESERVED**
+
+`${LATERAL_PROBING_GUIDANCE}` is included in the proposed Stage 2 prompt.
+
+---
+
+### 12. `<dispatch>` off-ramps preserved
+
+**Status: PRESERVED (EXPANDED)**
+
+Existing off-ramps (`EXPLAIN_PROCESS`, `HANDLE_MEMORY_REQUEST`) are preserved. New `EXPLAIN_EMPATHY_PURPOSE` off-ramp added for Stage 2 specifically, with a full dispatch handler, prompt builder, and fallback response.
+
+---
+
+## BASE/SHARED FEATURES
+
+### 1. SIMPLE_LANGUAGE_PROMPT (or equivalent)
+
+**Status: MODIFIED (EXPANDED)**
+
+Current: 1 line — `STYLE: Warm, clear, direct. No jargon. One question max.`
+
+Proposed: Multi-section with voice description, rules (short sentences, plain words, one question max, 1-3 sentences), and before/after examples.
+
+All original rules preserved: warm, clear, direct, no jargon, one question max. Significantly expanded with concrete examples.
+
+**Assessment: SAFE.** Note that `SIMPLE_LANGUAGE_PROMPT` is used in many places (invitation, initial messages, etc.). The expanded version adds more tokens to every prompt that includes it. This is a trade-off — better guidance vs. higher token usage.
+
+---
+
+### 2. PINNED_CONSTITUTION (safety/privacy core)
+
+**Status: MODIFIED (SAFE)**
+
+All three safety rules are preserved:
+
+| Rule | Current | Proposed |
+|------|---------|----------|
+| Privacy | "never claim the partner's thoughts unless explicitly shared with consent" | "Never claim to know what the other person said or feels unless it was explicitly shared with consent" |
+| Safety | "de-escalate when language is attacking or unsafe; stay non-shaming" | "If someone's language becomes attacking or unsafe, calmly de-escalate. Never shame." |
+| Sharing boundary | "keep the user's original words private; only suggest optional 'sendable' rewrites when sharing is imminent or requested" | "Keep the user's raw words private. Only suggest optional 'sendable' rewrites when sharing is about to happen or they ask for one." |
+
+Identity changed: "mediator in a private, consent-based space" → "here to help two people understand each other better." This is intentional per the de-therapize goal.
+
+**Assessment: SAFE.** All safety guardrails preserved in full. Only the framing language changed.
+
+---
+
+### 3. PRIVACY_GUIDANCE
+
+**Status: PRESERVED (UNCHANGED)**
+
+Listed in proposed-stage1.md "What's Preserved" table. Not modified.
+
+---
+
+### 4. buildResponseProtocol() format
+
+**Status: MODIFIED (ADDITIVE)**
+
+The Stage 2 proposal adds one conditional off-ramp (`EXPLAIN_EMPATHY_PURPOSE`) that only appears when `stage === 2`. For all other stages, the output is byte-identical.
+
+```typescript
+const empathyOffRamp = stage === 2
+  ? '\n- If asked why they\'re doing this / ...: <dispatch>EXPLAIN_EMPATHY_PURPOSE</dispatch>'
+  : '';
+```
+
+**Assessment: SAFE.** Additive change, no impact on non-Stage-2 prompts.
+
+---
+
+### 5. Process overview (conditional on user asking)
+
+**Status: PRESERVED**
+
+`isProcessQuestion()` function unchanged. `PROCESS_OVERVIEW` constant unchanged. Conditional injection pattern in `buildBaseSystemPrompt()` is identical:
+```typescript
+const processOverviewSection = userMessage && isProcessQuestion(userMessage) ? PROCESS_OVERVIEW : '';
+```
+
+---
+
+### 6. Invalid memory request handling
+
+**Status: MODIFIED (SAFE)**
+
+`INVALID_MEMORY_GUIDANCE` constant is unchanged. The section in `buildBaseSystemPrompt()` for invalid requests has updated language:
+
+| | Current | Proposed |
+|---|---------|----------|
+| Conflict reason | "This conflicts with therapeutic values" | "This conflicts with how we work" |
+| Response instruction | "maintaining therapeutic integrity. Be warm and non-judgmental." | "Be direct, not clinical." |
+
+Core behavior preserved: detect, acknowledge, explain, offer alternative.
+
+---
+
+## CRITICAL FINDINGS
+
+### No MISSING features detected.
+
+All features from the current prompts are accounted for in the proposals. Nothing was dropped.
+
+---
+
+## ISSUES TO FLAG (non-critical)
+
+### Issue 1: Stage 1 "don't mirror intensity" instruction now conditional
+
+**Severity: LOW**
+
+Current Stage 1 always includes "do NOT mirror this intensity in your tone" in the emotional intensity line.
+Proposed Stage 1 only includes "Do NOT match their intensity" when `isHighIntensity` (8+) is true.
+
+For medium intensity (5-7), the explicit "don't mirror" instruction is absent. The overall prompt tone is calm by design, so this is unlikely to cause problems, but the explicit guard is gone for non-high intensities.
+
+**Recommendation:** Add "do NOT match their intensity in your tone" to the intensity line in Stage 1, like the proposed Stage 2 does.
+
+### Issue 2: FACILITATOR_RULES shared with Stages 3 and 4
+
+**Severity: MEDIUM**
+
+The new `FACILITATOR_RULES` is significantly different from the current version. It includes phase-aware guidance (gathering vs. reflecting based on turn count). Stages 3 and 4, which are NOT being redesigned, both reference `${FACILITATOR_RULES}` (current lines 448, 489).
+
+The new version will change behavior in Stages 3 and 4:
+- Stages 3/4 early turns will now be in "gathering phase" (acknowledge briefly + ask question) instead of "reflect → validate → one next move"
+- This is probably appropriate for Stages 3/4 too, but it's an unintended side effect of the Stage 1 redesign
+
+**Recommendation:** Explicitly verify that the new FACILITATOR_RULES works for Stages 3 and 4, or create stage-specific variants.
+
+### Issue 3: FeelHeardCheck "too early" threshold raised
+
+**Severity: LOW**
+
+Changed from `turnCount < 2` to `turnCount < 3`. This delays the possibility of FeelHeardCheck:Y by one turn. Aligns with the "gather first" philosophy but is a behavioral change.
+
+### Issue 4: Expanded SIMPLE_LANGUAGE_PROMPT increases token usage
+
+**Severity: LOW**
+
+The expanded prompt (from ~15 tokens to ~120 tokens) is included in every prompt that calls `buildBaseSystemPrompt()` or uses `SIMPLE_LANGUAGE_PROMPT` directly — including invitation prompts, initial messages, and inner work prompts. This is a trade-off: better guidance vs. ~100 extra tokens per prompt.
+
+### Issue 5: Empathy refinement field name correction
+
+**Severity: LOW (positive)**
+
+The current Stage 2 refinement mode references `"offerReadyToShare": true` and `"proposedEmpathyStatement"` — these appear to be legacy JSON field names that don't match the actual semantic tag response protocol. The proposed version corrects these to `ReadyShare:Y` and `<draft>` tags. This is a bug fix, not a regression.
+
+---
+
+## SUMMARY TABLE
+
+### Stage 1
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Response protocol format | PRESERVED | |
+| FeelHeardCheck Y/N with conditions | PRESERVED | |
+| FeelHeardCheck too early guard | MODIFIED | Threshold raised from < 2 to < 3 (safe) |
+| WitnessOnlyMode / high intensity | PRESERVED | Renamed but equivalent |
+| Emotional intensity parameter | PRESERVED | "Don't mirror" instruction now conditional (see Issue 1) |
+| High intensity behavior | PRESERVED | |
+| Length constraint (1-3 sentences) | PRESERVED | Strengthened |
+| Forbidden phrases | PRESERVED | One phrase added |
+| Neutrality lint | MODIFIED | Upgraded to full constant (improvement) |
+| Lateral probing | MODIFIED | Absorbed into FACILITATOR_RULES (equivalent) |
+| Turn count parameter | PRESERVED | |
+| `<dispatch>` off-ramps | PRESERVED | |
+
+### Stage 2
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Response protocol format | PRESERVED | |
+| Four modes | PRESERVED | Descriptions updated, behavioral intent intact |
+| ReadyShare Y/N with conditions | PRESERVED | |
+| Turn < 4 too early for draft | PRESERVED | |
+| Draft in `<draft>` tags | PRESERVED | |
+| Empathy draft refinement | MODIFIED | Field names corrected to match protocol (improvement) |
+| Shared context from partner | PRESERVED | |
+| Early Stage 2 handling | PRESERVED | |
+| High intensity handling | PRESERVED | |
+| Partner name variable | PRESERVED | |
+| Lateral probing | PRESERVED | |
+| `<dispatch>` off-ramps | PRESERVED | New off-ramp added (expansion) |
+
+### Base/Shared
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| SIMPLE_LANGUAGE_PROMPT | MODIFIED | Expanded significantly (improvement, see Issue 4) |
+| PINNED_CONSTITUTION | MODIFIED | Safety rules intact, framing de-therapized (safe) |
+| PRIVACY_GUIDANCE | PRESERVED | |
+| buildResponseProtocol() | MODIFIED | One conditional off-ramp added for Stage 2 (additive) |
+| Process overview | PRESERVED | |
+| Invalid memory handling | MODIFIED | Language de-therapized, behavior identical |
+
+---
+
+## VERDICT
+
+**No critical regressions found.** All functional features are preserved. The modifications are either:
+1. Intentional improvements (neutrality upgrade, field name corrections, expanded guidance)
+2. Aligned with redesign goals (threshold adjustments, de-therapized language)
+3. Additive (new dispatch off-ramp, expanded forbidden phrases)
+
+The two items worth addressing are:
+1. **Stage 1 "don't mirror intensity" instruction** — should be unconditional like Stage 2
+2. **FACILITATOR_RULES impact on Stages 3/4** — verify the new version works for unmodified stages


### PR DESCRIPTION
## Summary

- **Stage 1**: Replace reflect-validate-question rhythm with gathering/reflecting phases. AI gathers info with short responses early on, then reflects using the user's own words once it has enough context. New 3-layer neutrality guidance (feelings → acknowledge, interpretations → explore, characterizations → never agree).
- **Stage 2**: Add purpose explanation for empathy step (why users are guessing partner's feelings). New `EXPLAIN_EMPATHY_PURPOSE` dispatch handler for explicit "why?" questions. Inline handling for "I don't know" / disengagement.
- **Shared**: De-therapize voice constants (`SIMPLE_LANGUAGE_PROMPT`, `PINNED_CONSTITUTION`). All Stages 3-4 prompts unchanged.
- **Mobile**: First-time hint on EmotionSlider ("Slide to update how you're feeling")
- **Docs**: Full research analysis, proposals, devil's advocate review, freshness check, and regression check from agent team

## Addresses user feedback
1. "The bot is talking a lot in the beginning" → gathering phase keeps responses to 1-3 sentences
2. "It's adding too much of its own opinion" → neutrality guidance + "use their words"
3. "We don't want to just agree with the person" → 3-layer neutrality framework
4. When someone says "I don't know" in empathy stage → re-explain purpose, try different angle
5. "There is nothing telling the user to slide to change their emotion" → slider hint

## Test plan
- [x] All 30 prompt + dispatch tests passing
- [x] Type checking clean on changed files
- [x] Stage 1 changes verified against proposal by review agent
- [x] Stage 2 changes verified against proposal by review agent
- [x] Regression check confirmed all unchanged features intact
- [x] Metadata leakage guardrail restored (caught by regression checker)
- [ ] Manual testing with real conversations to verify AI tone and behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)