### PR TITLE
fix(mobile): don't sign out on transient Clerk token-refresh errors

### DIFF
--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -210,37 +210,53 @@ apiClient.interceptors.response.use(
       ) {
         originalRequest[RETRY_KEY] = true;
 
-        // Attempt to get a fresh token from Clerk (force refresh to bypass cache)
+        // Attempt to get a fresh token from Clerk (force refresh to bypass cache).
+        // We distinguish three outcomes here because only one of them should
+        // sign the user out:
+        //   1. getToken throws (network hiccup, Clerk API 5xx): transient —
+        //      reject the current request but keep the session alive so the
+        //      user doesn't get booted mid-chat.
+        //   2. getToken returns an invalid-format token: impossible state —
+        //      sign out.
+        //   3. getToken returns null (authoritative "no session"): sign out.
         if (tokenProvider) {
+          let refreshThrew = false;
+          let freshToken: string | null = null;
           try {
-            const freshToken = await tokenProvider.getToken({ forceRefresh: true });
-            if (freshToken) {
-              // Validate the fresh token before retrying
-              if (isValidJwtFormat(freshToken)) {
-                // Update the request with fresh token and retry
-                originalRequest.headers.Authorization = `Bearer ${freshToken}`;
-                return apiClient(originalRequest);
-              } else {
-                // Fresh token is also invalid - don't retry, user needs to re-auth
-                console.warn(
-                  '[API] Fresh token from provider is also invalid. User needs to sign in again.'
-                );
-                originalRequest[INVALID_TOKEN_KEY] = true;
-              }
-            }
+            freshToken = await tokenProvider.getToken({ forceRefresh: true });
           } catch (refreshError) {
-            console.warn('[API] Failed to refresh auth token:', refreshError);
+            refreshThrew = true;
+            console.warn('[API] Token refresh errored (transient):', refreshError);
+            trackError('auth', 'TOKEN_REFRESH_FAILED', originalRequest?.url || 'unknown');
           }
+
+          if (!refreshThrew) {
+            if (freshToken && isValidJwtFormat(freshToken)) {
+              originalRequest.headers.Authorization = `Bearer ${freshToken}`;
+              return apiClient(originalRequest);
+            }
+            if (freshToken) {
+              // Got a token back but it's malformed — treat as unrecoverable.
+              console.warn(
+                '[API] Fresh token from provider is invalid. User needs to sign in again.'
+              );
+              originalRequest[INVALID_TOKEN_KEY] = true;
+            }
+            // Either freshToken was null (Clerk says no session) or invalid.
+            // Fall through to handleAuthFailure below.
+            console.warn('[API] Unauthorized - session expired, signing out');
+            trackError('auth', 'SESSION_EXPIRED', originalRequest?.url || 'unknown');
+            await handleAuthFailure();
+          }
+          // If refreshThrew: do NOT sign out. Fall through and reject this
+          // request with the original 401 so callers can surface an error;
+          // the next retriable API call will try the refresh again.
+        } else {
+          // No token provider wired up at all — nothing we can do.
+          console.warn('[API] No token provider; cannot refresh auth');
+          trackError('auth', 'SESSION_EXPIRED', originalRequest?.url || 'unknown');
+          await handleAuthFailure();
         }
-
-        // If we couldn't refresh or token is invalid, the user needs to re-authenticate
-        console.warn('[API] Unauthorized - session may have expired, please sign in again');
-
-        // Track auth error
-        trackError('auth', 'SESSION_EXPIRED', originalRequest?.url || 'unknown');
-
-        // Sign out the user to force re-authentication
-        await handleAuthFailure();
       }
 
       // Create standardized API error


### PR DESCRIPTION
## Symptom
Typing in a chat session at \`app.meetwithoutfear.com\`, the app suddenly redirects to the "Get Started" welcome screen (still on \`app.meetwithoutfear.com\`, not the marketing site — the web app's own signed-out screen has the same layout, easy to mistake). Console shows \`[UserSessionUpdates] Subscription error: Error: Ably connection timeout\` and \`[Realtime] Subscription setup error\`.

## Root cause
\`mobile/src/lib/api.ts\` 401-interceptor treats *all* failed token refreshes equivalently:

\`\`\`ts
try {
  const freshToken = await tokenProvider.getToken({ forceRefresh: true });
  // ... use it if valid
} catch (refreshError) {
  console.warn('[API] Failed to refresh auth token:', refreshError);
}
// If we couldn't refresh or token is invalid...
await handleAuthFailure();  // → Clerk.signOut()
\`\`\`

When \`getToken\` itself *throws* (network blip, Clerk API 5xx, brief connectivity loss — exactly the kinds of things happening when Ably also times out), we fall through to \`signOut()\`. \`(auth)/_layout.tsx\` sees \`!isSignedIn\` and \`<Redirect href="/(public)" />\` bounces the user to the welcome screen mid-chat.

## Fix
Split the refresh outcome into three cases — only authoritative signals sign out:

| Outcome | Meaning | Action |
|--|--|--|
| \`getToken\` throws | Transient (network / Clerk hiccup) | Reject this request only; keep session alive |
| Returns null | Clerk says "no session" | Sign out |
| Returns invalid-format token | Impossible state | Sign out |

Also adds a distinct \`TOKEN_REFRESH_FAILED\` error-tracking code so we can see how often case 1 fires in production.

## Out of scope
- The Ably timeouts themselves are a separate symptom of the same underlying network/Clerk instability. This fix doesn't address the realtime layer — but once we stop signing users out on transient refresh errors, short hiccups should be recoverable rather than session-ending.
- The COOP warnings in the console are Clerk OAuth popup artefacts and unrelated to this sign-out path.

## Test plan
- [x] \`npm --workspace mobile run check\` passes.
- [x] \`npm --workspace mobile run test -- --testPathPattern lib/__tests__/api\` — all 14 existing api tests pass.
- [ ] After deploy via OTA: reproduce the scenario (type in a chat session for several minutes); expect to stay signed in through any console "refresh errored (transient)" warnings rather than being redirected to the welcome screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)