### PR TITLE
Route #bugs-and-requests Slack channel to slack-triage

### DIFF
--- a/bot-workspaces/CLAUDE.md
+++ b/bot-workspaces/CLAUDE.md
@@ -8,6 +8,7 @@ Route each bot job to its workspace and entry stage. The workspace `CLAUDE.md` (
 |---|---|---|
 | `dm-reply` | `slack-triage/` | `1-fetch-and-classify` |
 | `slam-bot-reply` | `slack-triage/` | `1-fetch-and-classify` |
+| `bugs-and-requests-reply` | `slack-triage/` | `1-fetch-and-classify` |
 | `respond-github` | `github-respond/` | `respond` |
 | `review-pr` | `github-respond/` | `review` |
 | `fix-bugs` | `bug-fix/` | `01-select` |

--- a/bot-workspaces/expected-routes.json
+++ b/bot-workspaces/expected-routes.json
@@ -9,6 +9,10 @@
       "workspace": "slack-triage",
       "firstStage": "1-fetch-and-classify"
     },
+    "bugs-and-requests-reply": {
+      "workspace": "slack-triage",
+      "firstStage": "1-fetch-and-classify"
+    },
     "respond-github-*": {
       "workspace": "github-respond",
       "firstStage": "respond"

--- a/bot-workspaces/slack-triage/CLAUDE.md
+++ b/bot-workspaces/slack-triage/CLAUDE.md
@@ -1,6 +1,6 @@
 # Slack Triage Workspace (L1)
 
-Triage actionable messages from any Slack channel (DMs, #pmf1, #agentic-devs, #slam-bot). Classify each message and dispatch the appropriate action. **All substantive work must flow through GitHub issues with `bot:*` labels** — Slack is an intake channel, GitHub is where work happens visibly.
+Triage actionable messages from any Slack channel (DMs, #pmf1, #agentic-devs, #slam-bot, #bugs-and-requests). Classify each message and dispatch the appropriate action. **All substantive work must flow through GitHub issues with `bot:*` labels** — Slack is an intake channel, GitHub is where work happens visibly.
 
 ## What to Load
 
@@ -50,6 +50,11 @@ Adapt tone based on the source channel:
 - Treat every message like a DM — route through the full workspace tree
 - Technical detail is fine (team members watching)
 - Be concise and actionable
+
+**#bugs-and-requests** — Product-team intake for bugs and feature requests. Readers are testing the product, not engineers.
+- Keep it non-technical: no file paths, function names, stack traces
+- Acknowledge the report, link to the GitHub issue you filed
+- Warm and brief — mirror #pmf1 tone
 
 **DMs** — Direct conversation with a team member.
 - Match their tone and technical level

--- a/scripts/ec2-bot/configure-slack.sh
+++ b/scripts/ec2-bot/configure-slack.sh
@@ -13,8 +13,9 @@ echo
 
 read -rsp "Bot User OAuth Token (xoxb-...): " SLACK_BOT_TOKEN; echo
 read -rsp "App-Level Token (xapp-...):      " SLACK_APP_TOKEN; echo
-read -rp  "DM channel ID (D...):            " SHANTAM_SLACK_DM
-read -rp  "#slam-bot channel ID (C...):     " SLAM_BOT_CHANNEL_ID
+read -rp  "DM channel ID (D...):                " SHANTAM_SLACK_DM
+read -rp  "#slam-bot channel ID (C...):         " SLAM_BOT_CHANNEL_ID
+read -rp  "#bugs-and-requests channel ID (C...):" BUGS_AND_REQUESTS_CHANNEL_ID
 
 [[ "$SLACK_BOT_TOKEN" == xoxb-* ]] || { echo "ERROR: bot token should start with xoxb-"; exit 1; }
 [[ "$SLACK_APP_TOKEN" == xapp-* ]] || { echo "ERROR: app token should start with xapp-"; exit 1; }
@@ -39,6 +40,7 @@ SLACK_APP_TOKEN=$SLACK_APP_TOKEN
 SLAM_BOT_USER_ID=$SLAM_BOT_USER_ID
 SHANTAM_SLACK_DM=$SHANTAM_SLACK_DM
 SLAM_BOT_CHANNEL_ID=$SLAM_BOT_CHANNEL_ID
+BUGS_AND_REQUESTS_CHANNEL_ID=$BUGS_AND_REQUESTS_CHANNEL_ID
 ENV
 
 scp -q "$TMP" slam-bot:/tmp/slack-env.new
@@ -47,7 +49,7 @@ shred -u "$TMP" 2>/dev/null || rm -f "$TMP"
 ssh slam-bot bash <<'REMOTE'
 set -e
 # Strip any prior Slack keys from existing .env, then append the new ones
-grep -vE '^(SLACK_BOT_TOKEN|SLACK_APP_TOKEN|SLAM_BOT_USER_ID|SHANTAM_SLACK_DM|SLAM_BOT_CHANNEL_ID)=' /opt/slam-bot/.env > /tmp/.env.base 2>/dev/null || touch /tmp/.env.base
+grep -vE '^(SLACK_BOT_TOKEN|SLACK_APP_TOKEN|SLAM_BOT_USER_ID|SHANTAM_SLACK_DM|SLAM_BOT_CHANNEL_ID|BUGS_AND_REQUESTS_CHANNEL_ID)=' /opt/slam-bot/.env > /tmp/.env.base 2>/dev/null || touch /tmp/.env.base
 cat /tmp/.env.base /tmp/slack-env.new > /opt/slam-bot/.env
 chmod 600 /opt/slam-bot/.env
 rm -f /tmp/.env.base /tmp/slack-env.new

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -23,6 +23,7 @@
  *   PMF1_CHANNEL_ID       — Channel ID for #pmf1
  *   AGENTIC_DEVS_CHANNEL_ID — Channel ID for the #agentic-devs channel
  *   SLAM_BOT_CHANNEL_ID — Channel ID for the #slam-bot channel
+ *   BUGS_AND_REQUESTS_CHANNEL_ID — Channel ID for the #bugs-and-requests channel
  */
 
 import { SocketModeClient } from '@slack/socket-mode';
@@ -41,6 +42,7 @@ const BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
 const BOT_USER_ID = process.env.SLAM_BOT_USER_ID;
 const SHANTAM_DM = process.env.SHANTAM_SLACK_DM;
 const SLAM_BOT_CHANNEL = process.env.SLAM_BOT_CHANNEL_ID;
+const BUGS_AND_REQUESTS_CHANNEL = process.env.BUGS_AND_REQUESTS_CHANNEL_ID;
 
 if (!APP_TOKEN || !BOT_TOKEN || !BOT_USER_ID) {
   console.error('Missing required env vars: SLACK_APP_TOKEN, SLACK_BOT_TOKEN, SLAM_BOT_USER_ID');
@@ -129,6 +131,17 @@ if (SLAM_BOT_CHANNEL) {
     logName: 'check-slam-bot',
     channelName: '#slam-bot',
     commandSlug: 'slam-bot-reply',
+    workspace: 'slack-triage',
+    contextCount: 10,
+  };
+}
+
+// #bugs-and-requests channel — product-team intake for bugs and feature requests
+if (BUGS_AND_REQUESTS_CHANNEL) {
+  CHANNEL_CONFIG[BUGS_AND_REQUESTS_CHANNEL] = {
+    logName: 'check-bugs-and-requests',
+    channelName: '#bugs-and-requests',
+    commandSlug: 'bugs-and-requests-reply',
     workspace: 'slack-triage',
     contextCount: 10,
   };


### PR DESCRIPTION
## Summary

- Wire `#bugs-and-requests` into slam-bot's Socket Mode listener so messages get routed to the `slack-triage` workspace (same path as `#slam-bot` and DMs)
- Extend `configure-slack.sh` to prompt for the new channel ID and persist it to `/opt/slam-bot/.env`
- Add `#bugs-and-requests` tone guidance to the slack-triage workspace (defaulted to product-team / non-technical like `#pmf1`)
- Register the `bugs-and-requests-reply` command slug in the routing table and audit registry

## Activation steps (after merge)

1. `/invite @slam-bot` in `#bugs-and-requests`
2. Grab the channel ID from Slack (header → bottom of About)
3. Re-run `bash scripts/ec2-bot/configure-slack.sh` from local (re-prompts all Slack values + restarts `slam-bot-socket`), **or** SSH in and append `BUGS_AND_REQUESTS_CHANNEL_ID=C…` to `/opt/slam-bot/.env` and `sudo systemctl restart slam-bot-socket`
4. Smoke test by posting in `#bugs-and-requests` — expect 👀 → ✅ reactions + threaded reply

## Test plan

- [ ] After deployment, post a bug-style message in `#bugs-and-requests` and confirm a GitHub issue is filed with `bot:bug` label and a threaded reply appears
- [ ] Post a feature-style message and confirm `bot:feature` issue + threaded reply
- [ ] Post an "ok thanks" / observation and confirm the bot only reacts (no issue, no reply)
- [ ] Confirm tone is non-technical (no file paths / function names in replies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)