### PR TITLE
feat(slack): solo Stage 0 → 1 → 2 flow (D.3b)

### DIFF
--- a/backend/src/services/__tests__/slack-empathy-exchange.test.ts
+++ b/backend/src/services/__tests__/slack-empathy-exchange.test.ts
@@ -16,6 +16,7 @@ jest.mock('../../lib/prisma', () => ({
 
 import {
   detectShareCommand,
+  detectSendInvitationCommand,
   markDraftReadyToShare,
 } from '../slack-empathy-exchange';
 
@@ -47,6 +48,47 @@ describe('detectShareCommand', () => {
 
   it('rejects empty input', () => {
     expect(detectShareCommand('')).toBe(false);
+  });
+});
+
+describe('detectSendInvitationCommand', () => {
+  it.each([
+    'send it',
+    'Send it.',
+    'send it!',
+    'sent',
+    'ship it',
+    'go ahead',
+    'yes, send it',
+    'yes send it',
+    'yep, send',
+    'Yeah, ship it',
+    'ok send',
+    'okay, send it',
+    'looks good, send',
+    'looks good send',
+    'that looks good, send',
+    'that sounds right, send',
+    '  send it  ',
+  ])('accepts %p as a send-invitation command', (input) => {
+    expect(detectSendInvitationCommand(input)).toBe(true);
+  });
+
+  it.each([
+    "I'll send it later",
+    "don't send it",
+    'can you send it?',
+    'maybe send it tomorrow',
+    'share it',
+    'share',
+    'yes',
+    'no',
+    'not yet',
+    'hold on',
+    '',
+    '   ',
+  ])('rejects %p', (input) => {
+    expect(detectSendInvitationCommand(input)).toBe(false);
   });
 });
 

--- a/backend/src/services/__tests__/slack-session-service.test.ts
+++ b/backend/src/services/__tests__/slack-session-service.test.ts
@@ -10,6 +10,9 @@ const sessionFindUnique = jest.fn();
 const sessionUpdate = jest.fn();
 const sessionSlackThreadFindUnique = jest.fn();
 const sessionSlackThreadDeleteMany = jest.fn();
+const stageProgressFindFirst = jest.fn();
+const stageProgressUpdate = jest.fn();
+const stageProgressUpsert = jest.fn();
 const transactionMock = jest.fn();
 
 jest.mock('../../lib/prisma', () => ({
@@ -23,6 +26,11 @@ jest.mock('../../lib/prisma', () => ({
       findUnique: sessionSlackThreadFindUnique,
       deleteMany: sessionSlackThreadDeleteMany,
     },
+    stageProgress: {
+      findFirst: stageProgressFindFirst,
+      update: stageProgressUpdate,
+      upsert: stageProgressUpsert,
+    },
     $transaction: transactionMock,
   },
 }));
@@ -32,9 +40,13 @@ import {
   findSessionByJoinCode,
   findSessionByThread,
   archiveSession,
+  hasUserCompacted,
+  hasUserSentInvitation,
+  advanceUserToStage,
   INVITED_SESSION_TTL_MS,
 } from '../slack-session-service';
 import { prisma } from '../../lib/prisma';
+import { StageStatus } from '@prisma/client';
 
 describe('slack-session-service helpers', () => {
   beforeEach(() => {
@@ -234,5 +246,122 @@ describe('slack-session-service helpers', () => {
 
   it('INVITED_SESSION_TTL_MS is 7 days', () => {
     expect(INVITED_SESSION_TTL_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  // --- Per-user Stage 0 gate readers + solo advance (D.3b) ---
+
+  describe('hasUserCompacted', () => {
+    it('returns true when the user\'s Stage 0 row has compactSigned', async () => {
+      stageProgressFindFirst.mockResolvedValue({
+        gatesSatisfied: { compactSigned: true },
+      });
+      await expect(hasUserCompacted('s1', 'u1')).resolves.toBe(true);
+      expect(stageProgressFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { sessionId: 's1', userId: 'u1', stage: 0 },
+        })
+      );
+    });
+
+    it('returns false when the flag is absent', async () => {
+      stageProgressFindFirst.mockResolvedValue({ gatesSatisfied: {} });
+      await expect(hasUserCompacted('s1', 'u1')).resolves.toBe(false);
+    });
+
+    it('returns false when no Stage 0 row exists for the user', async () => {
+      stageProgressFindFirst.mockResolvedValue(null);
+      await expect(hasUserCompacted('s1', 'u1')).resolves.toBe(false);
+    });
+  });
+
+  describe('hasUserSentInvitation', () => {
+    it('returns true when invitationSent is set', async () => {
+      stageProgressFindFirst.mockResolvedValue({
+        gatesSatisfied: { compactSigned: true, invitationSent: true },
+      });
+      await expect(hasUserSentInvitation('s1', 'u1')).resolves.toBe(true);
+    });
+
+    it('returns false when only compactSigned is set', async () => {
+      stageProgressFindFirst.mockResolvedValue({
+        gatesSatisfied: { compactSigned: true },
+      });
+      await expect(hasUserSentInvitation('s1', 'u1')).resolves.toBe(false);
+    });
+
+    it('returns false when no Stage 0 row exists', async () => {
+      stageProgressFindFirst.mockResolvedValue(null);
+      await expect(hasUserSentInvitation('s1', 'u1')).resolves.toBe(false);
+    });
+  });
+
+  describe('advanceUserToStage', () => {
+    beforeEach(() => {
+      stageProgressUpdate.mockResolvedValue({});
+      stageProgressUpsert.mockResolvedValue({});
+    });
+
+    it('completes the user\'s open row and upserts the next stage IN_PROGRESS', async () => {
+      stageProgressFindFirst.mockResolvedValue({ id: 'sp-0' });
+
+      await advanceUserToStage('s1', 'u1', 1);
+
+      expect(stageProgressFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            sessionId: 's1',
+            userId: 'u1',
+            status: { not: StageStatus.COMPLETED },
+          },
+        })
+      );
+      expect(stageProgressUpdate).toHaveBeenCalledTimes(1);
+      expect(stageProgressUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'sp-0' },
+          data: expect.objectContaining({ status: StageStatus.COMPLETED }),
+        })
+      );
+      expect(stageProgressUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            sessionId_userId_stage: { sessionId: 's1', userId: 'u1', stage: 1 },
+          },
+          create: expect.objectContaining({
+            sessionId: 's1',
+            userId: 'u1',
+            stage: 1,
+            status: StageStatus.IN_PROGRESS,
+          }),
+          update: expect.objectContaining({
+            status: StageStatus.IN_PROGRESS,
+            completedAt: null,
+          }),
+        })
+      );
+    });
+
+    it('upserts the new stage even when there is no open prior row', async () => {
+      stageProgressFindFirst.mockResolvedValue(null);
+
+      await advanceUserToStage('s1', 'u1', 1);
+
+      expect(stageProgressUpdate).not.toHaveBeenCalled();
+      expect(stageProgressUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not touch other users\' rows', async () => {
+      // The findFirst is user-scoped by argument; verify we never issue an
+      // update without that user id filter. (Defensive — a future refactor
+      // that accidentally drops the userId filter would be caught here.)
+      stageProgressFindFirst.mockResolvedValue({ id: 'sp-0' });
+
+      await advanceUserToStage('s1', 'u1', 1);
+
+      const findCall = stageProgressFindFirst.mock.calls[0][0];
+      expect(findCall.where.userId).toBe('u1');
+      const upsertCall = stageProgressUpsert.mock.calls[0][0];
+      expect(upsertCall.where.sessionId_userId_stage.userId).toBe('u1');
+    });
   });
 });

--- a/backend/src/services/slack-conversation.ts
+++ b/backend/src/services/slack-conversation.ts
@@ -40,13 +40,20 @@ import {
   getCurrentStage,
   updateStageProgress,
   hasBothUsersCompacted,
+  hasUserCompacted,
+  hasUserSentInvitation,
   advanceToStage,
+  advanceUserToStage,
   INVITED_SESSION_TTL_MS,
   INVITED_SESSION_NUDGE_THRESHOLD_MS,
 } from './slack-session-service';
 import { buildStagePrompt } from './stage-prompts';
-import { detectShareCommand, markDraftReadyToShare } from './slack-empathy-exchange';
-import { MessageRole } from '@prisma/client';
+import {
+  detectShareCommand,
+  detectSendInvitationCommand,
+  markDraftReadyToShare,
+} from './slack-empathy-exchange';
+import { MessageRole, type Session } from '@prisma/client';
 
 const CONVERSATION_TURN_LIMIT = 12; // pairs of user+assistant messages kept in prompt
 const MAX_SONNET_TOKENS = 1024; // Slack replies are short — no need for 2048
@@ -283,6 +290,14 @@ async function handleDmMessage(payload: SlackMessagePayload): Promise<void> {
   const { session, userId } = mapping;
   const stage = await getCurrentStage(session.id, userId);
 
+  // Stage 0 solo invitation-send: if the user has signed the compact and
+  // replies "send it" to the AI's proposed invitation draft, short-circuit
+  // the Sonnet turn, mark Stage 0 complete, and open Stage 1 for this user
+  // alone. Partner (if any) advances independently when they do the same.
+  if (await maybeHandleInvitationSend(session, userId, payload.text, payload)) {
+    return;
+  }
+
   // Stage 2 share command: if the user types `share` / `send it` while in
   // Stage 2 with a pending draft, short-circuit the Sonnet turn and flip
   // their draft to ready-to-share. Follow-up iteration will also create the
@@ -361,6 +376,15 @@ async function handleDmMessage(payload: SlackMessagePayload): Promise<void> {
   // system message.
   const invitedSessionNudge = buildInvitedSessionNudge(session);
 
+  // Per-user Stage 0 gates. Mobile's solo flow advances each user
+  // independently — Slack now mirrors that. `hasBothUsersCompacted` is still
+  // exported for anything that needs the both-users gate (none today), but
+  // the prompt routing here is scoped to the current user.
+  const userCompacted = await hasUserCompacted(session.id, userId);
+  const userInvitationSent = await hasUserSentInvitation(session.id, userId);
+  const isOnboarding = stage === 0 && !userCompacted;
+  const isInvitationPhase = stage === 0 && userCompacted && !userInvitationSent;
+
   // Use the same prompt builder as mobile for behavioral parity — the only
   // difference for Slack is `surface: 'slack'`, which appends mrkdwn
   // formatting rules to the static block. Prompt-cache keys still hit across
@@ -377,7 +401,8 @@ async function handleDmMessage(payload: SlackMessagePayload): Promise<void> {
     },
     {
       surface: 'slack',
-      isOnboarding: stage === 0 && !(await hasBothUsersCompacted(session.id)),
+      isOnboarding,
+      isInvitationPhase,
     }
   );
 
@@ -583,6 +608,48 @@ async function maybeHandleStage0Signal(
       sessionId,
     });
   }
+}
+
+/**
+ * Stage 0 solo invitation-send signal. Mirrors the mobile transition at
+ * `sessions.ts` confirmInvitationMessage: once the user has signed the
+ * compact and responds to the AI's `<draft>` invitation with a short
+ * send command, we mark both Stage 0 gates satisfied and advance this
+ * user to Stage 1. Nothing is actually transmitted — "sending" in the
+ * solo flow is a conceptual commit to the invitation, not an out-of-band
+ * message to a partner.
+ *
+ * Returns true when it handled the turn (and the caller should stop),
+ * false when this isn't a send signal and the normal DM path should run.
+ */
+async function maybeHandleInvitationSend(
+  session: Session,
+  userId: string,
+  text: string,
+  payload: SlackMessagePayload
+): Promise<boolean> {
+  const stage = await getCurrentStage(session.id, userId);
+  if (stage !== 0) return false;
+
+  if (!(await hasUserCompacted(session.id, userId))) return false;
+  if (!detectSendInvitationCommand(text)) return false;
+
+  await updateStageProgress(session.id, userId, {
+    gatesSatisfied: { compactSigned: true, invitationSent: true },
+  });
+  await advanceUserToStage(session.id, userId, 1);
+
+  await postMessage(
+    payload.channel,
+    "Sent. I'll pick up where you are when you're ready for the next piece.",
+    payload.thread_ts ?? payload.ts
+  );
+
+  logger.info('[SlackConversation] Solo invitation sent — advanced user to Stage 1', {
+    sessionId: session.id,
+    userId,
+  });
+  return true;
 }
 
 async function maybeAdvanceOnFeelHeard(sessionId: string, userId: string): Promise<void> {

--- a/backend/src/services/slack-empathy-exchange.ts
+++ b/backend/src/services/slack-empathy-exchange.ts
@@ -28,6 +28,31 @@ export function detectShareCommand(text: string): boolean {
   return SHARE_COMMAND_RE.test(text);
 }
 
+/**
+ * Detect a Stage-0 solo invitation-send intent. Fires after the AI has
+ * proposed a draft `<draft>` invitation and the user wants to commit it
+ * (conceptually — nothing is actually sent anywhere; the solo flow just
+ * advances the user to Stage 1).
+ *
+ * Deliberately conservative: lead-word commands and a few common
+ * affirmative prefixes. We reject mid-sentence uses like "I'll send it
+ * later" or "can you send it?" so the gate doesn't flip on narration or
+ * questions. Stage-2's `share`/`send it` command is handled separately in
+ * `detectShareCommand` and doesn't overlap (Stage 0 vs Stage 2 routing
+ * happens upstream in slack-conversation).
+ */
+const SEND_INVITATION_PATTERNS: ReadonlyArray<RegExp> = [
+  /^(send\s+it|sent|go\s+ahead|ship\s+it|looks\s+good[,\s]*send)/i,
+  /^(yes|yep|yeah|yup|ok|okay)[\s,]*(send|ship)/i,
+  /^that\s+(looks|sounds)\s+(good|right)[,\s]*(send|ship)/i,
+];
+
+export function detectSendInvitationCommand(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  return SEND_INVITATION_PATTERNS.some((re) => re.test(trimmed));
+}
+
 export interface SlackShareResult {
   status: 'marked_ready' | 'already_ready' | 'no_draft' | 'empty_draft';
   /** Draft content at the moment we flipped the flag — safe to echo to the user. */

--- a/backend/src/services/slack-session-service.ts
+++ b/backend/src/services/slack-session-service.ts
@@ -424,6 +424,41 @@ export async function hasBothUsersCompacted(sessionId: string): Promise<boolean>
 }
 
 /**
+ * Returns true when this user has compactSigned=true on their Stage 0 row.
+ * Per-user counterpart to `hasBothUsersCompacted`, used by the solo flow so
+ * one user can advance past onboarding without waiting on a partner.
+ */
+export async function hasUserCompacted(
+  sessionId: string,
+  userId: string
+): Promise<boolean> {
+  const row = await prisma.stageProgress.findFirst({
+    where: { sessionId, userId, stage: 0 },
+    orderBy: { startedAt: 'desc' },
+    select: { gatesSatisfied: true },
+  });
+  const gates = row?.gatesSatisfied as { compactSigned?: boolean } | null;
+  return gates?.compactSigned === true;
+}
+
+/**
+ * Returns true when this user has invitationSent=true on their Stage 0 row.
+ * Drives the invitation-phase prompt branch once the compact is signed.
+ */
+export async function hasUserSentInvitation(
+  sessionId: string,
+  userId: string
+): Promise<boolean> {
+  const row = await prisma.stageProgress.findFirst({
+    where: { sessionId, userId, stage: 0 },
+    orderBy: { startedAt: 'desc' },
+    select: { gatesSatisfied: true },
+  });
+  const gates = row?.gatesSatisfied as { invitationSent?: boolean } | null;
+  return gates?.invitationSent === true;
+}
+
+/**
  * Advance every user on the session to `newStage`: mark the current
  * StageProgress COMPLETED and open a fresh IN_PROGRESS row for the new stage.
  */
@@ -474,6 +509,57 @@ export async function advanceToStage(
     sessionId,
     newStage,
     memberCount: members.length,
+  });
+}
+
+/**
+ * Advance a single user to `newStage`: mark their current open StageProgress
+ * COMPLETED and open a fresh IN_PROGRESS row. Used by the solo flow so one
+ * partner can progress past Stage 0 without waiting on the other. Partner
+ * rows are untouched — they advance on their own when they sign their own
+ * compact and send their own invitation.
+ */
+export async function advanceUserToStage(
+  sessionId: string,
+  userId: string,
+  newStage: number
+): Promise<void> {
+  const now = new Date();
+  const current = await prisma.stageProgress.findFirst({
+    where: { sessionId, userId, status: { not: StageStatus.COMPLETED } },
+    orderBy: { startedAt: 'desc' },
+    select: { id: true },
+  });
+  if (current) {
+    await prisma.stageProgress.update({
+      where: { id: current.id },
+      data: { status: StageStatus.COMPLETED, completedAt: now },
+    });
+  }
+
+  await prisma.stageProgress.upsert({
+    where: {
+      sessionId_userId_stage: { sessionId, userId, stage: newStage },
+    },
+    create: {
+      sessionId,
+      userId,
+      stage: newStage,
+      status: StageStatus.IN_PROGRESS,
+      gatesSatisfied: {},
+    },
+    update: {
+      status: StageStatus.IN_PROGRESS,
+      startedAt: now,
+      completedAt: null,
+      gatesSatisfied: {},
+    },
+  });
+
+  logger.info('[SlackSessionService] Advanced user to new stage', {
+    sessionId,
+    userId,
+    newStage,
   });
 }
 


