### PR TITLE
docs: fix drift from 24h incremental audit (2026-04-17)

### DIFF
--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -165,7 +165,7 @@ project-root/
   - `useMessages.ts` - Message querying + mutations (30KB); optimistic updates + streaming. Also hosts emotion tracking for messages (`useEmotionalHistory`, `useRecordEmotion`) alongside `useEmotions.ts`. `useInfiniteMessages` here is still the pagination source (wrapped by `useUnifiedSession`); `useTimeline.ts` is a newer companion hook that does not yet fully replace it.
   - `useSessions.ts` - Session CRUD + list (32KB). Uses the cache-first pattern: `useConfirmInvitationMessage` optimistically updates the cache in `onMutate` before the server confirms. `useArchiveSession` is deprecated in favor of `useDeleteSession`, which handles proper data cleanup.
   - `useStages.ts` - Stage mutations + gate validation (64KB)
-  - `useRealtime.ts` - Ably subscription setup (32KB); session-scoped realtime events + fire-and-forget AI messages with stale-closure defense via `userIdRef`. Exports convenience hooks: `usePartnerTyping()`, `usePartnerPresence()`, `useSessionEvents()`, `useUserSessionUpdates()`. Handles app foreground/background state (re-enters/leaves presence, reconnects on resume).
+  - `useRealtime.ts` - Ably subscription setup (29KB); session-scoped realtime events + fire-and-forget AI messages with stale-closure defense via `userIdRef`. Exports convenience hooks: `usePartnerTyping()`, `usePartnerPresence()`, `useSessionEvents()`, `useUserSessionUpdates()`. Handles app foreground/background state (re-enters/leaves presence, reconnects on resume).
   - `useStreamingMessage.ts` - SSE streaming setup + metadata handling (27KB)
   - `useChatUIState.ts` - Derives UI state from cache values (9KB wrapper around `utils/chatUIState.ts`)
   - `useAnimationQueue.ts` - Animation sequencing for chat UI

--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -165,7 +165,7 @@ project-root/
   - `useMessages.ts` - Message querying + mutations (30KB); optimistic updates + streaming. Also hosts emotion tracking for messages (`useEmotionalHistory`, `useRecordEmotion`) alongside `useEmotions.ts`. `useInfiniteMessages` here is still the pagination source (wrapped by `useUnifiedSession`); `useTimeline.ts` is a newer companion hook that does not yet fully replace it.
   - `useSessions.ts` - Session CRUD + list (32KB). Uses the cache-first pattern: `useConfirmInvitationMessage` optimistically updates the cache in `onMutate` before the server confirms. `useArchiveSession` is deprecated in favor of `useDeleteSession`, which handles proper data cleanup.
   - `useStages.ts` - Stage mutations + gate validation (64KB)
-  - `useRealtime.ts` - Ably subscription setup (29KB); listens to session events
+  - `useRealtime.ts` - Ably subscription setup (32KB); session-scoped realtime events + fire-and-forget AI messages with stale-closure defense via `userIdRef`. Exports convenience hooks: `usePartnerTyping()`, `usePartnerPresence()`, `useSessionEvents()`, `useUserSessionUpdates()`. Handles app foreground/background state (re-enters/leaves presence, reconnects on resume).
   - `useStreamingMessage.ts` - SSE streaming setup + metadata handling (27KB)
   - `useChatUIState.ts` - Derives UI state from cache values (9KB wrapper around `utils/chatUIState.ts`)
   - `useAnimationQueue.ts` - Animation sequencing for chat UI

