### PR TITLE
docs: fix drift from 24h incremental audit (2026-04-16)

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -3,7 +3,7 @@ title: Deployment
 sidebar_position: 1
 description: Production deployment targets and distribution options for the Meet Without Fear platform.
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-04-16
 status: living
 ---
 # Deployment
@@ -20,7 +20,7 @@ The Express API is deployed to Render.com as a web service. Configuration is def
 - **Runtime**: Node.js (20.x per `package.json` engines; `render.yaml` specifies `runtime: node`)
 - **Plan**: Starter
 - **Branch**: `main`
-- **Build command**: `npm install && npm run prisma:generate --workspace=backend && npm run build --workspace=backend`
+- **Build command**: `npm ci && npm run prisma:generate --workspace=backend && npm run build --workspace=backend`
 - **Start command**: `cd backend && npx prisma migrate deploy && node dist/backend/src/server.js`
 - **Environment variables**: Loaded from the `be-heard-api-env` environment group on Render
 

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -2,7 +2,7 @@
 title: Infrastructure
 sidebar_position: 1
 description: Slam bot (EC2), Render hosting, Vercel deploys, GitHub automation.
-updated: 2026-04-15
+updated: 2026-04-16
 ---
 
 # Infrastructure
@@ -12,6 +12,7 @@ Operational infrastructure for Meet Without Fear.
 ## Slam Bot (autonomous agent on EC2)
 
 - Runs on a t3.medium EC2 instance in us-west-2, tagged `slam-bot`.
+- **Display name**: "Slam Paws" (in Slack and GitHub). System paths (`/opt/slam-bot/`) retain the original name for backward compatibility.
 - GitHub identity: `slam-paws` (collaborator on `shantamg/meet-without-fear` with write access).
 - Scripts at `/opt/slam-bot/scripts` (symlink to `~/meet-without-fear/scripts/ec2-bot/scripts` on the box).
 - Workspaces at `~/meet-without-fear/bot-workspaces/` with a router (`CLAUDE.md`) + label registry (`label-registry.json`).
@@ -49,7 +50,7 @@ Local operator scripts live at `scripts/ec2-bot/`:
 | `provision.sh` | One-shot AWS provisioning (security group, EIP, instance, SSH config entry) |
 | `setup.sh` | First-time bootstrap of a fresh instance (Node, gh, claude, directories) |
 | `deploy.sh` | Symlink scripts, install systemd units + crontab + logrotate |
-| `configure-slack.sh` | Write Slack tokens + channel IDs to `/opt/slam-bot/.env` and start the socket service |
+| `configure-slack.sh` | Write Slack tokens + channel IDs (including `BUGS_AND_REQUESTS_CHANNEL_ID` for `#bugs-and-requests`) to `/opt/slam-bot/.env` and start the socket service |
 | `configure-mixpanel.sh` | Write Mixpanel service-account credentials |
 | `configure-db.sh` | Create/rotate `slam_bot_readonly` role on the Render Postgres |
 
@@ -65,3 +66,5 @@ See [deployment](../deployment/index.md) for release procedures and env var refe
 ## GitHub workflows
 
 - `.github/workflows/docs-impact.yml` — PR-time check that code changes and their mapped docs are updated together. Mapping rules in `docs/code-to-docs-mapping.json`.
+- `.github/workflows/ci.yml` — PR-time CI: spins up a Postgres 15 service container, installs deps (`npm ci`), generates the Prisma client, runs `npm run check`, migrates the test DB, and runs `npm run test`. Skipped for docs-only changes via `dorny/paths-filter`. A `ci-success` gate job is the single required status check for branch protection.
+- `.github/workflows/render-deploy.yml` — Push-to-`main` backend deploy: filters to pushes that touch `backend/`, `shared/`, the lockfile, `render.yaml`, or the workflow itself, then POSTs the Render deploy hook (stored in repo secret `RENDER_DEPLOY_HOOK`). Render's built-in auto-deploy must be **off** — this workflow is the sole deploy trigger.

--- a/docs/mobile/wireframes/index.md
+++ b/docs/mobile/wireframes/index.md
@@ -25,7 +25,14 @@ The mobile app ships an Inner Work hub alongside partner sessions. These surface
 - `NeedsAssessmentScreen` — "Am I OK?" self-assessment across the 19-need catalog
 - `KnowledgeBaseIndexScreen` / `KnowledgeBaseTopicScreen` — browse reflections by topic, person, theme
 
-> Some previously listed wireframes (Home Dashboard with hero card, Stage Controls, standalone Emotional Barometer UI, Authentication & First-Run, Notifications UX) don't correspond to screens that currently exist — the app consolidates stage UI inside `UnifiedSessionScreen`, and auth is handled entirely by the Clerk-provided UI. Those pages are omitted from this index rather than pointing at missing docs.
+### Settings
+Settings screens exist in the app but don't have dedicated wireframe docs yet. Refer to the components directly:
+- `app/(auth)/settings/` — Settings hub routing
+- `help.tsx` — FAQ, email support, feedback, documentation links
+- `privacy.tsx` — Visibility toggles, analytics opt-out, legal links (Terms/Privacy open via in-app browser)
+- `account.tsx` — Profile editing, data export, account deletion
+
+> Some previously listed wireframes (Home Dashboard with hero card, Stage Controls, standalone Emotional Barometer UI, Authentication & First-Run, Notifications UX, Curiosity Compact, Waiting Room) don't correspond to screens that currently exist — the app consolidates stage UI inside `UnifiedSessionScreen`, auth is handled entirely by the Clerk-provided UI, and the onboarding compact/waiting screens were removed. Those pages are omitted from this index rather than pointing at missing docs.
 
 ## Design Principles
 
@@ -54,11 +61,6 @@ flowchart TB
         NewSession[New Session Flow]
     end
 
-    subgraph Onboarding[Onboarding]
-        Compact[Curiosity Compact]
-        Wait[Waiting Room]
-    end
-
     subgraph Core[Core Experience]
         Chat[Chat Interface]
         Progress[Progress View]
@@ -74,8 +76,7 @@ flowchart TB
     Home --> PersonDetail
     Home --> NewSession
     PersonDetail --> SessionDash
-    SessionDash --> Onboarding
-    Onboarding --> Core
+    SessionDash --> Core
     Core --> Support
     Support --> Core
 ```


### PR DESCRIPTION
## Changes
- Fix: `docs/deployment/index.md` build command `npm install` → `npm ci` (matches render.yaml)
- Fix: `docs/infrastructure/index.md` — add `ci.yml` and `render-deploy.yml` workflow docs; clarify Slam Paws display name vs system paths; note `BUGS_AND_REQUESTS_CHANNEL_ID` in configure-slack.sh entry
- Fix: `docs/mobile/wireframes/index.md` — remove deleted Curiosity Compact + Waiting Room from flowchart; add Settings screens section (help, privacy, account)

## Provenance
- **Channel:** cron / audit-docs
- **Requested by:** automated nightly docs-audit
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs workspace → incremental stage

## Docs updated
- `docs/deployment/index.md`
- `docs/infrastructure/index.md`
- `docs/mobile/wireframes/index.md`