### PR TITLE
fix(website): use webpack for next build; Turbopack fights Vercel's tracing root

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -1,10 +1,4 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
-
-// Derive __dirname in an ESM-safe way — Next 16 loads config as ESM, so the
-// CommonJS `__dirname` global is undefined.
-const here = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   // Enable React strict mode for better development experience
@@ -12,14 +6,6 @@ const nextConfig: NextConfig = {
 
   // Disable Next.js dev indicator
   devIndicators: false,
-
-  // Pin Turbopack's workspace root to the monorepo root. `next` is hoisted
-  // there by npm workspaces, so restricting the root to website/ alone makes
-  // it unresolvable. Without this pin, Next 16's multi-lockfile heuristic
-  // picks different roots on different machines and fails the build on CI.
-  turbopack: {
-    root: path.resolve(here, ".."),
-  },
 
   // Configure environment variables that can be exposed to the browser
   env: {

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "next lint",
     "check": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- Previous fix (#126) pinned \`turbopack.root\` to the monorepo root. That works locally, but on Vercel CI the build logs show:

  > ⚠ Both \`outputFileTracingRoot\` and \`turbopack.root\` are set, but they must have the same value.
  > Using \`outputFileTracingRoot\` value: /home/runner/work/meet-without-fear/meet-without-fear/website.

  Vercel forces \`outputFileTracingRoot=website/\`, Next prefers that over our config, and Turbopack still can't resolve \`next\` from \`website/app/\`.
- Fix: switch \`next build\` to \`--webpack\`. Webpack's module resolution walks up directory trees naturally, so it finds \`next\` whether it's hoisted to the monorepo root (local) or installed in \`website/node_modules\` (Vercel). Dev (\`next dev\`) continues to use the default bundler; only production builds change.
- Removes the now-unused \`turbopack.root\` config from \`next.config.ts\`.

## Test plan
- [x] \`npm --workspace website run build\` succeeds locally with no warnings.
- [ ] \`Vercel Deploy — Website\` workflow on main completes green after merge.
- [ ] meetwithoutfear.com serves the new home copy, \`/app\` 307s to \`app.meetwithoutfear.com\`, \`/download\` renders the TestFlight/APK page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)