### PR TITLE
docs: add file-based state refs to mwf-session references

### DIFF
--- a/bot-workspaces/mwf-session/references/privacy-model.md
+++ b/bot-workspaces/mwf-session/references/privacy-model.md
@@ -35,6 +35,20 @@ When the AI creates cross-user content, it must:
 - **Anonymize** strategy proposals (Stage 4) — no attribution
 - **Frame** partner perspectives as possibilities ("they might feel..."), not certainties
 
+## File-Level Access Rules
+
+Each stage enforces strict retrieval contracts on the file-based state tree:
+
+| Stage | Files Readable | Files Forbidden |
+|---|---|---|
+| 0 | `session.json`, `stage-progress.json` | All vessel files |
+| 1 | Own `vessel-{x}/*`, `conversation-summary.md` | Partner's vessel, `shared/*` |
+| 2 | Own vessel + `shared/consented-content.json` | Partner's raw vessel |
+| 3 | Own `vessel-{x}/needs.json` + `shared/consented-content.json`, `shared/common-ground.json` | Partner's raw vessel, own raw events |
+| 4 | `shared/*` (all) | Both users' raw vessels |
+
+The `synthesis/` directory is **never** read during user-facing turns — it exists for dev/monitoring purposes only.
+
 ## Vessel Contents
 
 Each user's Vessel stores:

--- a/bot-workspaces/mwf-session/references/stage-progression.md
+++ b/bot-workspaces/mwf-session/references/stage-progression.md
@@ -22,6 +22,18 @@ Each stage has an advancement gate. Both users must satisfy it before the sessio
 | 3 | At least one common-ground need identified and confirmed by both users |
 | 4 | Mutual agreement on at least one micro-experiment |
 
+## Gate Keys
+
+Gate state is persisted in `stage-progress.json`. Each key is a boolean that must be satisfied before the stage can advance. Stage advancement requires **both users** to satisfy all gate keys for the current stage.
+
+| Stage | Gate Keys |
+|---|---|
+| 0 | `agreedToTerms` |
+| 1 | `feelHeardConfirmed` |
+| 2 | `empathyDraftReady`, `empathyConsented`, `partnerValidated` |
+| 3 | `needsConfirmed`, `commonGroundConfirmed` |
+| 4 | `strategiesSubmitted`, `rankingsSubmitted`, `agreementCreated` |
+
 ## Per-User Status
 
 Each user tracks their own `StageStatus` independently:


### PR DESCRIPTION
## Changes
- Add: file-level access rules table to `privacy-model.md` showing per-stage readable/forbidden files
- Add: note that `synthesis/` directory is dev/monitoring only, never read during user-facing turns
- Add: gate keys per stage table to `stage-progression.md` with boolean keys for each stage gate
- Add: reference to `stage-progress.json` as the persistence mechanism for gate state

Related to #55

## Provenance
- **Channel:** GitHub Issues
- **Requested by:** slam-paws (bot-created from #36 milestone plan)
- **Original message:** Issue #55 — Update privacy-model and stage-progression references for file-based state
- **Prompt(s) used:** general-pr workspace, stages 01-implement → 02-pr

## Docs updated
No living docs under `docs/` affected — changes are to bot-workspace reference files (`bot-workspaces/mwf-session/references/`)