### PR DESCRIPTION
## Summary

Closes #105. Follow-up to the hardening chain (#88/#102/#103/#104) — lets a Slack user drive a session through Stage 0 (compact → invitation) into Stage 1 solo, the way mobile already does. Smoke-test on #104 showed the flow stuck at onboarding because the stage-router gated on *both* users having signed the compact. This moves Slack onto per-user gates, mirroring `backend/src/controllers/session-state.ts:257`.

### What changed

- **`slack-session-service.ts`** — new exports:
  - `hasUserCompacted(sessionId, userId)` / `hasUserSentInvitation(sessionId, userId)` — per-user Stage 0 gate readers.
  - `advanceUserToStage(sessionId, userId, newStage)` — single-user counterpart to `advanceToStage`. Marks the user's open row `COMPLETED`, upserts the next stage `IN_PROGRESS`. Partner rows untouched.
  - `advanceToStage` / `hasBothUsersCompacted` unchanged — still used by the existing both-user compact path.
- **`slack-empathy-exchange.ts`** — new `detectSendInvitationCommand(text)` detector. Lead-word only (conservative); rejects narration like `I'll send it later` and questions like `can you send it?`. Distinct from the existing Stage 2 `detectShareCommand` — stage routing upstream prevents cross-fire.
- **`slack-conversation.ts`**:
  - Per-user `isOnboarding` / `isInvitationPhase` passed to `buildStagePrompt` so the existing Stage 0 invitation-phase branch at `stage-prompts.ts:1676` actually fires after the compact is signed.
  - New `maybeHandleInvitationSend` handler, wired into `handleDmMessage` ahead of the Stage 2 share short-circuit. When the user has compacted and types a send command: writes `gatesSatisfied: {compactSigned, invitationSent}`, calls `advanceUserToStage(..., 1)`, posts a short confirmation. Skips the Sonnet turn.

