### PR TITLE
feat: add Slack thread routing for #mwf-sessions channel

### DIFF
--- a/bot-workspaces/CLAUDE.md
+++ b/bot-workspaces/CLAUDE.md
@@ -9,6 +9,7 @@ Route each bot job to its workspace and entry stage. The workspace `CLAUDE.md` (
 | `dm-reply` | `slack-triage/` | `1-fetch-and-classify` |
 | `slam-paws-reply` | `slack-triage/` | `1-fetch-and-classify` |
 | `bugs-and-requests-reply` | `slack-triage/` | `1-fetch-and-classify` |
+| `mwf-session-reply` | `mwf-session/` | `0-onboarding` |
 | `respond-github` | `github-respond/` | `respond` |
 | `review-pr` | `github-respond/` | `review` |
 | `fix-bugs` | `bug-fix/` | `01-select` |

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -24,6 +24,7 @@
  *   AGENTIC_DEVS_CHANNEL_ID — Channel ID for the #agentic-devs channel
  *   SLAM_BOT_CHANNEL_ID — Channel ID for the #slam-paws channel
  *   BUGS_AND_REQUESTS_CHANNEL_ID — Channel ID for the #bugs-and-requests channel
+ *   MWF_SESSIONS_CHANNEL_ID — Channel ID for the #mwf-sessions channel
  */
 
 import { SocketModeClient } from '@slack/socket-mode';
@@ -43,6 +44,7 @@ const BOT_USER_ID = process.env.SLAM_BOT_USER_ID;
 const SHANTAM_DM = process.env.SHANTAM_SLACK_DM;
 const SLAM_BOT_CHANNEL = process.env.SLAM_BOT_CHANNEL_ID;
 const BUGS_AND_REQUESTS_CHANNEL = process.env.BUGS_AND_REQUESTS_CHANNEL_ID;
+const MWF_SESSIONS_CHANNEL = process.env.MWF_SESSIONS_CHANNEL_ID;
 
 if (!APP_TOKEN || !BOT_TOKEN || !BOT_USER_ID) {
   console.error('Missing required env vars: SLACK_APP_TOKEN, SLACK_BOT_TOKEN, SLAM_BOT_USER_ID');
@@ -147,8 +149,19 @@ if (BUGS_AND_REQUESTS_CHANNEL) {
   };
 }
 
+// #mwf-sessions channel — MWF test session threads
+if (MWF_SESSIONS_CHANNEL) {
+  CHANNEL_CONFIG[MWF_SESSIONS_CHANNEL] = {
+    logName: 'check-mwf-sessions',
+    channelName: '#mwf-sessions',
+    commandSlug: 'mwf-session-reply',
+    workspace: 'mwf-session',
+    contextCount: 10,
+  };
+}
+
 // ---------------------------------------------------------------------------
-// All channels now use workspace mode (slack-triage). The workspace CLAUDE.md
+// All channels now use workspace mode. The workspace CLAUDE.md
 // provides classification + dispatch; the prompt provides the specific message.
 // Channel-specific tone is handled by the workspace based on channelName.
 


### PR DESCRIPTION
## Changes
- Add `MWF_SESSIONS_CHANNEL_ID` env var and `CHANNEL_CONFIG` entry in `socket-listener.mjs` routing `#mwf-sessions` to the `mwf-session` workspace
- Add `mwf-session-reply` job slug to the L0 routing table in `bot-workspaces/CLAUDE.md`
- Channel config follows the existing pattern: workspace mode dispatch with thread-aware session continuity

Related to #37

## Activation steps
1. Create `#mwf-sessions` channel in Slack
2. Set `MWF_SESSIONS_CHANNEL_ID=<channel-id>` in the EC2 bot `.env` file
3. Restart `slam-bot-socket.service`

## Dependencies
- **PR #39** (issue #35) creates the `mwf-session/` workspace directory with stage contracts. This PR provides the socket-listener plumbing; PR #39 provides the workspace it routes to. Both are needed for end-to-end functionality.

## Provenance
- **Channel:** GitHub issue
- **Requested by:** bot pipeline (issue #37, label `bot:pr`)
- **Original message:** Issue #37 — "Build Slack thread routing for MWF test sessions"

## Docs updated
No doc changes needed — the infrastructure doc describes the socket-listener system generically and doesn't list individual channels.