### PR TITLE
chore(docs): add code-to-docs mapping for backend/src/controllers

### DIFF
--- a/docs/code-to-docs-mapping.json
+++ b/docs/code-to-docs-mapping.json
@@ -6,6 +6,7 @@
     { "code": "backend/src/app.ts",                      "label": "backend/src/app.ts",            "docs": ["docs/architecture/backend-overview.md"] },
     { "code": "backend/src/server.ts",                   "label": "backend/src/server.ts",         "docs": ["docs/architecture/backend-overview.md"] },
     { "code": "backend/src/routes/**",                   "label": "backend/src/routes",            "docs": ["docs/backend/api/index.md"] },
+    { "code": "backend/src/controllers/**",             "label": "backend/src/controllers",       "docs": ["docs/backend/api/index.md"] },
     { "code": "backend/src/routes/auth.ts",              "label": "backend/src/routes/auth.ts",    "docs": ["docs/backend/api/auth.md"] },
     { "code": "backend/src/controllers/auth.ts",         "label": "backend/src/controllers/auth.ts", "docs": ["docs/backend/api/auth.md"] },
     { "code": "backend/src/routes/stage0.ts",            "label": "backend/src/routes/stage0.ts",  "docs": ["docs/backend/api/stage-0.md", "docs/product/stages/stage-0-onboarding.md"] },


### PR DESCRIPTION
## Changes
- Add: catch-all glob `backend/src/controllers/**` → `docs/backend/api/index.md` in `docs/code-to-docs-mapping.json`

Related to #101

## Provenance
- **Channel:** GitHub issue
- **Requested by:** Slam Paws (bot self-filed during PR #88 doc-impact review)
- **Original message:** [PR #88 comment](https://github.com/shantamg/meet-without-fear/pull/88#issuecomment-4269077100)
- **Prompt(s) used:** `general-pr` workspace

## Docs updated
No doc changes needed — this PR updates the doc-infrastructure mapping file itself.