### PR TITLE
Phase A: Slack/Bedrock hardening pass

### DIFF
--- a/backend/prisma/migrations/20260416000000_add_slack_session_fields/migration.sql
+++ b/backend/prisma/migrations/20260416000000_add_slack_session_fields/migration.sql
@@ -1,3 +1,14 @@
+-- Operator note: this migration is purely additive — nullable columns, new
+-- table, indexes on columns that are currently all-NULL. Safe to run against
+-- production without downtime.
+--
+-- At current scale (small User/Session tables, Render starter tier) the
+-- `CREATE UNIQUE INDEX` statements below complete in milliseconds. At 1M+
+-- rows, `CREATE UNIQUE INDEX` takes an ACCESS EXCLUSIVE lock for the build
+-- duration, which blocks writes. If rerunning this style of migration at
+-- scale, split it into two steps: `CREATE UNIQUE INDEX CONCURRENTLY` (no
+-- lock) on a prior deploy, then the constraint add.
+
 -- AlterTable: add Slack user identity to User
 ALTER TABLE "User" ADD COLUMN "slackUserId" TEXT;
 CREATE UNIQUE INDEX "User_slackUserId_key" ON "User"("slackUserId");

--- a/backend/src/services/__tests__/slack-client.test.ts
+++ b/backend/src/services/__tests__/slack-client.test.ts
@@ -63,4 +63,64 @@ describe('toSlackMrkdwn', () => {
   it('does not touch single underscore italics', () => {
     expect(toSlackMrkdwn('_already italic_')).toBe('_already italic_');
   });
+
+  describe('multi-line blockquote normalization', () => {
+    it('adds `> ` prefix to lazy-continuation lines', () => {
+      const input = '> first line\nsecond line\nthird line';
+      expect(toSlackMrkdwn(input)).toBe(
+        '> first line\n> second line\n> third line'
+      );
+    });
+
+    it('ends the blockquote at a blank line', () => {
+      const input = '> inside quote\nstill inside\n\nafter quote';
+      expect(toSlackMrkdwn(input)).toBe(
+        '> inside quote\n> still inside\n\nafter quote'
+      );
+    });
+
+    it('preserves a single-line blockquote unchanged', () => {
+      expect(toSlackMrkdwn('> just one line\n\nbody')).toBe(
+        '> just one line\n\nbody'
+      );
+    });
+
+    it('handles two separate blockquotes', () => {
+      const input = '> quote one\nmore of one\n\n> quote two\nmore of two';
+      expect(toSlackMrkdwn(input)).toBe(
+        '> quote one\n> more of one\n\n> quote two\n> more of two'
+      );
+    });
+
+    it('does not re-prefix already-prefixed lines', () => {
+      const input = '> line a\n> line b\n> line c';
+      expect(toSlackMrkdwn(input)).toBe('> line a\n> line b\n> line c');
+    });
+
+    it('works for reconciler-style quoted partner context', () => {
+      // Matches the kind of output the Stage 2B / reconciler flow produces.
+      const input =
+        '💡 *Partner just shared this:*\n> I think what\'s hard for me\nis that I feel unheard\nwhen plans change.\n\nKeep going when ready.';
+      expect(toSlackMrkdwn(input)).toContain(
+        '> I think what\'s hard for me\n> is that I feel unheard\n> when plans change.'
+      );
+    });
+  });
+
+  describe('nested bullets', () => {
+    it('normalizes tab indentation to two-space for nested bullets', () => {
+      const input = '- top\n\t- nested\n\t\t- deeper';
+      expect(toSlackMrkdwn(input)).toBe('• top\n  • nested\n    • deeper');
+    });
+
+    it('preserves existing space indentation', () => {
+      const input = '- top\n  - nested\n    - deeper';
+      expect(toSlackMrkdwn(input)).toBe('• top\n  • nested\n    • deeper');
+    });
+
+    it('converts * bullets at any indent level', () => {
+      const input = '* a\n  * b\n    * c';
+      expect(toSlackMrkdwn(input)).toBe('• a\n  • b\n    • c');
+    });
+  });
 });

