### PR TITLE
docs: fix drift from 24h incremental audit (2026-04-18)

### DIFF
--- a/docs/backend/api/index.md
+++ b/docs/backend/api/index.md
@@ -183,6 +183,7 @@ Slack-originated MWF sessions. These routes use shared-secret auth (not Clerk JW
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
+| `GET`  | `/slack/session-check` | Check if a `(channel, thread_ts)` pair is an active MWF session thread. Used by the EC2 socket listener to route DMs. Returns `{ ok: true, isSession: bool, activeThreadTs: string\|null }` |
 | `POST` | `/slack/mwf-session` | Accept a Slack message payload from the EC2 socket listener |
 | `GET`  | `/slack/health` | Health check: workspace load status and Slack configuration |
 

--- a/docs/backend/prompt-caching.md
+++ b/docs/backend/prompt-caching.md
@@ -3,7 +3,7 @@ title: Prompt Caching Strategy for Meet Without Fear
 sidebar_position: 4
 description: "This document describes how Anthropic's prompt caching works and how we implement it. Our system prompts are split into static and dynamic blocks (the \"2-blo..."
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-04-18
 status: living
 ---
 # Prompt Caching Strategy for Meet Without Fear
@@ -183,6 +183,8 @@ Response protocol              (~100 tokens)
 
 **What about `userName` and `partnerName`?** These are session-stable (never change within a conversation) and caches are per-user anyway on Bedrock, so including them in the static block is fine. They don't bust the cache.
 
+**Slack surface addition:** When `BuildStagePromptOptions.surface === 'slack'`, `SLACK_FORMATTING_RULES` (~60 tokens) is appended to the static block. This block is identical on every Slack turn, so it caches normally. All stage token counts above reflect the mobile surface; Slack adds ~60 tokens to each static block but all stages remain well above the 1,024-token threshold.
+
 ### Block 2: Dynamic Turn Context (~10-70 tokens, NOT cached)
 
 Everything that changes every turn:
@@ -196,6 +198,7 @@ Feel-heard turn guard                     (~15 tokens)  "Too early (turn < 3)"
 Early stage flags                         (~15 tokens)  Conditional on turnCount
 Post-share context                        (~varies)     Only after sharing events
 Transition injection                      (~varies)     Only on stage transitions
+Invited-session nudge                     (~varies)     Only when invitedSessionNudge is set (Slack INVITED sessions nearing 7-day TTL)
 ```
 
 ### What We Send to Claude

--- a/docs/backend/prompting-architecture.md
+++ b/docs/backend/prompting-architecture.md
@@ -3,7 +3,7 @@ title: Backend Prompting Architecture Audit
 sidebar_position: 5
 description: "Last Updated: 2026-03-11"
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-04-18
 status: living
 ---
 # Backend Prompting Architecture Audit
@@ -477,6 +477,11 @@ graph TD
    - User memories (preferences, names, communication style)
    - **Categorized session facts** (People, Logistics, Conflict, Emotional, History)
    - Retrieved context (cross-session, relevant history)
+
+4. **Surface-Specific Formatting (Slack):**
+   When `BuildStagePromptOptions.surface === 'slack'`, `SLACK_FORMATTING_RULES` is appended to the static block. This block instructs the model to use Slack mrkdwn (single `*asterisks*` for bold, `•` for bullets, `<url|label>` for links) instead of standard Markdown. The rules are kept in the static block to preserve prompt caching — they are identical across turns. No other behavior changes: prompt logic, context assembly, and model routing are the same for both surfaces.
+
+   When `PromptContext.invitedSessionNudge` is set (non-null), its content is appended to the dynamic block as `OPERATIONAL NUDGE:`. This signals the AI to weave in an invite-expiry reminder. Only used for Slack-originated `INVITED` sessions approaching their 7-day TTL.
 
 4. **Dynamic Elements:**
    - Turn count

--- a/docs/backend/prompting-architecture.md
+++ b/docs/backend/prompting-architecture.md
@@ -483,7 +483,7 @@ graph TD
 
    When `PromptContext.invitedSessionNudge` is set (non-null), its content is appended to the dynamic block as `OPERATIONAL NUDGE:`. This signals the AI to weave in an invite-expiry reminder. Only used for Slack-originated `INVITED` sessions approaching their 7-day TTL.
 
-4. **Dynamic Elements:**
+5. **Dynamic Elements:**
    - Turn count
    - Emotional intensity
    - Surfacing style

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -3,7 +3,7 @@ title: "Stage 2: Perspective Stretch - Empathy Exchange Flow"
 sidebar_position: 6
 description: This document describes the empathy exchange flow in Stage 2, including the reconciler system that analyzes empathy accuracy and manages the sharing of addit...
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-04-18
 status: living
 ---
 # Stage 2: Perspective Stretch - Empathy Exchange Flow
@@ -182,6 +182,12 @@ sequenceDiagram
 > **Implementation:** Share suggestion generation is handled by `reconciler/sharing.ts` which contains
 > `generateShareSuggestion()`, `respondToShareSuggestion()`, `generatePostShareContinuation()`, and
 > `generateContextReceivedReflection()`. The module includes delivery status tracking and fallback messages for AI failures.
+
+### Slack Gentle Interrupt
+
+When the subject shares context and `refinementFinalizeHandler` delivers it to the guesser, an async Slack DM notification is sent to the guesser (if they are a Slack user) via `notifyGuesserOfShareViaSlack()` in `slack-reconciler-notify.ts`.
+
+This is fire-and-forget: it runs non-blocking (`catch` logs the error) so a Slack outage cannot affect the mobile delivery path. Mobile users receive no Slack notification — the in-app Ably event is the only signal for them.
 
 ## User Experience: Both Users' Perspective
 

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -2,7 +2,7 @@
 title: Infrastructure
 sidebar_position: 1
 description: Slam bot (EC2), Render hosting, Vercel deploys, GitHub automation.
-updated: 2026-04-17
+updated: 2026-04-18
 ---
 
 # Infrastructure
@@ -22,7 +22,7 @@ Operational infrastructure for Meet Without Fear.
 
 | Service | Purpose |
 |---|---|
-| `slam-bot-socket.service` | Socket Mode listener for real-time Slack events. For `#mwf-sessions` channel messages, the listener forwards payloads to the backend via `POST /api/slack/mwf-session` (authenticated with `SLACK_INGRESS_SECRET`) instead of spawning a Claude Code agent. The backend runs the full Bedrock pipeline and posts replies back to Slack. |
+| `slam-bot-socket.service` | Socket Mode listener for real-time Slack events. For each DM, first queries `GET /api/slack/session-check` (authenticated with `SLACK_INGRESS_SECRET`) to detect active MWF sessions in Postgres. If `isSession=true`, forwards the payload to `POST /api/slack/mwf-session` (backend Bedrock pipeline); otherwise dispatches to the `slack-triage` workspace. For `#mwf-sessions` lobby messages, always forwards to the backend. |
 | `slam-bot-state-scanner.service` | GitHub state scanner daemon (`github-state-scanner.sh` loop). Hardened with `MemoryMax=256M` and `TasksMax=64` to prevent runaway resource use. |
 
 ### Cron jobs
@@ -61,21 +61,16 @@ The bot maintains session state on disk at `~/meet-without-fear/`:
 | Directory | Purpose |
 |---|---|
 | `data/mwf-sessions/` | MWF session data, one subdirectory per session ID |
-| `data/mwf-sessions/thread-index.json` | Maps `{channel}:{thread_ts}` → `{session_id}` for DM routing lookup |
 | `data/mwf-users/` | Per-user profile data (name, previous sessions, etc.) |
-
-`thread-index.json` is read on every incoming DM to check if the message belongs to an active MWF session. It is maintained by the `route` stage in the `mwf-session` workspace.
 
 ### MWF session routing
 
 The socket listener implements session-aware message routing:
 
-- **Session detection**: On each DM message, checks `data/mwf-sessions/thread-index.json` for active session threads
-- **DM → mwf-session mapping**: Messages in a DM thread matching an active MWF session are routed to the `mwf-session` workspace instead of `slack-triage`
-- **Stray DM prevention**: Top-level DMs (outside any thread) from users with active sessions are redirected with a nudge to use their session thread
+- **Session detection**: On each DM message, queries `GET /api/slack/session-check?channel=C&thread_ts=T` (authenticated with `SLACK_INGRESS_SECRET`) to check if the thread is an active MWF session. Session state lives in Postgres (`SessionSlackThread` table); the backend is the authoritative source.
+- **DM → mwf-session mapping**: Messages where the backend returns `isSession=true` are POSTed to `POST /api/slack/mwf-session` (Bedrock pipeline) instead of dispatched to a Claude agent workspace
+- **Stray DM prevention**: Top-level DMs (outside any thread) in a channel with an active session receive the `activeThreadTs` from the session-check response; the listener nudges the user back to their session thread
 - **Lobby channel**: `#mwf-sessions` is used for session setup only; actual conversations happen in private DMs (one DM thread per user) to enforce vessel privacy at the transport layer
-
-See `bot-workspaces/mwf-session/CLAUDE.md` for full architecture and stage contracts.
 
 ## Production hosting
 


### PR DESCRIPTION
## Changes
- Add: `GET /slack/session-check` endpoint to Slack Ingress table in `docs/backend/api/index.md`
- Fix: Remove stale `thread-index.json` references from `docs/infrastructure/index.md`; replace with backend session-check API description
- Fix: Update systemd socket service description to reflect new DM routing flow
- Add: Slack gentle interrupt documentation to `docs/backend/reconciler-flow.md`
- Add: Slack surface (`surface?: 'mobile' | 'slack'`) and `invitedSessionNudge` documentation to `docs/backend/prompting-architecture.md` and `docs/backend/prompt-caching.md`

## Provenance
- **Channel:** cron / audit-docs
- **Requested by:** automated nightly audit
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** incremental audit stage

## Docs updated
- `docs/backend/api/index.md` — added missing `/slack/session-check` endpoint
- `docs/infrastructure/index.md` — removed `thread-index.json` (legacy file replaced by backend API), updated MWF session routing description
- `docs/backend/reconciler-flow.md` — added Slack gentle interrupt note
- `docs/backend/prompting-architecture.md` — added Slack surface and `invitedSessionNudge` documentation
- `docs/backend/prompt-caching.md` — added Slack surface static-block addition and `invitedSessionNudge` dynamic-block entry