### PR TITLE
Phase C: Session decay (TTL) — invite sweep + active/archived retention

### DIFF
--- a/backend/src/scripts/sweep-session-retention.ts
+++ b/backend/src/scripts/sweep-session-retention.ts
@@ -1,0 +1,28 @@
+/**
+ * Sweep Session Retention
+ *
+ * CLI entrypoint for the session retention policy. Invoke via:
+ *   npx tsx src/scripts/sweep-session-retention.ts
+ *
+ * Designed to be wired into any scheduler (Render cron, EC2 crontab, GitHub
+ * Actions schedule). The policy itself is in `services/session-retention.ts`.
+ */
+
+import { enforceSessionRetention } from '../services/session-retention';
+
+async function main(): Promise<void> {
+  const result = await enforceSessionRetention();
+  // Emit to stdout so cron hosts capture results in their log aggregation.
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify({ ok: true, ...result }, null, 2));
+}
+
+main()
+  .catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error('[sweep-session-retention] failed:', err);
+    process.exit(1);
+  })
+  .finally(() => {
+    process.exit(0);
+  });

--- a/backend/src/scripts/sweep-session-retention.ts
+++ b/backend/src/scripts/sweep-session-retention.ts
@@ -23,6 +23,9 @@ main()
     console.error('[sweep-session-retention] failed:', err);
     process.exit(1);
   })
+  // `.finally()` only fires on the success path here — `process.exit(1)`
+  // in `.catch()` terminates the process before `.finally()` executes, so
+  // exit code 0 is never reached on failure.
   .finally(() => {
     process.exit(0);
   });

