### PR TITLE
feat: lobby-driven session setup with invitation crafting + thread UX

### DIFF
--- a/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
@@ -89,7 +89,12 @@ Triggered when a user starts a new MWF session and no existing session is found 
    - Use facts to inform questions and reflections naturally — do NOT say "I remember from last time"
    - See `references/global-facts.md` for loading rules and privacy constraints
 
-5. **Reply with join code**:
+5. **Ask for the user's name**:
+   - "What's your first name?" (or preferred name)
+   - Store the response as `display_name` in `session.json` under `user_a`
+   - Use this name throughout the session for personalization
+
+6. **Reply with join code**:
    - Tell the user their session is created
    - Provide the join code for them to share with their conversation partner
    - Transition to Phase B (Invitation Crafting) in the same thread
@@ -103,26 +108,30 @@ Triggered when a message contains a join code and no existing session is found f
    - If not found → reply: "I couldn't find a session with that code. Double-check and try again."
    - If found but `status` is not `waiting_for_partner` → reply: "That session already has two participants."
 
-2. **Pair the users**:
+2. **Ask for User B's name**:
+   - "What's your first name?" (or preferred name)
+   - Use the response as `display_name` below
+
+3. **Pair the users**:
    - Update `session.json`:
-     - Set `user_b` to `{ "slack_user_id": "<user_id>", "display_name": "<userName>", "thread_ts": "<thread_ts>" }`
+     - Set `user_b` to `{ "slack_user_id": "<user_id>", "display_name": "<name from step 2>", "thread_ts": "<thread_ts>" }`
      - Set `status` to `active`
    - Update `stage-progress.json`:
      - Add User B entry: `{ "stage_status": "NOT_STARTED", "gates_satisfied": { "agreedToTerms": false }, "last_active": "<ISO-8601>" }`
 
-3. **Update thread index**:
+4. **Update thread index**:
    - Add User B's `"{channel_id}:{thread_ts}": "{session_id}"` entry to `thread-index.json`
 
-4. **Create vessel directories**:
+5. **Create vessel directories**:
    - Create `data/mwf-sessions/{session_id}/vessel-a/`
    - Create `data/mwf-sessions/{session_id}/vessel-b/`
 
-5. **Load global facts** (returning user context):
+6. **Load global facts** (returning user context):
    - For both User A and User B, check if `data/mwf-users/{slack_user_id}/global-facts.json` exists
    - If it exists and is non-empty, load as background context for this user's session thread
    - See `references/global-facts.md` for loading rules and privacy constraints
 
-6. **Notify both users**:
+7. **Notify both users**:
    - In User A's thread: "Your partner has joined! Let's begin."
    - In User B's thread: Welcome and begin Phase A (Curiosity Compact)
    - Both users enter Phase A

