### PR TITLE
fix: stop retriggering workspaces waiting for human input

### DIFF
--- a/bot-workspaces/needs-info/stages/02-interview/CONTEXT.md
+++ b/bot-workspaces/needs-info/stages/02-interview/CONTEXT.md
@@ -30,12 +30,12 @@ Any other `gh` read call indicates a bug.
 1. **Read all issue comments** via `gh issue view <number> --comments`.
 2. **Find the most recent bot comment** and extract the metadata from its HTML comment tag.
 3. **Check for user responses** since the last bot comment:
-   - **User responded**: Analyze the response against graduation criteria.
+   - **User responded**: Analyze the response against graduation criteria. Remove waiting-human marker (see below).
      - If criteria met → proceed to stage 03 (graduate).
-     - If more info needed → post follow-up questions (max 2-3 per round), update metadata with incremented `questions_asked` and `last_response` timestamp.
-   - **No response, <24h since last bot comment**: Do nothing, exit.
-   - **No response, 24-72h**: Post a gentle nudge on the GitHub issue AND on the original Slack thread (see Slack follow-up below).
-   - **No response, >72h**: Add `stale` label, post a closing comment, remove `bot:needs-info` label. Exit.
+     - If more info needed → post follow-up questions (max 2-3 per round), update metadata with incremented `questions_asked` and `last_response` timestamp. Write waiting-human marker (see below).
+   - **No response, <24h since last bot comment**: Write waiting-human marker (see below), exit.
+   - **No response, 24-72h**: Post a gentle nudge on the GitHub issue AND on the original Slack thread (see Slack follow-up below). Write waiting-human marker (see below), exit.
+   - **No response, >72h**: Add `stale` label, post a closing comment, remove `bot:needs-info` label. Remove waiting-human marker (see below). Exit.
 4. **Update metadata** in each new bot comment:
    ```
    <!-- bot:needs-info-meta: {"questions_asked": N, "last_response": "<ISO>", "category": "<category>"} -->
@@ -69,6 +69,17 @@ When posting a 24h nudge, also notify the requester on the original Slack thread
 
    No rush, just reply here when you get a chance.
    ```
+
+## Waiting-Human Marker
+
+When exiting without a human response (all exit paths except graduation), write a marker file so the dispatcher skips this issue until a human responds. The pipeline-monitor (Check 7) clears it when a new human comment is detected.
+
+```bash
+# Write on exit without human response:
+date -Iseconds > "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+# Remove on graduation or stale closure:
+rm -f "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+```
 
 ## Completion
 

--- a/bot-workspaces/pipeline-monitor/stages/tick/CONTEXT.md
+++ b/bot-workspaces/pipeline-monitor/stages/tick/CONTEXT.md
@@ -137,8 +137,10 @@ For each issue found:
    gh api repos/shantamg/meet-without-fear/issues/$N/comments --paginate --jq 'sort_by(.created_at) | reverse | .[] | {user: .user.login, created_at: .created_at, bot: (.user.type == "Bot" or .user.login == "slam-paws" or .user.login == "github-actions[bot]")}' | head -20
    ```
 2. Find the most recent bot comment and the most recent non-bot comment.
-3. **If a non-bot user commented AFTER the bot's last comment**, the issue is unblocked — re-trigger the current workspace:
+3. **If a non-bot user commented AFTER the bot's last comment**, the issue is unblocked — clear the waiting-human marker and re-trigger the current workspace:
    ```bash
+   # Clear the waiting-human marker so the dispatcher will pick this up
+   rm -f "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${N}.txt"
    CURRENT_LABEL="bot:spec-builder"  # or whichever label the issue has
    gh issue edit $N --repo shantamg/meet-without-fear --remove-label "$CURRENT_LABEL"
    # Brief pause to ensure label removal is registered

--- a/bot-workspaces/spec-builder/CLAUDE.md
+++ b/bot-workspaces/spec-builder/CLAUDE.md
@@ -14,6 +14,9 @@ Determine the current stage from the meta tag in the latest bot comment. If no m
 | `shared/rubrics.md` | Stages 02-04 | Checklist rubrics for adaptive depth per stage |
 | `shared/draft-template.md` | Stages 01-05 | Spec draft structure and section headers |
 | `shared/commands.md` | Stages 02-04 | Slash-command vocabulary and validation rules |
+| `shared/slack/slack-post.md` | Stages 02-04 (question post) | Slack thread reply for DM notification |
+| `shared/references/slack-format.md` | Stages 02-04 (question post) | Slack mrkdwn formatting rules |
+| `.claude/config/services.json` | Stages 02-04 (question post) | Channel ID lookup |
 
 ## What NOT to Load
 
@@ -22,7 +25,7 @@ Determine the current stage from the meta tag in the latest bot comment. If no m
 | repo root source code | Workspace operates on issue comments, not app code (v1.1 adds sub-agent codebase research) |
 | `docs/` | Not needed for interview loop |
 | `shared/diagnostics/` | No diagnostic work involved |