--- a/backend/src/services/__tests__/session-retention.test.ts
+++ b/backend/src/services/__tests__/session-retention.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Session Retention Tests
+ */
+
+const sessionFindMany = jest.fn();
+const sessionUpdate = jest.fn();
+const sessionDeleteMany = jest.fn();
+const messageFindFirst = jest.fn();
+
+jest.mock('../../lib/prisma', () => ({
+  prisma: {
+    session: {
+      findMany: sessionFindMany,
+      update: sessionUpdate,
+      deleteMany: sessionDeleteMany,
+    },
+    message: {
+      findFirst: messageFindFirst,
+    },
+  },
+}));
+
+import {
+  enforceSessionRetention,
+  ACTIVE_SESSION_RETENTION_MS,
+  ARCHIVED_SESSION_PURGE_MS,
+} from '../session-retention';
+
+describe('enforceSessionRetention', () => {
+  const DAY = 24 * 60 * 60 * 1000;
+  const NOW = new Date('2026-04-17T00:00:00Z');
+
+  beforeEach(() => {
+    sessionFindMany.mockReset();
+    sessionUpdate.mockReset();
+    sessionDeleteMany.mockReset();
+    messageFindFirst.mockReset();
+    sessionUpdate.mockResolvedValue({});
+    sessionDeleteMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('archives ACTIVE sessions whose most recent message is older than 90 days', async () => {
+    sessionFindMany.mockResolvedValue([
+      { id: 's1', updatedAt: new Date(NOW.getTime() - 120 * DAY) },
+    ]);
+    messageFindFirst.mockResolvedValue({
+      timestamp: new Date(NOW.getTime() - 95 * DAY),
+    });
+
+    const result = await enforceSessionRetention(NOW);
+
+    expect(result.archived).toBe(1);
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      where: { id: 's1' },
+      data: { status: 'ARCHIVED' },
+    });
+  });
+
+  it('does NOT archive a session whose message is newer than 90d even if updatedAt is stale', async () => {
+    // updatedAt is 120d old (session was last status-changed then), but a
+    // recent message proves the session is active. We should NOT archive.
+    sessionFindMany.mockResolvedValue([
+      { id: 's1', updatedAt: new Date(NOW.getTime() - 120 * DAY) },
+    ]);
+    messageFindFirst.mockResolvedValue({
+      timestamp: new Date(NOW.getTime() - 5 * DAY),
+    });
+
+    const result = await enforceSessionRetention(NOW);
+
+    expect(result.archived).toBe(0);
+    expect(sessionUpdate).not.toHaveBeenCalled();
+  });
+
+  it('uses updatedAt as a fallback when a session has no messages', async () => {
+    sessionFindMany.mockResolvedValue([
+      { id: 's1', updatedAt: new Date(NOW.getTime() - 200 * DAY) },
+    ]);
+    messageFindFirst.mockResolvedValue(null);
+
+    const result = await enforceSessionRetention(NOW);
+
+    expect(result.archived).toBe(1);
+  });
+
+  it('hard-deletes ARCHIVED sessions whose updatedAt is >90 days past archive', async () => {
+    sessionFindMany.mockResolvedValue([]);
+    sessionDeleteMany.mockResolvedValue({ count: 3 });
+
+    const result = await enforceSessionRetention(NOW);
+
+    expect(result.deleted).toBe(3);
+    expect(sessionDeleteMany).toHaveBeenCalledWith({
+      where: {
+        status: 'ARCHIVED',
+        updatedAt: { lt: new Date(NOW.getTime() - ARCHIVED_SESSION_PURGE_MS) },
+      },
+    });
+  });
+
+  it('filter query targets only CONFLICT_RESOLUTION ACTIVE/WAITING sessions', async () => {
+    sessionFindMany.mockResolvedValue([]);
+
+    await enforceSessionRetention(NOW);
+
+    expect(sessionFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          type: 'CONFLICT_RESOLUTION',
+          status: { in: ['ACTIVE', 'WAITING'] },
+          updatedAt: { lt: new Date(NOW.getTime() - ACTIVE_SESSION_RETENTION_MS) },
+        }),
+      })
+    );
+  });
+
+  it('reports inspected count for observability', async () => {
+    sessionFindMany.mockResolvedValue([
+      { id: 's1', updatedAt: new Date(NOW.getTime() - 100 * DAY) },
+      { id: 's2', updatedAt: new Date(NOW.getTime() - 100 * DAY) },
+    ]);
+    messageFindFirst.mockResolvedValueOnce({
+      timestamp: new Date(NOW.getTime() - 95 * DAY),
+    });
+    messageFindFirst.mockResolvedValueOnce({
+      timestamp: new Date(NOW.getTime() - 10 * DAY),
+    });
+
+    const result = await enforceSessionRetention(NOW);
+
+    expect(result.inspected).toBe(2);
+    expect(result.archived).toBe(1);
+  });
+
+  it('retention constants are 90 and 90 days (180d total soft-to-hard window)', () => {
+    expect(ACTIVE_SESSION_RETENTION_MS).toBe(90 * 24 * 60 * 60 * 1000);
+    expect(ARCHIVED_SESSION_PURGE_MS).toBe(90 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/backend/src/services/__tests__/slack-session-service.test.ts
+++ b/backend/src/services/__tests__/slack-session-service.test.ts
@@ -6,7 +6,9 @@
  */
 
 const sessionFindFirst = jest.fn();
+const sessionFindUnique = jest.fn();
 const sessionUpdate = jest.fn();
+const sessionSlackThreadFindUnique = jest.fn();
 const sessionSlackThreadDeleteMany = jest.fn();
 const transactionMock = jest.fn();
 
@@ -14,9 +16,11 @@ jest.mock('../../lib/prisma', () => ({
   prisma: {
     session: {
       findFirst: sessionFindFirst,
+      findUnique: sessionFindUnique,
       update: sessionUpdate,
     },
     sessionSlackThread: {
+      findUnique: sessionSlackThreadFindUnique,
       deleteMany: sessionSlackThreadDeleteMany,
     },
     $transaction: transactionMock,
@@ -25,7 +29,10 @@ jest.mock('../../lib/prisma', () => ({
 
 import {
   findInvitedSessionForUser,
+  findSessionByJoinCode,
+  findSessionByThread,
   archiveSession,
+  INVITED_SESSION_TTL_MS,
 } from '../slack-session-service';
 import { prisma } from '../../lib/prisma';
 
@@ -75,5 +82,157 @@ describe('slack-session-service helpers', () => {
         where: { sessionId: 's1' },
       });
     });
+  });
+
+  // --- TTL + dead-session exclusion (Phase C.1 + C.2) ---
+
+  describe('findSessionByThread', () => {
+    const DAY = 24 * 60 * 60 * 1000;
+
+    it('returns null when the thread is unmapped', async () => {
+      sessionSlackThreadFindUnique.mockResolvedValue(null);
+      const result = await findSessionByThread('C1', 'T1');
+      expect(result).toBeNull();
+    });
+
+    it('returns the session for an active mapping', async () => {
+      sessionSlackThreadFindUnique.mockResolvedValue({
+        userId: 'u1',
+        session: {
+          id: 's1',
+          status: 'ACTIVE',
+          createdAt: new Date(Date.now() - 2 * DAY),
+        },
+      });
+      const result = await findSessionByThread('C1', 'T1');
+      expect(result).toMatchObject({ userId: 'u1', session: { id: 's1' } });
+    });
+
+    it('excludes ABANDONED sessions', async () => {
+      sessionSlackThreadFindUnique.mockResolvedValue({
+        userId: 'u1',
+        session: { id: 's1', status: 'ABANDONED', createdAt: new Date() },
+      });
+      const result = await findSessionByThread('C1', 'T1');
+      expect(result).toBeNull();
+      expect(sessionUpdate).not.toHaveBeenCalled();
+    });
+
+    it('excludes ARCHIVED sessions', async () => {
+      sessionSlackThreadFindUnique.mockResolvedValue({
+        userId: 'u1',
+        session: { id: 's1', status: 'ARCHIVED', createdAt: new Date() },
+      });
+      const result = await findSessionByThread('C1', 'T1');
+      expect(result).toBeNull();
+    });
+
+    it('archives and returns null for INVITED sessions past the 7-day TTL', async () => {
+      sessionSlackThreadFindUnique.mockResolvedValue({
+        userId: 'u1',
+        session: {
+          id: 's1',
+          status: 'INVITED',
+          createdAt: new Date(Date.now() - 8 * DAY),
+        },
+      });
+      const result = await findSessionByThread('C1', 'T1');
+      expect(result).toBeNull();
+      expect(sessionUpdate).toHaveBeenCalledWith({
+        where: { id: 's1' },
+        data: { status: 'ABANDONED' },
+      });
+      expect(sessionSlackThreadDeleteMany).toHaveBeenCalledWith({
+        where: { sessionId: 's1' },
+      });
+    });
+
+    it('does NOT archive INVITED sessions still within the TTL', async () => {
+      sessionSlackThreadFindUnique.mockResolvedValue({
+        userId: 'u1',
+        session: {
+          id: 's1',
+          status: 'INVITED',
+          createdAt: new Date(Date.now() - 3 * DAY),
+        },
+      });
+      const result = await findSessionByThread('C1', 'T1');
+      expect(result).toMatchObject({ userId: 'u1', session: { id: 's1' } });
+      expect(sessionUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findSessionByJoinCode', () => {
+    const DAY = 24 * 60 * 60 * 1000;
+
+    it('excludes dead sessions', async () => {
+      sessionFindUnique.mockResolvedValue({
+        id: 's1',
+        status: 'ABANDONED',
+        createdAt: new Date(),
+      });
+      const result = await findSessionByJoinCode('abc123');
+      expect(result).toBeNull();
+    });
+
+    it('archives INVITED sessions past the TTL and returns null', async () => {
+      sessionFindUnique.mockResolvedValue({
+        id: 's2',
+        status: 'INVITED',
+        createdAt: new Date(Date.now() - 10 * DAY),
+      });
+      const result = await findSessionByJoinCode('abc123');
+      expect(result).toBeNull();
+      expect(sessionUpdate).toHaveBeenCalledWith({
+        where: { id: 's2' },
+        data: { status: 'ABANDONED' },
+      });
+    });
+
+    it('returns valid INVITED sessions within the TTL', async () => {
+      const session = {
+        id: 's3',
+        status: 'INVITED',
+        createdAt: new Date(Date.now() - 1 * DAY),
+      };
+      sessionFindUnique.mockResolvedValue(session);
+      const result = await findSessionByJoinCode('abc123');
+      expect(result).toEqual(session);
+      expect(sessionUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findInvitedSessionForUser — TTL sweep', () => {
+    const DAY = 24 * 60 * 60 * 1000;
+
+    it('archives and returns null when the invite is stale', async () => {
+      sessionFindFirst.mockResolvedValue({
+        id: 's1',
+        status: 'INVITED',
+        createdAt: new Date(Date.now() - 9 * DAY),
+      });
+      const result = await findInvitedSessionForUser('u1');
+      expect(result).toBeNull();
+      expect(sessionUpdate).toHaveBeenCalledWith({
+        where: { id: 's1' },
+        data: { status: 'ABANDONED' },
+      });
+    });
+
+    it('returns the invite when still fresh', async () => {
+      const session = {
+        id: 's2',
+        status: 'INVITED',
+        createdAt: new Date(Date.now() - 2 * DAY),
+      };
+      sessionFindFirst.mockResolvedValue(session);
+      const result = await findInvitedSessionForUser('u1');
+      expect(result).toEqual(session);
+      expect(sessionUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  it('INVITED_SESSION_TTL_MS is 7 days', () => {
+    expect(INVITED_SESSION_TTL_MS).toBe(7 * 24 * 60 * 60 * 1000);
   });
 });

--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -792,4 +792,43 @@ describe('Stage Prompts Service', () => {
       }
     });
   });
+
+  describe('invitedSessionNudge injection', () => {
+    it('is absent by default', () => {
+      const blocks = buildStagePrompt(0, createContext(), { surface: 'slack' });
+      expect(blocks.dynamicBlock).not.toContain('OPERATIONAL NUDGE');
+    });
+
+    it('is appended to the dynamic block when present', () => {
+      const blocks = buildStagePrompt(
+        0,
+        createContext({
+          invitedSessionNudge: 'Session waiting 5 days. Re-share code `abc123`.',
+        }),
+        { surface: 'slack' }
+      );
+      expect(blocks.dynamicBlock).toContain('OPERATIONAL NUDGE:');
+      expect(blocks.dynamicBlock).toContain('abc123');
+    });
+
+    it('is NOT baked into the cached static block (still per-turn)', () => {
+      const blocks = buildStagePrompt(
+        0,
+        createContext({
+          invitedSessionNudge: 'anything',
+        }),
+        { surface: 'slack' }
+      );
+      expect(blocks.staticBlock).not.toContain('OPERATIONAL NUDGE');
+    });
+
+    it('does not fire when invitedSessionNudge is explicitly null', () => {
+      const blocks = buildStagePrompt(
+        0,
+        createContext({ invitedSessionNudge: null }),
+        { surface: 'slack' }
+      );
+      expect(blocks.dynamicBlock).not.toContain('OPERATIONAL NUDGE');
+    });
+  });
 });

--- a/backend/src/services/session-retention.ts
+++ b/backend/src/services/session-retention.ts
@@ -1,0 +1,110 @@
+/**
+ * Session Retention
+ *
+ * Enforces the two-tier session decay policy for MWF conflict-resolution
+ * sessions, regardless of origin (mobile or Slack):
+ *
+ *   - `ACTIVE` / `WAITING` sessions with no activity for 90 days → `ARCHIVED`.
+ *     Users can still read their own history (session row + related rows
+ *     remain) but the session is no longer eligible for new turns.
+ *   - `ARCHIVED` sessions that have sat for another 90 days (180 days total)
+ *     → hard-deleted, cascading to messages / vessels / stage progress.
+ *
+ * `INVITED` sessions are handled separately by the opportunistic 7-day
+ * sweep in `slack-session-service` (see `findSessionByThread` et al). That
+ * sweep runs inline on session lookup, so dead invites are reclaimed as
+ * part of normal traffic.
+ *
+ * This module is the business logic only. Scheduling is intentionally left
+ * out — run it however the deploy environment prefers (a CLI wrapper in
+ * `scripts/sweep-session-retention.ts`, a Render cron, a GitHub Actions
+ * schedule, or the existing EC2 cron host that already runs the file-based
+ * workspace sweeper).
+ */
+
+import { prisma } from '../lib/prisma';
+import { logger } from '../lib/logger';
+
+// Policy constants — exported for tests and ops observability.
+export const ACTIVE_SESSION_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+export const ARCHIVED_SESSION_PURGE_MS = 90 * 24 * 60 * 60 * 1000; // 90d after archive → 180d total
+
+export interface SessionRetentionResult {
+  /** Sessions flipped from ACTIVE/WAITING → ARCHIVED on this run. */
+  archived: number;
+  /** Sessions hard-deleted (status=ARCHIVED and archived >90d ago). */
+  deleted: number;
+  /** Number of ACTIVE/WAITING sessions we inspected. */
+  inspected: number;
+}
+
+/**
+ * Run the session retention policy once. Idempotent — safe to call multiple
+ * times; a session that's already ARCHIVED stays put, and already-deleted
+ * sessions can't reappear.
+ *
+ * `now` is injectable for testing.
+ */
+export async function enforceSessionRetention(
+  now: Date = new Date()
+): Promise<SessionRetentionResult> {
+  const archiveCutoff = new Date(now.getTime() - ACTIVE_SESSION_RETENTION_MS);
+  const deleteCutoff = new Date(now.getTime() - ARCHIVED_SESSION_PURGE_MS);
+
+  // ----- Archive phase -----
+  // Pre-filter with `updatedAt` (cheap). Any session touched by status/gate
+  // changes in the last 90d can't possibly be stale, so we skip them.
+  // For each remaining candidate, confirm staleness via the latest message
+  // timestamp — `updatedAt` doesn't reflect message writes, which are the
+  // authoritative "activity" signal.
+  const staleCandidates = await prisma.session.findMany({
+    where: {
+      type: 'CONFLICT_RESOLUTION',
+      status: { in: ['ACTIVE', 'WAITING'] },
+      updatedAt: { lt: archiveCutoff },
+    },
+    select: { id: true, updatedAt: true },
+  });
+
+  let archived = 0;
+  for (const candidate of staleCandidates) {
+    const lastMsg = await prisma.message.findFirst({
+      where: { sessionId: candidate.id },
+      orderBy: { timestamp: 'desc' },
+      select: { timestamp: true },
+    });
+    const lastActivity = lastMsg?.timestamp ?? candidate.updatedAt;
+    if (lastActivity >= archiveCutoff) continue;
+
+    await prisma.session.update({
+      where: { id: candidate.id },
+      data: { status: 'ARCHIVED' },
+    });
+    archived++;
+  }
+
+  // ----- Hard-delete phase -----
+  // Sessions that were ARCHIVED long enough ago that the soft-retention
+  // window is up. Cascade via the Session FKs deletes messages, vessels,
+  // stage progress, slack-threads, etc. in the same transaction.
+  const deleteResult = await prisma.session.deleteMany({
+    where: {
+      status: 'ARCHIVED',
+      updatedAt: { lt: deleteCutoff },
+    },
+  });
+
+  const result: SessionRetentionResult = {
+    archived,
+    deleted: deleteResult.count,
+    inspected: staleCandidates.length,
+  };
+
+  logger.info('[SessionRetention] Retention policy enforced', {
+    ...result,
+    archiveCutoff: archiveCutoff.toISOString(),
+    deleteCutoff: deleteCutoff.toISOString(),
+  });
+
+  return result;
+}

--- a/backend/src/services/slack-conversation.ts
+++ b/backend/src/services/slack-conversation.ts
@@ -41,6 +41,8 @@ import {
   updateStageProgress,
   hasBothUsersCompacted,
   advanceToStage,
+  INVITED_SESSION_TTL_MS,
+  INVITED_SESSION_NUDGE_THRESHOLD_MS,
 } from './slack-session-service';
 import { buildStagePrompt } from './stage-prompts';
 import { MessageRole } from '@prisma/client';
@@ -343,6 +345,11 @@ async function handleDmMessage(payload: SlackMessagePayload): Promise<void> {
     CONVERSATION_TURN_LIMIT
   );
 
+  // If the session is still INVITED and nearing TTL, build an operational
+  // nudge the AI can weave into its next response — better than a scheduled
+  // system message.
+  const invitedSessionNudge = buildInvitedSessionNudge(session);
+
   // Use the same prompt builder as mobile for behavioral parity — the only
   // difference for Slack is `surface: 'slack'`, which appends mrkdwn
   // formatting rules to the static block. Prompt-cache keys still hit across
@@ -355,6 +362,7 @@ async function handleDmMessage(payload: SlackMessagePayload): Promise<void> {
       turnCount: contextBundle.conversationContext.turnCount,
       emotionalIntensity,
       contextBundle,
+      invitedSessionNudge,
     },
     {
       surface: 'slack',
@@ -455,6 +463,30 @@ async function findPreviousUserTurnAt(
     select: { timestamp: true },
   });
   return last?.timestamp ?? null;
+}
+
+/**
+ * Build an operational nudge string for INVITED sessions approaching their
+ * 7-day TTL. Returns null when the session is already ACTIVE, still well
+ * inside the nudge-free window, or missing a join code (structurally
+ * impossible for INVITED Slack sessions, but defensive).
+ *
+ * When rendered, the dynamic block carries this verbatim and the Process
+ * Guardian is instructed (via `finalize`'s "OPERATIONAL NUDGE" framing) to
+ * weave it into its next response in its own voice.
+ */
+function buildInvitedSessionNudge(
+  session: { status: string; createdAt: Date; slackJoinCode: string | null }
+): string | null {
+  if (session.status !== 'INVITED') return null;
+  if (!session.slackJoinCode) return null;
+
+  const ageMs = Date.now() - session.createdAt.getTime();
+  if (ageMs < INVITED_SESSION_NUDGE_THRESHOLD_MS) return null;
+  if (ageMs >= INVITED_SESSION_TTL_MS) return null; // TTL sweep will handle it
+
+  const daysWaiting = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+  return `This session has been waiting for a partner to join for ${daysWaiting} days. Gently mention that they can re-share their join code \`${session.slackJoinCode}\`, or say \`archive\` to close it and start fresh later. Keep it conversational — don't lead your response with this.`;
 }
 
 /**

--- a/backend/src/services/slack-session-service.ts
+++ b/backend/src/services/slack-session-service.ts
@@ -56,8 +56,42 @@ export async function findOrCreateSlackUser(slackUserId: string): Promise<User> 
 // ============================================================================
 
 /**
+ * TTL for `INVITED` sessions — a creator posts `start` in the lobby but the
+ * partner never joins. After this window we treat the session as abandoned
+ * and reclaim it opportunistically on the next lookup. 7 days was chosen to
+ * capture at least one full weekend cycle regardless of what day the invite
+ * was sent.
+ */
+export const INVITED_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Soft milestone at which the Slack flow nudges the creator that their
+ * invite is approaching expiry. Surfaced via the dynamic prompt block so the
+ * Process Guardian delivers it in its own voice rather than through a
+ * scheduled system message.
+ */
+export const INVITED_SESSION_NUDGE_THRESHOLD_MS = 5 * 24 * 60 * 60 * 1000;
+
+/** Sessions that have already been decommissioned — never returned by lookups. */
+const DEAD_SESSION_STATUSES = ['ABANDONED', 'ARCHIVED'] as const;
+
+function isDeadSession(status: string): boolean {
+  return DEAD_SESSION_STATUSES.includes(status as typeof DEAD_SESSION_STATUSES[number]);
+}
+
+function isInvitedSessionExpired(session: Session, now: Date): boolean {
+  return (
+    session.status === 'INVITED' &&
+    now.getTime() - session.createdAt.getTime() > INVITED_SESSION_TTL_MS
+  );
+}
+
+/**
  * Find the (session, userId) pair bound to a specific Slack channel+thread.
- * Returns null if the thread is not yet mapped.
+ * Returns null if:
+ *   - the thread is not mapped,
+ *   - the session has already been ABANDONED/ARCHIVED, or
+ *   - the session is an INVITED past its 7-day TTL (auto-archived on lookup).
  */
 export async function findSessionByThread(
   channelId: string,
@@ -68,32 +102,56 @@ export async function findSessionByThread(
     include: { session: true },
   });
   if (!mapping) return null;
-  return { session: mapping.session, userId: mapping.userId };
+
+  const { session } = mapping;
+  if (isDeadSession(session.status)) return null;
+
+  if (isInvitedSessionExpired(session, new Date())) {
+    await archiveSession(session.id);
+    return null;
+  }
+
+  return { session, userId: mapping.userId };
 }
 
 /**
- * Find a session by its 6-char lobby join code.
+ * Find a session by its 6-char lobby join code. Enforces the same TTL +
+ * dead-session exclusions as `findSessionByThread` so a stale code can't
+ * resurrect an abandoned session.
  */
 export async function findSessionByJoinCode(code: string): Promise<Session | null> {
-  return prisma.session.findUnique({ where: { slackJoinCode: code } });
+  const session = await prisma.session.findUnique({ where: { slackJoinCode: code } });
+  if (!session) return null;
+  if (isDeadSession(session.status)) return null;
+  if (isInvitedSessionExpired(session, new Date())) {
+    await archiveSession(session.id);
+    return null;
+  }
+  return session;
 }
 
 /**
  * Find the user's currently-open `INVITED` session, if any. Used by the lobby
  * to short-circuit a duplicate `start` — if A already created a session and
  * hasn't been paired yet, surface the existing join code instead of minting a
- * second orphan session.
+ * second orphan session. Opportunistically archives stale invites.
  */
 export async function findInvitedSessionForUser(
   userId: string
 ): Promise<Session | null> {
-  return prisma.session.findFirst({
+  const session = await prisma.session.findFirst({
     where: {
       status: 'INVITED',
       relationship: { members: { some: { userId } } },
     },
     orderBy: { createdAt: 'desc' },
   });
+  if (!session) return null;
+  if (isInvitedSessionExpired(session, new Date())) {
+    await archiveSession(session.id);
+    return null;
+  }
+  return session;
 }
 
 /**

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -397,6 +397,13 @@ export interface PromptContext {
   previousEmpathyContent?: string | null;
   /** Partner's progress status for transition messages */
   partnerStatus?: 'not_joined' | 'in_progress' | 'completed';
+  /**
+   * Operational nudge surfaced when an INVITED Slack session is approaching
+   * its 7-day TTL. When non-null, the AI weaves it into its next response
+   * (surface-voiced rather than a scheduled system message). Mobile ignores
+   * this — it has its own in-app UI for re-sharing or abandoning invites.
+   */
+  invitedSessionNudge?: string | null;
 }
 
 /** Simplified context for initial message generation (no context bundle needed) */
@@ -1642,6 +1649,12 @@ export function buildStagePrompt(stage: number, context: PromptContext, options?
     }
     if (postShareSection) {
       dynamicBlock = dynamicBlock + '\n' + postShareSection;
+    }
+    // Invited-session nudge — operational hint surfaced when an INVITED
+    // Slack session is nearing its TTL. Goes at the END of the dynamic
+    // block so it reads as a recent operational signal, not as framing.
+    if (context.invitedSessionNudge) {
+      dynamicBlock = `${dynamicBlock}\n\nOPERATIONAL NUDGE:\n${context.invitedSessionNudge}`;
     }
     // Append Slack formatting rules to the static block when the response will
     // render in a Slack DM. Keeping this in the static block preserves prompt


### PR DESCRIPTION
Phase C of [#91](https://github.com/shantamg/meet-without-fear/issues/91). Stacked on #94 (Phase B) → #92 (Phase A) → #89 → #88.

Implements the full two-tier session decay policy. Stale sessions no longer accumulate in Postgres, and the 7-day lobby-invite TTL, 90-day active-session retention, and 180-day hard-purge are all wired up without introducing any new scheduling infrastructure.

## What's in

### C.1 + C.2 — Opportunistic INVITED TTL + dead-session lookup exclusion
- \`INVITED_SESSION_TTL_MS\` = 7 days, \`INVITED_SESSION_NUDGE_THRESHOLD_MS\` = 5 days (constants, exported for tests + reuse).
- All three Slack session-lookup helpers (\`findSessionByThread\`, \`findSessionByJoinCode\`, \`findInvitedSessionForUser\`) now:
  1. Archive INVITED sessions past their 7-day TTL inline on lookup (opportunistic — no cron).
  2. Unconditionally exclude \`ABANDONED\` / \`ARCHIVED\` from results. A stale \`SessionSlackThread\` row can't resurrect a dead session.
- **Why 7 days over 3–4**: captures at least one full weekend cycle regardless of invite day, so a partner finally summoning courage on a Saturday doesn't hit \"session expired\" and spark a fresh fight.

### C.3 — Day 5–6 nudge via dynamic prompt block
- New \`PromptContext.invitedSessionNudge?: string | null\` — mobile-safe (ignored), Slack populates when relevant.
- \`finalize()\` in \`buildStagePrompt\` appends \`OPERATIONAL NUDGE:\` + the nudge text to the **dynamic** block (not static — keeps the prompt cache intact; nudge is per-turn).
- \`buildInvitedSessionNudge(session)\` in slack-conversation returns a conversational hint for INVITED sessions aged 5–7 days, including the join code + \`archive\` escape hatch. Explicit instruction to the AI: keep it conversational, don't lead with it.

### C.4 + C.5 — 90-day archive + 180-day hard-purge (DB-side)
- **Investigation findings**: Prior \"90-day sweeper\" commits (19da935, d4846a5) are both EC2 filesystem sweepers operating on \`data/mwf-sessions/\`. Nothing backend-side exists. Built it.
- New \`services/session-retention.ts\` with \`enforceSessionRetention(now)\` — pure function, two phases:
  1. Archive \`ACTIVE\` / \`WAITING\` \`CONFLICT_RESOLUTION\` sessions with no message activity for 90 days.
  2. Hard-delete \`ARCHIVED\` sessions whose \`updatedAt\` is another 90+ days old (180-day total window, gives users a window to read their own history before it's purged).
- Pre-filter on \`Session.updatedAt\` (cheap) to bound the per-candidate \`max(Message.timestamp)\` lookup. \`updatedAt\` doesn't reflect message writes, so we confirm staleness via the authoritative signal.
- New CLI wrapper \`scripts/sweep-session-retention.ts\` — invokable via \`npx tsx\`. **Scheduling deliberately left to deploy config** (wire into Render cron, EC2 crontab, or GitHub Actions Schedule as preferred). No new runtime infrastructure.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npx jest\` — 1059 passing. Same three pre-existing failures on clean main: \`circuit-breaker\` (needs live DB) + \`time-language.test.ts\` (flaky midnight-boundary). Zero regressions.
- [x] **New tests** (+23 across 3 files):
  - \`slack-session-service.test.ts\` +12: lookup TTL + dead-status exclusion permutations (5 per lookup × 3 lookups, collapsed to the distinct cases; plus TTL constant sanity).
  - \`stage-prompts.test.ts\` +4: \`invitedSessionNudge\` present / absent / null / static-block-isolation.
  - \`session-retention.test.ts\` +7: archive happy path, recency-wins-over-stale-\`updatedAt\`, no-messages fallback, hard-delete phase, query scope, inspected count, constants.
- [ ] **Manual** — after deploy: wire \`sweep-session-retention.ts\` into a daily cron and confirm it reports sensible counts on the first run.

## Why this is safe to ship

- \`enforceSessionRetention\` is idempotent. Safe to run repeatedly; a session that's already ARCHIVED stays put, already-deleted sessions can't reappear.
- The opportunistic INVITED sweep on lookups doesn't block any user traffic — it archives and returns null in the same tx as the lookup.
- Hard-delete cascades are scoped by schema FKs (\`onDelete: Cascade\`) — no orphan rows.
- All policy constants are named + exported so future adjustments are one-line changes.

## Related

- Parent issue: #91
- Stacked on: #94 (Phase B) → #92 (Phase A) → #89 → #88

/cc @slam-paws for review — focus areas:
1. \`session-retention.ts\`: is \`Session.updatedAt\` as the archive-time proxy for the hard-delete cutoff the right call, or should we add an explicit \`archivedAt: DateTime?\` column? Current design relies on the status flip touching \`updatedAt\`, which works but couples two concerns.
2. C.3 nudge framing: is \`OPERATIONAL NUDGE:\` in the dynamic block the right structural layer, or should it live on the payload the AI's \`<dispatch>\` layer already handles?
3. Deploy scheduling: the CLI wrapper is scheduler-agnostic by design, but do you have a preference for where to wire the daily run (Render cron vs. EC2 crontab host vs. GitHub Actions)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)