### PR TITLE
fix(slack): route DM replies via backend session-check endpoint

### DIFF
--- a/backend/src/controllers/slack-session.ts
+++ b/backend/src/controllers/slack-session.ts
@@ -15,6 +15,7 @@ import crypto from 'crypto';
 import { Request, Response } from 'express';
 import { logger } from '../lib/logger';
 import { handleSlackMessage } from '../services/slack-session-orchestrator';
+import { findSessionByThread, findLiveSessionThreadForChannel } from '../services/slack-session-service';
 import type { SlackMessagePayload } from '../services/slack-types';
 
 export type { SlackMessagePayload };
@@ -81,4 +82,45 @@ export function slackHealth(_req: Request, res: Response): void {
     slackConfigured: Boolean(process.env.SLACK_BOT_TOKEN),
     secretRequired: Boolean(process.env.SLACK_INGRESS_SECRET),
   });
+}
+
+/**
+ * GET /api/slack/session-check?channel=X&thread_ts=Y
+ *
+ * Authoritative "is this (channel, thread) an active MWF session thread?"
+ * lookup for the EC2 socket listener. The listener used to answer this
+ * from a local `thread-index.json` written by the legacy Claude-agent path;
+ * now that sessions live in Postgres, only the backend knows, so the
+ * listener queries here to decide whether to forward DM replies to
+ * `/slack/mwf-session` (vs. falling back to slack-triage).
+ *
+ * Also returns `activeThreadTs` for the channel so the listener can nudge a
+ * user back when they post a stray top-level DM outside their session thread
+ * (the same UX the old thread-index-based code offered).
+ */
+export async function slackSessionCheck(req: Request, res: Response): Promise<void> {
+  if (!validateSharedSecret(req)) {
+    res.status(401).json({ ok: false, error: 'unauthorized' });
+    return;
+  }
+
+  const channel = typeof req.query.channel === 'string' ? req.query.channel : '';
+  const threadTs = typeof req.query.thread_ts === 'string' ? req.query.thread_ts : '';
+  if (!channel) {
+    res.status(400).json({ ok: false, error: 'missing_channel' });
+    return;
+  }
+
+  let isSession = false;
+  if (threadTs) {
+    const mapping = await findSessionByThread(channel, threadTs);
+    isSession = Boolean(mapping);
+  }
+
+  // When a user posts a top-level DM (no thread_ts) in a channel that still
+  // has an active session thread, the listener wants to nudge them back to
+  // the thread. Surface the active thread_ts (if any) so it can do that.
+  const activeThreadTs = isSession ? null : await findLiveSessionThreadForChannel(channel);
+
+  res.status(200).json({ ok: true, isSession, activeThreadTs });
 }

--- a/backend/src/routes/slack.ts
+++ b/backend/src/routes/slack.ts
@@ -8,11 +8,12 @@
 
 import { Router } from 'express';
 import { asyncHandler } from '../middleware/errors';
-import { handleMwfSessionMessage, slackHealth } from '../controllers/slack-session';
+import { handleMwfSessionMessage, slackHealth, slackSessionCheck } from '../controllers/slack-session';
 
 const router = Router();
 
 router.get('/slack/health', slackHealth);
+router.get('/slack/session-check', asyncHandler(slackSessionCheck));
 router.post('/slack/mwf-session', asyncHandler(handleMwfSessionMessage));
 
 export default router;

--- a/backend/src/services/slack-lock.ts
+++ b/backend/src/services/slack-lock.ts
@@ -52,8 +52,11 @@ export async function withSlackUserLock<T>(
       // Blocking acquire — if another replica holds the lock for this user,
       // we queue behind it. Uses xact_lock so release is automatic at
       // transaction boundary.
+      // Explicit ::int cast on the namespace: Prisma binds JS numbers as bigint,
+      // and Postgres has no `pg_advisory_xact_lock(bigint, integer)` overload
+      // (only (bigint) and (int, int)), so we must land on the (int, int) form.
       await tx.$executeRaw`
-        SELECT pg_advisory_xact_lock(${LOCK_NAMESPACE}, hashtext(${slackUserId}))
+        SELECT pg_advisory_xact_lock(${LOCK_NAMESPACE}::int, hashtext(${slackUserId}))
       `;
       return fn();
     },

