### PR TITLE
fix: use Slack profile names instead of asking

### DIFF
--- a/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
@@ -89,10 +89,7 @@ Triggered when a user starts a new MWF session and no existing session is found 
    - Use facts to inform questions and reflections naturally — do NOT say "I remember from last time"
    - See `references/global-facts.md` for loading rules and privacy constraints
 
-5. **Ask for the user's name**:
-   - "What's your first name?" (or preferred name)
-   - Store the response as `display_name` in `session.json` under `user_a`
-   - Use this name throughout the session for personalization
+5. **Resolve user's name from Slack profile** (do NOT ask — use `display_name` or `real_name` from the Slack user profile, already available via the message event or `users.info`). Store as `display_name` in `session.json` under `user_a`.
 
 6. **Reply with join code**:
    - Tell the user their session is created
@@ -108,13 +105,11 @@ Triggered when a message contains a join code and no existing session is found f
    - If not found → reply: "I couldn't find a session with that code. Double-check and try again."
    - If found but `status` is not `waiting_for_partner` → reply: "That session already has two participants."
 
-2. **Ask for User B's name**:
-   - "What's your first name?" (or preferred name)
-   - Use the response as `display_name` below
+2. **Resolve User B's name from Slack profile** (do NOT ask — use `display_name` or `real_name` from Slack, available via `users.info`).
 
 3. **Pair the users**:
    - Update `session.json`:
-     - Set `user_b` to `{ "slack_user_id": "<user_id>", "display_name": "<name from step 2>", "thread_ts": "<thread_ts>" }`
+     - Set `user_b` to `{ "slack_user_id": "<user_id>", "display_name": "<name from Slack>", "thread_ts": "<thread_ts>" }`
      - Set `status` to `active`
    - Update `stage-progress.json`:
      - Add User B entry: `{ "stage_status": "NOT_STARTED", "gates_satisfied": { "agreedToTerms": false }, "last_active": "<ISO-8601>" }`

--- a/bot-workspaces/mwf-session/stages/route/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/route/CONTEXT.md
@@ -19,20 +19,18 @@ Check `channel_id` against the `#mwf-sessions` lobby channel ID (from `.claude/c
 
 ### 1A. Lobby Handler (#mwf-sessions)
 
-The lobby is a multi-turn conversation in a thread. The bot asks questions, the user answers, and once everything is gathered the bot sets up DMs.
+The lobby is a short exchange in a thread. The bot resolves the user's name from Slack (via the `user_id` in the event — use the Slack user's display name or real name from the message context) and asks one question: who to invite.
 
 **Step 1: User posts "start" (or similar) in `#mwf-sessions`**
 
 Reply in a thread:
-> "I'd love to help you start a conversation. What's your first name?"
+> "Hi {name}! Who would you like to have this conversation with? @mention them so I can send the invitation."
 
-**Step 2: User replies with their name**
+The user's name comes from their Slack profile (already available in the message event or via `users.info`). Do NOT ask for their name.
 
-> "Thanks, {name}! Who would you like to have this conversation with? @mention them so I can send the invitation."
+**Step 2: User @mentions their partner**
 
-**Step 3: User @mentions their partner**
-
-Extract the partner's Slack user ID from the @mention. Then:
+Extract the partner's Slack user ID from the @mention. Resolve the partner's display name from Slack as well. Then:
 
 1. **Create the session**:
    - Generate a UUID for `session_id`


### PR DESCRIPTION
Lobby asked for the user's name even though Slack already knows it. Now resolves names from Slack profiles and skips straight to asking who to invite.