### PR TITLE
feat: DM-based MWF sessions with lobby handoff

### DIFF
--- a/bot-workspaces/mwf-session/CLAUDE.md
+++ b/bot-workspaces/mwf-session/CLAUDE.md
@@ -1,13 +1,15 @@
 # MWF Session Workspace (L1)
 
-Thread-based MWF conversation workspace. Each Slack thread in `#mwf-sessions` is one conversation session. The bot guides users through the five MWF conversation stages (0-4) using session continuity (`--session` / `--resume`).
+DM-based MWF conversation workspace. `#mwf-sessions` is a **lobby** for starting/joining sessions. Actual conversations happen in **private DMs** between the bot and each user, ensuring vessel privacy by design.
 
 ## How It Works
 
-1. **Thread = session**: The socket-listener routes `#mwf-sessions` messages here with thread-scoped sessions. Claude resumes the full conversation history on each reply.
-2. **Stage detection**: On each message, determine the current stage from the conversation so far. New threads start at Stage 0.
-3. **Stage behavior**: Apply the appropriate stage's Process Guardian behavior (tone, goals, gate conditions).
-4. **Stage transitions**: When a stage's gate condition is met, announce the transition and begin the next stage's behavior.
+1. **Lobby → DM handoff**: User posts in `#mwf-sessions` to start or join a session. Bot opens a private DM with the user (via `conversations.open`) and conducts all conversation there.
+2. **DM thread = session**: Each user gets their own DM thread for the session. The socket-listener detects active session threads in DMs via `thread-index.json` and routes them here.
+3. **Stage detection**: On each message, load state from `data/mwf-sessions/{session_id}/` to determine current stage.
+4. **Stage behavior**: Apply the appropriate stage's Process Guardian behavior (tone, goals, gate conditions).
+5. **Stage transitions**: When a stage's gate condition is met, announce the transition and begin the next stage's behavior.
+6. **Privacy**: Each user's conversation is in a separate DM — Slack enforces isolation. No user can see the other's messages.
 
 ## Conversation Stages
 
@@ -45,13 +47,21 @@ Thread-based MWF conversation workspace. Each Slack thread in `#mwf-sessions` is
 
 ## Stage Progression
 
-1. `route` -- Detect current stage from conversation history, apply appropriate behavior
+1. `route` -- Detect message source (lobby vs DM), load session state, apply appropriate stage behavior
 
 This is a single-stage workspace. The `route` stage handles all messages by reading the session context and applying the correct stage behavior. There is no multi-stage pipeline -- the stage detection is inline.
 
 ## Two-User Model
 
-Unlike single-actor workspaces, MWF sessions track two participants. Each stage receives a `user_id` identifying which participant is messaging. Per-user state (Vessel data, stage progress) is tracked independently. Stage advancement requires both users to satisfy the gate condition.
+Unlike single-actor workspaces, MWF sessions track two participants. Each user has their own private DM thread with the bot. Per-user state (Vessel data, stage progress) is tracked independently. Stage advancement requires both users to satisfy the gate condition.
+
+## Lobby vs DM
+
+| Source | What happens |
+|--------|-------------|
+| `#mwf-sessions` (lobby) | "Start session" → create session + open DM. Join code → pair + open DM. All other messages → prompt user to check DMs. |
+| DM (session thread) | Route to stage handler based on `thread-index.json` lookup. This is where all conversation happens. |
+| DM (non-session) | Not handled by this workspace — falls through to `slack-triage`. |
 
 ## Tone
 
@@ -66,4 +76,5 @@ Unlike single-actor workspaces, MWF sessions track two participants. Each stage 
 1. Never share one user's private reflections with others
 2. Never diagnose, label, or pathologize
 3. If a user expresses distress, acknowledge it and suggest professional support
-4. Never post outside the thread
+4. Never post outside the user's DM thread — no cross-posting to the lobby or to the other user's DM
+5. Never reveal one user's DM channel ID or thread to the other user

