### PR TITLE
fix(backend): scope turn count to current stage, extend Stage 3 threshold

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -35,6 +35,7 @@ import { consolidateGlobalFacts } from '../services/global-memory';
 import { assembleContextBundle, formatContextForPrompt } from '../services/context-assembler';
 import type { MemoryIntentResult } from '../services/memory-intent';
 import { handleDispatch, type DispatchContext } from '../services/dispatch-handler';
+import { runStage3SafetyNetExtraction } from '../services/needs';
 import { getMilestoneContext, getSharedContentContext } from '../services/shared-context';
 import { CONTEXT_WINDOW, trimConversationHistory } from '../utils/token-budget';
 import { estimateContextSizes, finalizeTurnMetrics, recordContextSizes } from '../services/llm-telemetry';
@@ -1840,17 +1841,16 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     });
     logger.info(`[sendMessageStream:${requestId}] AI message created: ${aiMessage.id}`);
 
-    // Stage 3 safety net: if user has sent many messages but no needs extracted, trigger extraction
+    // Stage 3 safety net: after enough stage-3 turns with no needs extracted,
+    // run a lightweight extraction so the system surfaces needs the AI may have
+    // missed, rather than just alerting a stalled state. Fire-and-forget —
+    // don't block the response stream on a Bedrock call.
     if (effectiveStage === 3 && stageTurnCount >= 6) {
-      const existingNeeds = await prisma.needScore.findMany({
-        where: { userId: user.id },
-        select: { id: true },
-        take: 1,
-      });
-      if (existingNeeds.length === 0) {
-        logger.warn(`[sendMessageStream:${requestId}] Stage 3 safety net: ${userTurnCount} turns but no needs extracted, notifying for refetch`);
-        await publishSessionEvent(sessionId, 'session.resumed', { userId: user.id, reason: 'needs-safety-net' });
-      }
+      void runStage3SafetyNetExtraction(
+        sessionId,
+        user.id,
+        `[sendMessageStream:${requestId}]`
+      );
     }
 
     // Broadcast to Status Site

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1200,14 +1200,28 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
 
     // Count ALL user messages for this session (not just from the limited history window)
     // This prevents turn IDs from getting stuck when conversation exceeds 20 messages
-    const userTurnCount = await prisma.message.count({
-      where: {
-        sessionId,
-        role: 'USER',
-        senderId: user.id,
-        forUserId: null,
-      },
-    });
+    // Also count user messages in the CURRENT stage only — stage-specific guards
+    // (e.g., feel-heard check, early-stage guidance) need stage-scoped counts so they
+    // don't fire prematurely due to accumulated turns from earlier stages.
+    const [userTurnCount, stageTurnCount] = await Promise.all([
+      prisma.message.count({
+        where: {
+          sessionId,
+          role: 'USER',
+          senderId: user.id,
+          forUserId: null,
+        },
+      }),
+      prisma.message.count({
+        where: {
+          sessionId,
+          role: 'USER',
+          senderId: user.id,
+          forUserId: null,
+          stage: currentStage,
+        },
+      }),
+    ]);
     const turnId = `${sessionId}-${user.id}-${userTurnCount}`;
     updateContext({ turnId, sessionId, userId: user.id });
 
