### PR TITLE
Fix invitation accept error rendering when backend returns structured errors

### DIFF
--- a/website/lib/api.ts
+++ b/website/lib/api.ts
@@ -19,7 +19,22 @@ export interface InvitationDetails {
 export interface ApiResponse<T> {
   success: boolean;
   data?: T;
-  error?: string;
+  error?: string | { code?: string; message?: string; details?: unknown };
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (typeof error === "string" && error.trim()) {
+    return error;
+  }
+
+  if (error && typeof error === "object") {
+    const message = "message" in error ? error.message : null;
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+
+  return fallback;
 }
 
 /**
@@ -68,7 +83,10 @@ export async function acceptInvitation(
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || "Failed to accept invitation" };
+      return {
+        success: false,
+        error: getErrorMessage(data.error, "Failed to accept invitation"),
+      };
     }
 
     return { success: true, sessionId: data.data?.session?.id };


### PR DESCRIPTION
### Motivation
- The invitation accept flow could receive structured error objects from the backend which were forwarded directly into UI state and then rendered, causing React to crash with an "objects are not valid as a React child" runtime invariant.
- The intent of the change is to normalize API error payloads into a safe string so the invitation page can show a readable message instead of crashing.
- This also makes the client resilient to both string and object-shaped `error` fields from the backend while preserving the existing behavior for other responses.

### Description
- Widened `ApiResponse.error` in `website/lib/api.ts` to accept either a `string` or an object with `{ code?, message?, details? }`.
- Added a `getErrorMessage(error, fallback)` helper that extracts a safe user-visible string from either a string or object-shaped error.
- Applied the helper to `acceptInvitation(...)` so it always returns a string `error` message on failure and no longer forwards raw objects to the UI.

### Testing
- Ran the TypeScript check with `npm --workspace website run check` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69add74e8adc8330b982576d069f72a0)