--- a/docs/backend/api/invitations.md
+++ b/docs/backend/api/invitations.md
@@ -69,11 +69,40 @@ interface InvitationDTO {
 
 ## Acknowledge Invitation
 
-Mark a pending invitation as viewed (flips a `viewedAt` timestamp for the inviter's UI). Requires authentication.
+Mark a pending invitation as viewed. Creates a notification so the invitee can see the invitation. Requires authentication.
 
 ```
 POST /api/v1/invitations/:id/acknowledge
 ```
+
+### Response
+
+```typescript
+interface AcknowledgeInvitationResponse {
+  acknowledged: boolean;
+  reason?: string;  // 'expired' or status name if not acknowledged
+  invitation: {
+    id: string;
+    status: InvitationStatus;
+    invitedBy: {
+      id: string;
+      name: string | null;
+    };
+    session?: {
+      id: string;
+      status: string;
+    };
+    expiresAt?: string;
+  };
+}
+```
+
+### Errors
+
+| Code | When |
+|------|------|
+| `VALIDATION_ERROR` (400) | User is the inviter (cannot acknowledge own invitation) |
+| `NOT_FOUND` | Invitation doesn't exist |
 
 ---
 

--- a/docs/backend/api/stage-2.md
+++ b/docs/backend/api/stage-2.md
@@ -124,9 +124,7 @@ POST /api/v1/sessions/:id/empathy/consent
 
 ```typescript
 interface ConsentToShareEmpathyRequest {
-  draftId: string;
-  // Optional: user can edit before sharing
-  finalContent?: string;
+  consent: boolean;  // true to consent and share
 }
 ```
 
@@ -135,19 +133,22 @@ interface ConsentToShareEmpathyRequest {
 ```typescript
 interface ConsentToShareEmpathyResponse {
   consented: boolean;
-  consentedAt: string;
-  waitingForPartner: boolean;
-
-  // If partner already consented, their attempt is returned
-  partnerAttempt?: EmpathyAttemptDTO;
-}
-
-interface EmpathyAttemptDTO {
-  id: string;
-  sourceUserId: string;
-  content: string;
-  sharedAt: string;
-  consentRecordId: string;
+  consentedAt: string | null;
+  partnerConsented: boolean;
+  canReveal: boolean;
+  status: 'HELD' | 'ANALYZING';  // HELD = waiting for partner; ANALYZING = both shared
+  empathyMessage: {
+    id: string;
+    content: string;
+    timestamp: string;
+    stage: number;
+  };
+  transitionMessage?: {
+    id: string;
+    content: string;
+    timestamp: string;
+    stage: number;
+  };
 }
 ```
 

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -2,7 +2,7 @@
 title: Infrastructure
 sidebar_position: 1
 description: Slam bot (EC2), Render hosting, Vercel deploys, GitHub automation.
-updated: 2026-04-16
+updated: 2026-04-17
 ---
 
 # Infrastructure
@@ -50,9 +50,32 @@ Local operator scripts live at `scripts/ec2-bot/`:
 | `provision.sh` | One-shot AWS provisioning (security group, EIP, instance, SSH config entry) |
 | `setup.sh` | First-time bootstrap of a fresh instance (Node, gh, claude, directories) |
 | `deploy.sh` | Symlink scripts, install systemd units + crontab + logrotate |
-| `configure-slack.sh` | Write Slack tokens + channel IDs (including `BUGS_AND_REQUESTS_CHANNEL_ID` for `#bugs-and-requests`) to `/opt/slam-bot/.env` and start the socket service |
+| `configure-slack.sh` | Write Slack tokens + channel IDs (including `BUGS_AND_REQUESTS_CHANNEL_ID` for `#bugs-and-requests` and `MWF_SESSIONS_CHANNEL_ID` for `#mwf-sessions`) to `/opt/slam-bot/.env` and start the socket service |
 | `configure-mixpanel.sh` | Write Mixpanel service-account credentials |
 | `configure-db.sh` | Create/rotate `slam_bot_readonly` role on the Render Postgres |
+
+### Session data directories
+
+The bot maintains session state on disk at `~/meet-without-fear/`:
+
+| Directory | Purpose |
+|---|---|
+| `data/mwf-sessions/` | MWF session data, one subdirectory per session ID |
+| `data/mwf-sessions/thread-index.json` | Maps `{channel}:{thread_ts}` → `{session_id}` for DM routing lookup |
+| `data/mwf-users/` | Per-user profile data (name, previous sessions, etc.) |
+
+`thread-index.json` is read on every incoming DM to check if the message belongs to an active MWF session. It is maintained by the `route` stage in the `mwf-session` workspace.
+
+### MWF session routing
+
+The socket listener implements session-aware message routing:
+
+- **Session detection**: On each DM message, checks `data/mwf-sessions/thread-index.json` for active session threads
+- **DM → mwf-session mapping**: Messages in a DM thread matching an active MWF session are routed to the `mwf-session` workspace instead of `slack-triage`
+- **Stray DM prevention**: Top-level DMs (outside any thread) from users with active sessions are redirected with a nudge to use their session thread
+- **Lobby channel**: `#mwf-sessions` is used for session setup only; actual conversations happen in private DMs (one DM thread per user) to enforce vessel privacy at the transport layer
+
+See `bot-workspaces/mwf-session/CLAUDE.md` for full architecture and stage contracts.
 
 ## Production hosting
 


### PR DESCRIPTION
## Changes
- Fix: `invitations.md` — expand acknowledge endpoint stub with full response schema and error table
- Fix: `stage-2.md` — correct ConsentToShare request body (`{consent: boolean}`, not `{draftId, finalContent?}`) and update response shape to match current code
- Add: `infrastructure/index.md` — MWF session routing section (DM routing, stray DM prevention, lobby model), session data directories (`data/mwf-sessions/`, `thread-index.json`, `data/mwf-users/`), `MWF_SESSIONS_CHANNEL_ID` in configure-slack.sh row
- Fix: `structure.md` — update `useRealtime.ts` size (29KB → 32KB) and document exported convenience hooks

## Provenance
- **Channel:** cron / audit-docs
- **Requested by:** automated nightly run
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** incremental docs audit stage contract

## Docs updated
- `docs/backend/api/invitations.md`
- `docs/backend/api/stage-2.md`
- `docs/infrastructure/index.md`
- `docs/architecture/structure.md`