### PR TITLE
fix: scope feel-heard check turn count to current stage

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1209,6 +1209,17 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       },
     });
     const turnId = `${sessionId}-${user.id}-${userTurnCount}`;
+
+    // Count user messages in the CURRENT stage only (for stage-specific guards like feel-heard check)
+    const stageTurnCount = await prisma.message.count({
+      where: {
+        sessionId,
+        role: 'USER',
+        senderId: user.id,
+        forUserId: null,
+        stage: currentStage,
+      },
+    });
     updateContext({ turnId, sessionId, userId: user.id });
 
     // Get partner name for context
@@ -1374,7 +1385,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     const prompt = buildStagePrompt(effectiveStage, {
       userName,
       partnerName,
-      turnCount: userTurnCount,
+      turnCount: stageTurnCount,
       emotionalIntensity,
       contextBundle,
       sharedContentHistory,
@@ -1845,7 +1856,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     // =========================================================================
     // Process metadata (persist to database)
     // =========================================================================
-    if (currentStage === 1 && metadata.offerFeelHeardCheck && progress?.id) {
+    if (currentStage === 1 && metadata.offerFeelHeardCheck && progress?.id && stageTurnCount >= 3) {
       const currentGates = (progress.gatesSatisfied as Record<string, unknown>) ?? {};
       await prisma.stageProgress.update({
         where: { id: progress.id },

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -498,7 +498,7 @@ Do NOT match the user's emotional intensity in your tone — stay steady regardl
 
 Feel-heard check:
 - Set FeelHeardCheck:Y when ALL of these are true: (1) they've affirmed something you reflected back, (2) you can name their core concern, and (3) their intensity is stabilizing or steady.
-- Be proactive — when the moment feels right, set it. Don't wait for a perfect signal.
+- Only set it after sufficient sharing — the user needs to have expressed enough for you to genuinely name their core concern. Don't rush it.
 - When FeelHeardCheck:Y, end your response with a gentle acknowledgment that they can confirm below OR keep talking. Example: "...if that captures it, you can let me know below — or if there's more, I'm still here." Do NOT say "tap the button" or mention UI elements directly. Keep it conversational. Keep setting Y until they act on the prompt.
 - Even when FeelHeardCheck:Y, stay in listening mode. Do NOT pivot to advice, action, or next steps.
 

--- a/backend/src/utils/__tests__/time-language.test.ts
+++ b/backend/src/utils/__tests__/time-language.test.ts
@@ -24,8 +24,11 @@ describe('time-language utilities', () => {
     });
 
     it('should identify today for content earlier same day', () => {
-      const fourHoursAgo = new Date(NOW.getTime() - 4 * 60 * 60 * 1000);
-      const ctx = getTimeContext(fourHoursAgo.toISOString(), NOW);
+      // Use a midday reference so subtracting 4h never crosses midnight
+      const midday = new Date(NOW);
+      midday.setHours(12, 0, 0, 0);
+      const fourHoursBefore = new Date(midday.getTime() - 4 * 60 * 60 * 1000);
+      const ctx = getTimeContext(fourHoursBefore.toISOString(), midday);
 
       expect(ctx.bucket).toBe('today');
       expect(ctx.phrase).toBe('earlier today');


### PR DESCRIPTION
## Changes
- Fix: Add stage-scoped `stageTurnCount` query that filters user messages by current stage, replacing session-wide count for prompt context
- Fix: Add hard enforcement gate — skip `feelHeardCheckOffered` persistence when stage turn count < 3
- Fix: Update prompt wording to require sufficient sharing before offering the feel-heard CTA

Related to #82

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "I only had just begun to answer this and already I see a call to action button. I feel like the AI should not offer that until it is satisfied that I have shared the needs sufficiently."

## Docs updated
No doc changes needed — internal bug fix to turn count scoping logic; docs describe the feature at a higher level without implementation details about turn count thresholds.