### PR TITLE
docs: add shared vessel, agreements, and session completion to stages 3-4

### DIFF
--- a/bot-workspaces/mwf-session/stages/3-need-mapping/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/3-need-mapping/CONTEXT.md
@@ -67,10 +67,66 @@ Use the user's exact words when reflecting needs. Never add context, feelings, o
 | **Early (turn ≤ 2)** | User may still be processing emotions from empathy work. Start in EXCAVATING mode. Give space before expecting named needs. |
 | **High intensity (8+)** | Slow down. Validate first, reframe gently. Calm and grounding tone, not matching their intensity. |
 
+### File-Based State Access
+
+Per the retrieval contract, Stage 3 operates in **Coordinated** mode — the AI reads cross-user content that has already been abstracted or consented to.
+
+**Readable files:**
+
+| File | Purpose |
+|---|---|
+| Own `vessel-{x}/needs.json` | Needs identified for this user (from Stage 1–2 extraction) |
+| `shared/consented-content.json` | Content previously consented to by both users |
+| `shared/common-ground.json` | Needs confirmed as shared by both users |
+
+**Forbidden files:**
+
+| File | Why |
+|---|---|
+| Partner's `vessel-{y}/*` | Raw partner content is never directly readable |
+| Own raw events (emotional-thread, boundaries) | Stage 3 works from abstracted needs, not raw material |
+
+### Common Ground Tracking
+
+When the AI identifies a need that both users share (based on each user's `needs.json` and conversation), write it to `shared/common-ground.json`:
+
+```json
+{
+  "need": "Both want to feel respected in family decisions",
+  "confirmed_by": ["U_A_ID", "U_B_ID"],
+  "ts": "ISO-8601"
+}
+```
+
+**Rules:**
+- A need enters common ground only after **both** users have confirmed it
+- Use universal need categories (Safety, Connection, Autonomy, Recognition, Meaning, Fairness) — not raw quotes
+- Each user confirms independently — do not assume confirmation from one means both
+
+### Gate Persistence
+
+Track gate satisfaction in `stage-progress.json` for each user:
+
+| Gate Key | Condition |
+|---|---|
+| `needsConfirmed` | User has confirmed at least one identified need as accurate |
+| `commonGroundConfirmed` | User has confirmed at least one need as shared with partner |
+
+When both users satisfy both gates → advance `current_stage` to 4.
+
+### Continuing from Prior Stages
+
+Continue these behaviors from Stages 1–2:
+- **Fact extraction** — update `notable-facts.json` with new facts from this stage
+- **Emotional tracking** — update `emotional-thread.json` with per-turn intensity readings
+- **Internal dialogue** — maintain the user's reflective process
+- **Conversation summary** — update `conversation-summary.md` with Stage 3 content
+
 ## Output
 
-- Per-user need maps with categories and rankings stored in Vessel
-- Common-ground needs confirmed by both users
+- Per-user need maps with categories and rankings stored in Vessel (`vessel-{x}/needs.json`)
+- Common-ground needs confirmed by both users (`shared/common-ground.json`)
+- Gate keys updated in `stage-progress.json`
 - Stage status: `GATE_PENDING` (common need confirmed) or `IN_PROGRESS`
 
 ## Completion

--- a/bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md
@@ -77,13 +77,84 @@ ProposedStrategy: Sunday evening phone call to plan the week ahead
 | **Early (turn ≤ 2)** | User may need help shifting from needs to action. Start in INVITING mode. Normalize that experiments can fail — the point is learning, not perfection. |
 | **High intensity (8+)** | Slow down. Validate first. This is NOT the moment for brainstorming — ground them before moving to action. Calm and steady tone. |
 
+### File-Based State Access
+
+Per the retrieval contract, Stage 4 operates in **Parallel → Coordinated** mode — independent proposals first, then anonymous pooling and agreement.
+
+**Readable files:**
+
+| File | Purpose |
+|---|---|
+| `shared/consented-content.json` | Previously consented content from both users |
+| `shared/common-ground.json` | Needs confirmed as shared (from Stage 3) |
+| `shared/agreements.json` | Finalized agreements between users |
+| `shared/micro-experiments.json` | Proposed experiments |
+
+**Forbidden files:**
+
+| File | Why |
+|---|---|
+| Either user's `vessel-{x}/*` | Stage 4 works entirely through the shared vessel — no raw vessel access |
+
+### Micro-Experiments
+
+Write proposed experiments to `shared/micro-experiments.json`. Each experiment must meet all four criteria (specific, time-bounded, reversible, measurable):
+
+```json
+{
+  "description": "10-minute check-in after dinner each night for one week",
+  "status": "proposed",
+  "follow_up": ""
+}
+```
+
+Status transitions: `proposed` → `in_progress` → `completed` or `skipped`.
+
+### Agreements
+
+When both users agree on a strategy or experiment, write it to `shared/agreements.json`:
+
+```json
+{
+  "description": "Schedule a weekly 30-minute check-in about caregiving tasks",
+  "agreed_by": ["U_A_ID", "U_B_ID"],
+  "status": "accepted",
+  "ts": "ISO-8601"
+}
+```
+
+Status values: `proposed`, `accepted`, `rejected`. An agreement is finalized only when `agreed_by` contains both user IDs and status is `accepted`.
+
+### Gate Persistence
+
+Track gate satisfaction in `stage-progress.json` for each user:
+
+| Gate Key | Condition |
+|---|---|
+| `strategiesSubmitted` | User has proposed at least one concrete strategy |
+| `rankingsSubmitted` | User has ranked the pooled strategies |
+| `agreementCreated` | User has agreed to at least one micro-experiment |
+
+When both users satisfy all three gates → set session status to `completed` in `session.json`.
+
+### Session Completion
+
+When both users have satisfied all Stage 4 gates:
+
+1. **Update `session.json`** — set `status` to `completed`
+2. **Post-completion messages** — acknowledge the work both users did, summarize the agreed micro-experiments, and offer to review agreements in a future check-in
+3. **Trigger global facts consolidation** — consolidate notable facts from this session into the user's `global-facts.json` (per-user cross-session file in `data/mwf-users/{user_id}/`)
+
 ## Output
 
 - Strategy proposals and rankings per user (in Vessel)
 - StrategyProposed signal: Y or N per turn, with ProposedStrategy lines when Y
-- Agreed micro-experiment with specifics (action, duration, check-in plan)
+- Micro-experiments written to `shared/micro-experiments.json`
+- Agreements written to `shared/agreements.json`
+- Gate keys updated in `stage-progress.json`
+- Session status updated in `session.json` on completion
 - Stage status: `COMPLETED` (agreement reached) or `IN_PROGRESS`
 
 ## Completion
 
-When both users agree on at least one micro-experiment, the session is complete. Offer a follow-up check-in to review how the experiment went.
+When both users agree on at least one micro-experiment, the session is complete. Update `session.json` status to `completed`. Offer a follow-up check-in to review how the experiment went.


### PR DESCRIPTION
## Changes
- Add file-based state access rules to Stage 3 (own needs.json + shared/consented-content.json + shared/common-ground.json)
- Add common-ground.json creation rules with dual-user confirmation requirement
- Add needsConfirmed and commonGroundConfirmed gate persistence to Stage 3
- Add continuation of fact extraction, emotional tracking, and conversation summary from prior stages
- Add full shared/* read access to Stage 4 (consented-content, common-ground, agreements, micro-experiments)
- Add micro-experiments.json write rules with status lifecycle (proposed → in_progress → completed/skipped)
- Add agreements.json creation with dual-user acceptance model
- Add three completion gates to Stage 4 (strategiesSubmitted, rankingsSubmitted, agreementCreated)
- Add session completion flow: session.json status update, post-completion messages, global facts consolidation

Related to #59

## Provenance
- **Channel:** GitHub issue
- **Requested by:** slam-paws (milestone plan)
- **Original message:** #59 — Update Stages 3-4 CONTEXT for shared vessel, agreements, and session completion
- **Prompt(s) used:** general-pr workspace, stage 01-implement

## Docs updated
- `bot-workspaces/mwf-session/stages/3-need-mapping/CONTEXT.md` — added file-based state access, common ground tracking, gate persistence, prior stage continuations
- `bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md` — added shared vessel access, micro-experiments, agreements, completion gates, session completion flow