### PR TITLE
fix(mobile): constrain NeedsDrawer content to visible area so buttons appear

### DIFF
--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -9,7 +9,7 @@
  * - `comparison`: Side-by-side view of both users' needs + common ground
  */
 
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect, useState } from 'react';
 import {
   View,
   Text,
@@ -109,12 +109,14 @@ export function NeedsDrawer({
   const backdropOpacity = useRef(new Animated.Value(0)).current;
   const isDragging = useRef(false);
   const currentSnap = useRef<'3q' | 'full'>('3q');
+  const [contentHeight, setContentHeight] = useState(SCREEN_HEIGHT - POSITION_3Q);
 
   // -------------------------------------------------------------------------
   // Open / Close / Snap animations
   // -------------------------------------------------------------------------
   const snapTo = useCallback(
     (position: number, backdrop: number) => {
+      setContentHeight(SCREEN_HEIGHT - position);
       Animated.parallel([
         Animated.spring(drawerTranslate, {
           toValue: position,
@@ -507,36 +509,39 @@ export function NeedsDrawer({
           },
         ]}
       >
-        {/* Drag handle */}
-        <View {...panResponder.panHandlers} style={styles.dragHandleArea}>
-          <View style={styles.dragHandle} />
+        {/* Content wrapper constrains layout to visible drawer area */}
+        <View style={{ height: contentHeight }}>
+          {/* Drag handle */}
+          <View {...panResponder.panHandlers} style={styles.dragHandleArea}>
+            <View style={styles.dragHandle} />
+          </View>
+
+          {/* Header */}
+          <Text
+            style={styles.header}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            testID={`${testID}-header`}
+          >
+            {headerText}
+          </Text>
+
+          {/* Scrollable content */}
+          <ScrollView
+            style={styles.scrollView}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator
+          >
+            {mode === 'needs' && renderNeedsMode()}
+            {mode === 'common-ground' && renderCommonGroundMode()}
+            {mode === 'comparison' && renderComparisonMode()}
+          </ScrollView>
+
+          {/* Fixed footer buttons */}
+          {mode === 'needs' && renderNeedsButtons()}
+          {mode === 'common-ground' && renderCommonGroundButtons()}
+          {mode === 'comparison' && renderComparisonButtons()}
         </View>
-
-        {/* Header */}
-        <Text
-          style={styles.header}
-          numberOfLines={1}
-          ellipsizeMode="tail"
-          testID={`${testID}-header`}
-        >
-          {headerText}
-        </Text>
-
-        {/* Scrollable content */}
-        <ScrollView
-          style={styles.scrollView}
-          contentContainerStyle={styles.scrollContent}
-          showsVerticalScrollIndicator
-        >
-          {mode === 'needs' && renderNeedsMode()}
-          {mode === 'common-ground' && renderCommonGroundMode()}
-          {mode === 'comparison' && renderComparisonMode()}
-        </ScrollView>
-
-        {/* Fixed footer buttons */}
-        {mode === 'needs' && renderNeedsButtons()}
-        {mode === 'common-ground' && renderCommonGroundButtons()}
-        {mode === 'comparison' && renderComparisonButtons()}
       </Animated.View>
     </View>
   );


### PR DESCRIPTION
## Changes
- Fix: Constrain NeedsDrawer content layout to the visible drawer area so confirm/adjust footer buttons render on-screen
- The drawer's internal layout used `height: SCREEN_HEIGHT` but at the 3/4 snap point (`translateY = 25%`), the bottom 25% extended below the viewport — hiding the footer buttons
- Add a content wrapper whose height tracks the visible portion (`SCREEN_HEIGHT - translateY`), updated on each snap change
- All three drawer modes (needs, common-ground, comparison) are fixed

Related to #99

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** I keep chatting and the nerds keep updating when I check back, but there seems to be nothing I can do to advance. When I tap to confirm my needs and I see this drawer, there is no button or action I can take.
- **Prompt(s) used:** Manual triage of missed message — original bot agent crashed before responding

## Docs updated
No doc changes needed — bug fix in a UI component with no corresponding living doc