--- a/backend/src/services/__tests__/slack-lock.test.ts
+++ b/backend/src/services/__tests__/slack-lock.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Slack Lock Tests
+ *
+ * Verifies that `withSlackUserLock` acquires an advisory lock inside a
+ * transaction, runs `fn`, and returns its result. Uses a mocked Prisma
+ * transaction runner so no live DB is required.
+ */
+
+const executeRawMock = jest.fn();
+
+jest.mock('../../lib/prisma', () => ({
+  prisma: {
+    $transaction: jest.fn(async (fn: (tx: unknown) => unknown, _opts?: unknown) => {
+      return fn({
+        $executeRaw: executeRawMock,
+      });
+    }),
+  },
+}));
+
+import { prisma } from '../../lib/prisma';
+import { withSlackUserLock } from '../slack-lock';
+
+describe('withSlackUserLock', () => {
+  beforeEach(() => {
+    executeRawMock.mockReset();
+    (prisma.$transaction as jest.Mock).mockClear();
+  });
+
+  it('acquires a pg_advisory_xact_lock before running the callback', async () => {
+    executeRawMock.mockResolvedValue(1);
+    const work = jest.fn().mockResolvedValue('done');
+
+    const result = await withSlackUserLock('U123', work);
+
+    expect(result).toBe('done');
+    expect(executeRawMock).toHaveBeenCalledTimes(1);
+    // ExecuteRaw is called with a TemplateStringsArray — flatten to check shape.
+    const [call] = executeRawMock.mock.calls;
+    const joined = String(call[0].raw.join(' ')).toLowerCase();
+    expect(joined).toContain('pg_advisory_xact_lock');
+    expect(joined).toContain('hashtext');
+    // Verify the lock was acquired BEFORE the work ran via invocation order.
+    const lockOrder = executeRawMock.mock.invocationCallOrder[0];
+    const workOrder = work.mock.invocationCallOrder[0];
+    expect(lockOrder).toBeLessThan(workOrder);
+  });
+
+  it('returns the callback result', async () => {
+    executeRawMock.mockResolvedValue(1);
+    const result = await withSlackUserLock('U456', async () => ({ ok: true }));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('propagates errors from the callback', async () => {
+    executeRawMock.mockResolvedValue(1);
+    await expect(
+      withSlackUserLock('U789', async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+  });
+
+  it('uses a long transaction timeout so a slow turn does not abort', async () => {
+    executeRawMock.mockResolvedValue(1);
+    await withSlackUserLock('U000', async () => 1);
+
+    const opts = (prisma.$transaction as jest.Mock).mock.calls[0][1];
+    expect(opts).toMatchObject({ timeout: expect.any(Number) });
+    expect(opts.timeout).toBeGreaterThanOrEqual(30_000);
+  });
+});

--- a/backend/src/services/__tests__/slack-session-service.test.ts
+++ b/backend/src/services/__tests__/slack-session-service.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Slack Session Service Tests (unit)
+ *
+ * Focus: the duplicate-session catch helpers added in Phase A.2. Uses a
+ * jest-mocked Prisma so no live DB is required.
+ */
+
+const sessionFindFirst = jest.fn();
+const sessionUpdate = jest.fn();
+const sessionSlackThreadDeleteMany = jest.fn();
+const transactionMock = jest.fn();
+
+jest.mock('../../lib/prisma', () => ({
+  prisma: {
+    session: {
+      findFirst: sessionFindFirst,
+      update: sessionUpdate,
+    },
+    sessionSlackThread: {
+      deleteMany: sessionSlackThreadDeleteMany,
+    },
+    $transaction: transactionMock,
+  },
+}));
+
+import {
+  findInvitedSessionForUser,
+  archiveSession,
+} from '../slack-session-service';
+import { prisma } from '../../lib/prisma';
+
+describe('slack-session-service helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    transactionMock.mockImplementation(async (ops: unknown[]) => ops);
+    sessionUpdate.mockResolvedValue({});
+    sessionSlackThreadDeleteMany.mockResolvedValue({ count: 0 });
+  });
+
+  describe('findInvitedSessionForUser', () => {
+    it('queries for the user\'s most recent INVITED session', async () => {
+      sessionFindFirst.mockResolvedValue({ id: 's1', slackJoinCode: 'abc123' });
+
+      const result = await findInvitedSessionForUser('user-1');
+
+      expect(result).toMatchObject({ id: 's1', slackJoinCode: 'abc123' });
+      expect(prisma.session.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: 'INVITED',
+            relationship: { members: { some: { userId: 'user-1' } } },
+          }),
+          orderBy: { createdAt: 'desc' },
+        })
+      );
+    });
+
+    it('returns null when no open invite exists', async () => {
+      sessionFindFirst.mockResolvedValue(null);
+      const result = await findInvitedSessionForUser('user-2');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('archiveSession', () => {
+    it('flips status to ABANDONED and deletes thread mappings in a single transaction', async () => {
+      await archiveSession('s1');
+
+      expect(transactionMock).toHaveBeenCalledTimes(1);
+      expect(sessionUpdate).toHaveBeenCalledWith({
+        where: { id: 's1' },
+        data: { status: 'ABANDONED' },
+      });
+      expect(sessionSlackThreadDeleteMany).toHaveBeenCalledWith({
+        where: { sessionId: 's1' },
+      });
+    });
+  });
+});

--- a/backend/src/services/slack-client.ts
+++ b/backend/src/services/slack-client.ts
@@ -25,7 +25,8 @@ import { logger } from '../lib/logger';
  *   • `__bold__` → `*bold*`
  *   • `[label](url)` → `<url|label>`
  *   • leading `# ` / `## ` / `### ` headers → `*bold line*`
- *   • leading `- ` / `* ` bullets → `• `
+ *   • leading `- ` / `* ` bullets → `• ` (tabs normalized to spaces for nesting)
+ *   • multi-line blockquotes with lazy continuation → `>` prefix on every line
  *
  * We deliberately don't touch single `*word*` (could be italic) or single
  * `_word_` (already valid Slack italic).
@@ -47,11 +48,47 @@ export function toSlackMrkdwn(text: string): string {
       // Headers → bold line (only consume horizontal whitespace — \s would eat
       // the blank line between a header and its body).
       out = out.replace(/^[ \t]{0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/gm, '*$1*');
-      // - / * bullets at line start → • (keep indentation)
-      out = out.replace(/^(\s*)[-*]\s+/gm, '$1• ');
+      // Bullets at line start → • (normalize tab indentation to spaces so
+      // Slack renders nested bullets correctly).
+      out = out.replace(/^([ \t]*)[-*][ \t]+/gm, (_m, indent: string) => {
+        const spaces = indent.replace(/\t/g, '  ');
+        return `${spaces}• `;
+      });
+      // Multi-line blockquote lazy continuation → explicit `>` per line.
+      out = normalizeBlockquotes(out);
       return out;
     })
     .join('');
+}
+
+/**
+ * Standard Markdown allows a blockquote paragraph to start with `>` on only
+ * the first line, with subsequent non-blank lines implicitly joining the
+ * quote ("lazy continuation"). Slack doesn't — it treats lines without `>`
+ * as plain text, so a multi-line quote renders flat past the first line.
+ * This walks the text line-by-line and prefixes continuation lines with `> `
+ * until a blank line or a new block-level construct ends the quote.
+ */
+function normalizeBlockquotes(text: string): string {
+  const lines = text.split('\n');
+  let inQuote = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^>\s?/.test(line)) {
+      inQuote = true;
+      continue;
+    }
+    if (line.trim() === '') {
+      inQuote = false;
+      continue;
+    }
+    if (inQuote) {
+      // Lazy continuation — extend the quote. Preserve leading whitespace
+      // after the `> ` prefix in case the line was indented.
+      lines[i] = `> ${line}`;
+    }
+  }
+  return lines.join('\n');
 }
 
 let client: WebClient | null | undefined;

