### PR TITLE
docs: add cross-session global facts accumulation

### DIFF
--- a/bot-workspaces/mwf-session/CLAUDE.md
+++ b/bot-workspaces/mwf-session/CLAUDE.md
@@ -27,6 +27,7 @@ Thread-based MWF conversation workspace. Each Slack thread in `#mwf-sessions` is
 | `references/guardian-constitution.md` | Always | Process Guardian identity, voice, and universal rules |
 | `references/stage-progression.md` | Always | Gate rules, parallel vs sequential logic |
 | `references/privacy-model.md` | Always | Per-stage sharing and Vessel rules |
+| `references/global-facts.md` | Stage 0 (session start), stage transitions, session completion | Cross-session fact accumulation lifecycle |
 | `shared/slack/slack-post.md` | Stage 2 (reply posting) | Posting thread replies via `slack-post.sh` |
 | `shared/references/slack-format.md` | Stage 2 (reply posting) | Slack mrkdwn syntax (NOT Markdown) |
 | `docs/product/stages/index.md` | First message in thread | Understand stage progression rules |

--- a/bot-workspaces/mwf-session/CONTEXT.md
+++ b/bot-workspaces/mwf-session/CONTEXT.md
@@ -17,6 +17,7 @@ Facilitate a Meet Without Fear conversation between two users through five seque
 - `references/stage-progression.md` — Gate conditions and coordination modes per stage
 - `references/privacy-model.md` — Vessel rules, consent requirements, per-stage sharing policy
 - `references/guardian-constitution.md` — Process Guardian identity, voice, and universal behavioral rules
+- `references/global-facts.md` — Cross-session fact accumulation: loading, consolidation, and privacy rules
 
 ## Key Conventions
 

--- a/bot-workspaces/mwf-session/references/global-facts.md
+++ b/bot-workspaces/mwf-session/references/global-facts.md
@@ -1,0 +1,85 @@
+# Global Facts — Cross-Session Accumulation
+
+Global facts give the Process Guardian continuity with returning users. Instead of starting from scratch each session, the bot has context about people, history, and emotional patterns the user has shared before.
+
+## Lifecycle
+
+```
+Session N (per-turn)          Session end / stage transition       Session N+1 (start)
+─────────────────────         ──────────────────────────────       ───────────────────
+Extract facts →               Consolidate into global-facts.json → Load as context
+vessel-{x}/notable-facts.json   data/mwf-users/{user_id}/           for new session
+```
+
+### 1. Extraction (per turn, Stages 1–3)
+
+Facts are extracted into each user's private vessel during conversation. See `schemas/notable-facts.schema.md` for the per-session schema.
+
+- Max 20 facts per session per user
+- Each fact has a stable UUID, category, and source stage
+- Facts stay in the user's vessel — never shared with the partner
+
+### 2. Consolidation (on trigger)
+
+Merge per-session `vessel-{x}/notable-facts.json` into `data/mwf-users/{slack_user_id}/global-facts.json`. See `schemas/global-facts.schema.md` for the target schema.
+
+**Triggers:**
+- **Session completion** — when both users satisfy all Stage 4 gates and `session.json` status is set to `completed`
+- **Stage transitions** — when `current_stage` advances in `stage-progress.json` (e.g., Stage 1 → 2, Stage 2 → 3, etc.)
+
+**Algorithm:**
+
+1. Read the user's `vessel-{x}/notable-facts.json` for the current session
+2. Read (or create) `data/mwf-users/{slack_user_id}/global-facts.json`
+3. For each session fact:
+   - **If the fact's UUID already exists in global facts**: update `last_confirmed` to now, append the current `session_id` to `source_sessions` (if not already present)
+   - **If the UUID is new**: map the session fact to a global fact entry:
+     ```
+     {
+       id:              <same UUID from session fact>,
+       category:        <same category>,
+       fact:            <same fact text>,
+       first_seen:      <session fact's extracted_at>,
+       last_confirmed:  <now>,
+       source_sessions: [<current session_id>]
+     }
+     ```
+4. Write the updated global facts back to file
+
+**Over-limit consolidation (max 50 facts):**
+
+If the merged result exceeds 50 facts:
+1. Sort by `last_confirmed` ascending (oldest-confirmed first)
+2. Group the oldest facts by `category`
+3. Within each category group, merge facts with similar content into a single summary fact:
+   - Combine `source_sessions` arrays
+   - Use the earliest `first_seen` and latest `last_confirmed`
+   - Rewrite `fact` as a concise summary covering all merged facts
+   - Generate a new UUID for the merged fact
+4. Repeat until the count is at or below 50
+
+### 3. Loading (on session start)
+
+When a new session begins (Stage 0, Phase 0A or Phase 0B), check if the user has existing global facts:
+
+1. Look up `data/mwf-users/{slack_user_id}/global-facts.json`
+2. If the file exists and is non-empty, load it as additional context
+3. Inject the facts into the session as background knowledge — the bot can reference them naturally without quoting them verbatim
+4. Do NOT tell the user "I remember from last time" or make the continuity feel surveillance-like — use the facts to inform questions and reflections naturally
+
+**Privacy rules:**
+- Global facts are per-user and private — never share one user's global facts with the other user
+- Facts follow the same Vessel isolation rules as all other per-user data
+- The partner cannot read or infer the contents of the other user's global facts
+
+## File Locations
+
+| File | Path | Scope |
+|---|---|---|
+| Per-session facts | `data/mwf-sessions/{session_id}/vessel-{a\|b}/notable-facts.json` | One session, one user |
+| Global facts | `data/mwf-users/{slack_user_id}/global-facts.json` | All sessions for one user |
+
+## Schema Reference
+
+- Per-session: `schemas/notable-facts.schema.md`
+- Global: `schemas/global-facts.schema.md`

