### PR TITLE
fix: use WebBrowser for meetwithoutfear.com URLs on mobile

### DIFF
--- a/mobile/app/(auth)/settings/help.tsx
+++ b/mobile/app/(auth)/settings/help.tsx
@@ -14,6 +14,7 @@ import {
   Alert,
 } from 'react-native';
 import { Stack } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
 import {
   HelpCircle,
   MessageCircle,
@@ -61,9 +62,7 @@ export default function HelpSupportScreen() {
   };
 
   const handleOpenDocs = () => {
-    Linking.openURL('https://meetwithoutfear.com/docs').catch(() => {
-      Alert.alert('Error', 'Could not open documentation');
-    });
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/docs');
   };
 
   const handleFeedback = () => {

--- a/mobile/app/(auth)/settings/privacy.tsx
+++ b/mobile/app/(auth)/settings/privacy.tsx
@@ -12,10 +12,9 @@ import {
   ScrollView,
   Switch,
   TouchableOpacity,
-  Linking,
-  Alert,
 } from 'react-native';
 import { Stack } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
 import { Shield, Eye, Users, FileText, ExternalLink } from 'lucide-react-native';
 import { colors } from '@/src/theme';
 
@@ -27,17 +26,11 @@ export default function PrivacySettingsScreen() {
   const [shareAnonymousAnalytics, setShareAnonymousAnalytics] = useState(true);
 
   const handlePrivacyPolicyPress = () => {
-    // Open privacy policy in browser
-    Linking.openURL('https://meetwithoutfear.com/privacy').catch(() => {
-      Alert.alert('Error', 'Could not open privacy policy');
-    });
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/privacy');
   };
 
   const handleTermsPress = () => {
-    // Open terms of service in browser
-    Linking.openURL('https://meetwithoutfear.com/terms').catch(() => {
-      Alert.alert('Error', 'Could not open terms of service');
-    });
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/terms');
   };
 
   return (

--- a/mobile/app/(public)/index.tsx
+++ b/mobile/app/(public)/index.tsx
@@ -1,5 +1,6 @@
-import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView, Linking } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
 import { useRouter } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
 import { colors } from '@/theme';
 import { Logo } from '@/src/components';
 
@@ -15,11 +16,11 @@ export default function WelcomeScreen() {
   };
 
   const handleTerms = () => {
-    Linking.openURL('https://meetwithoutfear.com/terms');
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/terms');
   };
 
   const handlePrivacy = () => {
-    Linking.openURL('https://meetwithoutfear.com/privacy');
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/privacy');
   };
 
   return (


### PR DESCRIPTION
## Changes
- Fix: Replace `Linking.openURL` with `WebBrowser.openBrowserAsync` for all `meetwithoutfear.com` URLs in the mobile app
- Fix: Resolves iOS universal link interception that prevented terms/privacy/docs pages from opening (Sentry MWF-MOBILE-1, 42 events, 4 users)
- Update: `mobile/app/(public)/index.tsx` — terms and privacy links on welcome screen
- Update: `mobile/app/(auth)/settings/privacy.tsx` — terms and privacy links in settings
- Update: `mobile/app/(auth)/settings/help.tsx` — docs link in help screen (preventive)

Related to #28

## Root Cause
`meetwithoutfear.com` is registered as a universal links domain via `associatedDomains` in `app.json`. On iOS, this causes the system to intercept `Linking.openURL` calls for this domain and route them back into the app, which fails because there are no in-app routes for `/terms`, `/privacy`, or `/docs`. `WebBrowser.openBrowserAsync` opens an in-app SFSafariViewController that bypasses universal link routing entirely. `expo-web-browser` was already installed.

## Provenance
- **Channel:** GitHub issue
- **Requested by:** health-check bot (via Sentry)
- **Original message:** Sentry MWF-MOBILE-1 — 42 occurrences of "Unable to open URL: https://meetwithoutfear.com/terms"

## Docs updated
No doc changes needed — the changed files have no entries in `code-to-docs-mapping.json`