@@ -1374,7 +1388,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     const prompt = buildStagePrompt(effectiveStage, {
       userName,
       partnerName,
-      turnCount: userTurnCount,
+      turnCount: stageTurnCount,
       emotionalIntensity,
       contextBundle,
       sharedContentHistory,
@@ -1827,7 +1841,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     logger.info(`[sendMessageStream:${requestId}] AI message created: ${aiMessage.id}`);
 
     // Stage 3 safety net: if user has sent many messages but no needs extracted, trigger extraction
-    if (effectiveStage === 3 && userTurnCount >= 6) {
+    if (effectiveStage === 3 && stageTurnCount >= 6) {
       const existingNeeds = await prisma.needScore.findMany({
         where: { userId: user.id },
         select: { id: true },

--- a/backend/src/controllers/stage3.ts
+++ b/backend/src/controllers/stage3.ts
@@ -12,46 +12,17 @@ import { Request, Response } from 'express';
 import { Prisma } from '@prisma/client';
 import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
-import { extractNeedsFromConversation, findCommonGround } from '../services/needs';
+import {
+  extractNeedsFromConversation,
+  findCommonGround,
+  isExtractionRunning,
+  acquireExtractionLock,
+  releaseExtractionLock,
+} from '../services/needs';
 import { confirmNeedsRequestSchema, ConsentContentType } from '@meet-without-fear/shared';
 import { notifyPartner, publishSessionEvent } from '../services/realtime';
 import { successResponse, errorResponse } from '../utils/response';
 import { getPartnerUserId } from '../utils/session';
-
-// ============================================================================
-// Extraction Lock (in-memory idempotency guard)
-// ============================================================================
-
-/**
- * Track in-progress needs extractions to prevent concurrent AI calls.
- * Key: `${sessionId}:${userId}`, Value: timestamp when extraction started.
- */
-const extractionLocks = new Map<string, number>();
-const EXTRACTION_LOCK_TIMEOUT_MS = 60_000; // 60 seconds max
-
-function getExtractionKey(sessionId: string, userId: string): string {
-  return `${sessionId}:${userId}`;
-}
-
-function isExtractionRunning(sessionId: string, userId: string): boolean {
-  const key = getExtractionKey(sessionId, userId);
-  const startedAt = extractionLocks.get(key);
-  if (!startedAt) return false;
-  // Auto-expire stale locks
-  if (Date.now() - startedAt > EXTRACTION_LOCK_TIMEOUT_MS) {
-    extractionLocks.delete(key);
-    return false;
-  }
-  return true;
-}
-
-function setExtractionLock(sessionId: string, userId: string): void {
-  extractionLocks.set(getExtractionKey(sessionId, userId), Date.now());
-}
-
-function clearExtractionLock(sessionId: string, userId: string): void {
-  extractionLocks.delete(getExtractionKey(sessionId, userId));
-}
 
 // ============================================================================
 // Common Ground Analysis Lock (in-memory idempotency guard)
@@ -232,7 +203,7 @@ export async function getNeeds(req: Request, res: Response): Promise<void> {
         return;
       }
 
-      setExtractionLock(sessionId, user.id);
+      acquireExtractionLock(sessionId, user.id);
       try {
         needs = await extractNeedsFromConversation(sessionId, user.id);
 
@@ -248,7 +219,7 @@ export async function getNeeds(req: Request, res: Response): Promise<void> {
           }
         }
       } finally {
-        clearExtractionLock(sessionId, user.id);
+        releaseExtractionLock(sessionId, user.id);
       }
     }
 

--- a/backend/src/routes/__tests__/stage3.test.ts
+++ b/backend/src/routes/__tests__/stage3.test.ts
@@ -16,6 +16,10 @@ jest.mock('../../lib/prisma');
 jest.mock('../../services/needs', () => ({
   extractNeedsFromConversation: jest.fn(),
   findCommonGround: jest.fn(),
+  isExtractionRunning: jest.fn().mockReturnValue(false),
+  acquireExtractionLock: jest.fn(),
+  releaseExtractionLock: jest.fn(),
+  runStage3SafetyNetExtraction: jest.fn(),
 }));
 
 // Mock realtime service

--- a/backend/src/services/__tests__/needs-safety-net.test.ts
+++ b/backend/src/services/__tests__/needs-safety-net.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the Stage 3 safety-net extraction helper in `services/needs.ts`.
+ *
+ * Covers the content-aware pacing counterpart to the stage-prompt changes:
+ * after 6 stage-3 turns with no extracted needs, we run extraction instead
+ * of just alerting a stalled state.
+ *
+ * Scope note: these tests verify the *control flow* of the safety-net —
+ * short-circuits, lock behavior, error containment — without trying to
+ * mock `extractNeedsFromConversation` itself. Internal module bindings
+ * bypass `jest.mock` on the same module, so we instead starve the real
+ * extraction path at the prisma boundary (empty messages → zero needs).
+ */
+
+import { prisma } from '../../lib/prisma';
+import {
+  runStage3SafetyNetExtraction,
+  isExtractionRunning,
+  acquireExtractionLock,
+  releaseExtractionLock,
+} from '../needs';
+import * as realtime from '../realtime';
+
+jest.mock('../../lib/prisma');
+jest.mock('../realtime');
+
+const SESSION_ID = 'sess_1';
+const USER_ID = 'user_1';
+const VESSEL_ID = 'vessel_1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  releaseExtractionLock(SESSION_ID, USER_ID);
+  // Default: no messages in history → extraction returns [] without AI call
+  (prisma.message.findMany as jest.Mock).mockResolvedValue([]);
+});
+
+describe('runStage3SafetyNetExtraction', () => {
+  it('no-ops when needs have already been extracted', async () => {
+    (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue({ id: VESSEL_ID });
+    (prisma.identifiedNeed.count as jest.Mock).mockResolvedValue(3);
+
+    await runStage3SafetyNetExtraction(SESSION_ID, USER_ID);
+
+    expect(prisma.message.findMany).not.toHaveBeenCalled();
+    expect(realtime.publishSessionEvent).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when no vessel exists yet for the user/session', async () => {
+    (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await runStage3SafetyNetExtraction(SESSION_ID, USER_ID);
+
+    expect(prisma.identifiedNeed.count).not.toHaveBeenCalled();
+    expect(prisma.message.findMany).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when another extraction is already running for the same (session, user)', async () => {
+    acquireExtractionLock(SESSION_ID, USER_ID);
+
+    await runStage3SafetyNetExtraction(SESSION_ID, USER_ID);
+
+    expect(prisma.userVessel.findUnique).not.toHaveBeenCalled();
+    expect(prisma.message.findMany).not.toHaveBeenCalled();
+
+    releaseExtractionLock(SESSION_ID, USER_ID);
+  });
+
+  it('enters the extraction path when vessel exists with zero identified needs', async () => {
+    (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue({ id: VESSEL_ID });
+    (prisma.identifiedNeed.count as jest.Mock).mockResolvedValue(0);
+
+    await runStage3SafetyNetExtraction(SESSION_ID, USER_ID);
+
+    // Proof we got past the gates and into extraction: it queried stage 1-2 messages.
+    expect(prisma.message.findMany).toHaveBeenCalled();
+    // Zero messages → zero needs → no event emitted.
+    expect(realtime.publishSessionEvent).not.toHaveBeenCalled();
+  });
+
+  it('releases the lock when extraction completes', async () => {
+    (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue({ id: VESSEL_ID });
+    (prisma.identifiedNeed.count as jest.Mock).mockResolvedValue(0);
+
+    await runStage3SafetyNetExtraction(SESSION_ID, USER_ID);
+
+    expect(isExtractionRunning(SESSION_ID, USER_ID)).toBe(false);
+  });
+
+  it('swallows errors so the caller (message stream) is not broken', async () => {
+    (prisma.userVessel.findUnique as jest.Mock).mockRejectedValue(
+      new Error('db down')
+    );
+
+    await expect(
+      runStage3SafetyNetExtraction(SESSION_ID, USER_ID)
+    ).resolves.toBeUndefined();
+  });
+
+  it('releases the lock even when extraction throws', async () => {
+    (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue({ id: VESSEL_ID });
+    (prisma.identifiedNeed.count as jest.Mock).mockResolvedValue(0);
+    (prisma.message.findMany as jest.Mock).mockRejectedValue(new Error('db down'));
+
+    await runStage3SafetyNetExtraction(SESSION_ID, USER_ID);
+
+    expect(isExtractionRunning(SESSION_ID, USER_ID)).toBe(false);
+  });
+});

--- a/backend/src/services/needs.ts
+++ b/backend/src/services/needs.ts
@@ -10,6 +10,7 @@ import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
 import { NeedCategory } from '@meet-without-fear/shared';
 import { getCurrentUserId } from '../lib/request-context';
+import { publishSessionEvent } from './realtime';
 
 // ============================================================================
 // Types
@@ -54,6 +55,96 @@ const MAX_TOKENS = 2048;
  */
 export function resetNeedsClient(): void {
   resetBedrockClient();
+}
+
+// ============================================================================
+// Extraction lock (module-level, shared across callers that trigger extraction)
+// Prevents concurrent AI calls for the same (session, user) — e.g. when the
+// stage 3 controller's `getNeeds` and the stage 3 safety net both decide to
+// run at roughly the same moment.
+// ============================================================================
+
+const extractionLocks = new Map<string, number>();
+const EXTRACTION_LOCK_TIMEOUT_MS = 60_000;
+
+function getExtractionLockKey(sessionId: string, userId: string): string {
+  return `${sessionId}:${userId}`;
+}
+
+export function isExtractionRunning(sessionId: string, userId: string): boolean {
+  const startedAt = extractionLocks.get(getExtractionLockKey(sessionId, userId));
+  if (!startedAt) return false;
+  if (Date.now() - startedAt > EXTRACTION_LOCK_TIMEOUT_MS) {
+    extractionLocks.delete(getExtractionLockKey(sessionId, userId));
+    return false;
+  }
+  return true;
+}
+
+export function acquireExtractionLock(sessionId: string, userId: string): void {
+  extractionLocks.set(getExtractionLockKey(sessionId, userId), Date.now());
+}
+
+export function releaseExtractionLock(sessionId: string, userId: string): void {
+  extractionLocks.delete(getExtractionLockKey(sessionId, userId));
+}
+
+/**
+ * Stage 3 safety-net extraction. If the user's vessel has no identified needs
+ * yet, run extraction against stages 1–2 history so the system surfaces needs
+ * the conversational AI may have missed. Fire-and-forget — callers should not
+ * await this on the message-send hot path.
+ *
+ * No-ops if: no vessel yet, needs already extracted, or another extraction
+ * is already running for this (session, user).
+ */
+export async function runStage3SafetyNetExtraction(
+  sessionId: string,
+  userId: string,
+  logPrefix = '[safety-net]'
+): Promise<void> {
+  try {
+    if (isExtractionRunning(sessionId, userId)) {
+      logger.info(`${logPrefix} Stage 3 safety net: extraction already in flight, skipping`);
+      return;
+    }
+
+    const vessel = await prisma.userVessel.findUnique({
+      where: { userId_sessionId: { userId, sessionId } },
+      select: { id: true },
+    });
+    if (!vessel) {
+      return;
+    }
+
+    const existingCount = await prisma.identifiedNeed.count({
+      where: { vesselId: vessel.id },
+    });
+    if (existingCount > 0) {
+      return;
+    }
+
+    acquireExtractionLock(sessionId, userId);
+    try {
+      logger.warn(`${logPrefix} Stage 3 safety net: no needs extracted yet, running extraction`);
+      const needs = await extractNeedsFromConversation(sessionId, userId);
+      if (needs.length > 0) {
+        try {
+          await publishSessionEvent(sessionId, 'session.needs_extracted' as any, {
+            userId,
+            needsCount: needs.length,
+            reason: 'needs-safety-net',
+          });
+        } catch (err) {
+          logger.error(`${logPrefix} Failed to publish needs_extracted event:`, err);
+        }
+      }
+    } finally {
+      releaseExtractionLock(sessionId, userId);
+    }
+  } catch (err) {
+    logger.error(`${logPrefix} Stage 3 safety-net extraction failed:`, err);
+  }
 }
 
 // ============================================================================

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -803,9 +803,9 @@ ${buildResponseProtocol(3)}`;
   const baseDynamic = buildBaseDynamicGuidance(context);
   if (baseDynamic) dynamicParts.push(baseDynamic);
 
-  const earlyStage3 = context.turnCount <= 2;
+  const earlyStage3 = context.turnCount <= 4;
   if (earlyStage3) {
-    dynamicParts.push('EARLY STAGE 3: User may still be processing emotions from empathy work. Start in EXCAVATING mode. Give space before expecting named needs.');
+    dynamicParts.push('EARLY STAGE 3: User may still be processing emotions from empathy work. Start in EXCAVATING mode. Give space before expecting named needs. Don\'t rush — they need time to distinguish positions from underlying needs.');
   }
   if (context.emotionalIntensity >= 8) {
     dynamicParts.push('HIGH USER INTENSITY: The user is very activated/distressed. Slow down. Validate first, reframe gently. Your tone should be calm and grounding, not matching their intensity.');

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -803,10 +803,16 @@ ${buildResponseProtocol(3)}`;
   const baseDynamic = buildBaseDynamicGuidance(context);
   if (baseDynamic) dynamicParts.push(baseDynamic);
 
-  const earlyStage3 = context.turnCount <= 4;
+  const earlyStage3 = context.turnCount <= 2;
   if (earlyStage3) {
-    dynamicParts.push('EARLY STAGE 3: User may still be processing emotions from empathy work. Start in EXCAVATING mode. Give space before expecting named needs. Don\'t rush — they need time to distinguish positions from underlying needs.');
+    dynamicParts.push('EARLY STAGE 3: User just arrived from empathy work. They may still be processing emotions — give them a breath before pushing toward needs.');
   }
+
+  // Content-aware pacing (every turn): let what the user said drive the mode,
+  // not a turn counter. A user who names three clear needs in one rich message
+  // should be validated; a user still venting in positions should be excavated.
+  dynamicParts.push('PACING — LET CONTENT DRIVE THE MODE, NOT TURN COUNT: If the user has clearly named specific underlying needs (e.g., "partnership", "to feel safe", "to be heard"), move into VALIDATING and reflect them back — do not artificially hold back to "give more time". If they are still speaking in positions, complaints, or general frustrations, stay in EXCAVATING — reframe positions into needs and ask what matters most. Do not rush users who are still exploring, and do not stall users who have already landed.');
+
   if (context.emotionalIntensity >= 8) {
     dynamicParts.push('HIGH USER INTENSITY: The user is very activated/distressed. Slow down. Validate first, reframe gently. Your tone should be calm and grounding, not matching their intensity.');
   }


### PR DESCRIPTION
## Changes
- Fix: Introduce `stageTurnCount` — counts user messages in the current stage only, not session-wide
- Fix: Pass stage-scoped turn count to `buildStagePrompt` so stage guards (early-stage flags, feel-heard timing) fire correctly for stages 2–4
- Fix: Stage 3 `earlyStage3` threshold increased from ≤2 to ≤4 turns, giving users more time in EXCAVATING mode before the AI shifts focus
- Fix: Stage 3 safety-net extraction trigger now uses stage-scoped count instead of session-wide count

Related to #115

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "I see the PR but this screenshot is from the stage where we identify needs (what matters most) but the PR is changing stage 1. I think stage 1 is already working fine (though I do like the stageTurnCount function for standardizing that. I think you could use that but look at all of the stages for where we might be concerned about the number of turns and make sure we are consistent about using the same function. But I think the whole point of the fix is to give more time in stage 3."

## Docs updated
No doc changes needed — the affected docs describe prompt architecture concepts, not specific threshold values. The `turnCount` references in `docs/backend/prompt-caching.md` and `docs/backend/prompts/index.md` are generic and remain accurate.