### PR TITLE
Split automated outputs across #bot-ops, #daily-summary, #agentic-devs

### DIFF
--- a/bot-workspaces/do-later-review/stages/03-report/CONTEXT.md
+++ b/bot-workspaces/do-later-review/stages/03-report/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Input
 
 - Evaluated issue list from Stage 02 (issues with recommendations and rationale)
-- Slack channel: `#bot-ops`
+- Slack channel: #bot-ops (`$BOT_OPS_CHANNEL_ID`)
 - `shared/references/github-ops.md` -- label operations
 - `shared/slack/slack-post.md` -- posting patterns
 
@@ -30,11 +30,11 @@
 4. **Apply changes for "keep" recommendations**:
    - Add a comment: "Reviewed [date] -- keeping deferred. Next review next month."
 
-5. **Post the summary to Slack** (`#bot-ops`)
+5. **Post the summary to Slack** (#bot-ops, `$BOT_OPS_CHANNEL_ID`)
 
 ## Output
 
-- Slack summary posted to #bot-ops
+- Slack summary posted to #bot-ops (`$BOT_OPS_CHANNEL_ID`)
 - Label changes applied to reopened/closed issues
 - Comments added to kept issues
 

--- a/bot-workspaces/docs-audit/CLAUDE.md
+++ b/bot-workspaces/docs-audit/CLAUDE.md
@@ -7,7 +7,7 @@ Documentation drift detection. Two modes: incremental (git-history-aware, for ni
 | Resource | When | Why |
 |---|---|---|
 | `stages/{current}/CONTEXT.md` | Always | Current stage contract |
-| `shared/slack/slack-post.md` | Always | Post summary to #agentic-devs |
+| `shared/slack/slack-post.md` | Always | Post summary to #agentic-devs (`$AGENTIC_DEVS_CHANNEL_ID`) |
 | `shared/skills/pr.md` | When fixes made | PR for doc updates |
 | `CLAUDE.md` | Always | Docs routing table for mapping code to docs |
 

--- a/bot-workspaces/docs-audit/CONTEXT.md
+++ b/bot-workspaces/docs-audit/CONTEXT.md
@@ -11,7 +11,7 @@ Detect documentation drift by comparing docs against code. Two modes: incrementa
 
 ## Shared Resources Used
 
-- `shared/slack/slack-post.md` — Summary to #agentic-devs
+- `shared/slack/slack-post.md` — Summary to #agentic-devs (`$AGENTIC_DEVS_CHANNEL_ID`)
 - `shared/skills/pr.md` — PR for doc updates
 
 ## Code-to-Doc Mapping

--- a/bot-workspaces/docs-audit/stages/full/CONTEXT.md
+++ b/bot-workspaces/docs-audit/stages/full/CONTEXT.md
@@ -17,7 +17,7 @@
    - Duplicate/overlap detection (similar filenames, same H1, >50% content overlap)
 6. **Fix all issues**: update drifted docs, create missing docs, archive plans, fix hygiene. Commit.
 7. **Create PR** (via `shared/skills/pr.md`)
-8. **Post summary** to #agentic-devs
+8. **Post summary** to #agentic-devs (`$AGENTIC_DEVS_CHANNEL_ID`)
 
 ## Output
 

--- a/bot-workspaces/docs-audit/stages/incremental/CONTEXT.md
+++ b/bot-workspaces/docs-audit/stages/incremental/CONTEXT.md
@@ -17,7 +17,7 @@
 5. **Doc hygiene** on modified docs: valid frontmatter, `updated` date bumped, correct section, referenced from index
 6. **Fix issues**: update drifted docs, create missing docs, fix frontmatter. Commit changes.
 7. **Create PR** if changes made (via `shared/skills/pr.md`)
-8. **Post summary** to #agentic-devs (channel `C0AM2J47R4L`)
+8. **Post summary** to #agentic-devs (`$AGENTIC_DEVS_CHANNEL_ID`)
 
 ## Output
 

--- a/bot-workspaces/health-check/CLAUDE.md
+++ b/bot-workspaces/health-check/CLAUDE.md
@@ -11,7 +11,7 @@ Daily production health audit. Cross-references Mixpanel activity, Render logs, 
 | `shared/diagnostics/check-mixpanel.md` | Always | Activity analysis |
 | `shared/diagnostics/check-sentry.md` | Always | Error tracking |
 | `shared/diagnostics/render-logs.md` | Always | Log analysis |
-| `shared/slack/slack-post.md` | Always | Post to #health-check |
+| `shared/slack/slack-post.md` | Always | Post to #bot-ops (`$BOT_OPS_CHANNEL_ID`) |
 | `shared/references/github-ops.md` | Always | Duplicate check, auto-creation thresholds |
 | `shared/diagnostics/check-thread-tracker.md` | Always | Thread tracker health checks |
 | `shared/github/create-issue.md` | When issues found | Issue creation |

--- a/bot-workspaces/health-check/CONTEXT.md
+++ b/bot-workspaces/health-check/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Cross-reference Mixpanel activity, Render logs, and Sentry errors to surface production issues. Creates GitHub issues for actionable findings and posts a summary to #health-check.
+Cross-reference Mixpanel activity, Render logs, and Sentry errors to surface production issues. Creates GitHub issues for actionable findings and posts a summary to #bot-ops.
 
 ## Stage Pointers
 
@@ -16,4 +16,4 @@ Cross-reference Mixpanel activity, Render logs, and Sentry errors to surface pro
 - `shared/diagnostics/render-logs.md` — Error/warning logs
 - `shared/github/create-issue.md` — Issue creation for findings
 - `shared/references/github-ops.md` — Auto-creation thresholds
-- `shared/slack/slack-post.md` — Summary to #health-check
+- `shared/slack/slack-post.md` — Summary to #bot-ops (`$BOT_OPS_CHANNEL_ID`)

--- a/bot-workspaces/health-check/stages/audit/CONTEXT.md
+++ b/bot-workspaces/health-check/stages/audit/CONTEXT.md
@@ -53,7 +53,7 @@ Use `github_state_*` helpers for all open issue/PR metadata lookups. Do NOT call
    Always add a `bot:investigate` label in addition to `bug`/`security` so the
    dispatcher picks the issue up for automated investigation. See the
    "Bot Pipeline Labels" section in `shared/references/github-ops.md`.
-7. **Post to #health-check** via `shared/slack/slack-post.md`:
+7. **Post to #bot-ops** (`$BOT_OPS_CHANNEL_ID`) via `shared/slack/slack-post.md`:
    - All clear: `All clear — no issues found.`
    - Minor: `N issues created — [brief]. [link]`
    - Needs attention: `N issues, user impact detected — [brief]. [links] cc @shantamg`

--- a/bot-workspaces/pipeline-monitor/CLAUDE.md
+++ b/bot-workspaces/pipeline-monitor/CLAUDE.md
@@ -8,7 +8,7 @@ Autonomous watcher that monitors active milestone-builder pipelines for failures
 |---|---|---|
 | `stages/tick/CONTEXT.md` | Always | Monitor checklist |
 | `shared/references/github-ops.md` (root) | Always | GitHub label and issue operations |
-| `shared/slack/slack-post.md` (root) | Always | Slack notification for auto-graduations (checks 7-9) |
+| `shared/slack/slack-post.md` (root) | Always | Slack notification to #bot-ops for auto-graduations (checks 7-9) |
 | `shared/references/slack-format.md` (root) | Always | Slack message formatting conventions |
 
 ## What NOT to Load
@@ -33,6 +33,6 @@ Autonomous watcher that monitors active milestone-builder pipelines for failures
 - Self-heal: fix wrong labels, promote stalled waves, clean stale `bot:in-progress`
 - Response detection: re-trigger interview workspaces when humans respond to bot questions
 - Auto-graduate: add `bot:verify` on approved PRs, re-trigger milestones when all sub-issues close
-- Slack notify: post to `daily-summary` channel when auto-graduating (checks 7-9)
+- Slack notify: post to #bot-ops (`$BOT_OPS_CHANNEL_ID`) when auto-graduating (checks 7-9)
 - Escalate: comment tagging humans for issues that can't be auto-fixed
 - Session continuity: remembers what it checked and fixed on prior ticks

--- a/bot-workspaces/pipeline-monitor/CONTEXT.md
+++ b/bot-workspaces/pipeline-monitor/CONTEXT.md
@@ -19,5 +19,5 @@ Watches active milestone-builder pipelines for known failure modes. Self-heals w
 - **Session continuity** — invoked with `--session monitor-milestone-{issue}` so `--resume` gives context across ticks
 - **Self-heal threshold** — fix the same issue up to 3 times. After 3 fixes for the same failure, escalate to humans instead of re-fixing.
 - **Response detection** — re-triggers interview workspaces (spec-builder, needs-info, research) when a human responds after the bot's last comment. Also detects PR approvals needing verification and milestone completions.
-- **Slack notifications** — posts to `daily-summary` channel when auto-graduating issues (checks 7-9)
+- **Slack notifications** — posts to #bot-ops (`$BOT_OPS_CHANNEL_ID`) when auto-graduating issues (checks 7-9)
 - **Tick frequency** — every 10 minutes via cron

--- a/bot-workspaces/pipeline-monitor/stages/tick/CONTEXT.md
+++ b/bot-workspaces/pipeline-monitor/stages/tick/CONTEXT.md
@@ -202,11 +202,11 @@ For each parent issue:
 
 ### 10. Slack notifications for auto-graduations
 
-When checks 7, 8, or 9 take action, post a brief Slack notification to the `daily-summary` channel. Use `shared/slack/slack-post.md` for formatting conventions.
+When checks 7, 8, or 9 take action, post a brief Slack notification to #bot-ops (`$BOT_OPS_CHANNEL_ID`). Use `shared/slack/slack-post.md` for formatting conventions.
 
 ```bash
 ${SLAM_BOT_SCRIPTS:-/opt/slam-bot/scripts}/slack-post.sh \
-  --channel "C0AMGACJN9E" \
+  --channel "$BOT_OPS_CHANNEL_ID" \
   --text "🔄 *Pipeline monitor*: <DESCRIPTION> on <https://github.com/shantamg/meet-without-fear/issues/$N|#$N>"
 ```
 

--- a/bot-workspaces/security-audit/CLAUDE.md
+++ b/bot-workspaces/security-audit/CLAUDE.md
@@ -9,7 +9,7 @@ Comprehensive security posture assessment using specialized parallel agents cove
 | `stages/{current}/CONTEXT.md` | Always | Current stage contract |
 | `shared/references/credentials.md` | Stage 1 | API access for scanning |
 | `shared/github/create-issue.md` | Stage 2 | Issue creation for findings |
-| `shared/slack/slack-post.md` | Stage 2 | Report to #security-audit |
+| `shared/slack/slack-post.md` | Stage 2 | Report to #bot-ops (`$BOT_OPS_CHANNEL_ID`) |
 | `docs/architecture/system-overview.md` | Stage 1 | System context |
 | `docs/infrastructure/production-access.md` | Stage 1 | Access controls |
 

--- a/bot-workspaces/security-audit/CONTEXT.md
+++ b/bot-workspaces/security-audit/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Run a comprehensive 12-point security audit using parallel specialist agents. Report findings to #security-audit and create GitHub issues for CRITICAL/HIGH findings.
+Run a comprehensive 12-point security audit using parallel specialist agents. Report findings to #bot-ops and create GitHub issues for CRITICAL/HIGH findings.
 
 ## Stage Pointers
 
@@ -13,7 +13,7 @@ Run a comprehensive 12-point security audit using parallel specialist agents. Re
 
 - `shared/references/credentials.md` — API access
 - `shared/github/create-issue.md` — Issue creation for findings
-- `shared/slack/slack-post.md` — Report to #security-audit
+- `shared/slack/slack-post.md` — Report to #bot-ops (`$BOT_OPS_CHANNEL_ID`)
 - `shared/references/github-ops.md` — Issue labeling and assignment
 
 ## Key Docs to Read First

--- a/bot-workspaces/security-audit/stages/2-report/CONTEXT.md
+++ b/bot-workspaces/security-audit/stages/2-report/CONTEXT.md
@@ -48,7 +48,7 @@ Any other `gh` read call indicates a bug.
    - MEDIUM: single consolidated issue, label `security` + `bot:investigate`
    - LOW/INFO: Slack report only
    - Always add `bot:investigate` so findings enter the bot pipeline for automated investigation (see `shared/references/github-ops.md` Bot Pipeline Labels)
-4. **Post to #security-audit** (channel `C0AMBNDFL9X`):
+4. **Post to #bot-ops** (`$BOT_OPS_CHANNEL_ID`):
    - Summary: total findings by severity
    - Critical & High findings with impact and remediation
    - Third-party data handling matrix (service, data sent, training opt-out, DPA status)
@@ -57,7 +57,7 @@ Any other `gh` read call indicates a bug.
 ## Output
 
 - GitHub issues for CRITICAL/HIGH/MEDIUM findings
-- Slack report posted to #security-audit
+- Slack report posted to #bot-ops
 - Summary: total findings, issue links, top 3 priorities
 
 ## Completion

--- a/bot-workspaces/stale-sweeper/CLAUDE.md
+++ b/bot-workspaces/stale-sweeper/CLAUDE.md
@@ -8,7 +8,7 @@ Process stale GitHub issues and PRs. The cron script pre-triages items and tells
 |---|---|---|
 | `stages/{current}/CONTEXT.md` | Always | Current stage contract |
 | `shared/references/github-ops.md` | Always | Issue/PR patterns |
-| `shared/slack/slack-post.md` | Stage 2 | Summary to #agentic-devs |
+| `shared/slack/slack-post.md` | Stage 2 | Summary to #bot-ops (`$BOT_OPS_CHANNEL_ID`) |
 | `shared/skills/pr.md` | Stage 2 (if fixing) | PR creation for fixes |
 
 ## What NOT to Load

--- a/bot-workspaces/stale-sweeper/CONTEXT.md
+++ b/bot-workspaces/stale-sweeper/CONTEXT.md
@@ -12,5 +12,5 @@ Process stale GitHub issues and PRs that need action (comments, fixes, conflict 
 ## Shared Resources Used
 
 - `shared/references/github-ops.md` — Issue/PR operations
-- `shared/slack/slack-post.md` — Summary to #agentic-devs
+- `shared/slack/slack-post.md` — Summary to #bot-ops (`$BOT_OPS_CHANNEL_ID`)
 - `shared/skills/pr.md` — PR creation for fixes

--- a/bot-workspaces/stale-sweeper/stages/2-process/CONTEXT.md
+++ b/bot-workspaces/stale-sweeper/stages/2-process/CONTEXT.md
@@ -19,7 +19,7 @@ Rules:
 - ~5 min per item max — if complex, post analysis and move on
 - Clickable GitHub links in Slack: `<https://github.com/shantamg/meet-without-fear/issues/N|#N>`
 
-After all items processed, post summary to #agentic-devs via `shared/slack/slack-post.md`:
+After all items processed, post summary to #bot-ops (`$BOT_OPS_CHANNEL_ID`) via `shared/slack/slack-post.md`:
 ```
 *Stale Sweeper — [Date]*
 Triaged [N] items:

--- a/bot-workspaces/systems-architect/stages/02-report/CONTEXT.md
+++ b/bot-workspaces/systems-architect/stages/02-report/CONTEXT.md
@@ -18,7 +18,7 @@
    - MEDIUM: single consolidated issue, label `architecture`
    - LOW/INFO: Slack report only
 
-3. **Post to #eng-systems** (or fallback #pmf1):
+3. **Post to #agentic-devs** (`$AGENTIC_DEVS_CHANNEL_ID`):
    - Summary: total findings by severity, domains scanned
    - Critical & High findings with file locations and remediation
    - Drift summary: patterns introduced in recent commits that diverge from formalized architecture

--- a/scripts/ec2-bot/configure-slack.sh
+++ b/scripts/ec2-bot/configure-slack.sh
@@ -16,6 +16,9 @@ read -rsp "App-Level Token (xapp-...):      " SLACK_APP_TOKEN; echo
 read -rp  "DM channel ID (D...):                " SHANTAM_SLACK_DM
 read -rp  "#slam-bot channel ID (C...):         " SLAM_BOT_CHANNEL_ID
 read -rp  "#bugs-and-requests channel ID (C...):" BUGS_AND_REQUESTS_CHANNEL_ID
+read -rp  "#bot-ops channel ID (C...):          " BOT_OPS_CHANNEL_ID
+read -rp  "#daily-summary channel ID (C...):    " DAILY_SUMMARY_CHANNEL_ID
+read -rp  "#agentic-devs channel ID (C...):     " AGENTIC_DEVS_CHANNEL_ID
 
 [[ "$SLACK_BOT_TOKEN" == xoxb-* ]] || { echo "ERROR: bot token should start with xoxb-"; exit 1; }
 [[ "$SLACK_APP_TOKEN" == xapp-* ]] || { echo "ERROR: app token should start with xapp-"; exit 1; }
@@ -41,6 +44,9 @@ SLAM_BOT_USER_ID=$SLAM_BOT_USER_ID
 SHANTAM_SLACK_DM=$SHANTAM_SLACK_DM
 SLAM_BOT_CHANNEL_ID=$SLAM_BOT_CHANNEL_ID
 BUGS_AND_REQUESTS_CHANNEL_ID=$BUGS_AND_REQUESTS_CHANNEL_ID
+BOT_OPS_CHANNEL_ID=$BOT_OPS_CHANNEL_ID
+DAILY_SUMMARY_CHANNEL_ID=$DAILY_SUMMARY_CHANNEL_ID
+AGENTIC_DEVS_CHANNEL_ID=$AGENTIC_DEVS_CHANNEL_ID
 ENV
 
 scp -q "$TMP" slam-bot:/tmp/slack-env.new
@@ -49,7 +55,7 @@ shred -u "$TMP" 2>/dev/null || rm -f "$TMP"
 ssh slam-bot bash <<'REMOTE'
 set -e
 # Strip any prior Slack keys from existing .env, then append the new ones
-grep -vE '^(SLACK_BOT_TOKEN|SLACK_APP_TOKEN|SLAM_BOT_USER_ID|SHANTAM_SLACK_DM|SLAM_BOT_CHANNEL_ID|BUGS_AND_REQUESTS_CHANNEL_ID)=' /opt/slam-bot/.env > /tmp/.env.base 2>/dev/null || touch /tmp/.env.base
+grep -vE '^(SLACK_BOT_TOKEN|SLACK_APP_TOKEN|SLAM_BOT_USER_ID|SHANTAM_SLACK_DM|SLAM_BOT_CHANNEL_ID|BUGS_AND_REQUESTS_CHANNEL_ID|BOT_OPS_CHANNEL_ID|DAILY_SUMMARY_CHANNEL_ID|AGENTIC_DEVS_CHANNEL_ID)=' /opt/slam-bot/.env > /tmp/.env.base 2>/dev/null || touch /tmp/.env.base
 cat /tmp/.env.base /tmp/slack-env.new > /opt/slam-bot/.env
 chmod 600 /opt/slam-bot/.env
 rm -f /tmp/.env.base /tmp/slack-env.new

--- a/scripts/ec2-bot/scripts/lib/config.sh
+++ b/scripts/ec2-bot/scripts/lib/config.sh
@@ -60,7 +60,13 @@ TRIAGE_MIN_AGE="${TRIAGE_MIN_AGE:-10}"
 HARD_CAP_MIN="${HARD_CAP_MIN:-45}"
 
 # ── Slack ───────────────────────────────────────────────────────────────────
+# Three output channels for automated workspace results:
+#   #bot-ops       — health-check, stale-sweeper, security-audit, pipeline-monitor
+#   #daily-summary — daily summary digests
+#   #agentic-devs  — PR creation, code reviews, spec work, docs-audit, systems-architect
 BOT_OPS_CHANNEL_ID="${BOT_OPS_CHANNEL_ID:-}"
+DAILY_SUMMARY_CHANNEL_ID="${DAILY_SUMMARY_CHANNEL_ID:-}"
+AGENTIC_DEVS_CHANNEL_ID="${AGENTIC_DEVS_CHANNEL_ID:-}"
 
 # ── Heartbeats ──────────────────────────────────────────────────────────────
 HEARTBEAT_DIR="${HEARTBEAT_DIR:-${BOT_STATE_DIR}/heartbeats}"

--- a/scripts/ec2-bot/scripts/stale-sweeper.sh
+++ b/scripts/ec2-bot/scripts/stale-sweeper.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/lib/shared.sh"
 LOGFILE="$BOT_LOG_DIR/stale-sweeper.log"
 REPO="$GITHUB_REPO"
 SLACK_SCRIPT="$BOT_SCRIPTS_DIR/slack-post.sh"
-AGENTIC_DEVS="C0AM2J47R4L"
+OUTPUT_CHANNEL="${BOT_OPS_CHANNEL_ID}"
 STALE_HOURS=24
 
 # Labels that exempt items from sweeping
@@ -191,7 +191,7 @@ Never auto-close issues or auto-merge PRs.
 
 ${TASK_LIST}
 
-When done, post a summary to #agentic-devs (${AGENTIC_DEVS}) via /slack-post listing what you did for each item. Include clickable GitHub links." \
+When done, post a summary to #bot-ops (${OUTPUT_CHANNEL}) via /slack-post listing what you did for each item. Include clickable GitHub links." \
     "$HOME/meet-without-fear/.claude/commands/stale-sweeper.md"
 fi
 
@@ -203,7 +203,7 @@ if [ "${#ACTIONS_TAKEN[@]}" -gt 0 ] && [ "${#CLAUDE_QUEUE[@]}" -eq 0 ]; then
   for action in "${ACTIONS_TAKEN[@]}"; do
     SUMMARY+="• ${action}"$'\n'
   done
-  "$SLACK_SCRIPT" --channel "$AGENTIC_DEVS" --text "$SUMMARY" 2>/dev/null || \
+  "$SLACK_SCRIPT" --channel "$OUTPUT_CHANNEL" --text "$SUMMARY" 2>/dev/null || \
     log "Failed to post Slack summary"
 fi
 

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -21,9 +21,11 @@
  *   SLAM_BOT_USER_ID   — Bot's Slack user ID (to filter self-messages)
  *   SHANTAM_SLACK_DM      — Channel ID for Shantam's DM
  *   PMF1_CHANNEL_ID       — Channel ID for #pmf1
- *   AGENTIC_DEVS_CHANNEL_ID — Channel ID for the #agentic-devs channel
  *   SLAM_BOT_CHANNEL_ID — Channel ID for the #slam-paws channel
  *   BUGS_AND_REQUESTS_CHANNEL_ID — Channel ID for the #bugs-and-requests channel
+ *   BOT_OPS_CHANNEL_ID          — Channel ID for #bot-ops (health/ops outputs)
+ *   DAILY_SUMMARY_CHANNEL_ID    — Channel ID for #daily-summary (daily digests)
+ *   AGENTIC_DEVS_CHANNEL_ID     — Channel ID for #agentic-devs (dev activity outputs)
  */
 
 import { SocketModeClient } from '@slack/socket-mode';


### PR DESCRIPTION
## Changes

- Add `DAILY_SUMMARY_CHANNEL_ID` and `AGENTIC_DEVS_CHANNEL_ID` env vars alongside `BOT_OPS_CHANNEL_ID` in `config.sh`
- Update `configure-slack.sh` to prompt for all three output channel IDs and merge them into `.env`
- Route bot health/ops workspaces (health-check, stale-sweeper, security-audit, pipeline-monitor, do-later-review) to `$BOT_OPS_CHANNEL_ID`
- Route dev activity workspaces (docs-audit, systems-architect) to `$AGENTIC_DEVS_CHANNEL_ID`
- Replace all hardcoded channel IDs (`C0AM2J47R4L`, `C0AMBNDFL9X`, `C0AMGACJN9E`) with env var references
- Update `stale-sweeper.sh` to use `$BOT_OPS_CHANNEL_ID` instead of hardcoded `#agentic-devs` channel ID
- Document new env vars in `socket-listener.mjs` header

### Channel routing

| Channel | Env var | Workspaces |
|---|---|---|
| **#bot-ops** | `$BOT_OPS_CHANNEL_ID` | health-check, stale-sweeper, security-audit, pipeline-monitor, do-later-review |
| **#daily-summary** | `$DAILY_SUMMARY_CHANNEL_ID` | (env var added, no workspace currently posts here) |
| **#agentic-devs** | `$AGENTIC_DEVS_CHANNEL_ID` | docs-audit, systems-architect |

Supersedes #49. Related to #50

## Provenance
- **Channel:** DM (Shantam)
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** Regarding PR #47 — I added the two channels. Can you find them and do the rest?

## Docs updated
No doc changes needed — config and workspace routing only.