### PR TITLE
chore(bot): remove cooldown on bot:expert-review

### DIFF
--- a/bot-workspaces/label-registry.json
+++ b/bot-workspaces/label-registry.json
@@ -51,6 +51,7 @@
       "entry_stage": "01-initialize",
       "trigger": "label",
       "keep_label": true,
+      "cooldown_secs": 0,
       "effort": "max"
     },
     "bot:milestone-builder": {


### PR DESCRIPTION
## Summary

Set `cooldown_secs: 0` on `bot:expert-review` so the workspace-dispatcher runs each pass back-to-back instead of waiting the default 1800s (30 min) between experts.

The expert-review state machine advances on its own (`current_expert_index` in the state JSON ramps 0→1→2→3 across passes, then terminates), so the cooldown was only a safety net preventing relaunch loops — unnecessary for a workspace that naturally terminates.

All other multi-pass workspaces (`bot:needs-info`, anything else `keep_label: true`) keep their default 1800s via `KEEP_LABEL_COOLDOWN_SECS`.

## Test plan

- [x] JSON validates (`python3 -c 'import json; json.load(open(...))'`)
- [ ] After merge: slam-bot's git-pull cron picks up the change within ≤1 min
- [ ] Next tick of `/opt/slam-bot/scripts/workspace-dispatcher.sh` reads the new `cooldown_secs: 0` and dispatches #108 immediately on completion of the previous pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)