-| `shared/slack/` | Output goes to GitHub, not Slack |
+| `shared/slack/` (wholesale) | Only load `slack-post.md` for DM notifications, not the full directory |
 | Other workspace stage files | Only read current stage CONTEXT.md |
 
 ## Stage Progression

--- a/bot-workspaces/spec-builder/stages/02-scope/CONTEXT.md
+++ b/bot-workspaces/spec-builder/stages/02-scope/CONTEXT.md
@@ -13,9 +13,9 @@
 1. **Read latest meta tag** from most recent bot comment. Verify `stage` is `scope`.
 2. **Check for slash commands** in the latest human comment (`/skip-to-technical`, `/publish-now`, `/pause`, `/restart-stage`). If found, handle per `shared/commands.md`.
 3. **Check staleness**:
-   - No human response and `last_human_response_at` > 72h ago and `nudge_sent` is false → post single-line nudge, set `nudge_sent: true`, exit.
-   - No human response and `last_human_response_at` > 7 days ago → post paused comment, remove `bot:spec-builder` label, record `abandoned_at_stage: scope`, exit.
-   - No human response and < 72h → do nothing, exit.
+   - No human response and `last_human_response_at` > 72h ago and `nudge_sent` is false → post single-line nudge, set `nudge_sent: true`, write waiting-human marker (see below), exit.
+   - No human response and `last_human_response_at` > 7 days ago → post paused comment, remove `bot:spec-builder` label, remove waiting-human marker, record `abandoned_at_stage: scope`, exit.
+   - No human response and < 72h → write waiting-human marker (see below), exit.
 4. **If human responded**: reset `nudge_sent` to false, update `last_human_response_at`.
 5. **Evaluate Scope rubric** against the current draft + latest human response:
    - `problem_statement`: clear problem defined? (`met | partial | missing`)
@@ -31,6 +31,42 @@
 - Meta tag updated with rubric status, round count, timestamps
 - Draft snapshot posted if content changed
 - Issue body updated if `draft_hash` changed
+
+## Waiting-Human Marker
+
+When exiting without a human response (the < 72h and nudge paths), write a marker file so the dispatcher skips this issue until a human responds. The pipeline-monitor (Check 7) clears it when a new human comment is detected.
+
+```bash
+date -Iseconds > "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+```
+
+When the issue is abandoned (7-day stale) or the label is removed, clean up the marker:
+```bash
+rm -f "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+```
+
+## Slack DM on Question Post
+
+When posting questions (step 7) and entering a waiting state, also notify the requester via Slack so they don't have to monitor GitHub.
+
+1. **Parse the issue body's Provenance block** for `Channel` and `Timestamp`. If either is missing, skip — not every issue originates from Slack.
+2. **Look up the channel ID** from `.claude/config/services.json` (`slack.channels.<name>`).
+3. **Post a thread reply** with the outstanding questions:
+   ```bash
+   ${SLAM_BOT_SCRIPTS:-/opt/slam-bot/scripts}/slack-post.sh \
+     --channel "$CHANNEL_ID" \
+     --text "$MESSAGE" \
+     --thread-ts "$THREAD_TS"
+   ```
+4. **Message format** — plain language, adapted to channel tone:
+   ```
+   Hey — I have a few questions on your spec before we can move forward:
+
+   • [Question 1]
+   • [Question 2]
+
+   You can reply here or on the GitHub issue.
+   ```
 
 ## Completion
 

--- a/bot-workspaces/spec-builder/stages/03-deepen/CONTEXT.md
+++ b/bot-workspaces/spec-builder/stages/03-deepen/CONTEXT.md
@@ -12,7 +12,7 @@
 
 1. **Read latest meta tag** from most recent bot comment. Verify `stage` is `deepen`.
 2. **Check for slash commands** in latest human comment. Handle per `shared/commands.md`.
-3. **Check staleness** (same 72h nudge / 7-day stale pattern as Scope).
+3. **Check staleness** (same 72h nudge / 7-day stale pattern as Scope, including waiting-human marker — see `02-scope/CONTEXT.md`).
 4. **If human responded**: reset `nudge_sent`, update `last_human_response_at`.
 5. **Evaluate Deepen rubric** against the current draft + latest human response:
    - `user_stories`: at least 2 user stories with "As a [role], I want [action], so that [benefit]" format? (`met | partial | missing`)
@@ -29,6 +29,21 @@
 - Meta tag updated with rubric status, round count, timestamps
 - Draft snapshot posted if content changed
 - Issue body updated if `draft_hash` changed
+
+## Waiting-Human Marker
+
+Same as `02-scope/CONTEXT.md`: write `waiting-human-${ISSUE_NUMBER}.txt` when exiting without a human response, remove it on stale/label removal.
+
+```bash
+# Write on exit without human response:
+date -Iseconds > "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+# Remove on stale/abandon:
+rm -f "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+```
+
+## Slack DM on Question Post
+
+Same as `02-scope/CONTEXT.md`: when posting questions (step 7), also notify the requester via Slack thread reply using the Provenance block's channel and timestamp. See `02-scope/CONTEXT.md` for full instructions.
 
 ## Completion
 

