### PR TITLE
fix(slack): cast advisory lock namespace to int

### DIFF
--- a/backend/src/services/slack-lock.ts
+++ b/backend/src/services/slack-lock.ts
@@ -52,8 +52,11 @@ export async function withSlackUserLock<T>(
       // Blocking acquire — if another replica holds the lock for this user,
       // we queue behind it. Uses xact_lock so release is automatic at
       // transaction boundary.
+      // Explicit ::int cast on the namespace: Prisma binds JS numbers as bigint,
+      // and Postgres has no `pg_advisory_xact_lock(bigint, integer)` overload
+      // (only (bigint) and (int, int)), so we must land on the (int, int) form.
       await tx.$executeRaw`
-        SELECT pg_advisory_xact_lock(${LOCK_NAMESPACE}, hashtext(${slackUserId}))
+        SELECT pg_advisory_xact_lock(${LOCK_NAMESPACE}::int, hashtext(${slackUserId}))
       `;
       return fn();
     },


### PR DESCRIPTION
## Summary
- Postgres has no `pg_advisory_xact_lock(bigint, integer)` overload — only `(bigint)` and `(int, int)`. Prisma binds JS numbers as bigint, so every Slack turn was crashing with `42883 function does not exist`.
- Cast the namespace to `::int` to land on the `(int, int)` overload.
- Caught by smoke test right after the #102 consolidated deploy went live.

## Test plan
- [x] Unit test (`slack-lock.test.ts`) still validates SQL shape — passes
- [x] Parameterized query runs cleanly against a real local Postgres
- [ ] Re-smoke in #mwf-sessions after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)