--- a/backend/src/services/slack-session-service.ts
+++ b/backend/src/services/slack-session-service.ts
@@ -115,6 +115,29 @@ export async function findSessionByThread(
 }
 
 /**
+ * Return the thread_ts of a live (non-dead, non-expired-INVITED) session
+ * bound to this Slack channel, if any. Used by the socket-listener's
+ * session-check endpoint to redirect stray top-level DMs back into an
+ * active session thread.
+ */
+export async function findLiveSessionThreadForChannel(
+  channelId: string
+): Promise<string | null> {
+  const mappings = await prisma.sessionSlackThread.findMany({
+    where: { channelId },
+    include: { session: true },
+    orderBy: { createdAt: 'desc' },
+  });
+  const now = new Date();
+  for (const m of mappings) {
+    if (isDeadSession(m.session.status)) continue;
+    if (isInvitedSessionExpired(m.session, now)) continue;
+    return m.threadTs;
+  }
+  return null;
+}
+
+/**
  * Find a session by its 6-char lobby join code. Enforces the same TTL +
  * dead-session exclusions as `findSessionByThread` so a stale code can't
  * resurrect an abandoned session.

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -560,45 +560,50 @@ async function drainThreadQueue(tKey) {
 }
 
 // ---------------------------------------------------------------------------
-// MWF session detection — check if a DM thread is an active MWF session
+// MWF session detection — ask the backend whether a DM thread is a session.
 // ---------------------------------------------------------------------------
+//
+// Historically this was answered from a local `thread-index.json` written by
+// the legacy Claude-agent path. Now that sessions live in the backend DB
+// (Render), only the backend knows — so we query its `/slack/session-check`
+// endpoint, which also returns the live thread_ts for the channel (used to
+// nudge stray top-level DMs back into their session thread).
+//
+// Combined call saves a round trip: one GET returns both `isSession` (for
+// the thread-reply path) and `activeThreadTs` (for the stray-DM path).
+//
+// Fails closed on network errors — better to miss one routing hint than to
+// spam the user or double-handle a message.
 
-const THREAD_INDEX_PATH = join(MWF_APP_DIR, 'data', 'mwf-sessions', 'thread-index.json');
-
-/**
- * Check if a DM message belongs to an active MWF session.
- * Reads thread-index.json and looks for a matching {channel}:{thread_ts} key.
- * Returns the session ID if found, null otherwise.
- */
-function checkMwfSessionThread(channel, threadTs) {
-  if (!threadTs) return null;
-  try {
-    const index = JSON.parse(readFileSync(THREAD_INDEX_PATH, 'utf8'));
-    const key = `${channel}:${threadTs}`;
-    return index[key] || null;
-  } catch {
-    return null; // File doesn't exist yet or is unreadable
-  }
+function sessionCheckUrl() {
+  if (!MWF_BACKEND_URL) return null;
+  // MWF_BACKEND_URL looks like https://…/api/v1/slack/mwf-session — swap the
+  // last path segment so /slack/session-check lands at the same mount point.
+  return MWF_BACKEND_URL.replace(/\/mwf-session\/?$/, '/session-check');
 }
 
-/**
- * Check if a DM channel has ANY active MWF session (regardless of thread).
- * Used to detect stray top-level DMs from users who should be replying in
- * their session thread. Returns the thread_ts they should be using, or null.
- */
-function findSessionThreadForChannel(channel) {
+async function fetchSessionInfo(channel, threadTs) {
+  const base = sessionCheckUrl();
+  if (!base) return { isSession: false, activeThreadTs: null };
+  const params = new URLSearchParams({ channel });
+  if (threadTs) params.set('thread_ts', threadTs);
+  const headers = {};
+  if (MWF_INGRESS_SECRET) headers['x-slack-ingress-secret'] = MWF_INGRESS_SECRET;
   try {
-    const index = JSON.parse(readFileSync(THREAD_INDEX_PATH, 'utf8'));
-    const prefix = `${channel}:`;
-    for (const key of Object.keys(index)) {
-      if (key.startsWith(prefix)) {
-        return key.split(':')[1]; // Return the thread_ts
-      }
+    const res = await fetch(`${base}?${params.toString()}`, { headers });
+    if (!res.ok) {
+      logMain(`session-check ${res.status} — treating as non-session`);
+      return { isSession: false, activeThreadTs: null };
     }
-  } catch {
-    // File doesn't exist yet or is unreadable
+    const data = await res.json();
+    return {
+      isSession: Boolean(data.isSession),
+      activeThreadTs: data.activeThreadTs ?? null,
+    };
+  } catch (err) {
+    logMain(`session-check fetch failed: ${err.message}`);
+    return { isSession: false, activeThreadTs: null };
   }
-  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -706,33 +711,30 @@ async function handleMessageEvent(event) {
   // Also catches stray top-level DMs from users who have an active session
   // in this DM channel — replies telling them to use the session thread.
   if (config && config.workspace === 'slack-triage') {
-    const threadTs = event.thread_ts || event.ts;
-    const sessionId = checkMwfSessionThread(channel, threadTs);
-    if (sessionId) {
+    const threadTs = event.thread_ts || null;
+    const info = await fetchSessionInfo(channel, threadTs);
+    if (info.isSession) {
       config = {
         ...config,
         logName: 'check-mwf-session',
         commandSlug: 'mwf-session-reply',
         workspace: 'mwf-session',
       };
-      logMain(`DM message ${ts} matched MWF session ${sessionId} — routing to mwf-session`);
-    } else if (!event.thread_ts) {
-      // Top-level DM (not in any thread) — check if this channel has an active session
-      const sessionThreadTs = findSessionThreadForChannel(channel);
-      if (sessionThreadTs) {
-        // User posted outside their session thread — nudge them back
-        logMain(`Stray DM ${ts} in channel with active session thread ${sessionThreadTs} — sending redirect`);
-        try {
-          await slack.chat.postMessage({
-            channel,
-            text: `It looks like you have an active session here. Please reply in the conversation thread above to continue.`,
-            thread_ts: ts, // Reply to their stray message
-          });
-        } catch (err) {
-          logMain(`Failed to send session redirect: ${err.message}`);
-        }
-        return; // Don't dispatch an agent for this
+      logMain(`DM message ${ts} matched MWF session thread — routing to mwf-session`);
+    } else if (!event.thread_ts && info.activeThreadTs) {
+      // Top-level DM posted while an active session thread exists on the same
+      // channel — nudge them back rather than dispatching an agent.
+      logMain(`Stray DM ${ts} in channel with active session thread ${info.activeThreadTs} — sending redirect`);
+      try {
+        await slack.chat.postMessage({
+          channel,
+          text: `It looks like you have an active session here. Please reply in the conversation thread above to continue.`,
+          thread_ts: ts,
+        });
+      } catch (err) {
+        logMain(`Failed to send session redirect: ${err.message}`);
       }
+      return;
     }
   }
 


### PR DESCRIPTION
## Summary
- After #88, socket listener's DM routing still relied on a local `thread-index.json` written only by the legacy Claude-agent path. Since the backend now owns session state, that file never gets populated — so DM replies were never forwarded, and the bot went silent after the welcome DM.
- Add backend endpoint `GET /api/v1/slack/session-check` (shared-secret auth) that returns `{ isSession, activeThreadTs }` in one round trip.
- Socket listener calls that endpoint instead of reading the stale local file.

## Test plan
- [x] Type check passes
- [x] `slack-session.test.ts` passes (6 tests including auth path)
- [ ] Post-deploy: reply in the DM after `start` and see bot response

🤖 Generated with [Claude Code](https://claude.com/claude-code)