### PR TITLE
ci: add GitHub Actions CI + Render deploy hook, switch render build to npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'backend/**'
+              - 'mobile/**'
+              - 'shared/**'
+              - 'e2e/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
+
+  ci:
+    name: Checks & Tests
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: meetwithoutfear_user
+          POSTGRES_PASSWORD: meetwithoutfear_password
+          POSTGRES_DB: meetwithoutfear_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://meetwithoutfear_user:meetwithoutfear_password@localhost:5432/meetwithoutfear_test
+      SHADOW_DATABASE_URL: postgresql://meetwithoutfear_user:meetwithoutfear_password@localhost:5432/meetwithoutfear_test_shadow
+      NODE_ENV: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Prisma engines
+        uses: actions/cache@v4
+        with:
+          path: |
+            backend/node_modules/.prisma
+            ~/.cache/prisma
+          key: ${{ runner.os }}-prisma-${{ hashFiles('backend/prisma/schema.prisma') }}
+          restore-keys: |
+            ${{ runner.os }}-prisma-
+
+      - name: Generate Prisma client
+        run: npm run prisma:generate --workspace=backend
+        env:
+          PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING: 1
+
+      - name: Run checks (lint & type-check)
+        run: npm run check
+
+      - name: Run database migrations
+        run: npx prisma migrate deploy --schema=backend/prisma/schema.prisma
+
+      - name: Run tests
+        run: npm run test
+
+  # Gate job for branch protection — always runs, fails if any real job failed.
+  # Set this as the required status check instead of the individual jobs.
+  ci-success:
+    name: CI Result
+    if: always()
+    needs: [changes, ci]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all checks passed
+        run: |
+          echo "changes: ${{ needs.changes.result }}"
+          echo "ci:      ${{ needs.ci.result }}"
+
+          # Allowlist: only 'success' and 'skipped' are acceptable.
+          # Catches 'failure', 'cancelled', and any unexpected state.
+          for result in \
+            "${{ needs.changes.result }}" \
+            "${{ needs.ci.result }}"; do
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "::error::Job returned unexpected result: $result"
+              exit 1
+            fi
+          done
+          echo "All checks passed (or were correctly skipped)"

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,49 @@
+name: Render Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: render-deploy-${{ github.sha }}
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        # workflow_dispatch should always deploy
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'shared/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'render.yaml'
+              - '.github/workflows/render-deploy.yml'
+
+  deploy:
+    name: Deploy meet-without-fear-api
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render deploy
+        run: |
+          if [ -z "${{ secrets.RENDER_DEPLOY_HOOK }}" ]; then
+            echo "::error::RENDER_DEPLOY_HOOK secret is not set. Create a deploy hook on the meet-without-fear-api service in the Render dashboard and add the URL as a repo secret."
+            exit 1
+          fi
+          curl -fsS -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -64,19 +64,29 @@ Build profiles are defined in `mobile/eas.json`. Most profiles set `EXPO_PUBLIC_
 
 ## CI/CD Pipeline
 
-GitHub Actions runs on every push to `main` and every pull request targeting `main`. The workflow is defined in `.github/workflows/ci.yml`.
+Two GitHub Actions workflows split the concerns:
+
+### `.github/workflows/ci.yml` — tests on PRs
+Runs on every PR targeting `main`. Short-circuited via `dorny/paths-filter` when only docs or unrelated files change.
 
 **Steps:**
 
-1. Starts a PostgreSQL 16 service container (health-checked with `pg_isready`)
-2. Checks out the repository and sets up Node.js 20 with npm caching
-3. Installs dependencies (`npm ci`)
-4. Generates the Prisma client (`npx prisma generate` in `backend/`)
-5. Runs database migrations (`npx prisma migrate deploy` in `backend/`)
-6. Runs type checking across all workspaces (`npm run check`)
-7. Runs tests across all workspaces (`npm run test`)
+1. Starts a PostgreSQL 15 service container (health-checked with `pg_isready`).
+2. Checks out the repository and sets up Node.js 20 with npm caching.
+3. Installs dependencies (`npm ci`).
+4. Generates the Prisma client (`npm run prisma:generate --workspace=backend`, with `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1`).
+5. Runs type checking across all workspaces (`npm run check`).
+6. Runs database migrations (`npx prisma migrate deploy --schema=backend/prisma/schema.prisma`).
+7. Runs tests across all workspaces (`npm run test`).
 
-The pipeline uses a dedicated test database (`meetwithoutfear_test`) with `NODE_ENV=test`. All steps must pass before a PR can be merged.
+A gate job (`ci-success`) rolls the individual jobs up — set that as the single required status check for branch protection.
+
+The pipeline uses a dedicated test database (`meetwithoutfear_test`) with `NODE_ENV=test`.
+
+### `.github/workflows/render-deploy.yml` — explicit deploys on main
+Runs on push to `main`. A `dorny/paths-filter` step restricts deploys to pushes that actually change `backend/`, `shared/`, the lockfile, `render.yaml`, or the workflow itself. On a match, the workflow `curl -X POST`s the Render **deploy hook** stored in repo secret `RENDER_DEPLOY_HOOK`.
+
+> Render's built-in "auto-deploy on push" must be **off** for the `meet-without-fear-api` service — GitHub Actions is the only deploy trigger. This prevents docs-only pushes from rebuilding the backend.
 
 ## Key Environment Variables
 

--- a/docs/deployment/render-config.md
+++ b/docs/deployment/render-config.md
@@ -19,7 +19,7 @@ services:
     runtime: node
     plan: starter
     branch: main
-    buildCommand: npm install && npm run prisma:generate --workspace=backend && npm run build --workspace=backend
+    buildCommand: npm ci && npm run prisma:generate --workspace=backend && npm run build --workspace=backend
     startCommand: cd backend && npx prisma migrate deploy && node dist/backend/src/server.js
     envVars:
       - fromGroup: meet-without-fear-api-env
@@ -28,11 +28,12 @@ services:
 ### Key facts from this blueprint
 
 - **Service name**: `meet-without-fear-api` (hyphens, not camelCase)
-- **Monorepo-aware build**: Both `prisma:generate` and `build` use `--workspace=backend` so the root-level `npm install` works across the full monorepo
+- **Monorepo-aware build**: Both `prisma:generate` and `build` use `--workspace=backend`; `npm ci` runs at the repo root so the full monorepo's `node_modules` is hydrated from `package-lock.json`. Using `npm ci` (rather than `npm install`) guarantees a clean, lockfile-strict install so Render's build cache can't mask stale transitive dependencies between deploys.
 - **Migrations auto-run on every deploy**: `startCommand` runs `npx prisma migrate deploy` from inside `backend/` before starting the server — there is no separate manual migration step
 - **Entry point**: `dist/backend/src/server.js` (nested under `backend/dist/` because TS compiles from the repo root)
 - **Env group**: All secrets (DB URL, Clerk keys, Bedrock credentials, Ably, Resend, etc.) live in the Render env group `meet-without-fear-api-env` — update them in the Render dashboard; the blueprint just wires the whole group into the service via `fromGroup`
 - **Database**: managed separately as a Render Postgres instance (not declared in this `render.yaml`); connection string is injected into the env group
+- **Auto-deploy disabled**: Render's built-in "auto-deploy on push" should be turned OFF for this service. Deploys are instead triggered by the GitHub Actions workflow `.github/workflows/render-deploy.yml`, which fires the service's deploy hook only when `backend/`, `shared/`, `package-lock.json`, or `render.yaml` actually changed. This prevents docs-only pushes from rebuilding the backend.
 
 ## Database Setup
 

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     runtime: node
     plan: starter
     branch: main
-    buildCommand: npm install && npm run prisma:generate --workspace=backend && npm run build --workspace=backend
+    buildCommand: npm ci && npm run prisma:generate --workspace=backend && npm run build --workspace=backend
     startCommand: cd backend && npx prisma migrate deploy && node dist/backend/src/server.js
     envVars:
       - fromGroup: meet-without-fear-api-env


### PR DESCRIPTION
## Summary

- Ports lovely's two-workflow pattern so PR tests gate merges and backend deploys only fire when backend code actually changes.
- `.github/workflows/ci.yml` — Postgres service + `npm ci` + Prisma + `check` + `test` on PRs, with a `ci-success` gate job for branch protection.
- `.github/workflows/render-deploy.yml` — on push to `main`, curls `RENDER_DEPLOY_HOOK` only when `backend/`, `shared/`, the lockfile, or `render.yaml` changed.
- `render.yaml` — switch build command from `npm install` to `npm ci` so lockfile drift can't hide transitive deps (fixes the current `@prisma/config` → missing `effect` build failure).
- Updated `docs/deployment/{index,render-config}.md` to match.

Docs-only pushes (like the whole docs-verification sweep on main) will no longer rebuild the backend after this merges and the Render auto-deploy is turned off.

## Switchover checklist (operator, after merge)

- [ ] In the Render dashboard, **create a Deploy Hook** on the `meet-without-fear-api` service (Settings → Deploy Hooks → Create Deploy Hook). Copy the URL.
- [ ] In GitHub repo settings → Secrets → Actions, add `RENDER_DEPLOY_HOOK` = that URL.
- [ ] In the Render dashboard, **turn off "Auto-Deploy"** on `meet-without-fear-api` (Settings → Build & Deploy). Otherwise every push will deploy twice — once via Render's hook, once via GitHub.
- [ ] Trigger a manual run of **Render Deploy** via GitHub Actions → Run workflow to smoke-test the hook end-to-end (and to kick the cache-refresh so `npm ci` catches up).
- [ ] (Optional) Add `CI Result` as a required status check on `main` in branch protection.

## Test plan

- [ ] PR smoke test: open this PR; verify the new `CI Result` status appears on the PR and passes.
- [ ] Deploy smoke test: after merge, push a no-op commit that touches `backend/` and confirm a Render deploy fires; push a doc-only commit and confirm it does **not**.
- [ ] Stale-cache fix: confirm the first successful Render deploy after this merge completes without the `Cannot find module '.../effect/dist/cjs/index.js'` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)