### PR TITLE
Fix git-pull to always checkout main before resetting

### DIFF
--- a/scripts/ec2-bot/scripts/git-pull.sh
+++ b/scripts/ec2-bot/scripts/git-pull.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Bootstrap: use hardcoded path for the initial git pull (config.sh
 # may not exist yet on first-ever pull, and PULL_LOG isn't defined yet).
 cd ~/meet-without-fear
+git checkout main >> /var/log/slam-bot/git-pull.log 2>&1 || true
 git fetch origin main && git reset --hard origin/main >> /var/log/slam-bot/git-pull.log 2>&1
 
 # Now source config.sh (guaranteed to exist after pull)


### PR DESCRIPTION
## Summary

- Add `git checkout main` before `git reset --hard origin/main` in git-pull.sh

## Problem

If an agent leaves the repo on a feature branch (e.g., Claude runs `git checkout -b feat/...` in the project dir instead of the worktree), `git reset --hard origin/main` moves that branch's pointer but doesn't switch back to main. This cascades:

1. Repo stays on feature branch
2. Next agent's `setup-worktree.sh` sees `CURRENT_BRANCH != "main"` → skips worktree
3. Agent works directly in project dir → git-pull clobbers its work
4. Agent gets killed as "stuck" → `bot:failed`

## Fix

One line: `git checkout main || true` before the fetch+reset. Self-healing — even if an agent misbehaves, the next git-pull tick (1 min) recovers.

## Test plan

- [ ] Verify git-pull.log shows `Switched to branch 'main'` on next tick
- [ ] After merge, manually `git checkout feat/test` on EC2, wait 1 min, confirm repo returns to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)