--- a/bot-workspaces/mwf-session/references/privacy-model.md
+++ b/bot-workspaces/mwf-session/references/privacy-model.md
@@ -2,6 +2,10 @@
 
 The Vessel model ensures each user's raw content stays private unless they give explicit consent to share. Every stage has specific sharing rules.
 
+## Transport-Level Isolation
+
+Each user's conversation happens in a **private DM** between the user and the bot. Slack enforces this — no other user can see the DM. The `#mwf-sessions` channel is a lobby for starting/joining sessions only; no session content is ever posted there.
+
 ## Core Principle
 
 Raw user content (quotes, stories, venting) is stored in the user's Vessel and **never** shared directly with the other user. The AI synthesizes, summarizes, or translates content into safe forms before any cross-user exchange.

--- a/bot-workspaces/mwf-session/stages/route/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/route/CONTEXT.md
@@ -2,27 +2,72 @@
 
 ## Input
 
-- Slack message from `#mwf-sessions` thread (via prompt file)
+- Slack message (via prompt file) from either:
+  - `#mwf-sessions` channel (lobby — start/join only)
+  - A DM with the bot (active session conversation)
 - `channel_id` and `thread_ts` from the incoming message
 - `user_id` identifying which participant sent this message
 
 ## Process
 
-### 1. Thread-to-Session Lookup
+### 1. Determine Message Source
 
-Look up the incoming thread in the session index:
+Check `channel_id` against the `#mwf-sessions` lobby channel ID (from `.claude/config/services.json` or env).
+
+**If lobby message** → go to step 1A (Lobby Handler).
+**If DM message** → go to step 2 (Session Lookup).
+
+### 1A. Lobby Handler (#mwf-sessions)
+
+The lobby handles two actions only:
+
+**Start a new session:**
+- User posts "start", "new session", or similar
+- Create a new session:
+  1. Generate a UUID for `session_id` and a 6-char alphanumeric `join_code`
+  2. Create `data/mwf-sessions/{session_id}/session.json` (status: `waiting_for_partner`, user_a populated)
+  3. Create `data/mwf-sessions/{session_id}/stage-progress.json` (current_stage: 0, user_a: IN_PROGRESS)
+  4. Create empty vessel dirs: `vessel-a/`, `shared/`, `synthesis/`
+- Open a DM with the user:
+  ```bash
+  # Use Slack MCP tool or curl to open a DM
+  # conversations.open with users=<user_id> returns a DM channel ID
+  ```
+- Post the Stage 0 welcome message in the DM (this creates a thread)
+- Write the DM thread mapping to `data/mwf-sessions/thread-index.json`:
+  ```json
+  { "{dm_channel_id}:{thread_ts}": "{session_id}" }
+  ```
+- Reply in the lobby thread: "I've sent you a private message to start your session. Your join code is `{join_code}` — share it with your conversation partner."
+
+**Join an existing session:**
+- User posts a 6-char alphanumeric code
+- Look up the code in `data/mwf-sessions/*/session.json` (scan for matching `join_code`)
+- If found and status is `waiting_for_partner`:
+  1. Update `session.json`: populate `user_b`, set status to `active`
+  2. Update `stage-progress.json`: add user_b with stage 0 IN_PROGRESS
+  3. Create `vessel-b/` directory
+  4. Open a DM with User B (`conversations.open`)
+  5. Post Stage 0 welcome in User B's DM
+  6. Write User B's DM thread to `thread-index.json`
+  7. Reply in lobby thread: "You've joined the session! Check your DMs."
+  8. Notify User A in their DM thread: "Your partner has joined the session."
+- If not found or already paired → reply in lobby: "That code didn't match an open session."
+
+**Any other lobby message** → reply in thread: "This channel is for starting and joining sessions. Post `start` to begin a new session, or paste a 6-character join code."
+
+### 2. Session Lookup (DM messages)
+
+Look up the incoming DM thread in the session index:
 
 1. Construct key: `{channel_id}:{thread_ts}`
 2. Read `data/mwf-sessions/thread-index.json` (see `schemas/thread-index.schema.md`)
 3. Look up the constructed key in the index
 
