### PR TITLE
feat: conversation-state-model — milestone merge (#36)

### DIFF
--- a/bot-workspaces/mwf-session/CLAUDE.md
+++ b/bot-workspaces/mwf-session/CLAUDE.md
@@ -27,6 +27,7 @@ Thread-based MWF conversation workspace. Each Slack thread in `#mwf-sessions` is
 | `references/guardian-constitution.md` | Always | Process Guardian identity, voice, and universal rules |
 | `references/stage-progression.md` | Always | Gate rules, parallel vs sequential logic |
 | `references/privacy-model.md` | Always | Per-stage sharing and Vessel rules |
+| `references/global-facts.md` | Stage 0 (session start), stage transitions, session completion | Cross-session fact accumulation lifecycle |
 | `shared/slack/slack-post.md` | Stage 2 (reply posting) | Posting thread replies via `slack-post.sh` |
 | `shared/references/slack-format.md` | Stage 2 (reply posting) | Slack mrkdwn syntax (NOT Markdown) |
 | `docs/product/stages/index.md` | First message in thread | Understand stage progression rules |

--- a/bot-workspaces/mwf-session/CONTEXT.md
+++ b/bot-workspaces/mwf-session/CONTEXT.md
@@ -17,6 +17,7 @@ Facilitate a Meet Without Fear conversation between two users through five seque
 - `references/stage-progression.md` — Gate conditions and coordination modes per stage
 - `references/privacy-model.md` — Vessel rules, consent requirements, per-stage sharing policy
 - `references/guardian-constitution.md` — Process Guardian identity, voice, and universal behavioral rules
+- `references/global-facts.md` — Cross-session fact accumulation: loading, consolidation, and privacy rules
 
 ## Key Conventions
 

--- a/bot-workspaces/mwf-session/references/global-facts.md
+++ b/bot-workspaces/mwf-session/references/global-facts.md
@@ -1,0 +1,85 @@
+# Global Facts — Cross-Session Accumulation
+
+Global facts give the Process Guardian continuity with returning users. Instead of starting from scratch each session, the bot has context about people, history, and emotional patterns the user has shared before.
+
+## Lifecycle
+
+```
+Session N (per-turn)          Session end / stage transition       Session N+1 (start)
+─────────────────────         ──────────────────────────────       ───────────────────
+Extract facts →               Consolidate into global-facts.json → Load as context
+vessel-{x}/notable-facts.json   data/mwf-users/{user_id}/           for new session
+```
+
+### 1. Extraction (per turn, Stages 1–3)
+
+Facts are extracted into each user's private vessel during conversation. See `schemas/notable-facts.schema.md` for the per-session schema.
+
+- Max 20 facts per session per user
+- Each fact has a stable UUID, category, and source stage
+- Facts stay in the user's vessel — never shared with the partner
+
+### 2. Consolidation (on trigger)
+
+Merge per-session `vessel-{x}/notable-facts.json` into `data/mwf-users/{slack_user_id}/global-facts.json`. See `schemas/global-facts.schema.md` for the target schema.
+
+**Triggers:**
+- **Session completion** — when both users satisfy all Stage 4 gates and `session.json` status is set to `completed`
+- **Stage transitions** — when `current_stage` advances in `stage-progress.json` (e.g., Stage 1 → 2, Stage 2 → 3, etc.)
+
+**Algorithm:**
+
+1. Read the user's `vessel-{x}/notable-facts.json` for the current session
+2. Read (or create) `data/mwf-users/{slack_user_id}/global-facts.json`
+3. For each session fact:
+   - **If the fact's UUID already exists in global facts**: update `last_confirmed` to now, append the current `session_id` to `source_sessions` (if not already present)
+   - **If the UUID is new**: map the session fact to a global fact entry:
+     ```
+     {
+       id:              <same UUID from session fact>,
+       category:        <same category>,
+       fact:            <same fact text>,
+       first_seen:      <session fact's extracted_at>,
+       last_confirmed:  <now>,
+       source_sessions: [<current session_id>]
+     }
+     ```
+4. Write the updated global facts back to file
+
+**Over-limit consolidation (max 50 facts):**
+
+If the merged result exceeds 50 facts:
+1. Sort by `last_confirmed` ascending (oldest-confirmed first)
+2. Group the oldest facts by `category`
+3. Within each category group, merge facts with similar content into a single summary fact:
+   - Combine `source_sessions` arrays
+   - Use the earliest `first_seen` and latest `last_confirmed`
+   - Rewrite `fact` as a concise summary covering all merged facts
+   - Generate a new UUID for the merged fact
+4. Repeat until the count is at or below 50
+
+### 3. Loading (on session start)
+
+When a new session begins (Stage 0, Phase 0A or Phase 0B), check if the user has existing global facts:
+
+1. Look up `data/mwf-users/{slack_user_id}/global-facts.json`
+2. If the file exists and is non-empty, load it as additional context
+3. Inject the facts into the session as background knowledge — the bot can reference them naturally without quoting them verbatim
+4. Do NOT tell the user "I remember from last time" or make the continuity feel surveillance-like — use the facts to inform questions and reflections naturally
+
+**Privacy rules:**
+- Global facts are per-user and private — never share one user's global facts with the other user
+- Facts follow the same Vessel isolation rules as all other per-user data
+- The partner cannot read or infer the contents of the other user's global facts
+
+## File Locations
+
+| File | Path | Scope |
+|---|---|---|
+| Per-session facts | `data/mwf-sessions/{session_id}/vessel-{a\|b}/notable-facts.json` | One session, one user |
+| Global facts | `data/mwf-users/{slack_user_id}/global-facts.json` | All sessions for one user |
+
+## Schema Reference
+
+- Per-session: `schemas/notable-facts.schema.md`
+- Global: `schemas/global-facts.schema.md`

--- a/bot-workspaces/mwf-session/references/privacy-model.md
+++ b/bot-workspaces/mwf-session/references/privacy-model.md
@@ -35,6 +35,20 @@ When the AI creates cross-user content, it must:
 - **Anonymize** strategy proposals (Stage 4) — no attribution
 - **Frame** partner perspectives as possibilities ("they might feel..."), not certainties
 
+## File-Level Access Rules
+
+Each stage enforces strict retrieval contracts on the file-based state tree:
+
+| Stage | Files Readable | Files Forbidden |
+|---|---|---|
+| 0 | `session.json`, `stage-progress.json` | All vessel files |
+| 1 | Own `vessel-{x}/*`, `conversation-summary.md` | Partner's vessel, `shared/*` |
+| 2 | Own vessel + `shared/consented-content.json` | Partner's raw vessel |
+| 3 | Own `vessel-{x}/needs.json` + `shared/consented-content.json`, `shared/common-ground.json` | Partner's raw vessel, own raw events |
+| 4 | `shared/*` (all) | Both users' raw vessels |
+
+The `synthesis/` directory is **never** read during user-facing turns — it exists for dev/monitoring purposes only.
+
 ## Vessel Contents
 
 Each user's Vessel stores:

--- a/bot-workspaces/mwf-session/references/stage-progression.md
+++ b/bot-workspaces/mwf-session/references/stage-progression.md
@@ -55,3 +55,12 @@ Each user tracks their own `StageStatus` independently:
 ## No Skipping
 
 Stages must be completed in order (0 → 1 → 2 → 3 → 4). A user cannot enter stage N+1 until stage N is `COMPLETED` for both users.
+
+## Global Facts Consolidation
+
+Notable facts are consolidated into each user's cross-session `global-facts.json` at two points:
+
+1. **Stage transitions** — when `current_stage` advances (both users `COMPLETED`), consolidate each user's `vessel-{x}/notable-facts.json` into `data/mwf-users/{slack_user_id}/global-facts.json`
+2. **Session completion** — when all Stage 4 gates are satisfied and `session.json` status is set to `completed`
+
+This ensures facts are preserved even if a session ends early or is abandoned after a stage transition. See `references/global-facts.md` for the full merge algorithm, deduplication rules, and 50-fact limit.

--- a/bot-workspaces/mwf-session/references/stage-progression.md
+++ b/bot-workspaces/mwf-session/references/stage-progression.md
@@ -22,6 +22,18 @@ Each stage has an advancement gate. Both users must satisfy it before the sessio
 | 3 | At least one common-ground need identified and confirmed by both users |
 | 4 | Mutual agreement on at least one micro-experiment |
 
+## Gate Keys
+
+Gate state is persisted in `stage-progress.json`. Each key is a boolean that must be satisfied before the stage can advance. Stage advancement requires **both users** to satisfy all gate keys for the current stage.
+
+| Stage | Gate Keys |
+|---|---|
+| 0 | `agreedToTerms` |
+| 1 | `feelHeardConfirmed` |
+| 2 | `empathyDraftReady`, `empathyConsented`, `partnerValidated` |
+| 3 | `needsConfirmed`, `commonGroundConfirmed` |
+| 4 | `strategiesSubmitted`, `rankingsSubmitted`, `agreementCreated` |
+
 ## Per-User Status
 
 Each user tracks their own `StageStatus` independently:

--- a/bot-workspaces/mwf-session/schemas/global-facts.schema.md
+++ b/bot-workspaces/mwf-session/schemas/global-facts.schema.md
@@ -1,0 +1,40 @@
+# global-facts.json
+
+Cross-session consolidated facts for a user. Built up over multiple MWF sessions to provide continuity for returning users.
+
+**Location:** `data/mwf-users/{slack_user_id}/global-facts.json`
+
+## Schema
+
+Array of fact objects:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` (UUID) | Unique fact identifier (matches original per-session fact ID) |
+| `category` | `string` enum | `People \| Logistics \| Conflict \| Emotional \| History` |
+| `fact` | `string` | Human-readable description of the fact |
+| `first_seen` | `string` (ISO-8601) | When the fact was first extracted |
+| `last_confirmed` | `string` (ISO-8601) | When the fact was last confirmed or referenced |
+| `source_sessions` | `string[]` | Session IDs where this fact appeared |
+
+## Example
+
+```json
+[
+  {
+    "id": "uuid",
+    "category": "People | Logistics | Conflict | Emotional | History",
+    "fact": "Has a sister they're close to since childhood",
+    "first_seen": "ISO-8601",
+    "last_confirmed": "ISO-8601",
+    "source_sessions": ["session_id_1", "session_id_2"]
+  }
+]
+```
+
+## Notes
+
+- Maximum 50 global facts per user
+- Facts are merged from per-session `notable-facts.json` at session completion or stage transitions
+- Deduplication by UUID — if the same fact ID already exists, `last_confirmed` and `source_sessions` are updated
+- Category enum matches `notable-facts.json`

--- a/bot-workspaces/mwf-session/schemas/notable-facts.schema.md
+++ b/bot-workspaces/mwf-session/schemas/notable-facts.schema.md
@@ -1,0 +1,47 @@
+# notable-facts.json
+
+Categorized facts extracted from a user's conversation. Stored per-user in their private vessel.
+
+**Location:** `data/mwf-sessions/{session_id}/vessel-{a|b}/notable-facts.json`
+
+## Schema
+
+Array of fact objects:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` (UUID) | Unique fact identifier |
+| `category` | `string` enum | Fact category |
+| `fact` | `string` | Human-readable description of the fact |
+| `extracted_at` | `string` (ISO-8601) | When the fact was extracted |
+| `source_stage` | `number` (0–4) | Stage during which the fact was extracted |
+
+### `category` enum
+
+| Value | Description |
+|---|---|
+| `People` | People mentioned in the conflict |
+| `Logistics` | Practical details (timing, location, arrangements) |
+| `Conflict` | Core conflict dynamics and triggers |
+| `Emotional` | Emotional states and responses |
+| `History` | Background and relationship history |
+
+## Example
+
+```json
+[
+  {
+    "id": "uuid",
+    "category": "People | Logistics | Conflict | Emotional | History",
+    "fact": "User's partner is their sister; they've been close since childhood",
+    "extracted_at": "ISO-8601",
+    "source_stage": 1
+  }
+]
+```
+
+## Notes
+
+- Maximum 20 facts per session per user
+- When the limit is exceeded, oldest facts by timestamp are consolidated/merged
+- Facts are private to each user's vessel — never readable by the other user's stage contract

--- a/bot-workspaces/mwf-session/schemas/session.schema.md
+++ b/bot-workspaces/mwf-session/schemas/session.schema.md
@@ -1,0 +1,52 @@
+# session.json
+
+Session metadata and pairing state. Created when a user starts an MWF session; updated when a partner joins.
+
+**Location:** `data/mwf-sessions/{session_id}/session.json`
+
+## Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `session_id` | `string` (UUID) | Unique session identifier |
+| `join_code` | `string` (6-char alphanumeric) | Code shared with conversation partner to join |
+| `created_at` | `string` (ISO-8601) | When the session was created |
+| `status` | `string` enum | Session lifecycle state |
+| `user_a` | `object \| null` | First user (session creator) |
+| `user_b` | `object \| null` | Second user (joins via code) |
+
+### `status` enum
+
+| Value | Meaning |
+|---|---|
+| `waiting_for_partner` | Session created, waiting for User B to join |
+| `active` | Both users paired, session in progress |
+| `completed` | All stages finished |
+| `abandoned` | Session abandoned (timeout or user exit) |
+
+### User object
+
+| Field | Type | Description |
+|---|---|---|
+| `slack_user_id` | `string` | Slack user ID (e.g. `U0AD3TF2U7L`) |
+| `display_name` | `string` | Slack display name |
+| `thread_ts` | `string` | Slack thread timestamp for this user's DM thread |
+
+## Example
+
+```json
+{
+  "session_id": "uuid",
+  "join_code": "abc123",
+  "created_at": "ISO-8601",
+  "status": "waiting_for_partner | active | completed | abandoned",
+  "user_a": { "slack_user_id": "U...", "display_name": "...", "thread_ts": "..." },
+  "user_b": { "slack_user_id": "U...", "display_name": "...", "thread_ts": "..." }
+}
+```
+
+## Notes
+
+- `user_b` is `null` until a partner joins via the `join_code`
+- `join_code` is generated once at creation and never changes
+- Sessions older than 90 days are auto-cleaned by the sweeper job

--- a/bot-workspaces/mwf-session/schemas/shared-vessel.schema.md
+++ b/bot-workspaces/mwf-session/schemas/shared-vessel.schema.md
@@ -1,0 +1,105 @@
+# Shared Vessel Files
+
+Consensual content shared between both users. Content only enters the shared vessel after explicit user consent.
+
+**Location:** `data/mwf-sessions/{session_id}/shared/`
+
+## consented-content.json
+
+Content that a user has consented to share with their partner. Raw input is transformed into an abstracted form before sharing.
+
+| Field | Type | Description |
+|---|---|---|
+| `source_user` | `string` | Slack user ID of the consenting user |
+| `transformed` | `string` | Abstracted/synthesized version of the content |
+| `consent_ts` | `string` (ISO-8601) | When consent was given |
+| `consent_active` | `boolean` | Whether consent is still active (can be revoked) |
+
+```json
+[
+  {
+    "source_user": "U0AD3TF2U7L",
+    "transformed": "Feels unacknowledged for daily caregiving responsibilities",
+    "consent_ts": "ISO-8601",
+    "consent_active": true
+  }
+]
+```
+
+## common-ground.json
+
+Needs or concerns confirmed by both users as shared.
+
+| Field | Type | Description |
+|---|---|---|
+| `need` | `string` | Description of the shared need |
+| `confirmed_by` | `string[]` | Slack user IDs of users who confirmed |
+| `ts` | `string` (ISO-8601) | When common ground was identified |
+
+```json
+[
+  {
+    "need": "Both want to feel respected in family decisions",
+    "confirmed_by": ["U_A_ID", "U_B_ID"],
+    "ts": "ISO-8601"
+  }
+]
+```
+
+## agreements.json
+
+Agreements reached between both users.
+
+| Field | Type | Description |
+|---|---|---|
+| `description` | `string` | What was agreed |
+| `agreed_by` | `string[]` | Slack user IDs of users who agreed |
+| `status` | `string` enum | `proposed \| accepted \| rejected` |
+| `ts` | `string` (ISO-8601) | When the agreement was created/updated |
+
+```json
+[
+  {
+    "description": "Schedule a weekly 30-minute check-in about caregiving tasks",
+    "agreed_by": ["U_A_ID", "U_B_ID"],
+    "status": "accepted",
+    "ts": "ISO-8601"
+  }
+]
+```
+
+## micro-experiments.json
+
+Small actionable experiments for users to try between sessions.
+
+| Field | Type | Description |
+|---|---|---|
+| `description` | `string` | What to try |
+| `status` | `string` enum | `proposed \| in_progress \| completed \| skipped` |
+| `follow_up` | `string` | Notes or outcome from the experiment |
+
+```json
+[
+  {
+    "description": "Try thanking each other for one caregiving task this week",
+    "status": "proposed",
+    "follow_up": ""
+  }
+]
+```
+
+## Retrieval Contract
+
+| Stage | Access |
+|---|---|
+| 0 | Not readable |
+| 1 | Not readable |
+| 2 | `consented-content.json` only |
+| 3 | `consented-content.json`, `common-ground.json` |
+| 4 | All shared files |
+
+## Notes
+
+- Content enters the shared vessel **only** after explicit user consent
+- If a user revokes consent (`consent_active: false`), the content is no longer readable by the partner's stage contract
+- Raw user input is never stored here — only transformed/abstracted versions

--- a/bot-workspaces/mwf-session/schemas/stage-progress.schema.md
+++ b/bot-workspaces/mwf-session/schemas/stage-progress.schema.md
@@ -1,0 +1,56 @@
+# stage-progress.json
+
+Per-user stage tracking and gate satisfaction. Read on every incoming message to determine which stage behavior to apply.
+
+**Location:** `data/mwf-sessions/{session_id}/stage-progress.json`
+
+## Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `current_stage` | `number` (0–4) | The stage both users are currently in |
+| `users` | `object` | Map of Slack user ID → per-user progress |
+
+### Per-user progress object
+
+| Field | Type | Description |
+|---|---|---|
+| `stage_status` | `string` enum | `NOT_STARTED \| IN_PROGRESS \| COMPLETE` |
+| `gates_satisfied` | `object` | Map of gate key → `boolean` for the current stage |
+| `last_active` | `string \| null` (ISO-8601) | Last message timestamp for this user |
+
+### Gate keys per stage
+
+| Stage | Gate Keys | Description |
+|---|---|---|
+| 0 | `agreedToTerms` | User accepted terms and onboarding |
+| 1 | `feelHeardConfirmed` | User confirmed feeling heard |
+| 2 | `empathyDraftReady`, `empathyConsented`, `partnerValidated` | Empathy synthesis drafted, consented, and validated by partner |
+| 3 | `needsConfirmed`, `commonGroundConfirmed` | User confirmed needs; common ground identified |
+| 4 | `strategiesSubmitted`, `rankingsSubmitted`, `agreementCreated` | Strategies proposed, ranked, and agreement created |
+
+## Example
+
+```json
+{
+  "current_stage": 0,
+  "users": {
+    "U_A_ID": {
+      "stage_status": "IN_PROGRESS",
+      "gates_satisfied": { "agreedToTerms": false },
+      "last_active": "ISO-8601"
+    },
+    "U_B_ID": {
+      "stage_status": "NOT_STARTED",
+      "gates_satisfied": {},
+      "last_active": null
+    }
+  }
+}
+```
+
+## Notes
+
+- `current_stage` advances only when **both** users have all gates satisfied for the current stage
+- `gates_satisfied` resets to the new stage's gate keys (all `false`) on stage advancement
+- If file corruption creates a state where users are in different stages, the bot falls back to the lower stage

--- a/bot-workspaces/mwf-session/schemas/thread-index.schema.md
+++ b/bot-workspaces/mwf-session/schemas/thread-index.schema.md
@@ -1,0 +1,35 @@
+# thread-index.json
+
+Maps Slack thread timestamps to session IDs. Used on each incoming message to look up which session a thread belongs to.
+
+**Location:** `data/mwf-sessions/thread-index.json`
+
+## Schema
+
+Object with keys of format `{channel_id}:{thread_ts}` mapping to session IDs.
+
+| Key format | Value type | Description |
+|---|---|---|
+| `{channel_id}:{thread_ts}` | `string` (UUID) | Session ID this thread belongs to |
+
+## Example
+
+```json
+{
+  "C_CHANNEL_ID:TS_USER_A": "session_id",
+  "C_CHANNEL_ID:TS_USER_B": "session_id"
+}
+```
+
+## Lookup Flow
+
+1. On each incoming message, construct key as `{channel_id}:{thread_ts}`
+2. Look up in `thread-index.json`
+3. If found → load that session's state files from `data/mwf-sessions/{session_id}/`
+4. If not found → check if message contains a join code or is a new session request
+
+## Notes
+
+- Each session has two entries (one per user thread), both pointing to the same session ID
+- Entries are added when a session is created (User A) and when a partner joins (User B)
+- Entries are removed when the session folder is cleaned by the 90-day sweeper

--- a/bot-workspaces/mwf-session/schemas/vessel-files.schema.md
+++ b/bot-workspaces/mwf-session/schemas/vessel-files.schema.md
@@ -1,0 +1,73 @@
+# Per-User Vessel Files
+
+Private vessel files for each user. These live in the user's vessel directory and are never directly readable by the other user.
+
+**Location:** `data/mwf-sessions/{session_id}/vessel-{a|b}/`
+
+## emotional-thread.json
+
+Emotional intensity readings tracked over the conversation.
+
+| Field | Type | Description |
+|---|---|---|
+| `ts` | `string` (ISO-8601) | Timestamp of the reading |
+| `intensity` | `number` (1–10) | Emotional intensity level |
+| `context` | `string` | Brief description of the emotional context |
+
+```json
+[
+  {
+    "ts": "ISO-8601",
+    "intensity": 6,
+    "context": "Frustration mixed with sadness when discussing caregiving"
+  }
+]
+```
+
+## needs.json
+
+Identified needs extracted from the user's conversation.
+
+| Field | Type | Description |
+|---|---|---|
+| `need` | `string` | Description of the identified need |
+| `evidence` | `string[]` | Quotes or references supporting the need |
+| `confirmed` | `boolean` | Whether the user has confirmed this need |
+
+```json
+[
+  {
+    "need": "To feel acknowledged for caregiving effort",
+    "evidence": ["I do everything and nobody notices"],
+    "confirmed": false
+  }
+]
+```
+
+## boundaries.json
+
+Stated boundaries from the user.
+
+| Field | Type | Description |
+|---|---|---|
+| `boundary` | `string` | Description of the boundary |
+| `non_negotiable` | `boolean` | Whether the user considers this non-negotiable |
+
+```json
+[
+  {
+    "boundary": "Won't discuss finances in front of the kids",
+    "non_negotiable": true
+  }
+]
+```
+
+## Retrieval Contract
+
+| Stage | Access |
+|---|---|
+| 0 | Not readable |
+| 1 | Own vessel only |
+| 2 | Own vessel only (shared content goes through Shared Vessel via consent) |
+| 3 | Own `needs.json` only |
+| 4 | Not readable (all interaction through Shared Vessel) |

--- a/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
@@ -5,8 +5,10 @@
 | Parameter | Source | Description |
 |---|---|---|
 | `user_id` | Session event | Which participant is messaging |
+| `channel_id` | Session event | Slack channel ID for the thread |
+| `thread_ts` | Session event | Slack thread timestamp |
 | `userName` | User profile | Display name for this user |
-| `partnerName` | Session data | Display name for the other participant |
+| `partnerName` | Session data | Display name for the other participant (null if unpaired) |
 | `turnCount` | Conversation state | Number of exchanges so far |
 | `emotionalIntensity` | Per-turn analysis | 1–10 rating of user's current state |
 | `isInvitationPhase` | Session state | Whether user is crafting an invitation (partner hasn't joined yet) |
@@ -14,9 +16,104 @@
 | `invitationMessage` | Session data | Current invitation draft text (if refining) |
 | `innerThoughtsContext` | Inner work session | Summary and themes from prior self-reflection (if any) |
 
+## State Files
+
+| File | Schema | Purpose |
+|---|---|---|
+| `data/mwf-sessions/thread-index.json` | `schemas/thread-index.schema.md` | Map `channel:thread_ts` → session ID |
+| `data/mwf-sessions/{session_id}/session.json` | `schemas/session.schema.md` | Session metadata and pairing state |
+| `data/mwf-sessions/{session_id}/stage-progress.json` | `schemas/stage-progress.schema.md` | Per-user stage and gate tracking |
+
 ## Process
 
 Load `references/guardian-constitution.md` for universal voice, identity, and behavioral rules. All rules below layer on top.
+
+### Routing: Determine Entry Point
+
+On each incoming message, determine which phase to enter:
+
+1. Construct lookup key: `{channel_id}:{thread_ts}`
+2. Check `thread-index.json` for an existing session
+3. Route based on result:
+   - **No session found + message contains a join code** (e.g., "Join mwf abc123") → **Phase 0B: Partner Pairing**
+   - **No session found + no join code** → **Phase 0A: Session Creation**
+   - **Session found + status `waiting_for_partner`** → **Phase B: Invitation Crafting** (existing user waiting)
+   - **Session found + status `active`** → **Phase A: Curiosity Compact**
+
+### Phase 0A: Session Creation
+
+Triggered when a user starts a new MWF session and no existing session is found in `thread-index.json`.
+
+1. **Generate session identifiers**:
+   - `session_id`: a new UUID
+   - `join_code`: a random 6-character alphanumeric code (lowercase + digits)
+
+2. **Create session files**:
+   - Create directory `data/mwf-sessions/{session_id}/`
+   - Write `session.json`:
+     ```json
+     {
+       "session_id": "<uuid>",
+       "join_code": "<6-char code>",
+       "created_at": "<ISO-8601>",
+       "status": "waiting_for_partner",
+       "user_a": {
+         "slack_user_id": "<user_id>",
+         "display_name": "<userName>",
+         "thread_ts": "<thread_ts>"
+       },
+       "user_b": null
+     }
+     ```
+   - Write `stage-progress.json`:
+     ```json
+     {
+       "current_stage": 0,
+       "users": {
+         "<user_id>": {
+           "stage_status": "NOT_STARTED",
+           "gates_satisfied": { "agreedToTerms": false },
+           "last_active": "<ISO-8601>"
+         }
+       }
+     }
+     ```
+
+3. **Update thread index**:
+   - Add `"{channel_id}:{thread_ts}": "{session_id}"` entry to `thread-index.json`
+
+4. **Reply with join code**:
+   - Tell the user their session is created
+   - Provide the join code for them to share with their conversation partner
+   - Transition to Phase B (Invitation Crafting) in the same thread
+
+### Phase 0B: Partner Pairing
+
+Triggered when a message contains a join code and no existing session is found for this thread.
+
+1. **Look up the join code**:
+   - Search across all `data/mwf-sessions/{session_id}/session.json` files for a matching `join_code`
+   - If not found → reply: "I couldn't find a session with that code. Double-check and try again."
+   - If found but `status` is not `waiting_for_partner` → reply: "That session already has two participants."
+
+2. **Pair the users**:
+   - Update `session.json`:
+     - Set `user_b` to `{ "slack_user_id": "<user_id>", "display_name": "<userName>", "thread_ts": "<thread_ts>" }`
+     - Set `status` to `active`
+   - Update `stage-progress.json`:
+     - Add User B entry: `{ "stage_status": "NOT_STARTED", "gates_satisfied": { "agreedToTerms": false }, "last_active": "<ISO-8601>" }`
+
+3. **Update thread index**:
+   - Add User B's `"{channel_id}:{thread_ts}": "{session_id}"` entry to `thread-index.json`
+
+4. **Create vessel directories**:
+   - Create `data/mwf-sessions/{session_id}/vessel-a/`
+   - Create `data/mwf-sessions/{session_id}/vessel-b/`
+
+5. **Notify both users**:
+   - In User A's thread: "Your partner has joined! Let's begin."
+   - In User B's thread: Welcome and begin Phase A (Curiosity Compact)
+   - Both users enter Phase A
 
 ### Phase A: Curiosity Compact (both users present)
 
@@ -39,11 +136,17 @@ Load `references/guardian-constitution.md` for universal voice, identity, and be
 4. **Collect signatures**:
    - Each user explicitly agrees (`agreedToTerms: true`)
    - Record signature timestamp per user
+   - **Persist to `stage-progress.json`**: set `gates_satisfied.agreedToTerms` to `true` and `stage_status` to `COMPLETE` for this user
    - If one user declines, session cannot proceed — acknowledge respectfully
 
-5. **Confirm both signed**:
-   - When both have signed, acknowledge the shared commitment
-   - Brief preview of Stage 1 (The Witness)
+5. **Check gate completion**:
+   - After each signature, read `stage-progress.json` to check if **both** users have `agreedToTerms: true`
+   - If only one user has signed: update their status and reply with "Waiting for your partner to agree as well."
+   - If both have signed:
+     - Advance `current_stage` to `1` in `stage-progress.json`
+     - Reset both users' `gates_satisfied` to `{ "feelHeardConfirmed": false }` and `stage_status` to `NOT_STARTED`
+     - Acknowledge the shared commitment
+     - Brief preview of Stage 1 (The Witness)
 
 ### Phase B: Invitation Crafting (one user, partner hasn't joined)
 
@@ -72,12 +175,22 @@ Load `references/guardian-constitution.md` for universal voice, identity, and be
 - Reference the summary and themes to inform the invitation
 - But don't share raw inner-work content in the invitation itself
 
+## Error Handling
+
+| Scenario | Response |
+|---|---|
+| Invalid join code | "I couldn't find a session with that code. Double-check and try again." |
+| Already-paired session | "That session already has two participants." |
+| User declines Curiosity Compact | Acknowledge respectfully; session cannot proceed without both signatures |
+
 ## Output
 
+- Session files created/updated (`session.json`, `stage-progress.json`, `thread-index.json`)
+- Vessel directories created on pairing (`vessel-a/`, `vessel-b/`)
 - Both users' Compact signatures with timestamps (Phase A)
 - Invitation draft with consent to send (Phase B)
-- Session status: `COMPLETED` (both signed) or blocked (awaiting signature / declined)
+- Gate state: `agreedToTerms` per user in `stage-progress.json`
 
 ## Completion
 
-When both users have signed, advance to `stages/1-witness/`. If either user declines, end the session gracefully.
+When both users have `agreedToTerms: true` in `stage-progress.json`, advance `current_stage` to `1` and proceed to `stages/1-witness/`. If either user declines, end the session gracefully.

--- a/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
@@ -23,6 +23,7 @@
 | `data/mwf-sessions/thread-index.json` | `schemas/thread-index.schema.md` | Map `channel:thread_ts` → session ID |
 | `data/mwf-sessions/{session_id}/session.json` | `schemas/session.schema.md` | Session metadata and pairing state |
 | `data/mwf-sessions/{session_id}/stage-progress.json` | `schemas/stage-progress.schema.md` | Per-user stage and gate tracking |
+| `data/mwf-users/{slack_user_id}/global-facts.json` | `schemas/global-facts.schema.md` | Cross-session accumulated facts (returning users) |
 
 ## Process
 
@@ -82,7 +83,13 @@ Triggered when a user starts a new MWF session and no existing session is found 
 3. **Update thread index**:
    - Add `"{channel_id}:{thread_ts}": "{session_id}"` entry to `thread-index.json`
 
-4. **Reply with join code**:
+4. **Load global facts** (returning user context):
+   - Check if `data/mwf-users/{user_id}/global-facts.json` exists
+   - If it exists and is non-empty, load the facts as background context for this session
+   - Use facts to inform questions and reflections naturally — do NOT say "I remember from last time"
+   - See `references/global-facts.md` for loading rules and privacy constraints
+
+5. **Reply with join code**:
    - Tell the user their session is created
    - Provide the join code for them to share with their conversation partner
    - Transition to Phase B (Invitation Crafting) in the same thread
@@ -110,7 +117,12 @@ Triggered when a message contains a join code and no existing session is found f
    - Create `data/mwf-sessions/{session_id}/vessel-a/`
    - Create `data/mwf-sessions/{session_id}/vessel-b/`
 
-5. **Notify both users**:
+5. **Load global facts** (returning user context):
+   - For both User A and User B, check if `data/mwf-users/{slack_user_id}/global-facts.json` exists
+   - If it exists and is non-empty, load as background context for this user's session thread
+   - See `references/global-facts.md` for loading rules and privacy constraints
+
+6. **Notify both users**:
    - In User A's thread: "Your partner has joined! Let's begin."
    - In User B's thread: Welcome and begin Phase A (Curiosity Compact)
    - Both users enter Phase A

--- a/bot-workspaces/mwf-session/stages/1-witness/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/1-witness/CONTEXT.md
@@ -81,11 +81,60 @@ The following adjustments are made based on the current turn state:
 | **Gathering (turn < 5, intensity < 8)** | Keep responses short — acknowledge briefly, then ask. Don't reflect yet unless something really heavy deserves more than a one-liner. |
 | **Reflecting (turn 5+, intensity < 8)** | Reflect back using their own words. Check if you've understood. Ask from understanding, not just gathering. |
 
+### Vessel File Writes (per turn)
+
+After composing the reply, update the user's private vessel files. See `schemas/vessel-files.schema.md` and `schemas/notable-facts.schema.md` for full schemas.
+
+**Notable Facts** — Append to `vessel-{x}/notable-facts.json`:
+- Extract facts the user reveals about the conflict, people, or situation
+- Categorize each fact: `People`, `Logistics`, `Conflict`, `Emotional`, `History`
+- Max 20 facts per session per user — when exceeded, consolidate oldest entries
+- Only add genuinely new information; skip facts already captured
+
+**Emotional Thread** — Append to `vessel-{x}/emotional-thread.json`:
+- Record one reading per turn: `{ ts, intensity (1–10), context }`
+- `context` is a brief phrase describing what drove the intensity (e.g., "Anger when recounting betrayal")
+
+**Conversation Summary** — Update `vessel-{x}/conversation-summary.md`:
+- Rolling narrative of what the user has shared so far
+- Written in third-person past tense ("User described...")
+- Replace the full file each turn — this is a summary, not an append log
+
+### Internal Dialogue Trace (per turn)
+
+Append to `synthesis/internal-dialogue.md` — dev-only, never exposed to users.
+
+Each entry includes:
+- Turn number and timestamp
+- Stage detection reasoning (gathering vs. reflecting)
+- Emotional assessment and any notable shifts
+- Mode decision (why you chose the response you did)
+- FeelHeardCheck reasoning (why Y or N)
+
+Format: fenced block per turn, newest at the bottom.
+
+### Gate Persistence
+
+Track the `feelHeardConfirmed` gate in `stage-progress.json` (see `schemas/stage-progress.schema.md`).
+
+- When the user explicitly confirms they feel heard → set `feelHeardConfirmed: true` and user status to `GATE_PENDING`
+- When **both** users have `feelHeardConfirmed: true` → advance `current_stage` to `2` and reset gate keys to Stage 2 defaults
+
 ## Output
 
-- User's Vessel populated with: raw messages, emotional readings, notable facts, conversation summary
-- User's stage status: `GATE_PENDING` (confirmed heard) or `IN_PROGRESS` (still sharing)
-- FeelHeardCheck signal: Y or N per turn
+After each turn, the following files are updated:
+
+| File | Location | Action |
+|---|---|---|
+| `notable-facts.json` | `vessel-{x}/` | Append new facts |
+| `emotional-thread.json` | `vessel-{x}/` | Append intensity reading |
+| `conversation-summary.md` | `vessel-{x}/` | Replace with updated summary |
+| `internal-dialogue.md` | `synthesis/` | Append reasoning trace |
+| `stage-progress.json` | Session root | Update gate if confirmed |
+
+Signals returned per turn:
+- FeelHeardCheck: Y or N
+- User stage status: `IN_PROGRESS` or `GATE_PENDING`
 
 ## Completion
 

--- a/bot-workspaces/mwf-session/stages/2-perspective-stretch/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/2-perspective-stretch/CONTEXT.md
@@ -98,12 +98,83 @@ When the user returns to refine empathy after their partner has shared additiona
 | **Early (turn ≤ 3)** | User may still have leftover feelings. Start in LISTENING mode. Give space before trying to shift focus. |
 | **High intensity (8+)** | Stay in LISTENING mode. Be calm and steady — don't match their intensity. Let them settle first. |
 
+### Vessel File Writes (per turn)
+
+Continue the same vessel file updates from Stage 1. See `schemas/vessel-files.schema.md` and `schemas/notable-facts.schema.md` for full schemas.
+
+**Notable Facts** — Append to `vessel-{x}/notable-facts.json`:
+- Continue extracting facts as the user reveals new information about the conflict or their partner
+- Same categories and 20-fact limit as Stage 1; `source_stage` is now `2`
+
+**Emotional Thread** — Append to `vessel-{x}/emotional-thread.json`:
+- One reading per turn: `{ ts, intensity (1–10), context }`
+
+**Conversation Summary** — Update `vessel-{x}/conversation-summary.md`:
+- Replace with updated rolling narrative including Stage 2 perspective-taking progress
+
+**Internal Dialogue Trace** — Append to `synthesis/internal-dialogue.md`:
+- Same format as Stage 1, but reasoning now includes mode selection (LISTENING/BRIDGING/BUILDING/MIRROR), ReadyShare reasoning, and Consensual Bridge decisions
+
+### Needs Identification
+
+Create or update `vessel-{x}/needs.json` (see `schemas/vessel-files.schema.md`).
+
+- As the user explores their partner's perspective, underlying needs surface for both parties
+- Extract needs with evidence quotes: `{ need, evidence[], confirmed: false }`
+- Needs are the user's own needs — not the partner's (partner needs go in the partner's vessel)
+- Mark `confirmed: true` only when the user explicitly validates a need
+- These feed into Stage 3 need mapping; accuracy matters more than completeness
+
+### Consensual Bridge Flow
+
+The Consensual Bridge is how private vessel content becomes available to the partner. Raw user input is **never** shared — only transformed, abstracted versions. See `schemas/shared-vessel.schema.md` for file format.
+
+**Trigger**: When the ReadyShare signal fires and the user has an empathy draft ready.
+
+**Steps**:
+1. **Identify sharable content** — Bot selects content from the user's vessel that would help the partner understand how they're being seen (the empathy draft and supporting context)
+2. **Transform** — Rewrite raw input into an abstracted form. Remove heat, preserve the need. Example: raw "they never listen to me about the kids" → transformed "Feels unheard on parenting decisions"
+3. **Ask for explicit consent** — Present the transformed content to the user and ask: "This is what would be shared with [partner]. Are you okay with that?" The user must say yes.
+4. **Write to shared vessel** — Only after consent: append to `shared/consented-content.json` with `{ source_user, transformed, consent_ts, consent_active: true }`
+5. **Partner reads on next turn** — The partner's Stage 2 contract can read `shared/consented-content.json` to inform Stage 2B refinement
+
+**Consent rules**:
+- Consent is per-item and revocable (`consent_active` can be set to `false`)
+- If the user declines, do not share. Acknowledge their choice and continue the conversation.
+- Never pressure the user to share. If they're hesitant, respect it.
+
+### Gate Persistence
+
+Track three gates in `stage-progress.json` (see `schemas/stage-progress.schema.md`):
+
+| Gate Key | When to set `true` |
+|---|---|
+| `empathyDraftReady` | User has a finalized empathy draft they're satisfied with |
+| `empathyConsented` | User consented to share their empathy draft with partner |
+| `partnerValidated` | Partner confirmed the empathy attempt feels accurate (or chose to proceed) |
+
+- `empathyDraftReady` and `empathyConsented` are set by this user's thread
+- `partnerValidated` is set by the **partner's** thread after reading the shared empathy content
+- When **both** users have all three gates satisfied → advance `current_stage` to `3` and reset gate keys to Stage 3 defaults
+
 ## Output
 
-- Empathy attempts with consent decisions and revision history per user
-- ReadyShare signal: Y or N per turn
-- Stage status: `GATE_PENDING` (feels reflected) or `IN_PROGRESS` (still iterating)
+After each turn, the following files are updated:
+
+| File | Location | Action |
+|---|---|---|
+| `notable-facts.json` | `vessel-{x}/` | Append new facts |
+| `emotional-thread.json` | `vessel-{x}/` | Append intensity reading |
+| `conversation-summary.md` | `vessel-{x}/` | Replace with updated summary |
+| `needs.json` | `vessel-{x}/` | Create/update identified needs |
+| `internal-dialogue.md` | `synthesis/` | Append reasoning trace |
+| `consented-content.json` | `shared/` | Append on consent (Consensual Bridge only) |
+| `stage-progress.json` | Session root | Update gates as satisfied |
+
+Signals returned per turn:
+- ReadyShare: Y or N
+- User stage status: `IN_PROGRESS` or `GATE_PENDING`
 
 ## Completion
 
-When both users feel accurately reflected (or choose to proceed), advance to `stages/3-need-mapping/`.
+When both users have all three gates satisfied (or choose to proceed), advance to `stages/3-need-mapping/`.

--- a/bot-workspaces/mwf-session/stages/3-need-mapping/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/3-need-mapping/CONTEXT.md
@@ -67,10 +67,66 @@ Use the user's exact words when reflecting needs. Never add context, feelings, o
 | **Early (turn ≤ 2)** | User may still be processing emotions from empathy work. Start in EXCAVATING mode. Give space before expecting named needs. |
 | **High intensity (8+)** | Slow down. Validate first, reframe gently. Calm and grounding tone, not matching their intensity. |
 
+### File-Based State Access
+
+Per the retrieval contract, Stage 3 operates in **Coordinated** mode — the AI reads cross-user content that has already been abstracted or consented to.
+
+**Readable files:**
+
+| File | Purpose |
+|---|---|
+| Own `vessel-{x}/needs.json` | Needs identified for this user (from Stage 1–2 extraction) |
+| `shared/consented-content.json` | Content previously consented to by both users |
+| `shared/common-ground.json` | Needs confirmed as shared by both users |
+
+**Forbidden files:**
+
+| File | Why |
+|---|---|
+| Partner's `vessel-{y}/*` | Raw partner content is never directly readable |
+| Own raw events (emotional-thread, boundaries) | Stage 3 works from abstracted needs, not raw material |
+
+### Common Ground Tracking
+
+When the AI identifies a need that both users share (based on each user's `needs.json` and conversation), write it to `shared/common-ground.json`:
+
+```json
+{
+  "need": "Both want to feel respected in family decisions",
+  "confirmed_by": ["U_A_ID", "U_B_ID"],
+  "ts": "ISO-8601"
+}
+```
+
+**Rules:**
+- A need enters common ground only after **both** users have confirmed it
+- Use universal need categories (Safety, Connection, Autonomy, Recognition, Meaning, Fairness) — not raw quotes
+- Each user confirms independently — do not assume confirmation from one means both
+
+### Gate Persistence
+
+Track gate satisfaction in `stage-progress.json` for each user:
+
+| Gate Key | Condition |
+|---|---|
+| `needsConfirmed` | User has confirmed at least one identified need as accurate |
+| `commonGroundConfirmed` | User has confirmed at least one need as shared with partner |
+
+When both users satisfy both gates → advance `current_stage` to 4.
+
+### Continuing from Prior Stages
+
+Continue these behaviors from Stages 1–2:
+- **Fact extraction** — update `notable-facts.json` with new facts from this stage
+- **Emotional tracking** — update `emotional-thread.json` with per-turn intensity readings
+- **Internal dialogue** — maintain the user's reflective process
+- **Conversation summary** — update `conversation-summary.md` with Stage 3 content
+
 ## Output
 
-- Per-user need maps with categories and rankings stored in Vessel
-- Common-ground needs confirmed by both users
+- Per-user need maps with categories and rankings stored in Vessel (`vessel-{x}/needs.json`)
+- Common-ground needs confirmed by both users (`shared/common-ground.json`)
+- Gate keys updated in `stage-progress.json`
 - Stage status: `GATE_PENDING` (common need confirmed) or `IN_PROGRESS`
 
 ## Completion

--- a/bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md
@@ -77,13 +77,84 @@ ProposedStrategy: Sunday evening phone call to plan the week ahead
 | **Early (turn ≤ 2)** | User may need help shifting from needs to action. Start in INVITING mode. Normalize that experiments can fail — the point is learning, not perfection. |
 | **High intensity (8+)** | Slow down. Validate first. This is NOT the moment for brainstorming — ground them before moving to action. Calm and steady tone. |
 
+### File-Based State Access
+
+Per the retrieval contract, Stage 4 operates in **Parallel → Coordinated** mode — independent proposals first, then anonymous pooling and agreement.
+
+**Readable files:**
+
+| File | Purpose |
+|---|---|
+| `shared/consented-content.json` | Previously consented content from both users |
+| `shared/common-ground.json` | Needs confirmed as shared (from Stage 3) |
+| `shared/agreements.json` | Finalized agreements between users |
+| `shared/micro-experiments.json` | Proposed experiments |
+
+**Forbidden files:**
+
+| File | Why |
+|---|---|
+| Either user's `vessel-{x}/*` | Stage 4 works entirely through the shared vessel — no raw vessel access |
+
+### Micro-Experiments
+
+Write proposed experiments to `shared/micro-experiments.json`. Each experiment must meet all four criteria (specific, time-bounded, reversible, measurable):
+
+```json
+{
+  "description": "10-minute check-in after dinner each night for one week",
+  "status": "proposed",
+  "follow_up": ""
+}
+```
+
+Status transitions: `proposed` → `in_progress` → `completed` or `skipped`.
+
+### Agreements
+
+When both users agree on a strategy or experiment, write it to `shared/agreements.json`:
+
+```json
+{
+  "description": "Schedule a weekly 30-minute check-in about caregiving tasks",
+  "agreed_by": ["U_A_ID", "U_B_ID"],
+  "status": "accepted",
+  "ts": "ISO-8601"
+}
+```
+
+Status values: `proposed`, `accepted`, `rejected`. An agreement is finalized only when `agreed_by` contains both user IDs and status is `accepted`.
+
+### Gate Persistence
+
+Track gate satisfaction in `stage-progress.json` for each user:
+
+| Gate Key | Condition |
+|---|---|
+| `strategiesSubmitted` | User has proposed at least one concrete strategy |
+| `rankingsSubmitted` | User has ranked the pooled strategies |
+| `agreementCreated` | User has agreed to at least one micro-experiment |
+
+When both users satisfy all three gates → set session status to `completed` in `session.json`.
+
+### Session Completion
+
+When both users have satisfied all Stage 4 gates:
+
+1. **Update `session.json`** — set `status` to `completed`
+2. **Post-completion messages** — acknowledge the work both users did, summarize the agreed micro-experiments, and offer to review agreements in a future check-in
+3. **Trigger global facts consolidation** — consolidate notable facts from this session into the user's `global-facts.json` (per-user cross-session file in `data/mwf-users/{user_id}/`)
+
 ## Output
 
 - Strategy proposals and rankings per user (in Vessel)
 - StrategyProposed signal: Y or N per turn, with ProposedStrategy lines when Y
-- Agreed micro-experiment with specifics (action, duration, check-in plan)
+- Micro-experiments written to `shared/micro-experiments.json`
+- Agreements written to `shared/agreements.json`
+- Gate keys updated in `stage-progress.json`
+- Session status updated in `session.json` on completion
 - Stage status: `COMPLETED` (agreement reached) or `IN_PROGRESS`
 
 ## Completion
 
-When both users agree on at least one micro-experiment, the session is complete. Offer a follow-up check-in to review how the experiment went.
+When both users agree on at least one micro-experiment, the session is complete. Update `session.json` status to `completed`. Offer a follow-up check-in to review how the experiment went.

--- a/bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/4-strategic-repair/CONTEXT.md
@@ -143,7 +143,13 @@ When both users have satisfied all Stage 4 gates:
 
 1. **Update `session.json`** — set `status` to `completed`
 2. **Post-completion messages** — acknowledge the work both users did, summarize the agreed micro-experiments, and offer to review agreements in a future check-in
-3. **Trigger global facts consolidation** — consolidate notable facts from this session into the user's `global-facts.json` (per-user cross-session file in `data/mwf-users/{user_id}/`)
+3. **Consolidate global facts** — for each user in the session:
+   a. Read `vessel-{x}/notable-facts.json` for this user's session facts
+   b. Read (or create) `data/mwf-users/{slack_user_id}/global-facts.json`
+   c. Merge: deduplicate by UUID (update `last_confirmed` and `source_sessions` for existing facts; add new facts with `first_seen` from `extracted_at`)
+   d. If over 50 facts, consolidate oldest by merging similar facts within the same category
+   e. Write updated global facts back to file
+   f. See `references/global-facts.md` for the full algorithm and privacy rules
 
 ## Output
 

--- a/bot-workspaces/mwf-session/stages/route/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/route/CONTEXT.md
@@ -3,60 +3,111 @@
 ## Input
 
 - Slack message from `#mwf-sessions` thread (via prompt file)
-- Session history (via `--resume` if this is a thread reply)
-- Channel context (recent messages if this is a new thread)
+- `channel_id` and `thread_ts` from the incoming message
+- `user_id` identifying which participant sent this message
 
 ## Process
 
-1. **Detect current stage**: Review the conversation history from the session.
-   - If no prior conversation (new thread): this is **Stage 0 — Onboarding**.
-   - If prior conversation exists: identify the current stage from context. Look for:
-     - Stage transition markers you previously announced
-     - Whether gate conditions have been met
-     - The last stage-specific behavior you applied
+### 1. Thread-to-Session Lookup
 
-2. **Apply stage behavior**:
+Look up the incoming thread in the session index:
 
-   **Stage 0 — Onboarding**
-   - Welcome the user to MWF
-   - Explain the Curiosity Compact (ground rules for the conversation)
-   - Ask the user to agree to the compact before proceeding
-   - Gate: user agrees to the ground rules
+1. Construct key: `{channel_id}:{thread_ts}`
+2. Read `data/mwf-sessions/thread-index.json` (see `schemas/thread-index.schema.md`)
+3. Look up the constructed key in the index
 
-   **Stage 1 — The Witness**
-   - Listen deeply to the user's perspective on their conflict
-   - Reflect back what you hear without judgment
-   - Ask clarifying questions to understand their experience fully
-   - Do not rush — hold space for as long as needed
-   - Gate: user confirms they feel fully heard
+**If found** → extract `session_id`, continue to step 2.
 
-   **Stage 2 — Perspective Stretch**
-   - Guide the user to consider their conversation partner's perspective
-   - Help them build an "empathy guess" — what might the other person be feeling/needing?
-   - Gate: user feels they understand their partner's perspective (or chooses to proceed)
+**If not found** → this is a new or unrecognized thread:
+- Check if the message body contains a 6-character alphanumeric join code → route to partner-join flow (Stage 0)
+- Otherwise treat as a new session request → route to Stage 0 (Onboarding) to create a new session
 
-   **Stage 3 — Need Mapping**
-   - Help identify underlying needs (not positions) for both parties
-   - Look for common ground — needs that both people share
-   - Gate: at least one common-ground need identified
+### 2. State File Loading
 
-   **Stage 4 — Strategic Repair**
-   - Help design a small, concrete "micro-experiment" — one action to try
-   - The experiment should be low-risk, time-bounded, and testable
-   - Gate: user agrees to try the micro-experiment
+Load session state from `data/mwf-sessions/{session_id}/`:
 
-3. **Handle stage transitions**: When a gate condition is met:
-   - Acknowledge the milestone warmly
-   - Announce the transition (e.g., "Now that you feel heard, let's explore your partner's perspective...")
-   - Begin applying the next stage's behavior
+1. Read `session.json` for session metadata (see `schemas/session.schema.md`)
+   - `status`: must be `active` or `waiting_for_partner` to proceed
+   - If `completed` or `abandoned` → reply that this session has ended
+   - `user_a` / `user_b`: identify which participant sent this message via `user_id` match
+2. Read `stage-progress.json` for current stage and gate status (see `schemas/stage-progress.schema.md`)
+   - `current_stage`: the stage number (0–4) to apply
+   - `users.{user_id}.stage_status`: this user's progress within the current stage
+   - `users.{user_id}.gates_satisfied`: which gates this user has already passed
 
-4. **Reply in thread**: Compose a response and post it as a Slack thread reply. See `shared/slack/slack-post.md` for the posting procedure and `shared/references/slack-format.md` for Slack mrkdwn formatting (not Markdown).
+### 3. Lockfile Acquisition
+
+Prevent concurrent processing of the same session:
+
+1. Attempt to create `data/mwf-sessions/{session_id}/.lock` (atomic create — fail if file already exists)
+2. **If lock acquired** → continue to step 4
+3. **If lock held** (file already exists) → reply: "I'm still processing your previous message — one moment." and stop
+
+The lock MUST be released (delete `.lock`) when processing completes, whether the turn succeeds or errors. Wrap all subsequent steps in a try/finally pattern.
+
+### 4. Retrieval Contract Enforcement
+
+Based on `current_stage` from `stage-progress.json`, enforce file access rules from `references/privacy-model.md`:
+
+| Stage | Files Readable | Files Forbidden |
+|---|---|---|
+| 0 | `session.json`, `stage-progress.json` | All vessel files |
+| 1 | Own `vessel-{x}/*`, `conversation-summary.md` | Partner's vessel, `shared/*` |
+| 2 | Own vessel + `shared/consented-content.json` | Partner's raw vessel |
+| 3 | Own `vessel-{x}/needs.json` + `shared/consented-content.json`, `shared/common-ground.json` | Partner's raw vessel, own raw events |
+| 4 | `shared/*` (all) | Both users' raw vessels |
+
+The `synthesis/` directory is **never** read during user-facing turns.
+
+Only load vessel files permitted for the current stage. If a stage handler requests a forbidden file, deny the read.
+
+### 5. Stage Dispatch
+
+Route to the appropriate stage CONTEXT based on `current_stage`:
+
+| `current_stage` | Stage CONTEXT |
+|---|---|
+| 0 | `stages/0-onboarding/CONTEXT.md` |
+| 1 | `stages/1-witness/CONTEXT.md` |
+| 2 | `stages/2-perspective-stretch/CONTEXT.md` |
+| 3 | `stages/3-need-mapping/CONTEXT.md` |
+| 4 | `stages/4-strategic-repair/CONTEXT.md` |
+
+Pass the loaded state as context for the stage to use:
+- `session.json` contents (session metadata, user pairing)
+- `stage-progress.json` contents (current stage, user's gate status)
+- Any permitted vessel/shared files loaded in step 4
+- The `user_id` of the current message sender
+
+### 6. Post-Turn State Updates
+
+After the stage handler completes and the reply is posted:
+
+1. **Update `stage-progress.json`**:
+   - Set `users.{user_id}.last_active` to current ISO-8601 timestamp
+   - Update `users.{user_id}.gates_satisfied` if any gates were satisfied during this turn
+   - If all gates for the current stage are satisfied for **both** users:
+     - Advance `current_stage` by 1
+     - Reset both users' `gates_satisfied` to the new stage's gate keys (all `false`)
+     - Set both users' `stage_status` to `IN_PROGRESS`
+   - If this user satisfied all gates but partner has not:
+     - Set this user's `stage_status` to `GATE_PENDING`
+2. **Update `session.json`** if session status changed (e.g., partner joined → `active`, all stages done → `completed`)
+3. **Update `thread-index.json`** if a new thread was created (new session or partner join)
+4. **Release lockfile**: delete `data/mwf-sessions/{session_id}/.lock`
+
+### 7. Reply in Thread
+
+Compose and post the response as a Slack thread reply. See `shared/slack/slack-post.md` for the posting procedure and `shared/references/slack-format.md` for Slack mrkdwn formatting (not Markdown).
 
 ## Output
 
 - A reply posted to the Slack thread
-- Stage progression tracked in the conversation session (Claude session state)
+- Updated `stage-progress.json` reflecting any gate changes or stage advancement
+- Updated `session.json` if session status changed
+- Updated `thread-index.json` if new thread mapping was added
+- Lockfile released
 
 ## Completion
 
-This stage runs once per message. No multi-stage pipeline — each invocation handles one message and replies.
+This stage runs once per message. No multi-stage pipeline — each invocation handles one message, updates state files, and replies.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,43 @@
+# Data Directory
+
+Runtime data for file-based MWF session state. Not checked into git (except `.gitkeep` files).
+
+## Directory Structure
+
+```
+data/
+├── mwf-sessions/                     # All MWF session state
+│   ├── thread-index.json             # Thread-TS → session ID mapping
+│   └── {session_id}/                 # Per-session folder
+│       ├── session.json              # Session metadata + pairing
+│       ├── stage-progress.json       # Per-user stage + gate tracking
+│       ├── .lock                     # Per-session lockfile (presence = locked)
+│       ├── vessel-a/                 # User A's private vessel
+│       │   ├── notable-facts.json
+│       │   ├── emotional-thread.json
+│       │   ├── needs.json
+│       │   └── boundaries.json
+│       ├── vessel-b/                 # User B's private vessel (same structure)
+│       │   └── ...
+│       ├── shared/                   # Shared Vessel (consensual content only)
+│       │   ├── consented-content.json
+│       │   ├── common-ground.json
+│       │   ├── agreements.json
+│       │   └── micro-experiments.json
+│       ├── synthesis/                # AI reasoning trace (dev-only)
+│       │   ├── internal-dialogue.md
+│       │   └── pattern-notes.md
+│       └── conversation-summary.md   # Rolling narrative summary
+│
+└── mwf-users/                        # Per-user cross-session data
+    └── {slack_user_id}/
+        └── global-facts.json         # Consolidated facts (max 50)
+```
+
+## Retention
+
+Completed and abandoned session folders are auto-cleaned after 90 days, matching Slack free-plan message retention.
+
+## Schema Reference
+
+Reference schemas for all JSON files are documented in `bot-workspaces/mwf-session/schemas/`.

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -366,6 +366,22 @@ async function buildPrompt(channel, config, msgEvent) {
     parts.push('');
   }
 
+  // MWF session routing: pass thread context for session/state lookup
+  if (config.workspace === 'mwf-session') {
+    const threadTs = msgEvent.thread_ts || msgEvent.ts;
+    const entryStage = isThreadReply ? 'route' : '0-onboarding';
+    parts.push('## MWF Session Routing\n');
+    parts.push(`Entry Stage: \`${entryStage}\``);
+    parts.push(`Workspace: mwf-session`);
+    parts.push(`Channel ID: ${channel}`);
+    parts.push(`Thread TS: ${threadTs}`);
+    parts.push(`Thread Key: ${channel}:${threadTs}`);
+    if (msgEvent.user) {
+      parts.push(`User ID: ${msgEvent.user}`);
+    }
+    parts.push('');
+  }
+
   // Message to handle
   parts.push('## Message to handle\n');
   parts.push(formatMessage(msgEvent));
@@ -436,6 +452,24 @@ function dispatchAgent(channel, ts, config, promptContent, provenance = {}, tKey
     args = [...sessionArgs, config.commandSlug, '', promptFile, ts];
   }
 
+  const env = {
+    ...process.env,
+    SLAM_BOT: '1',
+    PRIORITY: 'high',
+    CHANNEL: channel,
+    PROVENANCE_CHANNEL: provenance.channel || '',
+    PROVENANCE_REQUESTER: provenance.requester || '',
+    PROVENANCE_MESSAGE: provenance.message || '',
+  };
+
+  // MWF session thread context for state file lookup
+  if (config.workspace === 'mwf-session' && tKey) {
+    const threadTs = tKey.split(':')[1] || '';
+    env.MWF_THREAD_TS = threadTs;
+    env.MWF_CHANNEL = channel;
+    env.MWF_ENTRY_STAGE = threadTs === ts ? '0-onboarding' : 'route';
+  }
+
   const child = spawn(
     join(SCRIPTS_DIR, 'run-claude.sh'),
     args,
@@ -443,15 +477,7 @@ function dispatchAgent(channel, ts, config, promptContent, provenance = {}, tKey
       cwd: MWF_APP_DIR,
       stdio: 'ignore',
       detached: true,
-      env: {
-        ...process.env,
-        SLAM_BOT: '1',
-        PRIORITY: 'high',
-        CHANNEL: channel,
-        PROVENANCE_CHANNEL: provenance.channel || '',
-        PROVENANCE_REQUESTER: provenance.requester || '',
-        PROVENANCE_MESSAGE: provenance.message || '',
-      },
+      env,
     }
   );
 


### PR DESCRIPTION
## Summary
Merges the `milestone/conversation-state-model` branch to `main`.

### Issues Closed
- #54 — Add reference JSON schemas for session state files
- #55 — Update privacy-model and stage-progression references for file-based state
- #56 — Update route stage CONTEXT for file-based state loading and lockfile
- #57 — Update Stage 0 CONTEXT for session creation, pairing, and gate persistence
- #58 — Update Stages 1-2 CONTEXT for vessel I/O, fact extraction, and consent bridge
- #59 — Update Stages 3-4 CONTEXT for shared vessel, agreements, and session completion
- #62 — Update socket listener for MWF session-scoped thread routing
- #63 — Add cross-session global facts accumulation
- #64 — Add 90-day session retention sweeper (resolved via PR #79 to main)

### PRs Merged (to milestone branch)
- PR #60 — docs: add file-based state refs to mwf-session references
- PR #66 — docs: add reference JSON schemas for MWF session state files
- PR #67 — docs: add session creation, pairing, and gate persistence to Stage 0
- PR #68 — docs: add shared vessel, agreements, and session completion to stages 3-4
- PR #69 — docs: update route stage CONTEXT for file-based state loading
- PR #70 — docs: add vessel I/O, fact extraction, and consent bridge to Stages 1-2
- PR #72 — docs: add cross-session global facts accumulation
- PR #75 — feat(bot): MWF session-scoped thread routing in socket listener

### What Was Built
- File-based conversation state model for Slack MWF sessions: folder structure with per-session JSON/Markdown files for stage progress, vessel isolation, consent tracking, and AI synthesis
- Reference JSON schemas for all state files (session.json, stage-progress.json, notable-facts.json, etc.)
- Updated all mwf-session stage CONTEXT.md files (route, 0-4) with file-based state I/O contracts
- Privacy-model and stage-progression references updated for file-level retrieval contracts
- Socket listener updated for session-scoped thread routing via thread-index.json
- Cross-session global facts accumulation (per-user profile across sessions)

Related to #36