### PR TITLE
fix(mobile): anchor session drawer to the web mobile column

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -131,6 +131,11 @@ const styles = StyleSheet.create({
       web: {
         width: '100%',
         maxWidth: MOBILE_MAX_WIDTH,
+        // Establish a positioning context and clip overflow so absolutely-positioned
+        // descendants (Expo Router's Stack screens, the session drawer) anchor to the
+        // column's edges instead of the viewport.
+        position: 'relative',
+        overflow: 'hidden',
       },
       default: {},
     }),

--- a/mobile/src/components/SessionDrawer/index.tsx
+++ b/mobile/src/components/SessionDrawer/index.tsx
@@ -21,7 +21,8 @@ import {
   ActivityIndicator,
   Animated,
   Alert,
-  Dimensions,
+  Platform,
+  useWindowDimensions,
 } from 'react-native';
 import { Drawer } from 'react-native-drawer-layout';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -37,8 +38,10 @@ import { colors } from '../../theme';
 import type { SessionSummaryDTO } from '@meet-without-fear/shared';
 import { SessionStatus } from '@meet-without-fear/shared';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
-const DRAWER_WIDTH = SCREEN_WIDTH * 0.9;
+// On web the app is constrained to a centered mobile column (see mobile/app/_layout.tsx).
+// The drawer must not exceed that column, or `react-native-drawer-layout`'s
+// `left: calc(width * -1)` offset pushes it off-screen.
+const WEB_COLUMN_MAX_WIDTH = 480;
 
 // ============================================================================
 // Session Section Types
@@ -288,6 +291,11 @@ export function SessionDrawer({ children }: SessionDrawerProps) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { isOpen, closeDrawer, openDrawer } = useSessionDrawer();
+  const { width: windowWidth } = useWindowDimensions();
+  const drawerWidth = Math.min(
+    windowWidth * 0.9,
+    Platform.OS === 'web' ? WEB_COLUMN_MAX_WIDTH : windowWidth
+  );
 
   const handleNewSession = useCallback(() => {
     closeDrawer();
@@ -329,7 +337,7 @@ export function SessionDrawer({ children }: SessionDrawerProps) {
       onClose={closeDrawer}
       drawerPosition="left"
       drawerType="front"
-      drawerStyle={styles.drawer}
+      drawerStyle={[styles.drawer, { width: drawerWidth }]}
       overlayStyle={styles.overlay}
       renderDrawerContent={renderDrawerContent}
     >
@@ -348,7 +356,6 @@ const useStyles = () =>
       backgroundColor: 'rgba(0, 0, 0, 0.5)',
     },
     drawer: {
-      width: DRAWER_WIDTH,
       backgroundColor: t.colors.bgPrimary,
     },
     drawerContent: {


### PR DESCRIPTION
## Summary
- Cap the session drawer at the 480px web column width using `useWindowDimensions` (was a stale `Dimensions.get('window').width * 0.9`, which on wide desktops blew past the column).
- Make `webFrame` an explicit positioning context (`position: relative` + `overflow: hidden`) so Expo Router's absolutely-positioned Stack screens — and the drawer inside them — anchor to the centered mobile column instead of the viewport.

Before, opening the hamburger on `app.meetwithoutfear.com` slid the drawer into the left gutter (and off-screen on narrow windows). After, the drawer slides in flush with the column's left edge and stays inside the 480px frame at any width.

## Test plan
- [ ] Visit `app.meetwithoutfear.com` after deploy, open the hamburger, resize the window from wide → narrow. Drawer should stay inside the centered column.
- [ ] iOS / Android native: open the drawer; behavior unchanged (drawer covers ~90% of screen as before, since the web cap only applies on web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)