### PR TITLE
feat(mobile): cap web layout at a 480px mobile column

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/react-native';
 import * as SplashScreen from 'expo-splash-screen';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { SessionDrawerProvider } from '@/src/hooks/useSessionDrawer';
 import { useInvitationLink } from '@/src/hooks/useInvitation';
@@ -43,21 +43,23 @@ function AppShell({ includeMixpanel = true }: { includeMixpanel?: boolean }) {
   useInvitationLink();
 
   return (
-    <GestureHandlerRootView style={styles.container}>
-      <SafeAreaProvider>
-        <SessionDrawerProvider>
-          <ToastProvider>
-            {includeMixpanel && <MixpanelInitializer />}
-            <Stack screenOptions={{ headerShown: false }}>
-              <Stack.Screen name="(public)" />
-              <Stack.Screen name="(auth)" />
-              <Stack.Screen name="+not-found" options={{ headerShown: true }} />
-            </Stack>
-            <StatusBar style="light" />
-          </ToastProvider>
-        </SessionDrawerProvider>
-      </SafeAreaProvider>
-    </GestureHandlerRootView>
+    <View style={styles.webFrame}>
+      <GestureHandlerRootView style={styles.container}>
+        <SafeAreaProvider>
+          <SessionDrawerProvider>
+            <ToastProvider>
+              {includeMixpanel && <MixpanelInitializer />}
+              <Stack screenOptions={{ headerShown: false }}>
+                <Stack.Screen name="(public)" />
+                <Stack.Screen name="(auth)" />
+                <Stack.Screen name="+not-found" options={{ headerShown: true }} />
+              </Stack>
+              <StatusBar style="light" />
+            </ToastProvider>
+          </SessionDrawerProvider>
+        </SafeAreaProvider>
+      </GestureHandlerRootView>
+    </View>
   );
 }
 
@@ -104,7 +106,22 @@ function RootLayout() {
 
 export default Sentry.wrap(RootLayout);
 
+// Phone-width shim for web: cap the app at a mobile column and center it
+// until we design proper desktop/tablet layouts. No-op on native.
+const MOBILE_MAX_WIDTH = 480;
+
 const styles = StyleSheet.create({
+  webFrame: {
+    flex: 1,
+    ...Platform.select({
+      web: {
+        width: '100%',
+        maxWidth: MOBILE_MAX_WIDTH,
+        alignSelf: 'center',
+      },
+      default: {},
+    }),
+  },
   container: {
     flex: 1,
   },


### PR DESCRIPTION
## Summary
- Wraps the root `GestureHandlerRootView` in a web-only frame that caps width at 480px and centers on the viewport.
- Until we design desktop/tablet layouts, this keeps `app.meetwithoutfear.com` from stretching screens edge-to-edge on large monitors.
- No-op on native (iOS/Android layout unchanged).

## Test plan
- [ ] `npm run check --workspace=mobile` passes (done)
- [ ] Hit `https://app.meetwithoutfear.com/` on a wide browser after merge — content should render in a centered ≤480px column
- [ ] Native app still renders full-screen