-**If found** → extract `session_id`, continue to step 2.
+**If found** → extract `session_id`, continue to step 3.
+**If not found** → this DM is not part of an active session. Reply: "This doesn't seem to be part of an active session. Head to #mwf-sessions to start or join one."
 
-**If not found** → this is a new or unrecognized thread:
-- Check if the message body contains a 6-character alphanumeric join code → route to partner-join flow (Stage 0)
-- Otherwise treat as a new session request → route to Stage 0 (Onboarding) to create a new session
-
-### 2. State File Loading
+### 3. State File Loading
 
 Load session state from `data/mwf-sessions/{session_id}/`:
 
@@ -31,21 +76,21 @@ Load session state from `data/mwf-sessions/{session_id}/`:
    - If `completed` or `abandoned` → reply that this session has ended
    - `user_a` / `user_b`: identify which participant sent this message via `user_id` match
 2. Read `stage-progress.json` for current stage and gate status (see `schemas/stage-progress.schema.md`)
-   - `current_stage`: the stage number (0–4) to apply
+   - `current_stage`: the stage number (0-4) to apply
    - `users.{user_id}.stage_status`: this user's progress within the current stage
    - `users.{user_id}.gates_satisfied`: which gates this user has already passed
 
-### 3. Lockfile Acquisition
+### 4. Lockfile Acquisition
 
 Prevent concurrent processing of the same session:
 
-1. Attempt to create `data/mwf-sessions/{session_id}/.lock` (atomic create — fail if file already exists)
-2. **If lock acquired** → continue to step 4
-3. **If lock held** (file already exists) → reply: "I'm still processing your previous message — one moment." and stop
+1. Attempt to create `data/mwf-sessions/{session_id}/.lock` (atomic create -- fail if file already exists)
+2. **If lock acquired** → continue to step 5
+3. **If lock held** (file already exists) → reply: "I'm still processing your previous message -- one moment." and stop
 
 The lock MUST be released (delete `.lock`) when processing completes, whether the turn succeeds or errors. Wrap all subsequent steps in a try/finally pattern.
 
-### 4. Retrieval Contract Enforcement
+### 5. Retrieval Contract Enforcement
 
 Based on `current_stage` from `stage-progress.json`, enforce file access rules from `references/privacy-model.md`:
 
@@ -59,9 +104,7 @@ Based on `current_stage` from `stage-progress.json`, enforce file access rules f
 
 The `synthesis/` directory is **never** read during user-facing turns.
 
-Only load vessel files permitted for the current stage. If a stage handler requests a forbidden file, deny the read.
-
-### 5. Stage Dispatch
+### 6. Stage Dispatch
 
 Route to the appropriate stage CONTEXT based on `current_stage`:
 