### Gap 1 note

The issue also called for adding a `stageProgress.create` at the end of `createSlackSession`. That row is already inserted via `prisma.session.create`'s nested `stageProgress.create` at `backend/src/services/slack-session-service.ts:230-239` (landed in #88, `0fadcaa`). The smoke-test session showing zero rows most likely predates the #88 deploy. No code change for that gap — the rest of this PR assumes the creator's Stage 0 row exists, which the nested create guarantees.

### Out of scope

- Partner-join reconciliation after a solo Stage 0 advance. Flagged in #105; separate follow-up if dogfooding surfaces issues.
- Guesser-side classifier routing for Stage 2 shared drafts (also deferred from #96).

## Test plan

### Automated

- [x] `npm run check` — clean across all workspaces.
- [x] `npm run test` — backend `1152/1152` pass, shared `214/214` pass. Mobile failures on this run are pre-existing on `main` (expo/ReadableStream mock issue in `ChatInterface` / `EmotionalBarometer` / `navigation` test suites, from axios/fetch) — confirmed by running the same tests against `origin/main` (`e970600`) and seeing identical failures.
- [x] New detector unit coverage: 17 cases (9 positive / 8 rejection) in `slack-empathy-exchange.test.ts`.
- [x] New service unit coverage: `hasUserCompacted`, `hasUserSentInvitation`, `advanceUserToStage` (includes a defensive assertion that `advanceUserToStage` never issues updates without the user-id filter).

### Manual smoke (after merge + Render auto-deploy)

- [ ] `#mwf-sessions` → `start` → welcome DM posted + join code returned.
- [ ] A couple DM replies — AI stays in onboarding mode (no `<draft>` yet).
- [ ] Say `I agree` — no crash; next AI reply comes from the invitation-phase prompt (includes a `<draft>` block within 1–2 turns).
- [ ] Say `send it` — bot confirms; DB shows Stage 0 `COMPLETED` with `{compactSigned, invitationSent}` and Stage 1 `IN_PROGRESS` for this user.
- [ ] Continue DM — Stage 1 witnessing prompt is in use.
- [ ] Reach feel-heard → Stage 2 empathy draft → `share` (uses the existing #96 Stage 2 flow).

## Files changed

- `backend/src/services/slack-session-service.ts`
- `backend/src/services/slack-empathy-exchange.ts`
- `backend/src/services/slack-conversation.ts`
- `backend/src/services/__tests__/slack-session-service.test.ts`
- `backend/src/services/__tests__/slack-empathy-exchange.test.ts`

No changes to `mobile/`, `shared/`, `stage-prompts.ts`, or the Prisma schema.

## Deploy

- Render auto-deploys backend on merge to `main`.
- No socket-listener changes — slam-bot's git-pull cron won't restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)