### PR TITLE
fix(backend): allow app.meetwithoutfear.com in CORS

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,11 +12,15 @@ const app = express();
 // Security middleware
 app.use(helmet());
 
-// CORS - allow website, mobile, and dashboard origins
+// CORS - allow website, app (Expo Web), and dashboard origins
 const corsOrigins: (string | RegExp)[] = [
-  // Website (invitation acceptance flow)
+  // Website (marketing + invitation acceptance flow)
   'https://meetwithoutfear.com',
   'https://www.meetwithoutfear.com',
+  // App (Expo Web build)
+  'https://app.meetwithoutfear.com',
+  // Vercel preview deployments of mwf-app (mwf-<hash>-shantam.vercel.app etc)
+  /^https:\/\/mwf-[a-z0-9-]+\.vercel\.app$/,
   // Local development
   'http://localhost:3000',
   'http://localhost:3001',


### PR DESCRIPTION
## Summary
Signed-in users on `app.meetwithoutfear.com` were stuck on "Loading…" because every `/api/*` request from the new origin got blocked by the backend's CORS allowlist.

- Adds `https://app.meetwithoutfear.com` to `corsOrigins`.
- Adds a regex for Vercel preview URLs of `mwf-app` so deploy-preview testing works without further backend changes.

## Test plan
- [ ] `npm run check --workspace=backend` passes (done)
- [ ] After Render deploy: `curl -i -H "Origin: https://app.meetwithoutfear.com" https://api.meetwithoutfear.com/api/healthz` returns `Access-Control-Allow-Origin: https://app.meetwithoutfear.com`
- [ ] Reload `app.meetwithoutfear.com` — no CORS errors in console, authed user loads past "Loading…"