--- a/bot-workspaces/mwf-session/references/stage-progression.md
+++ b/bot-workspaces/mwf-session/references/stage-progression.md
@@ -55,3 +55,12 @@ Each user tracks their own `StageStatus` independently:
 ## No Skipping
 
 Stages must be completed in order (0 → 1 → 2 → 3 → 4). A user cannot enter stage N+1 until stage N is `COMPLETED` for both users.
+
+## Global Facts Consolidation
+
+Notable facts are consolidated into each user's cross-session `global-facts.json` at two points:
+
+1. **Stage transitions** — when `current_stage` advances (both users `COMPLETED`), consolidate each user's `vessel-{x}/notable-facts.json` into `data/mwf-users/{slack_user_id}/global-facts.json`
+2. **Session completion** — when all Stage 4 gates are satisfied and `session.json` status is set to `completed`
+
+This ensures facts are preserved even if a session ends early or is abandoned after a stage transition. See `references/global-facts.md` for the full merge algorithm, deduplication rules, and 50-fact limit.

--- a/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
@@ -23,6 +23,7 @@
 | `data/mwf-sessions/thread-index.json` | `schemas/thread-index.schema.md` | Map `channel:thread_ts` → session ID |
 | `data/mwf-sessions/{session_id}/session.json` | `schemas/session.schema.md` | Session metadata and pairing state |
 | `data/mwf-sessions/{session_id}/stage-progress.json` | `schemas/stage-progress.schema.md` | Per-user stage and gate tracking |
+| `data/mwf-users/{slack_user_id}/global-facts.json` | `schemas/global-facts.schema.md` | Cross-session accumulated facts (returning users) |
 
 ## Process
 
@@ -82,7 +83,13 @@ Triggered when a user starts a new MWF session and no existing session is found 
 3. **Update thread index**:
    - Add `"{channel_id}:{thread_ts}": "{session_id}"` entry to `thread-index.json`
 
-4. **Reply with join code**:
+4. **Load global facts** (returning user context):
+   - Check if `data/mwf-users/{user_id}/global-facts.json` exists
+   - If it exists and is non-empty, load the facts as background context for this session
+   - Use facts to inform questions and reflections naturally — do NOT say "I remember from last time"
+   - See `references/global-facts.md` for loading rules and privacy constraints
+
+5. **Reply with join code**:
    - Tell the user their session is created
    - Provide the join code for them to share with their conversation partner
    - Transition to Phase B (Invitation Crafting) in the same thread
@@ -110,7 +117,12 @@ Triggered when a message contains a join code and no existing session is found f
    - Create `data/mwf-sessions/{session_id}/vessel-a/`
    - Create `data/mwf-sessions/{session_id}/vessel-b/`
 
-5. **Notify both users**:
+5. **Load global facts** (returning user context):
+   - For both User A and User B, check if `data/mwf-users/{slack_user_id}/global-facts.json` exists
+   - If it exists and is non-empty, load as background context for this user's session thread
+   - See `references/global-facts.md` for loading rules and privacy constraints
+
+6. **Notify both users**:
    - In User A's thread: "Your partner has joined! Let's begin."
    - In User B's thread: Welcome and begin Phase A (Curiosity Compact)
    - Both users enter Phase A

--- a/bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md
@@ -143,7 +143,13 @@ When both users have satisfied all Stage 4 gates:
 
 1. **Update `session.json`** — set `status` to `completed`
 2. **Post-completion messages** — acknowledge the work both users did, summarize the agreed micro-experiments, and offer to review agreements in a future check-in
-3. **Trigger global facts consolidation** — consolidate notable facts from this session into the user's `global-facts.json` (per-user cross-session file in `data/mwf-users/{user_id}/`)
+3. **Consolidate global facts** — for each user in the session:
+   a. Read `vessel-{x}/notable-facts.json` for this user's session facts
+   b. Read (or create) `data/mwf-users/{slack_user_id}/global-facts.json`
+   c. Merge: deduplicate by UUID (update `last_confirmed` and `source_sessions` for existing facts; add new facts with `first_seen` from `extracted_at`)
+   d. If over 50 facts, consolidate oldest by merging similar facts within the same category
+   e. Write updated global facts back to file
+   f. See `references/global-facts.md` for the full algorithm and privacy rules
 
 ## Output
 


### PR DESCRIPTION
## Changes
- Add: `references/global-facts.md` — complete lifecycle reference for cross-session fact accumulation (extraction, consolidation algorithm, loading for returning users, privacy rules)
- Add: Global facts loading in Stage 0 — both session creation (Phase 0A) and partner pairing (Phase 0B) now check for returning user facts
- Update: Stage 4 session completion — expanded consolidation step with dedup-by-UUID algorithm, max-50 limit, and category-based merging
- Update: `stage-progression.md` — added consolidation triggers at stage transitions (not just session completion)
- Update: Workspace `CLAUDE.md` and `CONTEXT.md` — added `references/global-facts.md` to load tables

Related to #63

## Provenance
- **Channel:** GitHub issue
- **Requested by:** Slam Paws (bot automation)
- **Original message:** Issue #63 — Add cross-session global facts accumulation
- **Prompt(s) used:** general-pr workspace, stage 01-implement

## Docs updated
- `bot-workspaces/mwf-session/references/global-facts.md` (new — cross-session fact accumulation lifecycle)
- `bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md` (updated — global facts loading steps)
- `bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md` (updated — consolidation algorithm)
- `bot-workspaces/mwf-session/references/stage-progression.md` (updated — consolidation triggers)
- `bot-workspaces/mwf-session/CLAUDE.md` (updated — load table entry)
- `bot-workspaces/mwf-session/CONTEXT.md` (updated — shared resources list)