@@ -76,12 +119,12 @@ Route to the appropriate stage CONTEXT based on `current_stage`:
 Pass the loaded state as context for the stage to use:
 - `session.json` contents (session metadata, user pairing)
 - `stage-progress.json` contents (current stage, user's gate status)
-- Any permitted vessel/shared files loaded in step 4
+- Any permitted vessel/shared files loaded in step 5
 - The `user_id` of the current message sender
 
-### 6. Post-Turn State Updates
+### 7. Post-Turn State Updates
 
-After the stage handler completes and the reply is posted:
+After the stage handler completes and the reply is composed:
 
 1. **Update `stage-progress.json`**:
    - Set `users.{user_id}.last_active` to current ISO-8601 timestamp
@@ -96,18 +139,18 @@ After the stage handler completes and the reply is posted:
 3. **Update `thread-index.json`** if a new thread was created (new session or partner join)
 4. **Release lockfile**: delete `data/mwf-sessions/{session_id}/.lock`
 
-### 7. Reply in Thread
+### 8. Reply in DM Thread
 
-Compose and post the response as a Slack thread reply. See `shared/slack/slack-post.md` for the posting procedure and `shared/references/slack-format.md` for Slack mrkdwn formatting (not Markdown).
+Post the response in the user's DM thread. See `shared/slack/slack-post.md` for the posting procedure and `shared/references/slack-format.md` for Slack mrkdwn formatting (not Markdown).
+
+**Never post session content in the lobby channel.** Lobby replies are limited to "check your DMs" confirmations.
 
 ## Output
 
-- A reply posted to the Slack thread
-- Updated `stage-progress.json` reflecting any gate changes or stage advancement
-- Updated `session.json` if session status changed
-- Updated `thread-index.json` if new thread mapping was added
+- A reply posted to the user's DM thread (or lobby confirmation)
+- Updated state files as described in step 7
 - Lockfile released
 
 ## Completion
 
-This stage runs once per message. No multi-stage pipeline — each invocation handles one message, updates state files, and replies.
+This stage runs once per message. No multi-stage pipeline -- each invocation handles one message, updates state files, and replies.

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -554,6 +554,28 @@ async function drainThreadQueue(tKey) {
 }
 
 // ---------------------------------------------------------------------------
+// MWF session detection — check if a DM thread is an active MWF session
+// ---------------------------------------------------------------------------
+
+const THREAD_INDEX_PATH = join(MWF_APP_DIR, 'data', 'mwf-sessions', 'thread-index.json');
+
+/**
+ * Check if a DM message belongs to an active MWF session.
+ * Reads thread-index.json and looks for a matching {channel}:{thread_ts} key.
+ * Returns the session ID if found, null otherwise.
+ */
+function checkMwfSessionThread(channel, threadTs) {
+  if (!threadTs) return null;
+  try {
+    const index = JSON.parse(readFileSync(THREAD_INDEX_PATH, 'utf8'));
+    const key = `${channel}:${threadTs}`;
+    return index[key] || null;
+  } catch {
+    return null; // File doesn't exist yet or is unreadable
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Event handling
 // ---------------------------------------------------------------------------
 
@@ -570,7 +592,24 @@ async function handleMessageEvent(event) {
   if (subtype && subtype !== 'file_share') return;
 
   // Check if this channel is configured
-  const config = CHANNEL_CONFIG[channel];
+  let config = CHANNEL_CONFIG[channel];
+
+  // Session-aware DM routing: if this is a DM that matches an active MWF
+  // session thread, route to mwf-session workspace instead of slack-triage.
+  if (config && config.workspace === 'slack-triage') {
+    const threadTs = event.thread_ts || event.ts;
+    const sessionId = checkMwfSessionThread(channel, threadTs);
+    if (sessionId) {
+      config = {
+        ...config,
+        logName: 'check-mwf-session',
+        commandSlug: 'mwf-session-reply',
+        workspace: 'mwf-session',
+      };
+      logMain(`DM message ${ts} matched MWF session ${sessionId} — routing to mwf-session`);
+    }
+  }
+
   if (!config) return; // Not a monitored channel
 
   // Try to claim this message


### PR DESCRIPTION
## Summary

Redesigns MWF session architecture so conversations happen in **private DMs** instead of public channel threads. `#mwf-sessions` becomes a lobby for starting/joining sessions only.

### Why
The previous design had both users' conversations in `#mwf-sessions` threads — anyone in the channel could read both sides, completely breaking the vessel privacy model.

### How it works
1. User posts "start" in `#mwf-sessions` → bot creates session, opens a **DM** with the user, replies in lobby: "Check your DMs!"
2. Partner posts join code in `#mwf-sessions` → bot pairs them, opens a **DM** with partner
3. All stage 0-4 conversation happens in DMs — Slack enforces isolation
4. Socket listener checks `thread-index.json` on each DM message → if it matches an active session, routes to `mwf-session` workspace instead of `slack-triage`

### Changes
- **Route stage**: lobby handler (start/join) + DM-based conversation flow
- **Socket listener**: `checkMwfSessionThread()` function reads thread-index.json for session-aware DM routing
- **Privacy model**: documents transport-level DM isolation
- **CLAUDE.md**: updated architecture description

## Test plan
- [ ] Post "start" in `#mwf-sessions` → verify bot opens a DM and sends Stage 0 welcome
- [ ] Share join code with a second user → verify they get their own separate DM
- [ ] Confirm neither user can see the other's conversation
- [ ] Confirm non-session DMs still route to `slack-triage` normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)