--- a/backend/src/services/slack-conversation.ts
+++ b/backend/src/services/slack-conversation.ts
@@ -31,8 +31,10 @@ import {
   findOrCreateSlackUser,
   findSessionByJoinCode,
   findSessionByThread,
+  findInvitedSessionForUser,
   createSlackSession,
   pairSlackSession,
+  archiveSession,
   saveSlackMessage,
   getCurrentStage,
   updateStageProgress,
@@ -83,6 +85,12 @@ async function handleLobbyMessage(payload: SlackMessagePayload): Promise<void> {
     return;
   }
 
+  // Archive an existing INVITED session
+  if (lower === 'archive') {
+    await handleArchiveCommand(user.id, payload);
+    return;
+  }
+
   // Help fallback — don't start a random session on stray lobby chatter.
   await postMessage(
     payload.channel,
@@ -91,7 +99,42 @@ async function handleLobbyMessage(payload: SlackMessagePayload): Promise<void> {
   );
 }
 
+async function handleArchiveCommand(
+  userId: string,
+  payload: SlackMessagePayload
+): Promise<void> {
+  const existing = await findInvitedSessionForUser(userId);
+  if (!existing) {
+    await postMessage(
+      payload.channel,
+      "You don't have a session waiting to be archived. Say `start` to begin a new one.",
+      payload.thread_ts ?? payload.ts
+    );
+    return;
+  }
+  await archiveSession(existing.id);
+  await postMessage(
+    payload.channel,
+    'Archived. Say `start` whenever you\'re ready to begin a new session.',
+    payload.thread_ts ?? payload.ts
+  );
+}
+
 async function handleStartSession(userId: string, payload: SlackMessagePayload): Promise<void> {
+  // Duplicate-session catch: if the user already has an open INVITED session
+  // waiting for a partner, surface the existing join code instead of minting
+  // a second orphan. Gives them an explicit `archive` escape hatch if they
+  // really do want to start fresh.
+  const existingInvite = await findInvitedSessionForUser(userId);
+  if (existingInvite?.slackJoinCode) {
+    await postMessage(
+      payload.channel,
+      `You already have a session waiting for a partner — join code *${existingInvite.slackJoinCode}*. Share it with them, or say \`archive\` to close this one and start over.`,
+      payload.thread_ts ?? payload.ts
+    );
+    return;
+  }
+
   const dmChannel = await openDM(payload.user);
   if (!dmChannel) {
     logger.error('[SlackConversation] Could not open DM for user', payload.user);

--- a/backend/src/services/slack-lock.ts
+++ b/backend/src/services/slack-lock.ts
@@ -1,0 +1,58 @@
+/**
+ * Slack Session Lock
+ *
+ * Postgres advisory lock that serializes concurrent turns from the same Slack
+ * user across backend replicas. Replaces the single-process in-memory Map
+ * previously used in `slack-session-orchestrator.ts`.
+ *
+ * Why advisory locks (not Redis, not a lock table):
+ * - Fast enough for human-speed chat (< 1ms to acquire uncontended).
+ * - Lifecycle tied to the DB connection: a process crash auto-releases.
+ * - No new infrastructure — we already talk to Postgres via Prisma.
+ *
+ * Implementation notes:
+ * - We wrap the whole turn in a `$transaction` because `pg_advisory_xact_lock`
+ *   ties the lock to transaction lifetime (released on COMMIT / ROLLBACK /
+ *   connection drop). Transactions are long-running by necessity here — the
+ *   Sonnet call is typically 3–8s — so we extend the Prisma timeout.
+ * - This holds a DB connection for the lock duration. At MWF's scale
+ *   (default 10-conn pool, <10 concurrent active turns) that's fine. If
+ *   pool pressure becomes real, switch to a lock table with row-level
+ *   locking + explicit expiry; the call-site API stays the same.
+ */
+
+import { prisma } from '../lib/prisma';
+
+/**
+ * Numeric namespace for our advisory locks. Chosen to be distinctive in the
+ * `pg_locks` view so an operator can see at a glance which locks are ours.
+ * Value: 'slck' as a 32-bit signed int.
+ */
+const LOCK_NAMESPACE = 1936024171;
+
+/** Maximum time a single Slack turn can hold the lock before the tx aborts. */
+const LOCK_TIMEOUT_MS = 60_000;
+
+/**
+ * Acquire an advisory lock keyed on the Slack user id, run `fn`, release.
+ * Serializes turns from the same Slack user even across multiple backend
+ * replicas. Lock releases automatically on transaction end or connection
+ * loss (so a mid-turn crash doesn't leave a stuck lock).
+ */
+export async function withSlackUserLock<T>(
+  slackUserId: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  return prisma.$transaction(
+    async (tx) => {
+      // Blocking acquire — if another replica holds the lock for this user,
+      // we queue behind it. Uses xact_lock so release is automatic at
+      // transaction boundary.
+      await tx.$executeRaw`
+        SELECT pg_advisory_xact_lock(${LOCK_NAMESPACE}, hashtext(${slackUserId}))
+      `;
+      return fn();
+    },
+    { timeout: LOCK_TIMEOUT_MS, maxWait: LOCK_TIMEOUT_MS }
+  );
+}

--- a/backend/src/services/slack-session-orchestrator.ts
+++ b/backend/src/services/slack-session-orchestrator.ts
@@ -1,35 +1,23 @@
 /**
  * Slack Session Orchestrator
  *
- * Runs the full Bedrock conversation loop for a Slack-originated MWF session
- * turn. In Phase 1 this is a simple echo so end-to-end plumbing can be tested;
- * Phases 2–4 replace the body with context assembly, prompt building, and a
- * real Sonnet call.
+ * Runs one turn of an MWF session driven from Slack. Handles concurrency
+ * (advisory lock keyed on Slack user), the 👀/✅/❌ reaction UX, and top-level
+ * error boundary. Delegates the actual conversation logic to
+ * `slack-conversation.ts`.
  */
 
 import { logger } from '../lib/logger';
 import { postMessage, addReaction, removeReaction } from './slack-client';
 import type { SlackMessagePayload } from './slack-types';
 import { runConversationTurn } from './slack-conversation';
-
-/**
- * Naive in-memory per-user lock to serialize concurrent messages from the same
- * Slack user. Swap for a DB advisory lock once we deploy multiple backend
- * instances.
- */
-const inFlight = new Map<string, Promise<unknown>>();
+import { withSlackUserLock } from './slack-lock';
 
 export async function handleSlackMessage(payload: SlackMessagePayload): Promise<void> {
-  const key = `slack:${payload.user}`;
-  const prev = inFlight.get(key) ?? Promise.resolve();
-  const next = prev.finally(() => {}).then(() => processTurn(payload));
-  inFlight.set(
-    key,
-    next.finally(() => {
-      if (inFlight.get(key) === next) inFlight.delete(key);
-    })
-  );
-  await next;
+  // Serialize concurrent turns from the same Slack user via a Postgres
+  // advisory lock. Works across multiple backend replicas; lock auto-releases
+  // on tx end or connection drop (so a crashed process can't leave it stuck).
+  await withSlackUserLock(payload.user, () => processTurn(payload));
 }
 
 async function processTurn(payload: SlackMessagePayload): Promise<void> {

--- a/backend/src/services/slack-session-service.ts
+++ b/backend/src/services/slack-session-service.ts
@@ -78,6 +78,40 @@ export async function findSessionByJoinCode(code: string): Promise<Session | nul
   return prisma.session.findUnique({ where: { slackJoinCode: code } });
 }
 
+/**
+ * Find the user's currently-open `INVITED` session, if any. Used by the lobby
+ * to short-circuit a duplicate `start` — if A already created a session and
+ * hasn't been paired yet, surface the existing join code instead of minting a
+ * second orphan session.
+ */
+export async function findInvitedSessionForUser(
+  userId: string
+): Promise<Session | null> {
+  return prisma.session.findFirst({
+    where: {
+      status: 'INVITED',
+      relationship: { members: { some: { userId } } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+/**
+ * Mark a session as ABANDONED and drop its Slack thread mappings. Used when
+ * the user explicitly abandons an `INVITED` session via the lobby `archive`
+ * command, or when the opportunistic TTL sweeper finds a 7-day-old invite.
+ */
+export async function archiveSession(sessionId: string): Promise<void> {
+  await prisma.$transaction([
+    prisma.session.update({
+      where: { id: sessionId },
+      data: { status: 'ABANDONED' },
+    }),
+    prisma.sessionSlackThread.deleteMany({ where: { sessionId } }),
+  ]);
+  logger.info('[SlackSessionService] Archived Slack session', { sessionId });
+}
+
 // ============================================================================
 // Session creation & pairing
 // ============================================================================

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -606,13 +606,21 @@ function findSessionThreadForChannel(channel) {
 // ---------------------------------------------------------------------------
 
 /**
- * POST the incoming Slack event to the backend MWF endpoint. The backend
- * replies asynchronously (200 immediately, posts the real reply via Slack
- * Web API). We still manage reactions here so the existing 👀/✅/❌ flow
- * keeps working.
+ * POST the incoming Slack event to the backend MWF endpoint with retries.
+ * The backend replies asynchronously (200 immediately, posts the real reply
+ * via Slack Web API). We still manage reactions here so the existing
+ * 👀/✅/❌ flow keeps working.
+ *
+ * Retry policy: up to 2 retries with exponential-ish backoff (500ms, 2s).
+ * Covers brief Render deploy windows (~30–60s of 5xx) without looking like
+ * silent bot failure to the user. A single attempt that returns 4xx (e.g.
+ * 401 from a secret mismatch) is NOT retried — that's configuration, not
+ * transient outage.
  */
+const MWF_FORWARD_RETRY_DELAYS_MS = [500, 2000];
+
 async function forwardToMwfBackend(event, { isLobby }) {
-  if (!MWF_BACKEND_URL) return false;
+  if (!MWF_BACKEND_URL) return { ok: false, reason: 'no_backend_url' };
 
   const body = JSON.stringify({
     channel: event.channel,
@@ -627,21 +635,50 @@ async function forwardToMwfBackend(event, { isLobby }) {
   const headers = { 'content-type': 'application/json' };
   if (MWF_INGRESS_SECRET) headers['x-slack-ingress-secret'] = MWF_INGRESS_SECRET;
 
-  try {
-    const res = await fetch(MWF_BACKEND_URL, {
-      method: 'POST',
-      headers,
-      body,
-    });
-    if (!res.ok) {
+  const maxAttempts = MWF_FORWARD_RETRY_DELAYS_MS.length + 1;
+  let lastReason = 'unknown';
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetch(MWF_BACKEND_URL, { method: 'POST', headers, body });
+      if (res.ok) return { ok: true };
+
       const txt = await res.text().catch(() => '');
-      logMain(`MWF backend ${res.status}: ${txt.slice(0, 200)}`);
-      return false;
+      lastReason = `http_${res.status}`;
+      logMain(`MWF backend ${res.status} (attempt ${attempt}/${maxAttempts}): ${txt.slice(0, 200)}`);
+
+      // 4xx is a config/logic problem — don't retry, fail fast.
+      if (res.status >= 400 && res.status < 500) return { ok: false, reason: lastReason };
+    } catch (err) {
+      lastReason = 'network_error';
+      logMain(`MWF backend POST failed (attempt ${attempt}/${maxAttempts}): ${err.message}`);
     }
-    return true;
+
+    const nextDelay = MWF_FORWARD_RETRY_DELAYS_MS[attempt - 1];
+    if (nextDelay !== undefined) {
+      await new Promise((resolve) => setTimeout(resolve, nextDelay));
+    }
+  }
+
+  return { ok: false, reason: lastReason };
+}
+
+/**
+ * Surface a human-readable message to the user when we fully gave up
+ * forwarding. Better UX than a silent ❌ reaction — most users won't
+ * understand what the red-cross emoji means when their message didn't seem
+ * to go anywhere.
+ */
+async function postMwfForwardFallback(event) {
+  const threadTs = event.thread_ts || event.ts;
+  try {
+    await slack.chat.postMessage({
+      channel: event.channel,
+      thread_ts: threadTs,
+      text: "_I couldn't reach my model just now — please resend your message and I'll pick it up._",
+    });
   } catch (err) {
-    logMain(`MWF backend POST failed: ${err.message}`);
-    return false;
+    logMain(`MWF fallback DM failed: ${err.message}`);
   }
 }
 
@@ -715,10 +752,16 @@ async function handleMessageEvent(event) {
   if (config.workspace === 'mwf-session' && MWF_BACKEND_URL) {
     const isLobby = channel === MWF_SESSIONS_CHANNEL;
     await addReaction(channel, ts, 'eyes');
-    const ok = await forwardToMwfBackend(event, { isLobby });
-    if (!ok) {
+    const result = await forwardToMwfBackend(event, { isLobby });
+    if (!result.ok) {
       await removeReaction(channel, ts, 'eyes');
       await addReaction(channel, ts, 'x');
+      // Human-readable fallback so users understand the bot had a hiccup
+      // instead of just seeing a silent ❌. Only post if the failure was
+      // transient — for config failures (4xx) a DM would just confuse them.
+      if (result.reason && !result.reason.startsWith('http_4')) {
+        await postMwfForwardFallback(event);
+      }
     }
     try {
       writeFileSync(HEARTBEAT_FILE, new Date().toISOString());


### PR DESCRIPTION
First tranche of Phase A work from [#91](https://github.com/shantamg/meet-without-fear/issues/91). Stacked on #89 (consolidation) which is stacked on #88 (milestone). Five tightly-scoped hardening changes; each is independently reviewable.

## Changes

### A.1 — Postgres advisory lock replaces in-memory Map
`backend/src/services/slack-lock.ts` (new). `withSlackUserLock(slackUserId, fn)` wraps the turn in a `$transaction` that acquires `pg_advisory_xact_lock(NAMESPACE, hashtext(slackUserId))`. Auto-releases on transaction end or connection drop — a crashed process can't leave a stuck lock.

Replaces the previous single-process in-memory `Map` in `slack-session-orchestrator.ts`, which would break the moment a second backend replica came up.

_Why advisory over Redis_: no new infrastructure, tied to existing Postgres connection lifecycle, fast enough for human-speed chat. If connection pool pressure becomes real later, swap in a lock table with row-level locking + explicit expiry; call-site API stays the same.

### A.2 — Duplicate-session catch + `archive` lobby command
Before creating a session on `start`, look up whether the user already has an open `INVITED` session. If so, surface the existing join code and an explicit `archive` escape hatch rather than minting an orphan nobody will ever pair with.

`archive` flips the old session to `ABANDONED` and drops its Slack thread mappings in a single transaction.

New service helpers in `slack-session-service.ts`:
- `findInvitedSessionForUser(userId)` → `Session | null`
- `archiveSession(sessionId)` → void

### A.3 — `toSlackMrkdwn` handles multi-line blockquotes + nested bullets
Standard Markdown allows lazy blockquote continuation (only the first line needs `>`). Slack renders everything after the first line as plain text, so the Stage 2B and reconciler share flows — both of which rely on quoted partner content — were rendering flat past line 1.

New `normalizeBlockquotes()` walks the text line-by-line and explicitly prefixes continuation lines with `> ` until a blank line ends the quote.

Also normalizes tab-indented bullets (`\t- nested`) to two-space groups so Slack renders the nesting correctly.

### A.4 — Socket-listener retry + human-readable fallback
`forwardToMwfBackend` now retries up to 2x (500ms, 2s) on network errors and 5xx responses. 4xx responses fail fast (those are config problems, not transient).

On persistent transient failure, posts a human-readable fallback in the user's thread — _"I couldn't reach my model just now — please resend your message and I'll pick it up."_ — instead of a silent ❌ emoji that most users won't understand.

### A.5 — Migration comment about `CREATE UNIQUE INDEX` at scale
Operator note in `20260416000000_add_slack_session_fields/migration.sql` flagging that the unique index builds are safe now but take `ACCESS EXCLUSIVE` locks at scale. Suggests `CREATE INDEX CONCURRENTLY` + constraint add as a two-step pattern for future migrations against larger tables.

## Test plan

- [x] `npm run check` (backend) clean
- [x] `npx jest` — 1018 passing (+16 new tests from this PR); 11 pre-existing circuit-breaker integration failures (require live DB, unrelated)
- [x] `node --check` on `socket-listener.mjs` passes
- [x] New tests:
  - `slack-lock.test.ts` — 4 tests (lock acquired before work, errors propagate, timeout is generous)
  - `slack-session-service.test.ts` — 3 tests (findInvitedSessionForUser query shape, archiveSession transaction)
  - `slack-client.test.ts` — +9 tests (blockquote normalization, quote ends on blank, multi-quote separation, tab-indent nested bullets, * bullets)
- [ ] **Manual** — Once deployed, verify multi-turn quoted content renders correctly and that Render deploy windows no longer surface as silent ❌s

## Related

- Parent issue: #91
- Stacked on: #89 (prompt-builder consolidation), which stacks on #88 (milestone implementation)

/cc @slam-paws for review — focus areas:
1. Advisory lock: is holding a Prisma connection for the full Sonnet call (5–10s) OK at expected scale, or should we switch to a lock-table approach now?
2. Blockquote regex: any edge cases in the lazy-continuation detection I'm missing?
3. Retry policy: is 500ms + 2s backoff enough cover for typical Render deploy windows?

🤖 Generated with [Claude Code](https://claude.com/claude-code)