### PR TITLE
feat(backend): MWF Slack sessions on Bedrock engine

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@prisma/client": "6.12.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@sentry/node": "^10.45.0",
+    "@slack/web-api": "^7.15.1",
     "@types/ably": "^1.0.0",
     "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.17",

--- a/backend/prisma/migrations/20260416000000_add_slack_session_fields/migration.sql
+++ b/backend/prisma/migrations/20260416000000_add_slack_session_fields/migration.sql
@@ -1,0 +1,36 @@
+-- AlterTable: add Slack user identity to User
+ALTER TABLE "User" ADD COLUMN "slackUserId" TEXT;
+CREATE UNIQUE INDEX "User_slackUserId_key" ON "User"("slackUserId");
+
+-- AlterTable: add Slack join code to Session
+ALTER TABLE "Session" ADD COLUMN "slackJoinCode" TEXT;
+CREATE UNIQUE INDEX "Session_slackJoinCode_key" ON "Session"("slackJoinCode");
+
+-- CreateTable: SessionSlackThread (per-user DM thread mapping for MWF sessions)
+CREATE TABLE "SessionSlackThread" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "channelId" TEXT NOT NULL,
+    "threadTs" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SessionSlackThread_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "SessionSlackThread_channelId_threadTs_key"
+    ON "SessionSlackThread"("channelId", "threadTs");
+
+CREATE UNIQUE INDEX "SessionSlackThread_sessionId_userId_key"
+    ON "SessionSlackThread"("sessionId", "userId");
+
+CREATE INDEX "SessionSlackThread_sessionId_idx"
+    ON "SessionSlackThread"("sessionId");
+
+CREATE INDEX "SessionSlackThread_channelId_idx"
+    ON "SessionSlackThread"("channelId");
+
+ALTER TABLE "SessionSlackThread"
+    ADD CONSTRAINT "SessionSlackThread_sessionId_fkey"
+    FOREIGN KEY ("sessionId") REFERENCES "Session"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -4,8 +4,8 @@ generator client {
 }
 
 datasource db {
-  provider   = "postgresql"
-  url        = env("DATABASE_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
   // extensions = [vector]
 }
 
@@ -14,68 +14,68 @@ datasource db {
 // ============================================================================
 
 model User {
-  id                       String    @id @default(cuid())
-  clerkId                  String?   @unique // Clerk authentication user ID
-  email                    String    @unique
-  name                     String?   // Full name (computed from firstName + lastName)
-  firstName                String?
-  lastName                 String?
-  pushToken                String?   // Expo push token for realtime fallbacks
-  biometricEnabled         Boolean   @default(false)
-  biometricEnrolledAt      DateTime?
-  memoryPreferences        Json?     // MemoryPreferencesDTO - AI memory settings
-  notificationPreferences  Json?     // NotificationPreferencesDTO - notification settings
-  lastMoodIntensity        Int?      // Last mood intensity (1-10) for session entry default
-  createdAt                DateTime  @default(now())
-  updatedAt                DateTime  @updatedAt
+  id                      String    @id @default(cuid())
+  clerkId                 String?   @unique // Clerk authentication user ID
+  slackUserId             String?   @unique // Slack user ID for Slack-originated sessions
+  email                   String    @unique
+  name                    String? // Full name (computed from firstName + lastName)
+  firstName               String?
+  lastName                String?
+  pushToken               String? // Expo push token for realtime fallbacks
+  biometricEnabled        Boolean   @default(false)
+  biometricEnrolledAt     DateTime?
+  memoryPreferences       Json? // MemoryPreferencesDTO - AI memory settings
+  notificationPreferences Json? // NotificationPreferencesDTO - notification settings
+  lastMoodIntensity       Int? // Last mood intensity (1-10) for session entry default
+  createdAt               DateTime  @default(now())
+  updatedAt               DateTime  @updatedAt
 
   // === Global Facts ===
   // Consolidated facts about the user across all sessions
   // Format: [{ category: string, fact: string }]
   // Categories: People, Logistics, Conflict, Emotional, History, etc.
   // Max 50 facts, deduplicated and pruned during consolidation
-  globalFacts              Json?
+  globalFacts Json?
 
   // Relationships
-  relationships       RelationshipMember[]
-  vessels             UserVessel[]
-  stageProgress       StageProgress[]
-  messages            Message[]
-  consentsGiven       ConsentRecord[]               @relation("ConsentsGiven")
-  consentsRequested   ConsentRecord[]               @relation("ConsentsRequested")
-  consentedContent    ConsentedContent[]
-  empathyDrafts       EmpathyDraft[]
-  empathyAttempts     EmpathyAttempt[]
-  empathyValidations  EmpathyValidation[]
-  strategyProposals   StrategyProposal[]
-  strategyRankings    StrategyRanking[]
-  exerciseCompletions EmotionalExerciseCompletion[]
-  invitationsSent     Invitation[]                  @relation("InvitedBy")
-  innerWorkSessions   InnerWorkSession[]
-  userMemories        UserMemory[]
+  relationships            RelationshipMember[]
+  vessels                  UserVessel[]
+  stageProgress            StageProgress[]
+  messages                 Message[]
+  consentsGiven            ConsentRecord[]               @relation("ConsentsGiven")
+  consentsRequested        ConsentRecord[]               @relation("ConsentsRequested")
+  consentedContent         ConsentedContent[]
+  empathyDrafts            EmpathyDraft[]
+  empathyAttempts          EmpathyAttempt[]
+  empathyValidations       EmpathyValidation[]
+  strategyProposals        StrategyProposal[]
+  strategyRankings         StrategyRanking[]
+  exerciseCompletions      EmotionalExerciseCompletion[]
+  invitationsSent          Invitation[]                  @relation("InvitedBy")
+  innerWorkSessions        InnerWorkSession[]
+  userMemories             UserMemory[]
   validationFeedbackDrafts ValidationFeedbackDraft[]
 
-
   // Inner Work: Needs Assessment
-  needScores          NeedScore[]
+  needScores           NeedScore[]
   needsAssessmentState NeedsAssessmentState?
 
   // Inner Work: People Tracking
-  people              Person[]
+  people Person[]
 
   // Inner Work: Gratitude Practice
-  gratitudeEntries    GratitudeEntry[]
+  gratitudeEntries     GratitudeEntry[]
   gratitudePreferences GratitudePreferences?
 
   // Inner Work: Meditation
-  meditationSessions  MeditationSession[]
-  meditationStats     MeditationStats?
-  meditationFavorites MeditationFavorite[]
+  meditationSessions    MeditationSession[]
+  meditationStats       MeditationStats?
+  meditationFavorites   MeditationFavorite[]
   meditationPreferences MeditationPreferences?
-  savedMeditations    SavedMeditation[]
+  savedMeditations      SavedMeditation[]
 
   // Inner Work: Cross-Feature Intelligence
-  insights            Insight[]
+  insights Insight[]
 
   // Inner Work: Recurring Themes (Knowledge Base)
   recurringThemes RecurringTheme[]
@@ -99,10 +99,32 @@ model RelationshipMember {
   userId         String
   joinedAt       DateTime     @default(now())
   role           String       @default("member")
-  nickname       String?      // What this member calls their partner
+  nickname       String? // What this member calls their partner
 
   @@unique([relationshipId, userId])
   @@index([userId])
+}
+
+// ============================================================================
+// Slack Thread Mapping
+// ============================================================================
+
+/// Maps a Slack DM channel+thread to a (session, user) pair. Each MWF session
+/// involves two users, each with their own private DM thread. This replaces
+/// the file-based `thread-index.json` used by the Claude-agent workspace.
+model SessionSlackThread {
+  id        String   @id @default(cuid())
+  session   Session  @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId String
+  userId    String // the Slack-user's DB User.id (for cross-referencing messages/vessels)
+  channelId String // Slack DM channel id
+  threadTs  String // top-level thread timestamp
+  createdAt DateTime @default(now())
+
+  @@unique([channelId, threadTs])
+  @@unique([sessionId, userId])
+  @@index([sessionId])
+  @@index([channelId])
 }
 
 // ============================================================================
@@ -119,24 +141,28 @@ model Session {
   updatedAt      DateTime      @updatedAt
   resolvedAt     DateTime?
 
+  // Slack origin (null for mobile-originated sessions)
+  slackJoinCode String?              @unique // 6-char code for partner to pair via lobby
+  slackThreads  SessionSlackThread[]
+
   // Related entities
-  messages            Message[]
-  sharedVessel        SharedVessel?
-  stageProgress       StageProgress[]
-  userVessels         UserVessel[]
-  empathyDrafts       EmpathyDraft[]
-  empathyAttempts     EmpathyAttempt[]
-  empathyValidations  EmpathyValidation[]
-  strategyProposals   StrategyProposal[]
-  strategyRankings    StrategyRanking[]
-  consentRecords      ConsentRecord[]
-  exerciseCompletions EmotionalExerciseCompletion[]
-  invitations         Invitation[]
-  userMemories        UserMemory[]
-  validationFeedbackDrafts ValidationFeedbackDraft[]
+  messages                  Message[]
+  sharedVessel              SharedVessel?
+  stageProgress             StageProgress[]
+  userVessels               UserVessel[]
+  empathyDrafts             EmpathyDraft[]
+  empathyAttempts           EmpathyAttempt[]
+  empathyValidations        EmpathyValidation[]
+  strategyProposals         StrategyProposal[]
+  strategyRankings          StrategyRanking[]
+  consentRecords            ConsentRecord[]
+  exerciseCompletions       EmotionalExerciseCompletion[]
+  invitations               Invitation[]
+  userMemories              UserMemory[]
+  validationFeedbackDrafts  ValidationFeedbackDraft[]
   refinementAttemptCounters RefinementAttemptCounter[]
-  reconcilerResults        ReconcilerResult[]
-  brainActivities          BrainActivity[]
+  reconcilerResults         ReconcilerResult[]
+  brainActivities           BrainActivity[]
 
   // Linked Inner Thoughts sessions for private reflection during partner session
   linkedInnerThoughts InnerWorkSession[] @relation("LinkedInnerThoughts")
@@ -167,16 +193,16 @@ enum SessionStatus {
 // ============================================================================
 
 model InnerWorkSession {
-  id        String              @id @default(cuid())
-  user      User                @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId    String
-  title     String?             // Optional user-provided or AI-generated title
-  summary   String?             @db.Text // AI-generated summary of the session
-  theme     String?             // Detected theme (e.g., "anxiety", "relationship patterns")
-  status    InnerWorkStatus     @default(ACTIVE)
-  createdAt DateTime            @default(now())
-  updatedAt DateTime            @updatedAt
-  distilledAt DateTime?         // Set when distillation has been run on this session
+  id          String          @id @default(cuid())
+  user        User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId      String
+  title       String? // Optional user-provided or AI-generated title
+  summary     String?         @db.Text // AI-generated summary of the session
+  theme       String? // Detected theme (e.g., "anxiety", "relationship patterns")
+  status      InnerWorkStatus @default(ACTIVE)
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
+  distilledAt DateTime? // Set when distillation has been run on this session
 
   // Rolling conversation summary for long sessions (like partner session vessels)
   // Stores JSON: { text, keyThemes, emotionalJourney, unresolvedTopics, messageCount, generatedAt }
@@ -188,7 +214,7 @@ model InnerWorkSession {
   contentEmbedding Unsupported("vector(1024)")?
 
   // Messages in this inner work session
-  messages InnerWorkMessage[]
+  messages  InnerWorkMessage[]
   // Distilled takeaways from this session
   takeaways SessionTakeaway[]
 
@@ -199,8 +225,8 @@ model InnerWorkSession {
   // When set, AI has access to partner session context and can reference it
   linkedPartnerSession   Session? @relation("LinkedInnerThoughts", fields: [linkedPartnerSessionId], references: [id], onDelete: SetNull)
   linkedPartnerSessionId String?
-  linkedAtStage          Int?     // Stage when Inner Thoughts was opened (1, 2, 3, 4)
-  linkedTrigger          String?  // Why it was opened: "empathy_wait", "voluntary", "witness_wait"
+  linkedAtStage          Int? // Stage when Inner Thoughts was opened (1, 2, 3, 4)
+  linkedTrigger          String? // Why it was opened: "empathy_wait", "voluntary", "witness_wait"
 
   @@index([userId, updatedAt])
   @@index([status])
@@ -208,25 +234,25 @@ model InnerWorkSession {
 }
 
 enum InnerWorkStatus {
-  ACTIVE    // Ongoing inner work session
+  ACTIVE // Ongoing inner work session
   COMPLETED // User marked as complete or AI determined closure
-  ARCHIVED  // User archived this session
+  ARCHIVED // User archived this session
 }
 
 enum TakeawaySource {
-  AI    // Distilled by AI
-  USER  // Added or edited by user
+  AI // Distilled by AI
+  USER // Added or edited by user
 }
 
 enum TakeawayType {
-  INSIGHT      // A reflection or observation
-  ACTION_ITEM  // Something concrete to do
-  INTENTION    // A desire or aspiration (not a concrete action)
+  INSIGHT // A reflection or observation
+  ACTION_ITEM // Something concrete to do
+  INTENTION // A desire or aspiration (not a concrete action)
 }
 
 enum TakeawayLinkType {
-  AI_SEMANTIC  // Auto-detected via embedding similarity
-  USER_MANUAL  // Manually linked by the user
+  AI_SEMANTIC // Auto-detected via embedding similarity
+  USER_MANUAL // Manually linked by the user
 }
 
 model InnerWorkMessage {
@@ -349,9 +375,9 @@ model UserVessel {
   // === Session Read State ===
   // When the user last viewed/opened this session's chat
   // Used to determine: (1) if session has unread content, (2) where "new messages" line appears
-  lastViewedAt DateTime?
+  lastViewedAt         DateTime?
   // The ID of the last chat item the user saw (for "new messages" line placement)
-  lastSeenChatItemId String?
+  lastSeenChatItemId   String?
   // When the user last viewed the Share/Partner tab
   // Used to determine "seen" status for shared content (empathy, context)
   lastViewedShareTabAt DateTime?
@@ -613,10 +639,10 @@ enum MessageRole {
   USER
   AI
   SYSTEM
-  EMPATHY_STATEMENT     // User's shared empathy statement (shown in chat history)
-  EMPATHY_REVEAL_INTRO  // AI intro message when revealing partner's empathy to user
-  SHARED_CONTEXT        // Context shared by subject to help guesser refine empathy
-  SHARE_SUGGESTION      // Suggested content for subject to share (reconciler)
+  EMPATHY_STATEMENT // User's shared empathy statement (shown in chat history)
+  EMPATHY_REVEAL_INTRO // AI intro message when revealing partner's empathy to user
+  SHARED_CONTEXT // Context shared by subject to help guesser refine empathy
+  SHARE_SUGGESTION // Suggested content for subject to share (reconciler)
   EMPATHY_VALIDATION_PROMPT // AI prompt asking user to validate partner's understanding
 }
 
@@ -638,13 +664,13 @@ model PreSessionMessage {
   // embedding Unsupported("vector(1024)")?  -- pgvector not available
 
   // Metadata from intent detection
-  detectedIntent    String? // The intent detected for this message
-  emotionalTone     String? // neutral, upset, hopeful, anxious
-  extractedPerson   String? // If a person was mentioned
-  extractedTopic    String? // If a topic was identified
+  detectedIntent  String? // The intent detected for this message
+  emotionalTone   String? // neutral, upset, hopeful, anxious
+  extractedPerson String? // If a person was mentioned
+  extractedTopic  String? // If a topic was identified
 
   // Association tracking
-  associatedSessionId String?   // Set when message is linked to a session
+  associatedSessionId String? // Set when message is linked to a session
   associatedAt        DateTime? // When it was associated
 
   // Cleanup
@@ -691,16 +717,16 @@ model EmpathyAttempt {
 
   // Reconciler flow fields
   status        EmpathyStatus @default(HELD)
-  statusVersion Int           @default(0)  // Incremented on every status change for event ordering
+  statusVersion Int           @default(0) // Incremented on every status change for event ordering
   revealedAt    DateTime?
   revisionCount Int           @default(0)
 
   // Delivery status for showing pending/delivered/seen to the author
-  deliveryStatus    SharedContentDeliveryStatus @default(PENDING)
+  deliveryStatus SharedContentDeliveryStatus @default(PENDING)
   /// When the empathy statement was delivered to partner's chat (when revealed)
-  deliveredAt       DateTime?
+  deliveredAt    DateTime?
   /// When the partner acknowledged/saw the statement
-  seenAt            DateTime?
+  seenAt         DateTime?
 
   validations EmpathyValidation[]
 
@@ -711,14 +737,14 @@ model EmpathyAttempt {
 }
 
 enum EmpathyStatus {
-  HELD              // Waiting for partner to complete Stage 1
-  ANALYZING         // Reconciler is comparing guess vs actual Stage 1 content
-  AWAITING_SHARING  // Gaps detected, waiting for subject to respond to share suggestion
-  REFINING          // Guesser is refining after receiving shared context
-  NEEDS_WORK        // Significant gaps detected, guesser should refine (legacy - use AWAITING_SHARING)
-  READY             // Reconciler complete, waiting for partner to also complete Stage 2 before revealing
-  REVEALED          // Recipient can now see statement
-  VALIDATED         // Recipient has validated accuracy
+  HELD // Waiting for partner to complete Stage 1
+  ANALYZING // Reconciler is comparing guess vs actual Stage 1 content
+  AWAITING_SHARING // Gaps detected, waiting for subject to respond to share suggestion
+  REFINING // Guesser is refining after receiving shared context
+  NEEDS_WORK // Significant gaps detected, guesser should refine (legacy - use AWAITING_SHARING)
+  READY // Reconciler complete, waiting for partner to also complete Stage 2 before revealing
+  REVEALED // Recipient can now see statement
+  VALIDATED // Recipient has validated accuracy
 }
 
 model EmpathyValidation {
@@ -744,50 +770,50 @@ model EmpathyValidation {
 /// Stores the result of reconciler analysis comparing what one person
 /// guessed about the other vs what they actually expressed.
 model ReconcilerResult {
-  id        String   @id @default(cuid())
-  session   Session  @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  id        String  @id @default(cuid())
+  session   Session @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   sessionId String
 
   /// The user who made the empathy guess
-  guesserId     String
-  guesserName   String
+  guesserId   String
+  guesserName String
   /// The user being guessed about (whose feelings were analyzed)
-  subjectId     String
-  subjectName   String
+  subjectId   String
+  subjectName String
 
   // Alignment Analysis
-  alignmentScore     Int      // 0-100
-  alignmentSummary   String   @db.Text
+  alignmentScore      Int // 0-100
+  alignmentSummary    String   @db.Text
   correctlyIdentified String[] // Feelings/needs that were correctly identified
 
   // Gap Analysis
-  gapSeverity       String   // none, minor, moderate, significant
-  gapSummary        String   @db.Text
-  missedFeelings    String[] // Feelings/needs that were missed
-  misattributions   String[] // Incorrect assumptions made
-  mostImportantGap  String?  @db.Text // The single most important gap
+  gapSeverity      String // none, minor, moderate, significant
+  gapSummary       String   @db.Text
+  missedFeelings   String[] // Feelings/needs that were missed
+  misattributions  String[] // Incorrect assumptions made
+  mostImportantGap String?  @db.Text // The single most important gap
 
   // Recommendation
-  recommendedAction   String  // PROCEED, OFFER_OPTIONAL, OFFER_SHARING
+  recommendedAction   String // PROCEED, OFFER_OPTIONAL, OFFER_SHARING
   rationale           String  @db.Text
   sharingWouldHelp    Boolean
   suggestedShareFocus String? @db.Text
 
   // Abstract guidance for refinement (no specific partner content)
-  areaHint      String?   // e.g., "work and effort"
-  guidanceType  String?   // e.g., "explore_deeper_feelings"
-  promptSeed    String?   // e.g., "what might be underneath"
+  areaHint     String? // e.g., "work and effort"
+  guidanceType String? // e.g., "explore_deeper_feelings"
+  promptSeed   String? // e.g., "what might be underneath"
 
   // Suggestion for subject to share (generated when gaps are significant)
-  suggestedShareContent String?  @db.Text  // AI-generated suggestion for what subject could share
-  suggestedShareReason  String?  @db.Text  // Why this would help the guesser understand
+  suggestedShareContent String? @db.Text // AI-generated suggestion for what subject could share
+  suggestedShareReason  String? @db.Text // Why this would help the guesser understand
 
   /// Which iteration of the reconciler loop produced this result (1 = first run)
-  iteration         Int      @default(1)
+  iteration             Int       @default(1)
   /// Whether this result was produced by the circuit breaker forcing READY
-  wasCircuitBreakerTrip Boolean @default(false)
+  wasCircuitBreakerTrip Boolean   @default(false)
   /// When set, this result has been superseded by a newer analysis (audit trail)
-  supersededAt      DateTime?
+  supersededAt          DateTime?
 
   createdAt DateTime @default(now())
 
@@ -802,45 +828,45 @@ model ReconcilerResult {
 /// Tracks the share suggestion made to a user (the subject) and their response.
 /// This allows the subject to optionally share context to help the guesser understand better.
 model ReconcilerShareOffer {
-  id        String   @id @default(cuid())
-  result    ReconcilerResult @relation(fields: [resultId], references: [id], onDelete: Cascade)
-  resultId  String   @unique
+  id       String           @id @default(cuid())
+  result   ReconcilerResult @relation(fields: [resultId], references: [id], onDelete: Cascade)
+  resultId String           @unique
 
   /// The user being asked to share (the subject of the analysis)
-  userId    String
+  userId String
 
   /// Status of the share offer
-  status    ReconcilerShareStatus @default(NOT_OFFERED)
+  status ReconcilerShareStatus @default(NOT_OFFERED)
 
   /// AI-generated suggestion for what to share
-  suggestedContent   String?  @db.Text  // What the AI suggests the subject could share
-  suggestedReason    String?  @db.Text  // Why this would help the guesser
+  suggestedContent String? @db.Text // What the AI suggests the subject could share
+  suggestedReason  String? @db.Text // Why this would help the guesser
 
   /// The AI-generated message offering to share (shown to user)
-  offerMessage      String?  @db.Text
+  offerMessage String? @db.Text
 
   /// User's refined version (if they edited the suggestion)
-  refinedContent     String?  @db.Text
+  refinedContent String? @db.Text
 
   /// Final content that was shared (could be suggested, refined, or custom)
-  sharedContent     String?  @db.Text
-  sharedAt          DateTime?
+  sharedContent String?   @db.Text
+  sharedAt      DateTime?
 
   /// Delivery status of shared content (pending -> delivered -> seen)
-  deliveryStatus    SharedContentDeliveryStatus @default(PENDING)
+  deliveryStatus SharedContentDeliveryStatus @default(PENDING)
   /// When the content was delivered to the guesser
-  deliveredAt       DateTime?
+  deliveredAt    DateTime?
   /// When the guesser saw/acknowledged the content (sent first message after)
-  seenAt            DateTime?
+  seenAt         DateTime?
 
   /// If they declined
-  declinedAt        DateTime?
+  declinedAt DateTime?
 
   /// Legacy: skipped without responding
-  skippedAt         DateTime?
+  skippedAt DateTime?
 
   /// Which iteration of the reconciler loop this offer belongs to
-  iteration         Int      @default(1)
+  iteration          Int     @default(1)
   /// Whether the refinement chat was used before accepting/declining
   refinementChatUsed Boolean @default(false)
 
@@ -857,19 +883,19 @@ model ReconcilerShareOffer {
 
 /// Delivery status for shared content (empathy statements, shared context)
 enum SharedContentDeliveryStatus {
-  PENDING    // Content saved but not yet delivered
-  DELIVERED  // Content delivered to recipient's chat
-  SEEN       // Recipient has viewed/acknowledged the content
+  PENDING // Content saved but not yet delivered
+  DELIVERED // Content delivered to recipient's chat
+  SEEN // Recipient has viewed/acknowledged the content
 }
 
 enum ReconcilerShareStatus {
-  PENDING     // Suggestion generated, not yet shown to user
-  OFFERED     // Shown to user, awaiting response
-  ACCEPTED    // User accepted (with or without refinement)
-  DECLINED    // User declined to share
-  EXPIRED     // Offer expired (timeout)
+  PENDING // Suggestion generated, not yet shown to user
+  OFFERED // Shown to user, awaiting response
+  ACCEPTED // User accepted (with or without refinement)
+  DECLINED // User declined to share
+  EXPIRED // Offer expired (timeout)
   NOT_OFFERED // Legacy: no offer was made
-  SKIPPED     // Legacy: user skipped without responding
+  SKIPPED // Legacy: user skipped without responding
 }
 
 /// Tracks refinement attempts per direction to implement circuit breaker.
@@ -878,7 +904,7 @@ model RefinementAttemptCounter {
   id        String   @id @default(cuid())
   session   Session  @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   sessionId String
-  direction String   // "guesserId->subjectId" composite string
+  direction String // "guesserId->subjectId" composite string
   attempts  Int      @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -989,21 +1015,21 @@ enum GlobalLibrarySource {
 // ============================================================================
 
 model Invitation {
-  id                String           @id @default(cuid())
-  session           Session          @relation(fields: [sessionId], references: [id], onDelete: Cascade)
-  sessionId         String
-  invitedBy         User             @relation("InvitedBy", fields: [invitedById], references: [id], onDelete: Cascade)
-  invitedById       String
-  name              String?          // Display name for the invited person
-  invitationMessage   String?          @db.Text // The crafted invitation message
-  messageConfirmed    Boolean          @default(false) // User confirmed the message
-  messageConfirmedAt  DateTime?        // When the user confirmed the message (for chat indicator positioning)
-  status              InvitationStatus @default(PENDING)
-  createdAt         DateTime         @default(now())
-  expiresAt         DateTime
-  acceptedAt        DateTime?
-  declinedAt        DateTime?
-  declineReason     String?
+  id                 String           @id @default(cuid())
+  session            Session          @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId          String
+  invitedBy          User             @relation("InvitedBy", fields: [invitedById], references: [id], onDelete: Cascade)
+  invitedById        String
+  name               String? // Display name for the invited person
+  invitationMessage  String?          @db.Text // The crafted invitation message
+  messageConfirmed   Boolean          @default(false) // User confirmed the message
+  messageConfirmedAt DateTime? // When the user confirmed the message (for chat indicator positioning)
+  status             InvitationStatus @default(PENDING)
+  createdAt          DateTime         @default(now())
+  expiresAt          DateTime
+  acceptedAt         DateTime?
+  declinedAt         DateTime?
+  declineReason      String?
 
   @@index([sessionId])
   @@index([status])
@@ -1016,18 +1042,17 @@ enum InvitationStatus {
   EXPIRED
 }
 
-
 // ============================================================================
 // User Memory (Things to Always Remember)
 // ============================================================================
 
 enum MemoryCategory {
-  AI_NAME       // "Call me Alex"
-  LANGUAGE      // "Respond in Spanish"
+  AI_NAME // "Call me Alex"
+  LANGUAGE // "Respond in Spanish"
   COMMUNICATION // "Keep responses brief"
   PERSONAL_INFO // "Call me Sam", pronouns
-  RELATIONSHIP  // "Partner's name is Jordan"
-  PREFERENCE    // "Use examples when explaining"
+  RELATIONSHIP // "Partner's name is Jordan"
+  PREFERENCE // "Use examples when explaining"
 }
 
 enum MemoryStatus {
@@ -1038,8 +1063,8 @@ enum MemoryStatus {
 
 enum MemorySource {
   USER_APPROVED // AI suggested, user approved
-  USER_CREATED  // User created directly
-  USER_EDITED   // AI suggested, user edited before saving
+  USER_CREATED // User created directly
+  USER_EDITED // AI suggested, user edited before saving
 }
 
 model UserMemory {
@@ -1047,7 +1072,7 @@ model UserMemory {
   user        User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId      String
   session     Session?       @relation(fields: [sessionId], references: [id], onDelete: Cascade)
-  sessionId   String?        // null = global memory
+  sessionId   String? // null = global memory
   content     String         @db.Text
   category    MemoryCategory
   status      MemoryStatus   @default(ACTIVE)
@@ -1066,21 +1091,21 @@ model UserMemory {
 
 // Reference table for the 19 core human needs (seeded data)
 model Need {
-  id          Int          @id
-  name        String       // "Physical Safety"
-  slug        String       @unique // "physical-safety"
-  description String       @db.Text // Full question text
+  id          Int           @id
+  name        String // "Physical Safety"
+  slug        String        @unique // "physical-safety"
+  description String        @db.Text // Full question text
   category    NeedsCategory
-  order       Int          // Display order within category
+  order       Int // Display order within category
 
   scores NeedScore[]
 }
 
 enum NeedsCategory {
-  FOUNDATION    // Physical safety, health, rest, material security
-  EMOTIONAL     // Emotional safety, self-compassion, regulation, agency
-  RELATIONAL    // Being seen, belonging, trust, contribution
-  INTEGRATION   // Purpose, learning, integrity, hope
+  FOUNDATION // Physical safety, health, rest, material security
+  EMOTIONAL // Emotional safety, self-compassion, regulation, agency
+  RELATIONAL // Being seen, belonging, trust, contribution
+  INTEGRATION // Purpose, learning, integrity, hope
   TRANSCENDENCE // Presence, gratitude, connection to larger whole
 }
 
@@ -1091,7 +1116,7 @@ model NeedScore {
   userId        String
   need          Need     @relation(fields: [needId], references: [id], onDelete: Cascade)
   needId        Int
-  score         Int      // 0 = Not met, 1 = Somewhat met, 2 = Fully met
+  score         Int // 0 = Not met, 1 = Somewhat met, 2 = Fully met
   clarification String?  @db.Text // Optional user notes
   createdAt     DateTime @default(now())
 
@@ -1107,7 +1132,7 @@ model NeedsAssessmentState {
   baselineCompleted    Boolean   @default(false)
   baselineCompletedAt  DateTime?
   checkInFrequencyDays Int       @default(7) // 1-10 days
-  lastCheckInNeedId    Int?      // Which need was last checked
+  lastCheckInNeedId    Int? // Which need was last checked
   lastCheckInAt        DateTime?
   nextCheckInAt        DateTime?
 }
@@ -1121,9 +1146,9 @@ model Person {
   id             String   @id @default(cuid())
   user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId         String
-  name           String   // Primary name: "Sarah"
+  name           String // Primary name: "Sarah"
   aliases        String[] @default([]) // ["my friend Sarah", "Sarah W."]
-  relationship   String?  // "friend", "partner", "family", "coworker", etc.
+  relationship   String? // "friend", "partner", "family", "coworker", etc.
   firstMentioned DateTime @default(now())
   lastMentioned  DateTime @default(now())
 
@@ -1149,9 +1174,9 @@ model PersonMention {
   personId   String
   userId     String
   sourceType MentionSourceType
-  sourceId   String            // ID of the source entity
+  sourceId   String // ID of the source entity
   context    String?           @db.Text // Surrounding text snippet
-  sentiment  Float?            // -1 to 1
+  sentiment  Float? // -1 to 1
   createdAt  DateTime          @default(now())
 
   @@index([personId, createdAt])
@@ -1159,9 +1184,9 @@ model PersonMention {
 }
 
 enum MentionSourceType {
-  INNER_THOUGHTS  // InnerWorkMessage
-  GRATITUDE       // GratitudeEntry
-  NEEDS_CHECKIN   // NeedScore clarification
+  INNER_THOUGHTS // InnerWorkMessage
+  GRATITUDE // GratitudeEntry
+  NEEDS_CHECKIN // NeedScore clarification
   PARTNER_SESSION // Session message
 }
 
@@ -1171,25 +1196,25 @@ enum MentionSourceType {
 
 // AI-generated insights from cross-feature pattern recognition
 model Insight {
-  id         String      @id @default(cuid())
-  user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId     String
-  type       InsightType
-  summary    String      @db.Text // Human-readable insight summary
-  data       Json        // Structured data supporting the insight
-  priority   Int         @default(0) // Higher = more important (0-10)
-  dismissed  Boolean     @default(false)
-  expiresAt  DateTime?   // Auto-expire old insights
-  createdAt  DateTime    @default(now())
+  id        String      @id @default(cuid())
+  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  type      InsightType
+  summary   String      @db.Text // Human-readable insight summary
+  data      Json // Structured data supporting the insight
+  priority  Int         @default(0) // Higher = more important (0-10)
+  dismissed Boolean     @default(false)
+  expiresAt DateTime? // Auto-expire old insights
+  createdAt DateTime    @default(now())
 
   @@index([userId, dismissed, priority])
   @@index([userId, expiresAt])
 }
 
 enum InsightType {
-  PATTERN       // Recurring behavior or theme detected
+  PATTERN // Recurring behavior or theme detected
   CONTRADICTION // Conflicting self-reports or behaviors
-  SUGGESTION    // Recommended action based on patterns
+  SUGGESTION // Recommended action based on patterns
 }
 
 // ============================================================================
@@ -1200,9 +1225,9 @@ model RecurringTheme {
   id           String   @id @default(cuid())
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId       String
-  tag          String   // The theme tag (matches InnerWorkSession.theme)
-  sessionCount Int      // How many sessions share this theme (updated each time)
-  summary      String   @db.Text  // Haiku-generated cross-session summary
+  tag          String // The theme tag (matches InnerWorkSession.theme)
+  sessionCount Int // How many sessions share this theme (updated each time)
+  summary      String   @db.Text // Haiku-generated cross-session summary
   summaryAt    DateTime // When summary was last generated
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
@@ -1233,7 +1258,7 @@ model GratitudeEntry {
   // Connections
   linkedNeedIds    Int[]   @default([]) // Which needs this touches
   linkedConflictId String? // If mentioned an active conflict
-  sentimentScore   Float?  // -1 to 1, for trend tracking
+  sentimentScore   Float? // -1 to 1, for trend tracking
 
   // AI response to the gratitude
   aiResponse String? @db.Text
@@ -1253,8 +1278,8 @@ model GratitudePreferences {
   frequency       Int      @default(1) // 0-3 times per day
   preferredTimes  String[] @default(["20:00"]) // Array of HH:MM
   weekdayOnly     Boolean  @default(false)
-  quietHoursStart String?  // HH:MM
-  quietHoursEnd   String?  // HH:MM
+  quietHoursStart String? // HH:MM
+  quietHoursEnd   String? // HH:MM
 }
 
 // ============================================================================
@@ -1267,7 +1292,7 @@ model MeditationSession {
   userId          String
   type            MeditationType
   durationMinutes Int
-  focusArea       String?        // e.g., "grounding", "self-compassion"
+  focusArea       String? // e.g., "grounding", "self-compassion"
   completed       Boolean        @default(false)
   startedAt       DateTime       @default(now())
   completedAt     DateTime?
@@ -1322,7 +1347,7 @@ model MeditationFavorite {
   id              String       @id @default(cuid())
   user            User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId          String
-  name            String       // User-given or auto-generated name
+  name            String // User-given or auto-generated name
   focusArea       String
   durationMinutes Int
   favoriteType    FavoriteType
@@ -1350,10 +1375,10 @@ model SavedMeditation {
   id              String   @id @default(cuid())
   user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId          String
-  title           String   // User-provided or AI-generated title
+  title           String // User-provided or AI-generated title
   script          String   @db.Text // Full script with [PAUSE:Xs] tokens
-  durationSeconds Int      // Calculated from script
-  conversationId  String?  // Link to InnerWorkSession that created it (for editing)
+  durationSeconds Int // Calculated from script
+  conversationId  String? // Link to InnerWorkSession that created it (for editing)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
@@ -1369,33 +1394,33 @@ model SavedMeditation {
 // ============================================================================
 
 model BrainActivity {
-  id              String           @id @default(cuid())
-  session         Session?         @relation(fields: [sessionId], references: [id], onDelete: Cascade)
-  sessionId       String?
-  innerWorkSession InnerWorkSession? @relation(fields: [innerWorkSessionId], references: [id], onDelete: Cascade)
+  id                 String            @id @default(cuid())
+  session            Session?          @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId          String?
+  innerWorkSession   InnerWorkSession? @relation(fields: [innerWorkSessionId], references: [id], onDelete: Cascade)
   innerWorkSessionId String?
-  turnId          String?
-  activityType    ActivityType
-  model           String           // e.g. "claude-3-5-sonnet", "titan-embed"
+  turnId             String?
+  activityType       ActivityType
+  model              String // e.g. "claude-3-5-sonnet", "titan-embed"
 
   // Full telemetry
-  input           Json?            // Prompt, query, etc.
-  output          Json?            // Response, retrieved items, etc.
-  metadata        Json?            // Reasoning, confidence, errors
+  input    Json? // Prompt, query, etc.
+  output   Json? // Response, retrieved items, etc.
+  metadata Json? // Reasoning, confidence, errors
 
   // Typed call information for dashboard display
-  callType         BrainActivityCallType?  // Specific LLM call type for component rendering
-  structuredOutput Json?                   // Typed output data for dashboard components
+  callType         BrainActivityCallType? // Specific LLM call type for component rendering
+  structuredOutput Json? // Typed output data for dashboard components
 
   // Stats
-  tokenCountInput  Int             @default(0)
-  tokenCountOutput Int             @default(0)
-  cost             Float           @default(0.0)
-  durationMs       Int             @default(0)
+  tokenCountInput  Int   @default(0)
+  tokenCountOutput Int   @default(0)
+  cost             Float @default(0.0)
+  durationMs       Int   @default(0)
 
-  status          ActivityStatus   @default(PENDING)
-  createdAt       DateTime         @default(now())
-  completedAt     DateTime?
+  status      ActivityStatus @default(PENDING)
+  createdAt   DateTime       @default(now())
+  completedAt DateTime?
 
   @@index([sessionId])
   @@index([innerWorkSessionId])

--- a/backend/src/controllers/__tests__/slack-session.test.ts
+++ b/backend/src/controllers/__tests__/slack-session.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Slack Session Controller Tests
+ *
+ * Verifies the shared-secret validation and payload-validation logic of the
+ * `POST /api/slack/mwf-session` endpoint. The actual Bedrock pipeline is
+ * covered by the orchestrator/conversation tests and is mocked out here.
+ */
+
+jest.mock('../../services/slack-session-orchestrator', () => ({
+  handleSlackMessage: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../services/workspace-prompt-builder', () => ({
+  getWorkspaceStatus: jest.fn().mockReturnValue({
+    root: '/fake',
+    stagesLoaded: [0, 1, 2, 3, 4],
+    guardianLoaded: true,
+    privacyLoaded: true,
+    progressionLoaded: true,
+  }),
+}));
+
+import type { Request, Response } from 'express';
+import { handleMwfSessionMessage, slackHealth } from '../slack-session';
+import { handleSlackMessage } from '../../services/slack-session-orchestrator';
+
+function makeRes(): Response {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): Request {
+  return {
+    body,
+    header: (name: string) => headers[name.toLowerCase()] ?? headers[name],
+  } as unknown as Request;
+}
+
+describe('slack-session controller', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('handleMwfSessionMessage', () => {
+    const validPayload = {
+      channel: 'C123',
+      user: 'U123',
+      text: 'hello',
+      ts: '1.000',
+    };
+
+    it('accepts a valid payload without a secret when none is configured (dev)', async () => {
+      delete process.env.SLACK_INGRESS_SECRET;
+      (process.env as Record<string, string>).NODE_ENV = 'development';
+
+      const res = makeRes();
+      await handleMwfSessionMessage(makeReq(validPayload), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(handleSlackMessage).toHaveBeenCalledWith(expect.objectContaining({
+        channel: 'C123',
+        user: 'U123',
+      }));
+    });
+
+    it('rejects when production env has no secret configured', async () => {
+      delete process.env.SLACK_INGRESS_SECRET;
+      (process.env as Record<string, string>).NODE_ENV = 'production';
+
+      const res = makeRes();
+      await handleMwfSessionMessage(makeReq(validPayload), res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(handleSlackMessage).not.toHaveBeenCalled();
+    });
+
+    it('accepts when the correct shared secret is provided via header', async () => {
+      process.env.SLACK_INGRESS_SECRET = 'shhh';
+
+      const res = makeRes();
+      await handleMwfSessionMessage(
+        makeReq(validPayload, { 'x-slack-ingress-secret': 'shhh' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(handleSlackMessage).toHaveBeenCalled();
+    });
+
+    it('rejects when the shared secret is wrong', async () => {
+      process.env.SLACK_INGRESS_SECRET = 'shhh';
+
+      const res = makeRes();
+      await handleMwfSessionMessage(
+        makeReq(validPayload, { 'x-slack-ingress-secret': 'nope' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(handleSlackMessage).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed payloads with 400', async () => {
+      delete process.env.SLACK_INGRESS_SECRET;
+
+      const res = makeRes();
+      await handleMwfSessionMessage(
+        makeReq({ channel: 'C123' /* missing user/ts/text */ }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(handleSlackMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('slackHealth', () => {
+    it('reports slack config and workspace status', () => {
+      process.env.SLACK_BOT_TOKEN = 'xoxb-test';
+      const res = makeRes();
+      slackHealth({} as Request, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: true,
+          slackConfigured: true,
+          workspace: expect.objectContaining({
+            stagesLoaded: expect.arrayContaining([0, 1, 2, 3, 4]),
+            guardianLoaded: true,
+          }),
+        })
+      );
+    });
+  });
+});

--- a/backend/src/controllers/slack-session.ts
+++ b/backend/src/controllers/slack-session.ts
@@ -1,0 +1,93 @@
+/**
+ * Slack MWF Session Controller
+ *
+ * Entry point for messages originating from Slack. The EC2 socket listener
+ * POSTs incoming DM/lobby messages here; the backend orchestrates the full
+ * Bedrock pipeline (same engine as the mobile app) and posts the reply back
+ * to Slack via `slack-client`.
+ *
+ * Phase 1 scope (this file): validate shared-secret, ack the payload, and
+ * echo the message back to the same thread so end-to-end plumbing can be
+ * smoke-tested. Phases 3–4 replace the echo with the real session loop.
+ */
+
+import { Request, Response } from 'express';
+import { logger } from '../lib/logger';
+import { handleSlackMessage } from '../services/slack-session-orchestrator';
+import type { SlackMessagePayload } from '../services/slack-types';
+import { getWorkspaceStatus } from '../services/workspace-prompt-builder';
+
+export type { SlackMessagePayload };
+
+/**
+ * Validate the shared secret passed by the socket listener. Prevents random
+ * callers from posting arbitrary Slack messages through us.
+ */
+function validateSharedSecret(req: Request): boolean {
+  const expected = process.env.SLACK_INGRESS_SECRET;
+  if (!expected) {
+    // Dev fallback: allow when no secret is configured so local testing works.
+    if (process.env.NODE_ENV === 'production') {
+      logger.error('[SlackSession] SLACK_INGRESS_SECRET missing in production — rejecting');
+      return false;
+    }
+    return true;
+  }
+
+  const provided =
+    (req.header('x-slack-ingress-secret') as string | undefined) ??
+    (req.body?.secret as string | undefined);
+
+  return provided === expected;
+}
+
+/**
+ * POST /api/slack/mwf-session
+ *
+ * Accepts a Slack message payload, 200s immediately, then processes the
+ * conversation turn asynchronously so the socket listener can move on.
+ */
+export async function handleMwfSessionMessage(req: Request, res: Response): Promise<void> {
+  if (!validateSharedSecret(req)) {
+    res.status(401).json({ ok: false, error: 'unauthorized' });
+    return;
+  }
+
+  const payload = req.body as SlackMessagePayload;
+
+  if (!payload || !payload.channel || !payload.user || typeof payload.text !== 'string' || !payload.ts) {
+    res.status(400).json({ ok: false, error: 'invalid_payload' });
+    return;
+  }
+
+  logger.info(
+    `[SlackSession] Accepted message channel=${payload.channel} user=${payload.user} ts=${payload.ts} lobby=${payload.isLobby ?? false}`
+  );
+
+  res.status(200).json({ ok: true });
+
+  // Process in the background — do not block the socket listener.
+  handleSlackMessage(payload).catch((err: unknown) => {
+    logger.error('[SlackSession] handleSlackMessage failed:', err);
+  });
+}
+
+/**
+ * GET /api/slack/health — lightweight diag endpoint so the socket listener
+ * can verify the backend is reachable before wiring itself up.
+ */
+export function slackHealth(_req: Request, res: Response): void {
+  const workspace = getWorkspaceStatus();
+  res.status(200).json({
+    ok: true,
+    slackConfigured: Boolean(process.env.SLACK_BOT_TOKEN),
+    secretRequired: Boolean(process.env.SLACK_INGRESS_SECRET),
+    workspace: {
+      root: workspace.root,
+      stagesLoaded: workspace.stagesLoaded,
+      guardianLoaded: workspace.guardianLoaded,
+      privacyLoaded: workspace.privacyLoaded,
+      progressionLoaded: workspace.progressionLoaded,
+    },
+  });
+}

--- a/backend/src/controllers/slack-session.ts
+++ b/backend/src/controllers/slack-session.ts
@@ -11,6 +11,7 @@
  * smoke-tested. Phases 3–4 replace the echo with the real session loop.
  */
 
+import crypto from 'crypto';
 import { Request, Response } from 'express';
 import { logger } from '../lib/logger';
 import { handleSlackMessage } from '../services/slack-session-orchestrator';
@@ -34,11 +35,10 @@ function validateSharedSecret(req: Request): boolean {
     return true;
   }
 
-  const provided =
-    (req.header('x-slack-ingress-secret') as string | undefined) ??
-    (req.body?.secret as string | undefined);
+  const provided = req.header('x-slack-ingress-secret') ?? '';
 
-  return provided === expected;
+  if (provided.length !== expected.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
 }
 
 /**

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -14,6 +14,7 @@ import peopleRoutes from './people';
 import knowledgeBaseRoutes from './knowledge-base';
 import reconcilerRoutes from './reconciler';
 import sessionsRoutes from './sessions';
+import slackRoutes from './slack';
 import stage0Routes from './stage0';
 import messagesRoutes from './messages';
 import notificationsRoutes from './notifications';
@@ -35,6 +36,7 @@ router.use('/auth', authRoutes);
 router.use('/tts', ttsRoutes);
 router.use(voiceRoutes); // Voice transcription token endpoint
 router.use('/e2e', e2eRoutes); // E2E testing helpers - must be BEFORE routers with global auth middleware
+router.use(slackRoutes); // Slack ingress (socket-listener → backend) — uses shared-secret auth
 router.use(chatRoutes); // Unified chat router
 router.use(invitationsRoutes); // Must be before innerWorkRoutes (has public endpoints)
 router.use(innerThoughtsRoutes); // Inner Thoughts (solo self-reflection, optionally linked to partner sessions)

--- a/backend/src/routes/slack.ts
+++ b/backend/src/routes/slack.ts
@@ -1,0 +1,18 @@
+/**
+ * Slack Ingress Routes
+ *
+ * Public routes (no Clerk auth) that the EC2 socket listener POSTs into.
+ * Protected with a shared secret (SLACK_INGRESS_SECRET) validated inside the
+ * controller.
+ */
+
+import { Router } from 'express';
+import { asyncHandler } from '../middleware/errors';
+import { handleMwfSessionMessage, slackHealth } from '../controllers/slack-session';
+
+const router = Router();
+
+router.get('/slack/health', slackHealth);
+router.post('/slack/mwf-session', asyncHandler(handleMwfSessionMessage));
+
+export default router;

--- a/backend/src/services/__tests__/workspace-prompt-builder.test.ts
+++ b/backend/src/services/__tests__/workspace-prompt-builder.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Workspace Prompt Builder Tests
+ */
+
+import {
+  buildSlackStagePrompt,
+  getWorkspaceStatus,
+  __resetWorkspaceCache,
+} from '../workspace-prompt-builder';
+import type { ContextBundle } from '../context-assembler';
+import type { PromptContext } from '../stage-prompts';
+
+describe('Workspace Prompt Builder', () => {
+  beforeEach(() => {
+    __resetWorkspaceCache();
+  });
+
+  const makeBundle = (): ContextBundle => ({
+    conversationContext: {
+      recentTurns: [],
+      turnCount: 0,
+      sessionDurationMinutes: 0,
+    },
+    emotionalThread: {
+      initialIntensity: null,
+      currentIntensity: null,
+      trend: 'unknown',
+      notableShifts: [],
+    },
+    stageContext: { stage: 1, gatesSatisfied: {} },
+    userName: 'Alice',
+    intent: {
+      intent: 'emotional_validation',
+      depth: 'light',
+      reason: 'test',
+      threshold: 0.5,
+      maxCrossSession: 0,
+      allowCrossSession: false,
+      surfaceStyle: 'silent',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    assembledAt: new Date().toISOString(),
+  });
+
+  const makeContext = (overrides: Partial<PromptContext> = {}): PromptContext => ({
+    userName: 'Alice',
+    partnerName: 'Bob',
+    turnCount: 1,
+    emotionalIntensity: 5,
+    contextBundle: makeBundle(),
+    ...overrides,
+  });
+
+  it('loads workspace files and produces non-empty blocks for Stage 1', () => {
+    const blocks = buildSlackStagePrompt(1, makeContext());
+    expect(blocks.staticBlock.length).toBeGreaterThan(100);
+    expect(blocks.dynamicBlock.length).toBeGreaterThan(10);
+  });
+
+  it('embeds the guardian constitution and stage CONTEXT in the static block', () => {
+    const blocks = buildSlackStagePrompt(1, makeContext());
+    expect(blocks.staticBlock).toContain('Process Guardian');
+    expect(blocks.staticBlock).toContain('Stage 1');
+    // Witness-specific language should be present
+    expect(blocks.staticBlock.toLowerCase()).toContain('listen');
+  });
+
+  it('includes the micro-tag response protocol', () => {
+    const blocks = buildSlackStagePrompt(1, makeContext());
+    expect(blocks.staticBlock).toContain('<thinking>');
+    expect(blocks.staticBlock).toContain('FeelHeardCheck');
+    expect(blocks.staticBlock).toContain('<dispatch>');
+  });
+
+  it('includes slack-specific formatting guidance', () => {
+    const blocks = buildSlackStagePrompt(1, makeContext());
+    expect(blocks.staticBlock).toContain('SLACK FORMATTING');
+    expect(blocks.staticBlock).toContain('mrkdwn');
+  });
+
+  it('sets stage-specific flags for stage 2 (ReadyShare)', () => {
+    const blocks = buildSlackStagePrompt(2, makeContext());
+    expect(blocks.staticBlock).toContain('ReadyShare');
+  });
+
+  it('sets stage-specific flags for stage 4 (StrategyProposed)', () => {
+    const blocks = buildSlackStagePrompt(4, makeContext());
+    expect(blocks.staticBlock).toContain('StrategyProposed');
+  });
+
+  it('includes turn count and intensity in the dynamic block', () => {
+    const blocks = buildSlackStagePrompt(
+      1,
+      makeContext({ turnCount: 6, emotionalIntensity: 7 })
+    );
+    expect(blocks.dynamicBlock).toContain('Turn: 6');
+    expect(blocks.dynamicBlock).toContain('Emotional intensity: 7/10');
+  });
+
+  it('warns on very high intensity', () => {
+    const blocks = buildSlackStagePrompt(
+      1,
+      makeContext({ emotionalIntensity: 9 })
+    );
+    expect(blocks.dynamicBlock).toContain('HIGH INTENSITY');
+  });
+
+  it('guards against too-early feel-heard on stage 1', () => {
+    const blocks = buildSlackStagePrompt(
+      1,
+      makeContext({ turnCount: 1 })
+    );
+    expect(blocks.dynamicBlock).toContain('Feel-heard guard');
+  });
+
+  it('signals stage transition when requested', () => {
+    const blocks = buildSlackStagePrompt(2, makeContext(), {
+      isStageTransition: true,
+      previousStage: 1,
+    });
+    expect(blocks.dynamicBlock).toContain('STAGE TRANSITION');
+    expect(blocks.dynamicBlock).toContain('1 to stage 2');
+  });
+
+  it('falls back cleanly via fallbackOnly option', () => {
+    const blocks = buildSlackStagePrompt(1, makeContext(), { fallbackOnly: true });
+    expect(blocks.staticBlock).toBeTruthy();
+    expect(blocks.dynamicBlock).toBeTruthy();
+  });
+
+  it('reports loaded stages via getWorkspaceStatus', () => {
+    const status = getWorkspaceStatus();
+    expect(status.stagesLoaded).toEqual(expect.arrayContaining([0, 1, 2, 3, 4]));
+    expect(status.guardianLoaded).toBe(true);
+  });
+});

--- a/backend/src/services/slack-client.ts
+++ b/backend/src/services/slack-client.ts
@@ -1,0 +1,140 @@
+/**
+ * Slack Web API Client
+ *
+ * Thin wrapper around @slack/web-api for posting messages, opening DMs,
+ * adding reactions, and fetching user profile info. Used by the MWF session
+ * flow to post Bedrock-generated replies back to Slack DM threads without
+ * going through the EC2 bot.
+ */
+
+import { WebClient } from '@slack/web-api';
+import { logger } from '../lib/logger';
+
+let client: WebClient | null | undefined;
+
+/**
+ * Lazily construct the Slack client. Returns null when SLACK_BOT_TOKEN is
+ * missing — callers should treat that as "Slack is not configured" and skip
+ * posting without crashing.
+ */
+export function getSlackClient(): WebClient | null {
+  if (client !== undefined) return client;
+
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) {
+    logger.warn('[SlackClient] SLACK_BOT_TOKEN not set — Slack posting disabled');
+    client = null;
+    return null;
+  }
+
+  client = new WebClient(token);
+  return client;
+}
+
+export interface PostMessageResult {
+  ok: boolean;
+  ts?: string;
+  channel?: string;
+  error?: string;
+}
+
+export async function postMessage(
+  channel: string,
+  text: string,
+  threadTs?: string
+): Promise<PostMessageResult> {
+  const slack = getSlackClient();
+  if (!slack) return { ok: false, error: 'no_client' };
+
+  try {
+    const res = await slack.chat.postMessage({
+      channel,
+      text,
+      thread_ts: threadTs,
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+    return { ok: true, ts: res.ts, channel: res.channel };
+  } catch (err) {
+    logger.error('[SlackClient] postMessage failed:', err);
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+export async function openDM(userId: string): Promise<string | null> {
+  const slack = getSlackClient();
+  if (!slack) return null;
+
+  try {
+    const res = await slack.conversations.open({ users: userId });
+    return res.channel?.id ?? null;
+  } catch (err) {
+    logger.error('[SlackClient] openDM failed:', err);
+    return null;
+  }
+}
+
+export async function addReaction(
+  channel: string,
+  ts: string,
+  name: string
+): Promise<boolean> {
+  const slack = getSlackClient();
+  if (!slack) return false;
+
+  try {
+    await slack.reactions.add({ channel, timestamp: ts, name });
+    return true;
+  } catch (err) {
+    const code = (err as { data?: { error?: string } }).data?.error;
+    if (code === 'already_reacted') return true;
+    logger.warn('[SlackClient] addReaction failed:', err);
+    return false;
+  }
+}
+
+export async function removeReaction(
+  channel: string,
+  ts: string,
+  name: string
+): Promise<boolean> {
+  const slack = getSlackClient();
+  if (!slack) return false;
+
+  try {
+    await slack.reactions.remove({ channel, timestamp: ts, name });
+    return true;
+  } catch (err) {
+    const code = (err as { data?: { error?: string } }).data?.error;
+    if (code === 'no_reaction') return true;
+    logger.warn('[SlackClient] removeReaction failed:', err);
+    return false;
+  }
+}
+
+export interface SlackProfile {
+  userId: string;
+  displayName: string;
+  realName: string | null;
+  email: string | null;
+}
+
+export async function getUserInfo(userId: string): Promise<SlackProfile | null> {
+  const slack = getSlackClient();
+  if (!slack) return null;
+
+  try {
+    const res = await slack.users.info({ user: userId });
+    const u = res.user;
+    if (!u) return null;
+    return {
+      userId,
+      displayName: u.profile?.display_name || u.real_name || u.name || userId,
+      realName: u.real_name ?? null,
+      email: u.profile?.email ?? null,
+    };
+  } catch (err) {
+    logger.error('[SlackClient] getUserInfo failed:', err);
+    return null;
+  }
+}

--- a/backend/src/services/slack-conversation.ts
+++ b/backend/src/services/slack-conversation.ts
@@ -1,0 +1,410 @@
+/**
+ * Slack Conversation Runner
+ *
+ * Per-message orchestration for MWF sessions driven from Slack. Routes lobby
+ * messages (#mwf-sessions) vs DM messages, and for DMs runs the full Bedrock
+ * pipeline — the same engine the mobile app uses — built on:
+ *
+ *   assembleContextBundle → buildSlackStagePrompt → getSonnetResponse
+ *     → parseMicroTagResponse → postMessage (Slack) + saveSlackMessage
+ *
+ * This file replaces the stub echo from Phase 1 with the real Phase 4 loop.
+ * Phase 5 moves the socket-listener to POST here directly.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { logger } from '../lib/logger';
+import { getSonnetResponse } from '../lib/bedrock';
+import { prisma } from '../lib/prisma';
+import {
+  assembleContextBundle,
+  type ContextBundle,
+} from './context-assembler';
+import { formatContextForPrompt } from './context-formatters';
+import { determineMemoryIntent } from './memory-intent';
+import { parseMicroTagResponse } from '../utils/micro-tag-parser';
+import { trimConversationHistory } from '../utils/token-budget';
+import type { SlackMessagePayload } from './slack-types';
+import { openDM, postMessage } from './slack-client';
+import {
+  findOrCreateSlackUser,
+  findSessionByJoinCode,
+  findSessionByThread,
+  createSlackSession,
+  pairSlackSession,
+  saveSlackMessage,
+  getCurrentStage,
+  updateStageProgress,
+  hasBothUsersCompacted,
+  advanceToStage,
+} from './slack-session-service';
+import { buildSlackStagePrompt } from './workspace-prompt-builder';
+import { MessageRole } from '@prisma/client';
+
+const CONVERSATION_TURN_LIMIT = 12; // pairs of user+assistant messages kept in prompt
+const MAX_SONNET_TOKENS = 1024; // Slack replies are short — no need for 2048
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export async function runConversationTurn(payload: SlackMessagePayload): Promise<void> {
+  if (payload.isLobby) {
+    await handleLobbyMessage(payload);
+    return;
+  }
+
+  await handleDmMessage(payload);
+}
+
+// ---------------------------------------------------------------------------
+// Lobby flow (#mwf-sessions channel)
+// ---------------------------------------------------------------------------
+
+const JOIN_CODE_REGEX = /\bjoin\s+([a-z0-9]{6})\b/i;
+
+async function handleLobbyMessage(payload: SlackMessagePayload): Promise<void> {
+  const trimmed = payload.text.trim();
+  const lower = trimmed.toLowerCase();
+
+  const user = await findOrCreateSlackUser(payload.user);
+
+  // Pairing: "join <code>"
+  const joinMatch = trimmed.match(JOIN_CODE_REGEX);
+  if (joinMatch) {
+    await handleJoinCode(user.id, joinMatch[1].toLowerCase(), payload);
+    return;
+  }
+
+  // Start a new session
+  if (lower === 'start' || lower.startsWith('start ')) {
+    await handleStartSession(user.id, payload);
+    return;
+  }
+
+  // Help fallback — don't start a random session on stray lobby chatter.
+  await postMessage(
+    payload.channel,
+    'To begin, say `start`. To join a partner\'s session, say `join <code>`.',
+    payload.thread_ts ?? payload.ts
+  );
+}
+
+async function handleStartSession(userId: string, payload: SlackMessagePayload): Promise<void> {
+  const dmChannel = await openDM(payload.user);
+  if (!dmChannel) {
+    logger.error('[SlackConversation] Could not open DM for user', payload.user);
+    await postMessage(
+      payload.channel,
+      "I couldn't open a DM with you — please enable DMs from apps and try again.",
+      payload.thread_ts ?? payload.ts
+    );
+    return;
+  }
+
+  // Post the opening DM first so we can use its ts as the thread root for this
+  // user's side of the conversation.
+  const opener = await postMessage(
+    dmChannel,
+    "*Welcome to Meet Without Fear.* I'll help you prepare for a conversation with someone who matters to you. Tell me a little — who is this person, and what\'s on your mind?"
+  );
+  if (!opener.ok || !opener.ts) {
+    logger.error('[SlackConversation] Failed to send opening DM');
+    return;
+  }
+
+  const { session, joinCode } = await createSlackSession({
+    creatorUserId: userId,
+    channelId: dmChannel,
+    threadTs: opener.ts,
+  });
+
+  await postMessage(
+    payload.channel,
+    `Session started — head to your DM to begin. Share this code with your partner so they can join: *${joinCode}*`,
+    payload.thread_ts ?? payload.ts
+  );
+
+  // Save the AI opener to the transcript so it shows up in later context.
+  await saveSlackMessage({
+    sessionId: session.id,
+    userId,
+    content: "Welcome to Meet Without Fear. I'll help you prepare for a conversation with someone who matters to you. Tell me a little — who is this person, and what's on your mind?",
+    stage: 0,
+    role: 'AI',
+  });
+}
+
+async function handleJoinCode(
+  userId: string,
+  code: string,
+  payload: SlackMessagePayload
+): Promise<void> {
+  const session = await findSessionByJoinCode(code);
+  if (!session) {
+    await postMessage(
+      payload.channel,
+      "I couldn\'t find a session with that code. Double-check and try again.",
+      payload.thread_ts ?? payload.ts
+    );
+    return;
+  }
+  if (session.status !== 'INVITED') {
+    await postMessage(
+      payload.channel,
+      'That session already has two participants.',
+      payload.thread_ts ?? payload.ts
+    );
+    return;
+  }
+
+  const dmChannel = await openDM(payload.user);
+  if (!dmChannel) {
+    await postMessage(
+      payload.channel,
+      "I couldn\'t open a DM with you — please enable DMs from apps and try again.",
+      payload.thread_ts ?? payload.ts
+    );
+    return;
+  }
+
+  const opener = await postMessage(
+    dmChannel,
+    "*Welcome — your partner is ready for this conversation.* I'll help you prepare too. Tell me a little about the situation and what you\'re hoping for."
+  );
+  if (!opener.ok || !opener.ts) {
+    logger.error('[SlackConversation] Failed to send partner opening DM');
+    return;
+  }
+
+  await pairSlackSession({
+    sessionId: session.id,
+    partnerUserId: userId,
+    channelId: dmChannel,
+    threadTs: opener.ts,
+  });
+
+  await saveSlackMessage({
+    sessionId: session.id,
+    userId,
+    content: "Welcome — your partner is ready for this conversation. I'll help you prepare too. Tell me a little about the situation and what you're hoping for.",
+    stage: 0,
+    role: 'AI',
+  });
+
+  await postMessage(
+    payload.channel,
+    'Joined — head to your DM to begin.',
+    payload.thread_ts ?? payload.ts
+  );
+
+  // Ping the creator's DM too.
+  const creatorThread = session.id
+    ? await prisma.sessionSlackThread.findFirst({
+        where: { sessionId: session.id, NOT: { userId } },
+      })
+    : null;
+  if (creatorThread) {
+    await postMessage(
+      creatorThread.channelId,
+      '_Your partner has joined. Continue here whenever you\'re ready._',
+      creatorThread.threadTs
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DM flow (actual conversation)
+// ---------------------------------------------------------------------------
+
+async function handleDmMessage(payload: SlackMessagePayload): Promise<void> {
+  const threadTs = payload.thread_ts ?? payload.ts;
+  const mapping = await findSessionByThread(payload.channel, threadTs);
+  if (!mapping) {
+    // Not an MWF session thread — guide user to the lobby. Only reply once
+    // per unmapped top-level message.
+    if (!payload.thread_ts) {
+      await postMessage(
+        payload.channel,
+        "I can only run MWF sessions inside threads I started. Start a session in <#mwf-sessions> first."
+      );
+    }
+    return;
+  }
+
+  const { session, userId } = mapping;
+  const stage = await getCurrentStage(session.id, userId);
+
+  // Persist the incoming user message before we call the model so it's part of
+  // context on this turn too (matches the mobile controller).
+  await saveSlackMessage({
+    sessionId: session.id,
+    userId,
+    content: payload.text,
+    stage,
+    role: 'USER',
+  });
+
+  // If the user is in Stage 0 and answers yes to the compact, mark it and
+  // possibly advance.
+  await maybeHandleStage0Signal(session.id, userId, payload.text);
+
+  // Load history for both the Sonnet prompt and context assembly.
+  const history = await loadConversationForPrompt(session.id, userId);
+
+  // Determine memory intent (same as mobile).
+  const memoryIntent = determineMemoryIntent({
+    stage,
+    emotionalIntensity: 5,
+    userMessage: payload.text,
+    turnCount: Math.floor(history.length / 2),
+    isFirstTurnInSession: history.length <= 2,
+  });
+
+  let contextBundle: ContextBundle;
+  try {
+    contextBundle = await assembleContextBundle(session.id, userId, stage, memoryIntent);
+  } catch (err) {
+    logger.error('[SlackConversation] assembleContextBundle failed:', err);
+    return;
+  }
+
+  const userName = contextBundle.userName;
+  const partnerName = contextBundle.partnerName ?? undefined;
+  const emotionalIntensity =
+    contextBundle.emotionalThread.currentIntensity ?? 5;
+
+  const { trimmed: trimmedHistory } = trimConversationHistory(
+    history,
+    CONVERSATION_TURN_LIMIT
+  );
+
+  const prompt = buildSlackStagePrompt(
+    stage,
+    {
+      userName,
+      partnerName,
+      turnCount: contextBundle.conversationContext.turnCount,
+      emotionalIntensity,
+      contextBundle,
+    },
+    {
+      isOnboarding: stage === 0 && !(await hasBothUsersCompacted(session.id)),
+    }
+  );
+
+  // Inject the per-turn formatted context as a leading user message rather
+  // than baking it into the dynamic block, so prompt caching on the static
+  // block still gets hits across turns.
+  const contextText = formatContextForPrompt(contextBundle);
+
+  const messages = [
+    { role: 'user' as const, content: `(Context for this turn — do not reply to this directly)\n${contextText}` },
+    ...trimmedHistory,
+  ];
+
+  const turnId = randomUUID();
+  const raw = await getSonnetResponse({
+    systemPrompt: prompt,
+    messages,
+    sessionId: session.id,
+    turnId,
+    operation: 'slack-session-turn',
+    maxTokens: MAX_SONNET_TOKENS,
+  });
+
+  if (!raw) {
+    await postMessage(
+      payload.channel,
+      '_I hit a snag reaching my model — please try again in a moment._',
+      threadTs
+    );
+    return;
+  }
+
+  const parsed = parseMicroTagResponse(raw);
+  const replyText = parsed.response?.trim();
+
+  if (!replyText) {
+    logger.warn('[SlackConversation] Parsed response was empty', { dispatch: parsed.dispatchTag });
+    return;
+  }
+
+  // Persist AI turn first so subsequent turns see it in history.
+  await saveSlackMessage({
+    sessionId: session.id,
+    userId,
+    content: replyText,
+    stage,
+    role: 'AI',
+  });
+
+  await postMessage(payload.channel, replyText, threadTs);
+
+  // Stage-specific signal handling.
+  if (stage === 1 && parsed.offerFeelHeardCheck) {
+    await maybeAdvanceOnFeelHeard(session.id, userId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function loadConversationForPrompt(
+  sessionId: string,
+  userId: string
+): Promise<Array<{ role: 'user' | 'assistant'; content: string }>> {
+  const messages = await prisma.message.findMany({
+    where: {
+      sessionId,
+      forUserId: userId,
+      role: { in: [MessageRole.USER, MessageRole.AI] },
+    },
+    orderBy: { timestamp: 'asc' },
+    select: { role: true, content: true },
+  });
+
+  return messages.map((m) => ({
+    role: m.role === MessageRole.USER ? ('user' as const) : ('assistant' as const),
+    content: m.content,
+  }));
+}
+
+/**
+ * Stage 0 compact signal — look for an affirmative "I agree/yes/I'm in"
+ * response to the compact ask, and mark the gate.
+ */
+async function maybeHandleStage0Signal(
+  sessionId: string,
+  userId: string,
+  text: string
+): Promise<void> {
+  const stage = await getCurrentStage(sessionId, userId);
+  if (stage !== 0) return;
+
+  const affirmed = /\b(i\s+agree|i'?m\s+in|yes,?\s+i\s+agree|agreed|sign(?:ed)?\s+it)\b/i.test(text);
+  if (!affirmed) return;
+
+  await updateStageProgress(sessionId, userId, {
+    gatesSatisfied: { compactSigned: true },
+  });
+
+  if (await hasBothUsersCompacted(sessionId)) {
+    await advanceToStage(sessionId, 1);
+    logger.info('[SlackConversation] Both users signed compact — advancing to Stage 1', {
+      sessionId,
+    });
+  }
+}
+
+async function maybeAdvanceOnFeelHeard(sessionId: string, userId: string): Promise<void> {
+  // We don't auto-advance on feel-heard here — the AI already offered the
+  // check in the reply, and the user needs to explicitly confirm. Phase 6
+  // will wire the explicit confirmation flow via a DM button-style prompt.
+  // For now, just record that the signal was raised.
+  await updateStageProgress(sessionId, userId, {
+    gatesSatisfied: { feelHeardOffered: true },
+  });
+}

--- a/backend/src/services/slack-session-orchestrator.ts
+++ b/backend/src/services/slack-session-orchestrator.ts
@@ -1,0 +1,52 @@
+/**
+ * Slack Session Orchestrator
+ *
+ * Runs the full Bedrock conversation loop for a Slack-originated MWF session
+ * turn. In Phase 1 this is a simple echo so end-to-end plumbing can be tested;
+ * Phases 2–4 replace the body with context assembly, prompt building, and a
+ * real Sonnet call.
+ */
+
+import { logger } from '../lib/logger';
+import { postMessage, addReaction, removeReaction } from './slack-client';
+import type { SlackMessagePayload } from './slack-types';
+import { runConversationTurn } from './slack-conversation';
+
+/**
+ * Naive in-memory per-user lock to serialize concurrent messages from the same
+ * Slack user. Swap for a DB advisory lock once we deploy multiple backend
+ * instances.
+ */
+const inFlight = new Map<string, Promise<unknown>>();
+
+export async function handleSlackMessage(payload: SlackMessagePayload): Promise<void> {
+  const key = `slack:${payload.user}`;
+  const prev = inFlight.get(key) ?? Promise.resolve();
+  const next = prev.finally(() => {}).then(() => processTurn(payload));
+  inFlight.set(
+    key,
+    next.finally(() => {
+      if (inFlight.get(key) === next) inFlight.delete(key);
+    })
+  );
+  await next;
+}
+
+async function processTurn(payload: SlackMessagePayload): Promise<void> {
+  const { channel, ts } = payload;
+
+  try {
+    await runConversationTurn(payload);
+    await removeReaction(channel, ts, 'eyes');
+    await addReaction(channel, ts, 'white_check_mark');
+  } catch (err) {
+    logger.error('[SlackSessionOrchestrator] processTurn failed:', err);
+    await removeReaction(channel, ts, 'eyes').catch(() => {});
+    await addReaction(channel, ts, 'x').catch(() => {});
+    await postMessage(
+      channel,
+      "_I hit an error trying to respond — give me a moment and try again._",
+      payload.thread_ts ?? payload.ts
+    ).catch(() => {});
+  }
+}

--- a/backend/src/services/slack-session-service.ts
+++ b/backend/src/services/slack-session-service.ts
@@ -1,0 +1,377 @@
+/**
+ * Slack Session Service
+ *
+ * Pure async functions for managing MWF sessions originating from Slack. Owns
+ * user lookup/creation from Slack profiles, session/relationship scaffolding,
+ * Slack-thread-to-session mapping, message persistence, and stage progression.
+ *
+ * This is the DB persistence layer called by slack-conversation.ts on each
+ * turn, and by the lobby controller when pairing users via join code.
+ */
+
+import type { Message, Session, User } from '@prisma/client';
+import { MessageRole, Prisma, StageStatus } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { logger } from '../lib/logger';
+import { getUserInfo } from './slack-client';
+
+// ============================================================================
+// User resolution
+// ============================================================================
+
+/**
+ * Look up a User by their Slack user id, creating one (with a Slack profile
+ * pull) if they don't exist yet. Falls back to a placeholder email when Slack
+ * doesn't return one.
+ */
+export async function findOrCreateSlackUser(slackUserId: string): Promise<User> {
+  const existing = await prisma.user.findUnique({ where: { slackUserId } });
+  if (existing) return existing;
+
+  const profile = await getUserInfo(slackUserId);
+  const email = profile?.email ?? `slack-${slackUserId}@slack.local`;
+  const displayName = profile?.displayName ?? null;
+  const realName = profile?.realName ?? null;
+  const name = displayName || realName || null;
+  const firstName = name ? name.split(/\s+/)[0] : null;
+
+  logger.info('[SlackSessionService] Creating User for Slack user', {
+    slackUserId,
+    hasProfile: Boolean(profile),
+    hasEmail: Boolean(profile?.email),
+  });
+
+  return prisma.user.create({
+    data: {
+      slackUserId,
+      email,
+      name,
+      firstName,
+    },
+  });
+}
+
+// ============================================================================
+// Session lookup
+// ============================================================================
+
+/**
+ * Find the (session, userId) pair bound to a specific Slack channel+thread.
+ * Returns null if the thread is not yet mapped.
+ */
+export async function findSessionByThread(
+  channelId: string,
+  threadTs: string
+): Promise<{ session: Session; userId: string } | null> {
+  const mapping = await prisma.sessionSlackThread.findUnique({
+    where: { channelId_threadTs: { channelId, threadTs } },
+    include: { session: true },
+  });
+  if (!mapping) return null;
+  return { session: mapping.session, userId: mapping.userId };
+}
+
+/**
+ * Find a session by its 6-char lobby join code.
+ */
+export async function findSessionByJoinCode(code: string): Promise<Session | null> {
+  return prisma.session.findUnique({ where: { slackJoinCode: code } });
+}
+
+// ============================================================================
+// Session creation & pairing
+// ============================================================================
+
+export interface CreateSlackSessionParams {
+  creatorUserId: string;
+  channelId: string;
+  threadTs: string;
+}
+
+/**
+ * Create a fresh MWF session with the Slack creator as the sole member, ready
+ * for a partner to pair via join code. Returns the created session and the
+ * join code partners should use in the lobby.
+ */
+export async function createSlackSession(
+  params: CreateSlackSessionParams
+): Promise<{ session: Session; joinCode: string }> {
+  const { creatorUserId, channelId, threadTs } = params;
+  const joinCode = generateJoinCode();
+
+  const relationship = await prisma.relationship.create({
+    data: {
+      members: { create: [{ userId: creatorUserId }] },
+    },
+  });
+
+  const session = await prisma.session.create({
+    data: {
+      relationshipId: relationship.id,
+      status: 'INVITED',
+      type: 'CONFLICT_RESOLUTION',
+      slackJoinCode: joinCode,
+      userVessels: { create: [{ userId: creatorUserId }] },
+      stageProgress: {
+        create: [
+          {
+            userId: creatorUserId,
+            stage: 0,
+            status: StageStatus.IN_PROGRESS,
+            gatesSatisfied: {},
+          },
+        ],
+      },
+      slackThreads: {
+        create: [{ userId: creatorUserId, channelId, threadTs }],
+      },
+    },
+  });
+
+  logger.info('[SlackSessionService] Created Slack session', {
+    sessionId: session.id,
+    creatorUserId,
+    joinCode,
+  });
+
+  return { session, joinCode };
+}
+
+export interface PairSlackSessionParams {
+  sessionId: string;
+  partnerUserId: string;
+  channelId: string;
+  threadTs: string;
+}
+
+/**
+ * Add a partner to an existing Slack-originated session: extend the
+ * relationship, scaffold their vessel + stage 0 progress, map their DM thread,
+ * and flip the session to ACTIVE.
+ */
+export async function pairSlackSession(
+  params: PairSlackSessionParams
+): Promise<Session> {
+  const { sessionId, partnerUserId, channelId, threadTs } = params;
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { relationshipId: true },
+  });
+  if (!session) {
+    throw new Error(`Session not found: ${sessionId}`);
+  }
+
+  await prisma.relationshipMember.create({
+    data: { relationshipId: session.relationshipId, userId: partnerUserId },
+  });
+
+  await prisma.userVessel.create({
+    data: { sessionId, userId: partnerUserId },
+  });
+
+  await prisma.stageProgress.create({
+    data: {
+      sessionId,
+      userId: partnerUserId,
+      stage: 0,
+      status: StageStatus.IN_PROGRESS,
+      gatesSatisfied: {},
+    },
+  });
+
+  await prisma.sessionSlackThread.create({
+    data: { sessionId, userId: partnerUserId, channelId, threadTs },
+  });
+
+  const updated = await prisma.session.update({
+    where: { id: sessionId },
+    data: { status: 'ACTIVE' },
+    include: {
+      relationship: { include: { members: { include: { user: true } } } },
+      slackThreads: true,
+    },
+  });
+
+  logger.info('[SlackSessionService] Paired partner into Slack session', {
+    sessionId,
+    partnerUserId,
+  });
+
+  return updated;
+}
+
+// ============================================================================
+// Messages
+// ============================================================================
+
+export interface SaveSlackMessageParams {
+  sessionId: string;
+  userId: string;
+  content: string;
+  stage: number;
+  role: 'USER' | 'AI';
+}
+
+/**
+ * Persist a message to the session transcript. USER messages record both
+ * senderId and forUserId as the Slack user; AI messages set senderId=null and
+ * forUserId to the user the AI was responding to (matching the mobile-side
+ * convention in Message).
+ */
+export async function saveSlackMessage(
+  params: SaveSlackMessageParams
+): Promise<Message> {
+  const { sessionId, userId, content, stage, role } = params;
+  const isUser = role === 'USER';
+
+  return prisma.message.create({
+    data: {
+      sessionId,
+      role: isUser ? MessageRole.USER : MessageRole.AI,
+      content,
+      stage,
+      senderId: isUser ? userId : null,
+      forUserId: userId,
+    },
+  });
+}
+
+// ============================================================================
+// Stage progression
+// ============================================================================
+
+/**
+ * Return the user's current stage number in a session. Uses the most recently
+ * started StageProgress for the pair; defaults to 0 when none exists.
+ */
+export async function getCurrentStage(
+  sessionId: string,
+  userId: string
+): Promise<number> {
+  const progress = await prisma.stageProgress.findFirst({
+    where: { sessionId, userId },
+    orderBy: { startedAt: 'desc' },
+    select: { stage: true },
+  });
+  return progress?.stage ?? 0;
+}
+
+export interface UpdateStageProgressPatch {
+  gatesSatisfied?: Prisma.InputJsonValue;
+  status?: StageStatus;
+}
+
+/**
+ * Patch the user's most recent StageProgress row for a session. Used to record
+ * gate satisfaction (e.g. `compactSigned`) or flip status to COMPLETED.
+ */
+export async function updateStageProgress(
+  sessionId: string,
+  userId: string,
+  patch: UpdateStageProgressPatch
+): Promise<void> {
+  const latest = await prisma.stageProgress.findFirst({
+    where: { sessionId, userId },
+    orderBy: { startedAt: 'desc' },
+    select: { id: true },
+  });
+  if (!latest) {
+    throw new Error(
+      `No StageProgress found for session ${sessionId} user ${userId}`
+    );
+  }
+
+  const data: Prisma.StageProgressUpdateInput = {};
+  if (patch.gatesSatisfied !== undefined) data.gatesSatisfied = patch.gatesSatisfied;
+  if (patch.status !== undefined) {
+    data.status = patch.status;
+    if (patch.status === StageStatus.COMPLETED) data.completedAt = new Date();
+  }
+
+  await prisma.stageProgress.update({ where: { id: latest.id }, data });
+}
+
+/**
+ * Returns true when both users on a session have compactSigned=true in their
+ * Stage 0 gates. Used to gate the 0→1 transition.
+ */
+export async function hasBothUsersCompacted(sessionId: string): Promise<boolean> {
+  const stage0 = await prisma.stageProgress.findMany({
+    where: { sessionId, stage: 0 },
+    select: { gatesSatisfied: true },
+  });
+  if (stage0.length < 2) return false;
+  return stage0.every((p) => {
+    const gates = p.gatesSatisfied as { compactSigned?: boolean } | null;
+    return gates?.compactSigned === true;
+  });
+}
+
+/**
+ * Advance every user on the session to `newStage`: mark the current
+ * StageProgress COMPLETED and open a fresh IN_PROGRESS row for the new stage.
+ */
+export async function advanceToStage(
+  sessionId: string,
+  newStage: number
+): Promise<void> {
+  const members = await prisma.relationshipMember.findMany({
+    where: { relationship: { sessions: { some: { id: sessionId } } } },
+    select: { userId: true },
+  });
+
+  const now = new Date();
+  for (const { userId } of members) {
+    const current = await prisma.stageProgress.findFirst({
+      where: { sessionId, userId, status: { not: StageStatus.COMPLETED } },
+      orderBy: { startedAt: 'desc' },
+      select: { id: true },
+    });
+    if (current) {
+      await prisma.stageProgress.update({
+        where: { id: current.id },
+        data: { status: StageStatus.COMPLETED, completedAt: now },
+      });
+    }
+
+    await prisma.stageProgress.upsert({
+      where: {
+        sessionId_userId_stage: { sessionId, userId, stage: newStage },
+      },
+      create: {
+        sessionId,
+        userId,
+        stage: newStage,
+        status: StageStatus.IN_PROGRESS,
+        gatesSatisfied: {},
+      },
+      update: {
+        status: StageStatus.IN_PROGRESS,
+        startedAt: now,
+        completedAt: null,
+        gatesSatisfied: {},
+      },
+    });
+  }
+
+  logger.info('[SlackSessionService] Advanced session to new stage', {
+    sessionId,
+    newStage,
+    memberCount: members.length,
+  });
+}
+
+// ============================================================================
+// Internals
+// ============================================================================
+
+const JOIN_CODE_ALPHABET = 'abcdefghijkmnpqrstuvwxyz23456789'; // skip 0,o,l,1
+
+function generateJoinCode(): string {
+  let out = '';
+  for (let i = 0; i < 6; i++) {
+    out += JOIN_CODE_ALPHABET[Math.floor(Math.random() * JOIN_CODE_ALPHABET.length)];
+  }
+  return out;
+}

--- a/backend/src/services/slack-types.ts
+++ b/backend/src/services/slack-types.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared types for the Slack MWF session flow. Extracted into its own module
+ * so controllers and services can import the payload shape without creating a
+ * controller → service → controller cycle.
+ */
+
+export interface SlackMessagePayload {
+  channel: string;
+  user: string;
+  text: string;
+  thread_ts?: string;
+  ts: string;
+  /** `true` when the message was posted in the `#mwf-sessions` lobby channel. */
+  isLobby?: boolean;
+  /** Slack team id, useful for multi-workspace installs (unused today). */
+  team?: string;
+}

--- a/backend/src/services/workspace-prompt-builder.ts
+++ b/backend/src/services/workspace-prompt-builder.ts
@@ -1,0 +1,380 @@
+/**
+ * Workspace Prompt Builder
+ *
+ * Reads the `bot-workspaces/mwf-session/` workspace files (written by humans
+ * to guide Claude Code agents) and compiles them into the `{staticBlock,
+ * dynamicBlock}` format that our Bedrock caching expects.
+ *
+ * The intent: the workspace files are the single source of truth for the
+ * Process Guardian's voice and stage-specific rules, regardless of which
+ * surface (mobile app or Slack) is driving the conversation.
+ *
+ * Caching strategy:
+ * - `staticBlock` contains guardian constitution + stage-specific CONTEXT.md +
+ *   response protocol. Cached in Bedrock (`cache_control: ephemeral`) so we
+ *   get prompt cache hits across turns.
+ * - `dynamicBlock` carries per-turn state (turn count, intensity, phase
+ *   hints, user-specific context). Never cached.
+ *
+ * When a file is missing we fall back to the constants in `stage-prompts.ts`
+ * so nothing breaks during incremental migration.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { logger } from '../lib/logger';
+import type { PromptBlocks, PromptContext } from './stage-prompts';
+import { buildStagePrompt } from './stage-prompts';
+
+// ---------------------------------------------------------------------------
+// Filesystem layout
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the workspace root. Override via MWF_WORKSPACE_ROOT for tests or
+ * alternate deployment layouts. In production (compiled to dist/) we walk up
+ * until we find the workspace folder at the repo root.
+ */
+function resolveWorkspaceRoot(): string {
+  if (process.env.MWF_WORKSPACE_ROOT) return process.env.MWF_WORKSPACE_ROOT;
+
+  // Walk upward from this file until we find bot-workspaces/mwf-session/
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = path.join(dir, 'bot-workspaces', 'mwf-session');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  // Fallback to a reasonable default; loadFile() handles missing files.
+  return path.resolve(__dirname, '../../../../bot-workspaces/mwf-session');
+}
+
+const WORKSPACE_ROOT = resolveWorkspaceRoot();
+
+// Stage CONTEXT.md files, keyed by the stage number used by the backend.
+const STAGE_FILES: Record<number, string> = {
+  0: 'stages/0-onboarding/CONTEXT.md',
+  1: 'stages/1-witness/CONTEXT.md',
+  2: 'stages/2-perspective-stretch/CONTEXT.md',
+  3: 'stages/3-need-mapping/CONTEXT.md',
+  4: 'stages/4-strategic-repair/CONTEXT.md',
+};
+
+const REFERENCE_FILES = {
+  guardian: 'references/guardian-constitution.md',
+  privacy: 'references/privacy-model.md',
+  progression: 'references/stage-progression.md',
+};
+
+// ---------------------------------------------------------------------------
+// File cache
+// ---------------------------------------------------------------------------
+
+interface WorkspaceCache {
+  stages: Record<number, string | null>;
+  guardian: string | null;
+  privacy: string | null;
+  progression: string | null;
+  loadedAt: number;
+}
+
+let cache: WorkspaceCache | null = null;
+
+function loadFile(relative: string): string | null {
+  try {
+    const full = path.join(WORKSPACE_ROOT, relative);
+    if (!fs.existsSync(full)) {
+      logger.warn(`[WorkspacePromptBuilder] Missing workspace file: ${relative}`);
+      return null;
+    }
+    return fs.readFileSync(full, 'utf8');
+  } catch (err) {
+    logger.warn(`[WorkspacePromptBuilder] Failed to read ${relative}:`, err);
+    return null;
+  }
+}
+
+function loadCache(force = false): WorkspaceCache {
+  if (cache && !force) return cache;
+
+  const stages: Record<number, string | null> = {};
+  for (const [stageStr, rel] of Object.entries(STAGE_FILES)) {
+    stages[Number(stageStr)] = loadFile(rel);
+  }
+
+  cache = {
+    stages,
+    guardian: loadFile(REFERENCE_FILES.guardian),
+    privacy: loadFile(REFERENCE_FILES.privacy),
+    progression: loadFile(REFERENCE_FILES.progression),
+    loadedAt: Date.now(),
+  };
+
+  logger.info(
+    `[WorkspacePromptBuilder] Loaded workspace from ${WORKSPACE_ROOT} (stages: ${Object.keys(stages).join(',')})`
+  );
+  return cache;
+}
+
+/** Test helper: force the workspace to be re-read on the next build. */
+export function __resetWorkspaceCache(): void {
+  cache = null;
+}
+
+// ---------------------------------------------------------------------------
+// Response protocol (matches buildResponseProtocol in stage-prompts.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `<thinking>`/`<draft>`/`<dispatch>` response protocol. Mirrors
+ * `buildResponseProtocol()` in stage-prompts.ts so the micro-tag parser can
+ * consume responses from either engine identically.
+ */
+function buildResponseProtocol(
+  stage: number,
+  options?: { includesDraft?: boolean; draftPurpose?: 'invitation' | 'empathy' }
+): string {
+  const flags: string[] = ['UserIntensity: [1-10]'];
+  if (stage === 1) flags.push('FeelHeardCheck: [Y/N]');
+  else if (stage === 2) flags.push('ReadyShare: [Y/N]');
+  else if (stage === 4) flags.push('StrategyProposed: [Y/N]');
+
+  const draftSection = options?.includesDraft
+    ? `
+If you prepared a ${options.draftPurpose} draft, include:
+<draft>
+${options.draftPurpose} text
+</draft>`
+    : '';
+
+  const empathyOffRamp =
+    stage === 2
+      ? `\n- If asked why they're doing this / why guess partner's feelings / what's the point: <dispatch>EXPLAIN_EMPATHY_PURPOSE</dispatch>`
+      : '';
+
+  const strategySection =
+    stage === 4
+      ? `\nIf StrategyProposed is Y, list each concrete strategy the user committed to on its own line, prefixed with "ProposedStrategy: ". Only extract specific, actionable strategies — NOT vague ones like "communicate better".`
+      : '';
+
+  return `OUTPUT FORMAT:
+<thinking>
+Mode: [WITNESS|PERSPECTIVE|NEEDS|REPAIR|ONBOARDING|DISPATCH]
+${flags.join('\n')}
+Strategy: [brief]${strategySection}
+</thinking>${draftSection}
+
+Then write the user-facing response (plain text, no tags).
+IMPORTANT: All metadata (FeelHeardCheck, ReadyShare, Mode, etc.) belongs ONLY inside <thinking>. The user-facing response must be purely conversational — no brackets, flags, or annotations.
+
+OFF-RAMPS (only when needed):
+- If asked how this works / process: <dispatch>EXPLAIN_PROCESS</dispatch>
+- If asked to remember something: <dispatch>HANDLE_MEMORY_REQUEST</dispatch>${empathyOffRamp}
+
+If you use <dispatch>, output ONLY <thinking> + <dispatch> (no visible text).`;
+}
+
+// ---------------------------------------------------------------------------
+// Slack-specific formatting notes (layered on top of workspace rules)
+// ---------------------------------------------------------------------------
+
+const SLACK_FORMATTING_NOTES = `SLACK FORMATTING:
+- Use Slack mrkdwn, NOT Markdown. Bold is *bold* (single asterisks). Italics are _italic_ (underscores). Bullets are "• " (literal bullet).
+- Never post headers with #/##. Never use [link](url) — Slack uses <url|text>.
+- Keep responses tight — Slack is a chat surface, not a document. 1–3 short sentences unless genuinely unavoidable.`;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface SlackStagePromptOptions {
+  /** Stage 0 sub-phase: inviting a partner before they join. */
+  isInvitationPhase?: boolean;
+  /** User is redoing their invitation after Stage 1/2 insight. */
+  isRefiningInvitation?: boolean;
+  /** Onboarding (Curiosity Compact not yet signed). */
+  isOnboarding?: boolean;
+  /** First turn after a stage advance — add a contextual bridge. */
+  isStageTransition?: boolean;
+  /** Previous stage number, for transition messaging. */
+  previousStage?: number;
+  /**
+   * When true, reuse `stage-prompts.ts` instead of reading workspace files.
+   * Used during incremental migration / A-B testing.
+   */
+  fallbackOnly?: boolean;
+}
+
+/**
+ * Build the `{staticBlock, dynamicBlock}` prompt for a Slack-driven MWF turn.
+ *
+ * We merge workspace CONTEXT.md text (the prose the facilitation team writes)
+ * with the structured protocol and per-turn dynamic context the engine needs.
+ */
+export function buildSlackStagePrompt(
+  stage: number,
+  context: PromptContext,
+  options: SlackStagePromptOptions = {}
+): PromptBlocks {
+  // Fallback path: use the existing stage-prompts.ts builder verbatim. Useful
+  // when workspace files are missing, or when we want to A/B compare.
+  if (options.fallbackOnly) {
+    return buildStagePrompt(stage, context, {
+      isInvitationPhase: options.isInvitationPhase,
+      isRefiningInvitation: options.isRefiningInvitation,
+      isOnboarding: options.isOnboarding,
+      isStageTransition: options.isStageTransition,
+      previousStage: options.previousStage,
+    });
+  }
+
+  const ws = loadCache();
+
+  const stageText = ws.stages[stage];
+  if (!stageText || !ws.guardian) {
+    // Missing source of truth — fall back cleanly rather than shipping a
+    // half-formed prompt.
+    logger.warn(
+      `[WorkspacePromptBuilder] Falling back to stage-prompts.ts for stage ${stage} (missing workspace files)`
+    );
+    return buildStagePrompt(stage, context, {
+      isInvitationPhase: options.isInvitationPhase,
+      isRefiningInvitation: options.isRefiningInvitation,
+      isOnboarding: options.isOnboarding,
+      isStageTransition: options.isStageTransition,
+      previousStage: options.previousStage,
+    });
+  }
+
+  const userName = context.userName || 'there';
+  const partnerName = context.partnerName || 'your partner';
+
+  // ----- Static block -----
+  const includesDraft = stage === 2 || (stage === 0 && options.isInvitationPhase);
+  const draftPurpose = stage === 2 ? 'empathy' : 'invitation';
+  const protocol = buildResponseProtocol(stage, {
+    includesDraft,
+    draftPurpose: draftPurpose as 'invitation' | 'empathy',
+  });
+
+  const staticParts: string[] = [
+    `You are Meet Without Fear. You are currently facilitating a conversation for ${userName} (partner: ${partnerName}).`,
+    '',
+    '# Process Guardian Constitution',
+    ws.guardian.trim(),
+    '',
+    `# Stage ${stage} Rules`,
+    stageText.trim(),
+  ];
+
+  if (ws.privacy) {
+    staticParts.push('', '# Privacy Model', ws.privacy.trim());
+  }
+  if (ws.progression) {
+    staticParts.push('', '# Stage Progression', ws.progression.trim());
+  }
+
+  staticParts.push('', SLACK_FORMATTING_NOTES, '', protocol);
+
+  const staticBlock = staticParts.join('\n');
+
+  // ----- Dynamic block -----
+  const dynamicParts: string[] = [];
+
+  dynamicParts.push(`User: ${userName}`);
+  if (context.partnerName) dynamicParts.push(`Partner: ${context.partnerName}`);
+  dynamicParts.push(`Turn: ${context.turnCount}`);
+  dynamicParts.push(`Emotional intensity: ${context.emotionalIntensity}/10`);
+
+  if (context.emotionalIntensity >= 8) {
+    dynamicParts.push(
+      'HIGH INTENSITY — be calm and present. Short responses. Give them space.'
+    );
+  }
+
+  // Stage-specific pacing hints
+  if (stage === 1) {
+    const isGathering = context.turnCount < 5 && context.emotionalIntensity < 8;
+    const isTooEarlyForFeelHeard = context.turnCount < 3;
+    if (isGathering) {
+      dynamicParts.push(
+        'RIGHT NOW: Still gathering. Acknowledge briefly, then one focused question. Do not reflect or summarize yet.'
+      );
+    } else {
+      dynamicParts.push(
+        `RIGHT NOW: You have enough picture to reflect using ${userName}'s own words. Check if you got it right. Keep asking from understanding.`
+      );
+    }
+    if (isTooEarlyForFeelHeard) {
+      dynamicParts.push(
+        "Feel-heard guard: Too early (turn < 3) — do not set FeelHeardCheck:Y yet."
+      );
+    }
+  }
+
+  if (stage === 0 && options.isInvitationPhase) {
+    const urgency =
+      context.turnCount >= 3
+        ? 'Draft the invitation NOW — do not ask another question.'
+        : context.turnCount >= 2
+          ? 'You should have the gist. Draft the invitation — do not wait for a perfect picture.'
+          : 'LISTENING mode: one focused question per turn. Draft by turn 2–3.';
+    dynamicParts.push(`Invitation pacing: ${urgency}`);
+    if (context.invitationMessage) {
+      dynamicParts.push(`Current invitation draft: ${context.invitationMessage}`);
+    }
+  }
+
+  if (options.isStageTransition && options.previousStage !== undefined) {
+    dynamicParts.push(
+      `STAGE TRANSITION: You just moved from stage ${options.previousStage} to stage ${stage}. Weave a brief, conversational bridge into your first response — see the "Stage Transition Guidance" table in the Guardian Constitution.`
+    );
+  }
+
+  if (context.justSharedWithPartner) {
+    dynamicParts.push(
+      `CONTEXT JUST SHARED: ${userName} just shared this with ${partnerName}: "${context.justSharedWithPartner.sharedContent}". Briefly acknowledge, then continue with your stage work.`
+    );
+  }
+
+  if (context.innerThoughtsContext) {
+    dynamicParts.push(
+      `INNER THOUGHTS BACKGROUND (from a prior solo reflection): ${context.innerThoughtsContext.summary}`
+    );
+    if (context.innerThoughtsContext.themes?.length) {
+      dynamicParts.push(
+        `Themes: ${context.innerThoughtsContext.themes.join(', ')}`
+      );
+    }
+  }
+
+  const dynamicBlock = dynamicParts.join('\n');
+
+  return { staticBlock, dynamicBlock };
+}
+
+/**
+ * Diagnostic helper — returns a summary of which workspace files were loaded.
+ * Useful for the `/api/slack/health` endpoint and for test assertions.
+ */
+export function getWorkspaceStatus(): {
+  root: string;
+  stagesLoaded: number[];
+  guardianLoaded: boolean;
+  privacyLoaded: boolean;
+  progressionLoaded: boolean;
+} {
+  const ws = loadCache();
+  return {
+    root: WORKSPACE_ROOT,
+    stagesLoaded: Object.entries(ws.stages)
+      .filter(([, v]) => v !== null)
+      .map(([k]) => Number(k)),
+    guardianLoaded: ws.guardian !== null,
+    privacyLoaded: ws.privacy !== null,
+    progressionLoaded: ws.progression !== null,
+  };
+}

--- a/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/0-onboarding/CONTEXT.md
@@ -89,10 +89,7 @@ Triggered when a user starts a new MWF session and no existing session is found 
    - Use facts to inform questions and reflections naturally — do NOT say "I remember from last time"
    - See `references/global-facts.md` for loading rules and privacy constraints
 
-5. **Ask for the user's name**:
-   - "What's your first name?" (or preferred name)
-   - Store the response as `display_name` in `session.json` under `user_a`
-   - Use this name throughout the session for personalization
+5. **Resolve user's name from Slack profile** (do NOT ask — use `display_name` or `real_name` from the Slack user profile, already available via the message event or `users.info`). Store as `display_name` in `session.json` under `user_a`.
 
 6. **Reply with join code**:
    - Tell the user their session is created
@@ -108,13 +105,11 @@ Triggered when a message contains a join code and no existing session is found f
    - If not found → reply: "I couldn't find a session with that code. Double-check and try again."
    - If found but `status` is not `waiting_for_partner` → reply: "That session already has two participants."
 
-2. **Ask for User B's name**:
-   - "What's your first name?" (or preferred name)
-   - Use the response as `display_name` below
+2. **Resolve User B's name from Slack profile** (do NOT ask — use `display_name` or `real_name` from Slack, available via `users.info`).
 
 3. **Pair the users**:
    - Update `session.json`:
-     - Set `user_b` to `{ "slack_user_id": "<user_id>", "display_name": "<name from step 2>", "thread_ts": "<thread_ts>" }`
+     - Set `user_b` to `{ "slack_user_id": "<user_id>", "display_name": "<name from Slack>", "thread_ts": "<thread_ts>" }`
      - Set `status` to `active`
    - Update `stage-progress.json`:
      - Add User B entry: `{ "stage_status": "NOT_STARTED", "gates_satisfied": { "agreedToTerms": false }, "last_active": "<ISO-8601>" }`

--- a/bot-workspaces/mwf-session/stages/route/CONTEXT.md
+++ b/bot-workspaces/mwf-session/stages/route/CONTEXT.md
@@ -19,20 +19,18 @@ Check `channel_id` against the `#mwf-sessions` lobby channel ID (from `.claude/c
 
 ### 1A. Lobby Handler (#mwf-sessions)
 
-The lobby is a multi-turn conversation in a thread. The bot asks questions, the user answers, and once everything is gathered the bot sets up DMs.
+The lobby is a short exchange in a thread. The bot resolves the user's name from Slack (via the `user_id` in the event — use the Slack user's display name or real name from the message context) and asks one question: who to invite.
 
 **Step 1: User posts "start" (or similar) in `#mwf-sessions`**
 
 Reply in a thread:
-> "I'd love to help you start a conversation. What's your first name?"
+> "Hi {name}! Who would you like to have this conversation with? @mention them so I can send the invitation."
 
-**Step 2: User replies with their name**
+The user's name comes from their Slack profile (already available in the message event or via `users.info`). Do NOT ask for their name.
 
-> "Thanks, {name}! Who would you like to have this conversation with? @mention them so I can send the invitation."
+**Step 2: User @mentions their partner**
 
-**Step 3: User @mentions their partner**
-
-Extract the partner's Slack user ID from the @mention. Then:
+Extract the partner's Slack user ID from the @mention. Resolve the partner's display name from Slack as well. Then:
 
 1. **Create the session**:
    - Generate a UUID for `session_id`

--- a/docs/architecture/backend-overview.md
+++ b/docs/architecture/backend-overview.md
@@ -28,8 +28,8 @@ status: living
 - Purpose: REST API serving mobile client; message routing; session management; AI orchestration
 - Location: `backend/src/`
 - Contains: Route handlers, controllers, services, middleware, database logic, LLM integrations
-- Depends on: Prisma ORM, Bedrock LLM, Ably realtime, shared DTOs/contracts
-- Used by: Mobile client via HTTP; Ably realtime subscriptions
+- Depends on: Prisma ORM, Bedrock LLM, Ably realtime, Slack Web API (`@slack/web-api`), shared DTOs/contracts
+- Used by: Mobile client via HTTP; Ably realtime subscriptions; EC2 socket listener (Slack ingress)
 
 **Mobile Frontend (React Native + Expo):**
 - Purpose: User-facing chat interface; session management UI; inner work tools; invitations
@@ -144,6 +144,12 @@ status: living
 - Location: `backend/src/routes/index.ts`
 - Triggers: Server startup; mounts all feature routes (chat, invitations, stages, etc.)
 - Responsibilities: Centralizes route mounting; documents mount order and dependencies
+
+**Slack Ingress (Backend):**
+- Location: `backend/src/routes/slack.ts`, `backend/src/controllers/slack-session.ts`
+- Triggers: EC2 socket listener POSTs Slack messages to `/api/slack/mwf-session`
+- Responsibilities: Shared-secret validation; delegates to the same Bedrock pipeline (context assembly → stage prompts → Sonnet response) used by mobile; posts replies back to Slack DMs via `@slack/web-api`
+- Health check: `GET /api/slack/health` reports workspace load status and Slack configuration
 
 **Chat Unified Screen (Mobile):**
 - Location: `mobile/src/screens/UnifiedSessionScreen.tsx` (2722 lines, with sub-components extracted to `mobile/src/screens/session/`)

--- a/docs/backend/api/index.md
+++ b/docs/backend/api/index.md
@@ -178,6 +178,14 @@ Identity provisioning lives in Clerk; the backend only exposes profile and token
 | `GET`    | `/auth/me/notification-preferences` | Read push notification prefs |
 | `PATCH`  | `/auth/me/notification-preferences` | Partial update of prefs |
 
+### [Slack Ingress](../../architecture/backend-overview.md#slack-ingress-backend)
+Slack-originated MWF sessions. These routes use shared-secret auth (not Clerk JWT).
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/slack/mwf-session` | Accept a Slack message payload from the EC2 socket listener |
+| `GET`  | `/slack/health` | Health check: workspace load status and Slack configuration |
+
 ### Additional feature areas (not yet broken out in this index)
 
 The routes below are live; consult the source directly until dedicated pages exist:

--- a/docs/backend/data-model/prisma-schema.md
+++ b/docs/backend/data-model/prisma-schema.md
@@ -42,6 +42,7 @@ model User {
   biometricEnabled   Boolean  @default(false)
   biometricEnrolledAt DateTime?
   lastMoodIntensity  Int?
+  slackUserId        String?  @unique // Slack user ID for Slack-originated sessions
   globalFacts        Json?    // Fact-Ledger: consolidated cross-session insights
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
@@ -103,6 +104,10 @@ model Session {
   updatedAt      DateTime      @updatedAt
   resolvedAt     DateTime?
 
+  // Slack origin (null for mobile-originated sessions)
+  slackJoinCode String?              @unique // 6-char code for partner to pair via lobby
+  slackThreads  SessionSlackThread[]
+
   // Related entities
   messages      Message[]
   sharedVessel  SharedVessel?
@@ -118,6 +123,27 @@ enum SessionStatus {
   WAITING     // One user ahead, waiting for other
   RESOLVED    // Process completed
   ABANDONED   // Timeout or withdrawal
+}
+```
+
+### SessionSlackThread
+
+Maps a Slack DM channel+thread to a (session, user) pair. Each MWF session involves two users, each with their own private DM thread.
+
+```prisma
+model SessionSlackThread {
+  id        String   @id @default(cuid())
+  session   Session  @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId String
+  userId    String   // the Slack-user's DB User.id
+  channelId String   // Slack DM channel id
+  threadTs  String   // top-level thread timestamp
+  createdAt DateTime @default(now())
+
+  @@unique([channelId, threadTs])
+  @@unique([sessionId, userId])
+  @@index([sessionId])
+  @@index([channelId])
 }
 ```
 

--- a/docs/code-to-docs-mapping.json
+++ b/docs/code-to-docs-mapping.json
@@ -32,6 +32,8 @@
     { "code": "backend/src/services/stage-prompts*.ts",  "label": "backend/src/services/stage-prompts", "docs": ["docs/backend/prompts/index.md"] },
     { "code": "backend/src/controllers/emotions.ts", "label": "backend/src/controllers/emotions.ts", "docs": ["docs/backend/api/emotional-barometer.md", "docs/product/mechanisms/emotional-barometer.md"] },
     { "code": "backend/src/routes/emotions.ts",      "label": "backend/src/routes/emotions.ts",      "docs": ["docs/backend/api/emotional-barometer.md", "docs/product/mechanisms/emotional-barometer.md"] },
+    { "code": "backend/src/controllers/slack-session.ts", "label": "backend/src/controllers/slack-session.ts", "docs": ["docs/backend/api/index.md", "docs/architecture/backend-overview.md"] },
+    { "code": "backend/src/services/slack-*.ts",         "label": "backend/src/services/slack",    "docs": ["docs/backend/api/index.md", "docs/architecture/backend-overview.md"] },
     { "code": "backend/src/services/**",                 "label": "backend/src/services",          "docs": ["docs/backend/index.md"] },
     { "code": "backend/src/lib/bedrock.ts",              "label": "backend/src/lib/bedrock",       "docs": ["docs/architecture/integrations.md", "docs/backend/prompting-architecture.md"] },
     { "code": "backend/src/lib/prisma.ts",               "label": "backend/src/lib/prisma",        "docs": ["docs/architecture/backend-overview.md"] },

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -22,7 +22,7 @@ Operational infrastructure for Meet Without Fear.
 
 | Service | Purpose |
 |---|---|
-| `slam-bot-socket.service` | Socket Mode listener for real-time Slack events |
+| `slam-bot-socket.service` | Socket Mode listener for real-time Slack events. For `#mwf-sessions` channel messages, the listener forwards payloads to the backend via `POST /api/slack/mwf-session` (authenticated with `SLACK_INGRESS_SECRET`) instead of spawning a Claude Code agent. The backend runs the full Bedrock pipeline and posts replies back to Slack. |
 | `slam-bot-state-scanner.service` | GitHub state scanner daemon (`github-state-scanner.sh` loop). Hardened with `MemoryMax=256M` and `TasksMax=64` to prevent runaway resource use. |
 
 ### Cron jobs

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@prisma/client": "6.12.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@sentry/node": "^10.45.0",
+        "@slack/web-api": "^7.15.1",
         "@types/ably": "^1.0.0",
         "@types/compression": "^1.8.1",
         "@types/cors": "^2.8.17",
@@ -15305,6 +15306,81 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.1.tgz",
+      "integrity": "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.1.tgz",
+      "integrity": "sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.20.1",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.15.0",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@slack/web-api/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@slorber/remark-comment": {
@@ -31848,6 +31924,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -46,6 +46,12 @@ const SLAM_BOT_CHANNEL = process.env.SLAM_BOT_CHANNEL_ID;
 const BUGS_AND_REQUESTS_CHANNEL = process.env.BUGS_AND_REQUESTS_CHANNEL_ID;
 const MWF_SESSIONS_CHANNEL = process.env.MWF_SESSIONS_CHANNEL_ID;
 
+// Backend endpoint that owns MWF sessions (Bedrock engine, same as mobile).
+// When set, mwf-session messages are POSTed here instead of spawned into a
+// Claude Code agent. Falls back to the legacy agent path when unset.
+const MWF_BACKEND_URL = process.env.MWF_BACKEND_URL;
+const MWF_INGRESS_SECRET = process.env.SLACK_INGRESS_SECRET;
+
 if (!APP_TOKEN || !BOT_TOKEN || !BOT_USER_ID) {
   console.error('Missing required env vars: SLACK_APP_TOKEN, SLACK_BOT_TOKEN, SLAM_BOT_USER_ID');
   process.exit(1);
@@ -596,6 +602,50 @@ function findSessionThreadForChannel(channel) {
 }
 
 // ---------------------------------------------------------------------------
+// MWF backend forwarding — Bedrock engine owns MWF sessions, not Claude agents
+// ---------------------------------------------------------------------------
+
+/**
+ * POST the incoming Slack event to the backend MWF endpoint. The backend
+ * replies asynchronously (200 immediately, posts the real reply via Slack
+ * Web API). We still manage reactions here so the existing 👀/✅/❌ flow
+ * keeps working.
+ */
+async function forwardToMwfBackend(event, { isLobby }) {
+  if (!MWF_BACKEND_URL) return false;
+
+  const body = JSON.stringify({
+    channel: event.channel,
+    user: event.user,
+    text: event.text || '',
+    thread_ts: event.thread_ts,
+    ts: event.ts,
+    team: event.team,
+    isLobby,
+  });
+
+  const headers = { 'content-type': 'application/json' };
+  if (MWF_INGRESS_SECRET) headers['x-slack-ingress-secret'] = MWF_INGRESS_SECRET;
+
+  try {
+    const res = await fetch(MWF_BACKEND_URL, {
+      method: 'POST',
+      headers,
+      body,
+    });
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      logMain(`MWF backend ${res.status}: ${txt.slice(0, 200)}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    logMain(`MWF backend POST failed: ${err.message}`);
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Event handling
 // ---------------------------------------------------------------------------
 
@@ -658,6 +708,23 @@ async function handleMessageEvent(event) {
   }
 
   logMain(`Claimed message ${ts} in ${config.logName} from user=${user}`);
+
+  // MWF sessions run on the backend Bedrock engine, not Claude agents. Forward
+  // the event and short-circuit the agent dispatch path. The backend will
+  // manage reactions (✅/❌) and post the reply itself.
+  if (config.workspace === 'mwf-session' && MWF_BACKEND_URL) {
+    const isLobby = channel === MWF_SESSIONS_CHANNEL;
+    await addReaction(channel, ts, 'eyes');
+    const ok = await forwardToMwfBackend(event, { isLobby });
+    if (!ok) {
+      await removeReaction(channel, ts, 'eyes');
+      await addReaction(channel, ts, 'x');
+    }
+    try {
+      writeFileSync(HEARTBEAT_FILE, new Date().toISOString());
+    } catch { /* ignore */ }
+    return;
+  }
 
   // Thread-aware queuing: if an agent is already working on this thread,
   // queue this message instead of dispatching immediately.


### PR DESCRIPTION
## Summary

Implements [.planning/MILESTONE_SLACK_BEDROCK_SESSIONS.md](.planning/MILESTONE_SLACK_BEDROCK_SESSIONS.md) — replaces the Claude-Code-agent-driven MWF session flow with direct Bedrock calls using the **same pipeline the mobile app uses**. Workspace `CONTEXT.md` files become the single source of truth for Process Guardian voice & stage rules; the backend owns all session state in Prisma.

- Slack user posts \`start\` in \`#mwf-sessions\` → backend creates Session + DMs the user → Sonnet response via same prompt-caching + context-assembly pipeline as mobile.
- Partner pairs with \`join <code>\` → second DM opens, both conversations now run end-to-end on Bedrock.
- EC2 socket-listener becomes a thin dispatcher: POSTs mwf-session events to \`/api/slack/mwf-session\`, keeps 👀/✅/❌ reaction UX.

## What's in

**Phase 1** — Slack client (\`@slack/web-api\`), \`POST /api/slack/mwf-session\` endpoint with shared-secret validation, health endpoint, routes wired in.

**Phase 2** — \`workspace-prompt-builder.ts\` reads \`bot-workspaces/mwf-session/{stages,references}/*.md\` and produces \`{staticBlock, dynamicBlock}\` with the same micro-tag protocol (\`<thinking>\`/\`<draft>\`/\`<dispatch>\`) as \`stage-prompts.ts\`. Falls back to \`stage-prompts.ts\` constants when workspace files are missing.

**Phase 3** — Prisma schema additions (\`User.slackUserId\`, \`Session.slackJoinCode\`, \`SessionSlackThread\` mapping table) + migration. \`slack-session-service.ts\` owns user resolution from Slack profile, session creation, join-code pairing, and stage progression.

**Phase 4** — \`slack-conversation.ts\` runs the full turn: lobby routing → \`assembleContextBundle\` → \`buildSlackStagePrompt\` → \`formatContextForPrompt\` → \`trimConversationHistory\` → \`getSonnetResponse\` → \`parseMicroTagResponse\` → post reply. Stage 0 compact-signal detection advances both users on consent; Stage 1 feel-heard offer gate recorded.

**Phase 5** — \`scripts/ec2-bot/socket-mode/socket-listener.mjs\` forwards mwf-session messages to \`MWF_BACKEND_URL\` via HTTP POST with the \`SLACK_INGRESS_SECRET\` header. Other workspaces unchanged.

**Phase 6** — \`/api/slack/health\` reports workspace load status; controller + prompt-builder unit tests.

## Env vars (Render env group + EC2 .env)

| Var | Where | Purpose |
|-----|-------|---------|
| \`SLACK_BOT_TOKEN\` | Render backend | Posting DMs, managing reactions |
| \`SLACK_INGRESS_SECRET\` | Both | Shared secret for EC2 → backend auth |
| \`MWF_BACKEND_URL\` | EC2 \`.env\` | e.g. \`https://meet-without-fear-api.onrender.com/api/v1/slack/mwf-session\` |

## Migration

\`backend/prisma/migrations/20260416000000_add_slack_session_fields/migration.sql\` — additive only (nullable columns + new table). Safe to run on production before deploy.

## Out of scope (follow-up PRs in the same milestone)

- Haiku-based per-turn emotional barometer (currently defaults to 5)
- Empathy exchange flow + Stage 2B refinement (handled by existing mobile controllers — needs Slack bridge)
- Rate limiting & DB advisory lock for concurrent turns from the same user
- Streaming replies (not needed for Slack — post full reply when done)
- Mobile ↔ Slack cross-transport session continuation

## Test plan

- [x] \`npm run check --workspace=backend\` — clean
- [x] \`npx jest --testPathPattern "slack|workspace-prompt-builder"\` — 18/18 passing
- [x] Full backend suite — 997 passing (2 pre-existing integration failures requiring live DB, unrelated)
- [x] \`node --check scripts/ec2-bot/socket-mode/socket-listener.mjs\` — syntax clean
- [ ] **Manual** — deploy backend to Render with new env vars, run a lobby → DM → Stage 0 conversation end-to-end
- [ ] **Manual** — verify prompt cache hit rate >80% after 3–4 turns in the same stage
- [ ] **Manual** — verify Stage 0 → 1 advance fires when both users say "I agree"

🤖 Generated with [Claude Code](https://claude.com/claude-code)