### PR TITLE
fix: prevent session stuck state and cross-user message leak

### DIFF
--- a/backend/src/controllers/invitations.ts
+++ b/backend/src/controllers/invitations.ts
@@ -341,15 +341,51 @@ export async function createSession(req: Request, res: Response): Promise<void> 
       return;
     }
 
-    // Create session in CREATED status (becomes INVITED after message is confirmed)
-    const session = await prisma.session.create({
-      data: {
-        relationshipId: relationship.id,
-        status: 'CREATED',
-      },
+    // Create session, invitation, stage progress, and vessels atomically
+    const { session, invitation } = await prisma.$transaction(async (tx) => {
+      const sess = await tx.session.create({
+        data: {
+          relationshipId: relationship.id,
+          status: 'CREATED',
+        },
+      });
+
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      const inv = await tx.invitation.create({
+        data: {
+          sessionId: sess.id,
+          invitedById: user.id,
+          name: inviteName,
+          expiresAt,
+        },
+      });
+
+      await tx.stageProgress.create({
+        data: {
+          sessionId: sess.id,
+          userId: user.id,
+          stage: 0,
+          status: 'IN_PROGRESS',
+        },
+      });
+
+      await tx.userVessel.create({
+        data: {
+          sessionId: sess.id,
+          userId: user.id,
+        },
+      });
+
+      await tx.sharedVessel.create({
+        data: {
+          sessionId: sess.id,
+        },
+      });
+
+      return { session: sess, invitation: inv };
     });
 
-    // If originated from Inner Thoughts, link it back
+    // If originated from Inner Thoughts, link it back (non-critical, outside transaction)
     if (innerThoughtsId) {
       try {
         await prisma.innerWorkSession.updateMany({
@@ -365,44 +401,8 @@ export async function createSession(req: Request, res: Response): Promise<void> 
       }
     }
 
-    // Create invitation with 7-day expiry
-    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
-    const invitation = await prisma.invitation.create({
-      data: {
-        sessionId: session.id,
-        invitedById: user.id,
-        name: inviteName,
-        expiresAt,
-      },
-    });
-
     // Generate invitation URL (user shares via their own channels)
     const invitationUrl = createInvitationUrl(invitation.id);
-
-    // Create initial stage progress for inviter
-    await prisma.stageProgress.create({
-      data: {
-        sessionId: session.id,
-        userId: user.id,
-        stage: 0,
-        status: 'IN_PROGRESS',
-      },
-    });
-
-    // Create user vessel for inviter
-    await prisma.userVessel.create({
-      data: {
-        sessionId: session.id,
-        userId: user.id,
-      },
-    });
-
-    // Create shared vessel
-    await prisma.sharedVessel.create({
-      data: {
-        sessionId: session.id,
-      },
-    });
 
     // Note: Initial AI message is now generated via POST /messages/initial
     // when the user first enters the session (fetched by mobile app)
@@ -551,56 +551,55 @@ export async function acceptInvitation(req: Request, res: Response): Promise<voi
       return;
     }
 
-    // Join the relationship
-    const existingMembership = await prisma.relationshipMember.findUnique({
-      where: {
-        relationshipId_userId: {
-          relationshipId: invitation.session.relationshipId,
-          userId: user.id,
+    // Accept invitation, activate session, create stage progress + vessel atomically
+    await prisma.$transaction(async (tx) => {
+      // Join the relationship
+      const existingMembership = await tx.relationshipMember.findUnique({
+        where: {
+          relationshipId_userId: {
+            relationshipId: invitation.session.relationshipId,
+            userId: user.id,
+          },
         },
-      },
-    });
+      });
 
-    if (!existingMembership) {
-      await prisma.relationshipMember.create({
+      if (!existingMembership) {
+        await tx.relationshipMember.create({
+          data: {
+            relationshipId: invitation.session.relationshipId,
+            userId: user.id,
+          },
+        });
+      }
+
+      await tx.invitation.update({
+        where: { id },
         data: {
-          relationshipId: invitation.session.relationshipId,
+          status: 'ACCEPTED',
+          acceptedAt: new Date(),
+        },
+      });
+
+      await tx.session.update({
+        where: { id: invitation.sessionId },
+        data: { status: 'ACTIVE' },
+      });
+
+      await tx.stageProgress.create({
+        data: {
+          sessionId: invitation.sessionId,
+          userId: user.id,
+          stage: 0,
+          status: 'IN_PROGRESS',
+        },
+      });
+
+      await tx.userVessel.create({
+        data: {
+          sessionId: invitation.sessionId,
           userId: user.id,
         },
       });
-    }
-
-    // Update invitation status
-    await prisma.invitation.update({
-      where: { id },
-      data: {
-        status: 'ACCEPTED',
-        acceptedAt: new Date(),
-      },
-    });
-
-    // Update session to ACTIVE
-    await prisma.session.update({
-      where: { id: invitation.sessionId },
-      data: { status: 'ACTIVE' },
-    });
-
-    // Create stage progress for accepter
-    await prisma.stageProgress.create({
-      data: {
-        sessionId: invitation.sessionId,
-        userId: user.id,
-        stage: 0,
-        status: 'IN_PROGRESS',
-      },
-    });
-
-    // Create user vessel for accepter
-    await prisma.userVessel.create({
-      data: {
-        sessionId: invitation.sessionId,
-        userId: user.id,
-      },
     });
 
     // Get session summary for response

--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -1184,7 +1184,7 @@ export async function validateEmpathy(
     // Check if both have validated (Accurate/Partial) and trigger transition
     if (validated && partnerValidation?.validated) {
       triggerStage3Transition(sessionId, user.id, partnerId).catch(err =>
-        logger.warn('[validateEmpathy] Failed to trigger transition:', err)
+        logger.error('[validateEmpathy] Failed to trigger stage 3 transition:', err)
       );
     }
 
@@ -1310,7 +1310,7 @@ export async function skipRefinement(
       });
 
       // Check for mutual completion
-      triggerStage3Transition(sessionId, user.id, partnerId).catch((e) => logger.warn('[Stage2] Stage 3 transition failed:', e));
+      triggerStage3Transition(sessionId, user.id, partnerId).catch((e) => logger.error('[Stage2] Stage 3 transition failed:', e));
     }
 
     successResponse(res, { success: true });
@@ -1548,16 +1548,38 @@ Respond in JSON format:
     const message = messages[0];
 
     // 4. Update Stage Progress for both to Stage 3
+    // Backfill missing prior stage records (defensive — handles cases where
+    // session initialization failed to create StageProgress atomically)
+    const now = new Date();
+    for (const uid of userIds) {
+      for (const priorStage of [0, 1, 2]) {
+        await prisma.stageProgress.upsert({
+          where: {
+            sessionId_userId_stage: { sessionId, userId: uid, stage: priorStage }
+          },
+          create: {
+            sessionId,
+            userId: uid,
+            stage: priorStage,
+            status: 'COMPLETED',
+            completedAt: now,
+          },
+          update: {}
+        });
+      }
+    }
+
     // Mark Stage 2 as COMPLETED
     await prisma.stageProgress.updateMany({
       where: {
         sessionId,
         stage: 2,
-        userId: { in: userIds }
+        userId: { in: userIds },
+        status: { not: 'COMPLETED' }
       },
       data: {
         status: 'COMPLETED',
-        completedAt: new Date()
+        completedAt: now
       }
     });
 
@@ -1576,7 +1598,7 @@ Respond in JSON format:
           userId: uid,
           stage: 3,
           status: 'IN_PROGRESS',
-          startedAt: new Date(),
+          startedAt: now,
         },
         update: {}
       });

--- a/mobile/src/hooks/useRealtime.ts
+++ b/mobile/src/hooks/useRealtime.ts
@@ -156,6 +156,11 @@ export function useRealtime(config: RealtimeConfig): RealtimeState & RealtimeAct
   const isMountedRef = useRef(true);
   const reconnectAttemptsRef = useRef(0);
 
+  // Synchronous ref for user ID — prevents stale closure from leaking
+  // messages to the wrong user during auth transitions or app backgrounding
+  const userIdRef = useRef(user?.id);
+  userIdRef.current = user?.id;
+
   // Store callbacks in refs to avoid stale closures
   const callbacksRef = useRef({
     onConnectionChange,
@@ -214,11 +219,15 @@ export function useRealtime(config: RealtimeConfig): RealtimeState & RealtimeAct
     (message: Ably.Message) => {
       if (!isMountedRef.current) return;
 
+      // Use ref for user ID — avoids stale closure during auth transitions
+      const currentUserId = userIdRef.current;
+      if (!currentUserId) return;
+
       const eventName = message.name as SessionEventType;
       const eventData = message.data as SessionEventData;
 
       // Skip events from ourselves
-      if (eventData.excludeUserId === user?.id) {
+      if (eventData.excludeUserId === currentUserId) {
         return;
       }
 
@@ -266,7 +275,7 @@ export function useRealtime(config: RealtimeConfig): RealtimeState & RealtimeAct
           if (callbacksRef.current.onAIResponse) {
             const aiPayload = eventData as unknown as MessageAIResponsePayload;
             // Only handle if this message is for the current user
-            if (aiPayload.forUserId === user?.id) {
+            if (aiPayload.forUserId === currentUserId) {
               console.log('[Realtime] AI response received:', aiPayload.message?.id);
               callbacksRef.current.onAIResponse(aiPayload);
             }
@@ -277,7 +286,7 @@ export function useRealtime(config: RealtimeConfig): RealtimeState & RealtimeAct
           if (callbacksRef.current.onAIError) {
             const errorPayload = eventData as unknown as MessageErrorPayload;
             // Only handle if this error is for the current user
-            if (errorPayload.forUserId === user?.id) {
+            if (errorPayload.forUserId === currentUserId) {
               console.log('[Realtime] AI error received:', errorPayload.error);
               callbacksRef.current.onAIError(errorPayload);
             }
@@ -290,7 +299,8 @@ export function useRealtime(config: RealtimeConfig): RealtimeState & RealtimeAct
           break;
       }
     },
-    [user?.id]
+    // userIdRef is read synchronously — no dependency on user?.id needed
+    []
   );
 
   // ============================================================================


### PR DESCRIPTION
## Changes
- Fix: Wrap session + invitation creation in Prisma `$transaction` so StageProgress and UserVessel records are created atomically (prevents silent partial creation that leaves sessions stuck)
- Fix: Add defensive StageProgress backfill in `triggerStage3Transition` — ensures sessions with missing records can still transition to Stage 3
- Fix: Replace closure-captured `user?.id` with synchronous `userIdRef` in `useRealtime` message handler to prevent cross-user message leak during auth transitions
- Fix: Upgrade `triggerStage3Transition` error logging from `warn` to `error` for better observability

Related to #77

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** I just did a test session with my friend Jamal. It actually worked pretty well until we got to The point where both of us had accepted the shared empathy...

## Docs updated
No doc changes needed — internal transactional safety and error resilience fixes only, no API contract changes.