--- a/bot-workspaces/spec-builder/stages/04-technical/CONTEXT.md
+++ b/bot-workspaces/spec-builder/stages/04-technical/CONTEXT.md
@@ -12,7 +12,7 @@
 
 1. **Read latest meta tag** from most recent bot comment. Verify `stage` is `technical`.
 2. **Check for slash commands** in latest human comment. Handle per `shared/commands.md`.
-3. **Check staleness** (same 72h nudge / 7-day stale pattern as prior stages).
+3. **Check staleness** (same 72h nudge / 7-day stale pattern as prior stages, including waiting-human marker — see `02-scope/CONTEXT.md`).
 4. **If human responded**: reset `nudge_sent`, update `last_human_response_at`.
 5. **Evaluate Technical rubric** against the current draft + latest human response:
    - `technical_approach`: high-level approach described (which services, patterns, data flow)? (`met | partial | missing`)
@@ -29,6 +29,21 @@
 - Meta tag updated with rubric status, round count, timestamps
 - Draft snapshot posted if content changed
 - Issue body updated if `draft_hash` changed
+
+## Waiting-Human Marker
+
+Same as `02-scope/CONTEXT.md`: write `waiting-human-${ISSUE_NUMBER}.txt` when exiting without a human response, remove it on stale/label removal.
+
+```bash
+# Write on exit without human response:
+date -Iseconds > "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+# Remove on stale/abandon:
+rm -f "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+```
+
+## Slack DM on Question Post
+
+Same as `02-scope/CONTEXT.md`: when posting questions (step 7), also notify the requester via Slack thread reply using the Provenance block's channel and timestamp. See `02-scope/CONTEXT.md` for full instructions.
 
 ## Completion
 

--- a/scripts/ec2-bot/scripts/clear-stale-locks.sh
+++ b/scripts/ec2-bot/scripts/clear-stale-locks.sh
@@ -172,6 +172,12 @@ fi
 if [ -d "$CLAIMS_DIR" ]; then
   CLEANED=$(find "$CLAIMS_DIR" -name "claimed-*.txt" -mmin +1440 -delete -print 2>/dev/null | wc -l)
   [ "$CLEANED" -gt 0 ] && echo "[$(date)] Cleaned $CLEANED stale claim files" >> "$LOGFILE"
+
+  # Clean up stale waiting-human markers (>7 days old).
+  # These are written by keep-label workspaces (spec-builder, needs-info) when
+  # waiting for human input. 7 days matches the spec-builder stale threshold.
+  WAITING_CLEANED=$(find "$CLAIMS_DIR" -name "waiting-human-*.txt" -mmin +10080 -delete -print 2>/dev/null | wc -l)
+  [ "$WAITING_CLEANED" -gt 0 ] && echo "[$(date)] Cleaned $WAITING_CLEANED stale waiting-human markers" >> "$LOGFILE"
 fi
 
 # Clean up temp prompt/context files (>1 hour old)

--- a/scripts/ec2-bot/scripts/workspace-dispatcher.sh
+++ b/scripts/ec2-bot/scripts/workspace-dispatcher.sh
@@ -122,6 +122,16 @@ is_issue_active() {
     rm -f "$cooldown_file"
   fi
 
+  # Check for "waiting for human" marker. Keep-label workspaces (spec-builder,
+  # needs-info) write this file when they exit in a "waiting for human" state.
+  # The pipeline-monitor clears it when a human responds (Check 7). This
+  # replaces burning a full Claude invocation per cooldown cycle with a zero-cost
+  # file existence check.
+  local waiting_file="$CLAIMS_DIR/waiting-human-${issue_number}.txt"
+  if [ -f "$waiting_file" ]; then
+    return 0  # Still waiting for human — skip dispatch
+  fi
+
   return 1  # Not active
 }
 


### PR DESCRIPTION
## Changes
- Add: "waiting-human" marker file mechanism in the dispatcher — `is_issue_active()` now checks for `waiting-human-{N}.txt` and skips dispatch when present (zero API cost)
- Add: spec-builder stages 02-04 write the marker when exiting without a human response and send a Slack DM to the requester when posting questions
- Add: needs-info stage 02 writes the marker when exiting without a human response
- Add: pipeline-monitor Check 7 clears the marker when a human response is detected, unblocking dispatch
- Add: `clear-stale-locks.sh` cleans up waiting-human markers older than 7 days
- Update: spec-builder `CLAUDE.md` adds Slack resources to "What to Load" for DM notifications

Related to #45

## Provenance
- **Channel:** DM (Shantam)
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "Don't you think all of the triggering over and over is a bad pattern? If it's waiting for human input it should have sent me a slack message but also not keep invoking claude."

## Docs updated
No doc changes needed — changes are to bot workspace internals (shell scripts and CONTEXT.md stage contracts) which are self-documenting.