### PR TITLE
fix(website): pin Turbopack root to monorepo so CI can resolve next

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -1,4 +1,10 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
+
+// Derive __dirname in an ESM-safe way — Next 16 loads config as ESM, so the
+// CommonJS `__dirname` global is undefined.
+const here = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   // Enable React strict mode for better development experience
@@ -6,6 +12,14 @@ const nextConfig: NextConfig = {
 
   // Disable Next.js dev indicator
   devIndicators: false,
+
+  // Pin Turbopack's workspace root to the monorepo root. `next` is hoisted
+  // there by npm workspaces, so restricting the root to website/ alone makes
+  // it unresolvable. Without this pin, Next 16's multi-lockfile heuristic
+  // picks different roots on different machines and fails the build on CI.
+  turbopack: {
+    root: path.resolve(here, ".."),
+  },
 
   // Configure environment variables that can be exposed to the browser
   env: {


### PR DESCRIPTION
## Summary
- First run of the new \`Vercel Deploy — Website\` workflow failed with \`Turbopack build failed: couldn't find next/package.json from website/app\`.
- Root cause: Next 16's Turbopack infers the workspace root from the nearest lockfile. Our monorepo has both \`package-lock.json\` (root) and \`website/package-lock.json\`, so the inferred root varies by machine; in CI it landed above where \`next\` resolves, breaking the build.
- Fix: pin \`turbopack.root\` in \`website/next.config.ts\` to the monorepo root. \`next\` is hoisted there locally via npm workspaces, and on Vercel (standalone install inside \`website/\`) \`website/node_modules\` is inside that root as well — so resolution succeeds in both places without touching lockfiles or the install command.
- Uses \`fileURLToPath(import.meta.url)\` to derive the config directory because Next 16 loads \`next.config.ts\` as ESM, where \`__dirname\` is undefined.

## Test plan
- [x] \`npm --workspace website run build\` succeeds locally with no "inferred workspace root" warning.
- [ ] After merge, \`Vercel Deploy — Website\` workflow on main completes green.
- [ ] meetwithoutfear.com serves the new home copy, \`/app\` 307s to \`app.meetwithoutfear.com\`, \`/download\` renders the TestFlight/APK page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)