### PR TITLE
feat: add Slack thread routing and mwf-session workspace

### DIFF
--- a/bot-workspaces/CLAUDE.md
+++ b/bot-workspaces/CLAUDE.md
@@ -9,6 +9,7 @@ Route each bot job to its workspace and entry stage. The workspace `CLAUDE.md` (
 | `dm-reply` | `slack-triage/` | `1-fetch-and-classify` |
 | `slam-paws-reply` | `slack-triage/` | `1-fetch-and-classify` |
 | `bugs-and-requests-reply` | `slack-triage/` | `1-fetch-and-classify` |
+| `mwf-session-reply` | `mwf-session/` | `route` |
 | `respond-github` | `github-respond/` | `respond` |
 | `review-pr` | `github-respond/` | `review` |
 | `fix-bugs` | `bug-fix/` | `01-select` |

--- a/bot-workspaces/mwf-session/CLAUDE.md
+++ b/bot-workspaces/mwf-session/CLAUDE.md
@@ -1,0 +1,59 @@
+# MWF Session Workspace (L1)
+
+Thread-based MWF conversation workspace. Each Slack thread in `#mwf-sessions` is one conversation session. The bot guides users through the five MWF conversation stages (0-4) using session continuity (`--session` / `--resume`).
+
+## How It Works
+
+1. **Thread = session**: The socket-listener routes `#mwf-sessions` messages here with thread-scoped sessions. Claude resumes the full conversation history on each reply.
+2. **Stage detection**: On each message, determine the current stage from the conversation so far. New threads start at Stage 0.
+3. **Stage behavior**: Apply the appropriate stage's Process Guardian behavior (tone, goals, gate conditions).
+4. **Stage transitions**: When a stage's gate condition is met, announce the transition and begin the next stage's behavior.
+
+## Conversation Stages
+
+| Stage | Name | Gate Condition |
+|---|---|---|
+| 0 | Onboarding | User signs the Curiosity Compact (agrees to ground rules) |
+| 1 | The Witness | User confirms "I feel fully heard" |
+| 2 | Perspective Stretch | User feels accurately understood by their partner |
+| 3 | Need Mapping | At least one common-ground need identified |
+| 4 | Strategic Repair | Mutual agreement on a micro-experiment |
+
+## What to Load
+
+| Resource | When | Why |
+|---|---|---|
+| `stages/route/CONTEXT.md` | Always | Entry stage: detect current stage and apply behavior |
+| `docs/product/stages/index.md` | First message in thread | Understand stage progression rules |
+| `docs/product/concept.md` | First message in thread | MWF product philosophy |
+
+## What NOT to Load
+
+| Resource | Why |
+|---|---|
+| `docs/` wholesale | Only load stage docs as needed |
+| `shared/diagnostics/` | No diagnostic work in sessions |
+| `shared/github/` | Output goes to Slack thread, not GitHub |
+| Other workspace folders | Each invocation sees only its own workspace |
+| Backend source code | This workspace conducts conversations, not code changes |
+
+## Stage Progression
+
+1. `route` -- Detect current stage from conversation history, apply appropriate behavior
+
+This is a single-stage workspace. The `route` stage handles all messages by reading the session context and applying the correct stage behavior. There is no multi-stage pipeline -- the stage detection is inline.
+
+## Tone
+
+- Warm, empathetic, and non-judgmental
+- Match the user's emotional register
+- Never rush through stages -- hold space
+- Use Slack mrkdwn (`*bold*`, bullet `*`)
+- Always reply in the thread, never as a new channel message
+
+## Safety
+
+1. Never share one user's private reflections with others
+2. Never diagnose, label, or pathologize
+3. If a user expresses distress, acknowledge it and suggest professional support
+4. Never post outside the thread

--- a/bot-workspaces/mwf-session/stages/route/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/route/CONTEXT.md
@@ -1,0 +1,66 @@
+# Stage: Route
+
+## Input
+
+- Slack message from `#mwf-sessions` thread (via prompt file)
+- Session history (via `--resume` if this is a thread reply)
+- Channel context (recent messages if this is a new thread)
+
+## Process
+
+1. **Detect current stage**: Review the conversation history from the session.
+   - If no prior conversation (new thread): this is **Stage 0 — Onboarding**.
+   - If prior conversation exists: identify the current stage from context. Look for:
+     - Stage transition markers you previously announced
+     - Whether gate conditions have been met
+     - The last stage-specific behavior you applied
+
+2. **Apply stage behavior**:
+
+   **Stage 0 — Onboarding**
+   - Welcome the user to MWF
+   - Explain the Curiosity Compact (ground rules for the conversation)
+   - Ask the user to agree to the compact before proceeding
+   - Gate: user agrees to the ground rules
+
+   **Stage 1 — The Witness**
+   - Listen deeply to the user's perspective on their conflict
+   - Reflect back what you hear without judgment
+   - Ask clarifying questions to understand their experience fully
+   - Do not rush — hold space for as long as needed
+   - Gate: user confirms they feel fully heard
+
+   **Stage 2 — Perspective Stretch**
+   - Guide the user to consider their conversation partner's perspective
+   - Help them build an "empathy guess" — what might the other person be feeling/needing?
+   - Gate: user feels they understand their partner's perspective (or chooses to proceed)
+
+   **Stage 3 — Need Mapping**
+   - Help identify underlying needs (not positions) for both parties
+   - Look for common ground — needs that both people share
+   - Gate: at least one common-ground need identified
+
+   **Stage 4 — Strategic Repair**
+   - Help design a small, concrete "micro-experiment" — one action to try
+   - The experiment should be low-risk, time-bounded, and testable
+   - Gate: user agrees to try the micro-experiment
+
+3. **Handle stage transitions**: When a gate condition is met:
+   - Acknowledge the milestone warmly
+   - Announce the transition (e.g., "Now that you feel heard, let's explore your partner's perspective...")
+   - Begin applying the next stage's behavior
+
+4. **Reply in thread**: Compose a response and post it as a Slack thread reply using `slack-post.sh`:
+   ```bash
+   SLACK_MCP_XOXB_TOKEN="$SLACK_MCP_XOXB_TOKEN" bash scripts/slack-post.sh "$CHANNEL" "$THREAD_TS" "Your message here"
+   ```
+   Use Slack mrkdwn formatting (not Markdown).
+
+## Output
+
+- A reply posted to the Slack thread
+- Stage progression tracked in the conversation session (Claude session state)
+
+## Completion
+
+This stage runs once per message. No multi-stage pipeline — each invocation handles one message and replies.

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -24,6 +24,7 @@
  *   AGENTIC_DEVS_CHANNEL_ID — Channel ID for the #agentic-devs channel
  *   SLAM_BOT_CHANNEL_ID — Channel ID for the #slam-paws channel
  *   BUGS_AND_REQUESTS_CHANNEL_ID — Channel ID for the #bugs-and-requests channel
+ *   MWF_SESSIONS_CHANNEL_ID — Channel ID for the #mwf-sessions channel
  */
 
 import { SocketModeClient } from '@slack/socket-mode';
@@ -43,6 +44,7 @@ const BOT_USER_ID = process.env.SLAM_BOT_USER_ID;
 const SHANTAM_DM = process.env.SHANTAM_SLACK_DM;
 const SLAM_BOT_CHANNEL = process.env.SLAM_BOT_CHANNEL_ID;
 const BUGS_AND_REQUESTS_CHANNEL = process.env.BUGS_AND_REQUESTS_CHANNEL_ID;
+const MWF_SESSIONS_CHANNEL = process.env.MWF_SESSIONS_CHANNEL_ID;
 
 if (!APP_TOKEN || !BOT_TOKEN || !BOT_USER_ID) {
   console.error('Missing required env vars: SLACK_APP_TOKEN, SLACK_BOT_TOKEN, SLAM_BOT_USER_ID');
@@ -147,8 +149,19 @@ if (BUGS_AND_REQUESTS_CHANNEL) {
   };
 }
 
+// #mwf-sessions channel — MWF test session threads
+if (MWF_SESSIONS_CHANNEL) {
+  CHANNEL_CONFIG[MWF_SESSIONS_CHANNEL] = {
+    logName: 'check-mwf-sessions',
+    channelName: '#mwf-sessions',
+    commandSlug: 'mwf-session-reply',
+    workspace: 'mwf-session',
+    contextCount: 10,
+  };
+}
+
 // ---------------------------------------------------------------------------
-// All channels now use workspace mode (slack-triage). The workspace CLAUDE.md
+// All channels now use workspace mode. The workspace CLAUDE.md
 // provides classification + dispatch; the prompt provides the specific message.
 // Channel-specific tone is handled by the workspace based on channelName.
 


### PR DESCRIPTION
## Changes
- Add: `MWF_SESSIONS_CHANNEL_ID` env var and `CHANNEL_CONFIG` entry in `socket-listener.mjs` routing `#mwf-sessions` to the `mwf-session` workspace
- Add: `mwf-session-reply` job slug to the L0 routing table in `bot-workspaces/CLAUDE.md`
- Add: `bot-workspaces/mwf-session/` workspace with L1 `CLAUDE.md` defining stage-aware routing (stages 0-4)
- Add: `stages/route/CONTEXT.md` entry stage that detects conversation stage from session history and applies appropriate Process Guardian behavior

Related to #37

Supersedes #40 (which covered only the socket-listener and L0 routing changes without the workspace)

## Activation steps
1. Create `#mwf-sessions` channel in Slack
2. Set `MWF_SESSIONS_CHANNEL_ID=<channel-id>` in the EC2 bot `.env` file
3. Restart `slam-bot-socket.service`

## Provenance
- **Channel:** GitHub issue
- **Requested by:** bot pipeline (issue #37, label `bot:pr`)
- **Original message:** Issue #37 — "Build Slack thread routing for MWF test sessions"

## Docs updated
No doc changes needed — the infrastructure doc describes the socket-listener system generically and doesn't list individual channels. The new workspace is self-documenting via its CLAUDE.md.