--- a/bot-workspaces/mwf-session/stages/route/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/route/CONTEXT.md
@@ -19,42 +19,51 @@ Check `channel_id` against the `#mwf-sessions` lobby channel ID (from `.claude/c
 
 ### 1A. Lobby Handler (#mwf-sessions)
 
-The lobby handles two actions only:
+The lobby is a multi-turn conversation in a thread. The bot asks questions, the user answers, and once everything is gathered the bot sets up DMs.
 
-**Start a new session:**
-- User posts "start", "new session", or similar
-- Create a new session:
-  1. Generate a UUID for `session_id` and a 6-char alphanumeric `join_code`
-  2. Create `data/mwf-sessions/{session_id}/session.json` (status: `waiting_for_partner`, user_a populated)
-  3. Create `data/mwf-sessions/{session_id}/stage-progress.json` (current_stage: 0, user_a: IN_PROGRESS)
-  4. Create empty vessel dirs: `vessel-a/`, `shared/`, `synthesis/`
-- Open a DM with the user:
-  ```bash
-  # Use Slack MCP tool or curl to open a DM
-  # conversations.open with users=<user_id> returns a DM channel ID
-  ```
-- Post the Stage 0 welcome message in the DM (this creates a thread)
-- Write the DM thread mapping to `data/mwf-sessions/thread-index.json`:
-  ```json
-  { "{dm_channel_id}:{thread_ts}": "{session_id}" }
-  ```
-- Reply in the lobby thread: "I've sent you a private message to start your session. Your join code is `{join_code}` — share it with your conversation partner."
+**Step 1: User posts "start" (or similar) in `#mwf-sessions`**
 
-**Join an existing session:**
-- User posts a 6-char alphanumeric code
-- Look up the code in `data/mwf-sessions/*/session.json` (scan for matching `join_code`)
-- If found and status is `waiting_for_partner`:
-  1. Update `session.json`: populate `user_b`, set status to `active`
-  2. Update `stage-progress.json`: add user_b with stage 0 IN_PROGRESS
-  3. Create `vessel-b/` directory
-  4. Open a DM with User B (`conversations.open`)
-  5. Post Stage 0 welcome in User B's DM
-  6. Write User B's DM thread to `thread-index.json`
-  7. Reply in lobby thread: "You've joined the session! Check your DMs."
-  8. Notify User A in their DM thread: "Your partner has joined the session."
-- If not found or already paired → reply in lobby: "That code didn't match an open session."
+Reply in a thread:
+> "I'd love to help you start a conversation. What's your first name?"
 
-**Any other lobby message** → reply in thread: "This channel is for starting and joining sessions. Post `start` to begin a new session, or paste a 6-character join code."
+**Step 2: User replies with their name**
+
+> "Thanks, {name}! Who would you like to have this conversation with? @mention them so I can send the invitation."
+
+**Step 3: User @mentions their partner**
+
+Extract the partner's Slack user ID from the @mention. Then:
+
+1. **Create the session**:
+   - Generate a UUID for `session_id`
+   - Create `data/mwf-sessions/{session_id}/` directory
+   - Write `session.json` (status: `waiting_for_partner`, user_a populated with name + slack_user_id, partner's slack_user_id stored for later invitation delivery)
+   - Write `stage-progress.json` (current_stage: 0, user_a: NOT_STARTED)
+   - Create empty vessel dirs: `vessel-a/`, `shared/`, `synthesis/`
+
+2. **Open a DM with User A** (`conversations.open` with `users=<user_a_id>`):
+   - Post a welcome message as a top-level DM message
+   - **Reply to that message in a thread** to seed the conversation (e.g., "To get started, I'd like to walk you through a few ground rules...")
+   - Write to `thread-index.json`: `"{dm_channel_id}:{welcome_msg_ts}": "{session_id}"`
+   - Update `session.json` with User A's `thread_ts`
+
+3. **Reply in the lobby thread**:
+   > "I've sent you a private message to get started. Head over to your DMs with me."
+
+4. **User A continues in DM** → enters Stage 0 Phase A (Curiosity Compact), then Phase B (Invitation Crafting). The invitation crafting phase is a multi-turn conversation where the bot helps the user compose a thoughtful message to their partner (see `stages/0-onboarding/CONTEXT.md` Phase B). The invitation is NOT sent immediately.
+
+5. **When the invitation is finalized** (user approves the draft):
+   - Open a DM with the partner (`conversations.open` with `users=<partner_id>`)
+   - Post the crafted invitation as a top-level DM message
+   - **Reply to that message in a thread**: "If you'd like to participate, just reply here with your first name to get started."
+   - Write to `thread-index.json`: `"{partner_dm_channel_id}:{invitation_msg_ts}": "{session_id}"`
+
+**When the partner responds in their DM thread:**
+- The socket listener matches it via `thread-index.json` → routes to this workspace
+- The route stage loads the session, sees `status: waiting_for_partner` and this user is the partner
+- Ask for their name, pair them, then proceed to Phase 0B (pairing + onboarding)
+
+**Any other lobby message** → reply in thread: "To start a session, just say `start`."
 
 ### 2. Session Lookup (DM messages)
 

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -575,6 +575,26 @@ function checkMwfSessionThread(channel, threadTs) {
   }
 }
 
+/**
+ * Check if a DM channel has ANY active MWF session (regardless of thread).
+ * Used to detect stray top-level DMs from users who should be replying in
+ * their session thread. Returns the thread_ts they should be using, or null.
+ */
+function findSessionThreadForChannel(channel) {
+  try {
+    const index = JSON.parse(readFileSync(THREAD_INDEX_PATH, 'utf8'));
+    const prefix = `${channel}:`;
+    for (const key of Object.keys(index)) {
+      if (key.startsWith(prefix)) {
+        return key.split(':')[1]; // Return the thread_ts
+      }
+    }
+  } catch {
+    // File doesn't exist yet or is unreadable
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Event handling
 // ---------------------------------------------------------------------------
@@ -596,6 +616,8 @@ async function handleMessageEvent(event) {
 
   // Session-aware DM routing: if this is a DM that matches an active MWF
   // session thread, route to mwf-session workspace instead of slack-triage.
+  // Also catches stray top-level DMs from users who have an active session
+  // in this DM channel — replies telling them to use the session thread.
   if (config && config.workspace === 'slack-triage') {
     const threadTs = event.thread_ts || event.ts;
     const sessionId = checkMwfSessionThread(channel, threadTs);
@@ -607,6 +629,23 @@ async function handleMessageEvent(event) {
         workspace: 'mwf-session',
       };
       logMain(`DM message ${ts} matched MWF session ${sessionId} — routing to mwf-session`);
+    } else if (!event.thread_ts) {
+      // Top-level DM (not in any thread) — check if this channel has an active session
+      const sessionThreadTs = findSessionThreadForChannel(channel);
+      if (sessionThreadTs) {
+        // User posted outside their session thread — nudge them back
+        logMain(`Stray DM ${ts} in channel with active session thread ${sessionThreadTs} — sending redirect`);
+        try {
+          await slack.chat.postMessage({
+            channel,
+            text: `It looks like you have an active session here. Please reply in the conversation thread above to continue.`,
+            thread_ts: ts, // Reply to their stray message
+          });
+        } catch (err) {
+          logMain(`Failed to send session redirect: ${err.message}`);
+        }
+        return; // Don't dispatch an agent for this
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Refines the MWF session flow based on testing feedback:

### Lobby → Invitation crafting → DM handoff
- User says "start" in `#mwf-sessions` → bot asks name → asks who to invite (@mention)
- Bot opens DM with user, starts ground rules + **invitation crafting phase** (multi-turn)
- Partner invitation is sent **after** the user approves the crafted message (not immediately)
- No public join codes — bot handles delivery directly

### Thread UX
- Bot replies to its own welcome DM message to seed the thread — users naturally reply in-thread
- Stray top-level DMs from users with active sessions get a redirect: "Please reply in the conversation thread above"

### Name collection
- Both users are asked their first name during Stage 0 onboarding

## Test plan
- [ ] Post "start" in `#mwf-sessions` → bot asks name in thread → asks who to invite
- [ ] @mention a partner → bot opens DM, starts ground rules
- [ ] Verify DM has a seeded thread (bot replied to itself)
- [ ] Post a top-level DM outside the thread → verify redirect message
- [ ] Complete invitation crafting → verify partner receives the crafted invitation in their own DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)