### PR TITLE
fix(mobile): use Clerk redirect-flow on web to fix new-user sign-in

### DIFF
--- a/mobile/app/(public)/auth-options.web.tsx
+++ b/mobile/app/(public)/auth-options.web.tsx
@@ -1,0 +1,204 @@
+/**
+ * Web-only auth options screen.
+ *
+ * The native version (auth-options.tsx) uses `useOAuth()` which on web falls
+ * back to a popup-based flow. That popup pattern silently fails for many
+ * browsers/extensions (COOP blocking `popup.closed`, popup blockers, stale
+ * postMessage), so new users click "Continue with Google", complete the
+ * OAuth flow in the popup, and get dumped back on the sign-in screen with
+ * no session. Existing users hit a faster path in Clerk that doesn't need
+ * the popup handshake, which is why the bug looked account-specific.
+ *
+ * This web override swaps the popup flow for Clerk's full-page redirect
+ * flow (`signIn.authenticateWithRedirect`) — the same pattern the marketing
+ * site's `@clerk/nextjs` <SignIn/> component was using before the web app
+ * moved to the Expo Web bundle. The browser navigates to Google, back to
+ * Clerk, and finally to `/sso-callback` on our origin, where
+ * `useClerk().handleRedirectCallback()` finalizes the session.
+ */
+
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  SafeAreaView,
+  ActivityIndicator,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { useSignIn, useSignUp } from '@clerk/clerk-expo';
+import { AntDesign } from '@expo/vector-icons';
+import { colors } from '@/theme';
+
+type OAuthStrategy = 'oauth_google' | 'oauth_apple';
+
+export default function AuthOptionsScreenWeb() {
+  const { signIn, isLoaded: signInLoaded } = useSignIn();
+  const { isLoaded: signUpLoaded } = useSignUp();
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [busyProvider, setBusyProvider] = useState<OAuthStrategy | null>(null);
+
+  const loaded = signInLoaded && signUpLoaded;
+
+  const handleOAuthRedirect = async (strategy: OAuthStrategy, provider: string) => {
+    if (!loaded || !signIn || busyProvider) return;
+    setError(null);
+    setBusyProvider(strategy);
+
+    try {
+      const origin =
+        typeof window !== 'undefined' ? window.location.origin : '';
+
+      await signIn.authenticateWithRedirect({
+        strategy,
+        redirectUrl: `${origin}/sso-callback`,
+        redirectUrlComplete: `${origin}/`,
+      });
+      // The browser navigates away. Anything below this line only runs if
+      // the redirect was blocked somehow.
+    } catch (err) {
+      console.error(`[auth-options.web] OAuth redirect error (${provider}):`, err);
+      const message =
+        (err as { errors?: { message?: string }[] })?.errors?.[0]?.message ||
+        (err as Error)?.message ||
+        `Failed to continue with ${provider}`;
+      setError(message);
+      setBusyProvider(null);
+    }
+  };
+
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={handleBack} accessibilityLabel="Go back">
+          <AntDesign name="left" size={24} color={colors.textPrimary} />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.content}>
+        <Text style={styles.title}>Sign in</Text>
+        <Text style={styles.subtitle}>Sign in or create an account to continue</Text>
+
+        {error && <Text style={styles.error}>{error}</Text>}
+
+        <OAuthButton
+          iconName="google"
+          label="Continue with Google"
+          onPress={() => handleOAuthRedirect('oauth_google', 'Google')}
+          busy={busyProvider === 'oauth_google'}
+          disabled={!loaded || !!busyProvider}
+        />
+        <OAuthButton
+          // AntDesign types don't include 'apple1' even though the glyph
+          // exists — matches the cast in auth-options.tsx.
+          iconName={'apple1' as React.ComponentProps<typeof AntDesign>['name']}
+          label="Continue with Apple"
+          onPress={() => handleOAuthRedirect('oauth_apple', 'Apple')}
+          busy={busyProvider === 'oauth_apple'}
+          disabled={!loaded || !!busyProvider}
+        />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function OAuthButton({
+  iconName,
+  label,
+  onPress,
+  busy,
+  disabled,
+}: {
+  iconName: React.ComponentProps<typeof AntDesign>['name'];
+  label: string;
+  onPress: () => void;
+  busy: boolean;
+  disabled: boolean;
+}) {
+  return (
+    <TouchableOpacity
+      style={[styles.oauthButton, disabled && styles.oauthButtonDisabled]}
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityState={{ disabled, busy }}
+    >
+      {busy ? (
+        <ActivityIndicator size="small" color={colors.textPrimary} style={styles.buttonIcon} />
+      ) : (
+        <AntDesign name={iconName} size={20} color={colors.textPrimary} style={styles.buttonIcon} />
+      )}
+      <Text style={styles.oauthButtonText}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgPrimary,
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: colors.textPrimary,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: colors.textSecondary,
+    marginBottom: 32,
+    textAlign: 'center',
+  },
+  error: {
+    fontSize: 14,
+    color: colors.error,
+    marginBottom: 16,
+    paddingHorizontal: 4,
+    textAlign: 'center',
+  },
+  oauthButton: {
+    backgroundColor: colors.bgSecondary,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+    marginBottom: 12,
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  oauthButtonDisabled: {
+    opacity: 0.5,
+  },
+  oauthButtonText: {
+    color: colors.textPrimary,
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  buttonIcon: {
+    marginRight: 8,
+  },
+});

--- a/mobile/app/sso-callback.web.tsx
+++ b/mobile/app/sso-callback.web.tsx
@@ -1,0 +1,114 @@
+/**
+ * Web-only SSO callback route.
+ *
+ * When a user completes OAuth via `signIn.authenticateWithRedirect` in
+ * app/(public)/auth-options.web.tsx, Clerk redirects the browser back to
+ * this origin at `/sso-callback`. On mount we call
+ * `clerk.handleRedirectCallback()`, which reads the query/fragment Clerk
+ * attached, creates the session, and navigates to `redirectUrlComplete`.
+ *
+ * This route exists on web only (`.web.tsx`); native never hits it because
+ * the native auth flow uses `useOAuth()` with an in-app browser that
+ * returns control to the RN navigator directly.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { View, Text, ActivityIndicator, StyleSheet, TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useClerk } from '@clerk/clerk-expo';
+
+import { colors } from '@/theme';
+
+export default function SsoCallbackScreen() {
+  const clerk = useClerk();
+  const router = useRouter();
+  const started = useRef(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!clerk || started.current) return;
+    started.current = true;
+
+    (async () => {
+      try {
+        await clerk.handleRedirectCallback({
+          redirectUrl: '/sso-callback',
+          afterSignInUrl: '/',
+          afterSignUpUrl: '/',
+        });
+        // handleRedirectCallback typically triggers navigation on its own.
+        // Belt-and-braces: if we're still here 200ms later, route manually.
+        setTimeout(() => router.replace('/'), 200);
+      } catch (err) {
+        console.error('[sso-callback] handleRedirectCallback failed:', err);
+        const message =
+          (err as { errors?: { message?: string }[] })?.errors?.[0]?.message ||
+          (err as Error)?.message ||
+          'Failed to complete sign-in.';
+        setError(message);
+      }
+    })();
+  }, [clerk, router]);
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Sign-in failed</Text>
+        <Text style={styles.error}>{error}</Text>
+        <TouchableOpacity
+          style={styles.retryButton}
+          onPress={() => router.replace('/(public)/auth-options')}
+          accessibilityRole="button"
+        >
+          <Text style={styles.retryText}>Try again</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator color={colors.textPrimary} size="large" />
+      <Text style={styles.text}>Signing you in…</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgPrimary,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    gap: 16,
+  },
+  text: {
+    color: colors.textSecondary,
+    fontSize: 16,
+  },
+  title: {
+    color: colors.textPrimary,
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  error: {
+    color: colors.error,
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  retryButton: {
+    marginTop: 8,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 12,
+    backgroundColor: colors.bgSecondary,
+  },
+  retryText: {
+    color: colors.textPrimary,
+    fontSize: 16,
+    fontWeight: '500',
+  },
+});


### PR DESCRIPTION
## Symptom
New users on app.meetwithoutfear.com click "Continue with Google", go through the OAuth flow, and get silently dropped back on the sign-in screen. Existing users aren't affected. Regression since the marketing-site \`<SignIn/>\` was replaced by the Expo Web bundle's auth screen.

## Cause
\`@clerk/clerk-expo\`'s \`useOAuth()\` opens a popup window and polls \`popup.closed\` to detect completion. On web this fails in several common environments:
- COOP policies on Google/Clerk's domains break the popup-parent relationship ("Cross-Origin-Opener-Policy would block the window.closed call" warnings in the console)
- Safari/Brave/Firefox-strict block \`popup.closed\` reads outright
- Popup blockers suppress the popup

When any of those kicks in, the OAuth flow completes on Google's side but the web app never learns a session was created. Existing sign-ins still work because Clerk's returning-user path doesn't need the popup handshake the way the sign-up path does — which is why the bug looked account-specific.

## Fix (web-only)
Two new Expo Router \`.web.tsx\` files; native behavior is untouched.

- **\`mobile/app/(public)/auth-options.web.tsx\`** — calls \`signIn.authenticateWithRedirect({ strategy, redirectUrl: '/sso-callback', redirectUrlComplete: '/' })\`. Full-page browser redirects replace the popup handshake — same pattern the marketing site's \`<SignIn/>\` was using before the migration.
- **\`mobile/app/sso-callback.web.tsx\`** — mounts when Clerk redirects the browser back after Google, calls \`clerk.handleRedirectCallback()\`, which reads the OAuth response from the URL, activates the session, and navigates to \`/\`. The signed-in root then routes through \`(auth)\`.

A spinner + retry UI is shown during the ~200ms callback round-trip so it doesn't feel frozen.

## Before this ships
The Clerk dashboard needs \`https://app.meetwithoutfear.com/sso-callback\` authorized as a redirect destination. In the **Clerk dashboard** (app.clerk.com / dashboard.clerk.com) it's usually under **Paths / Domains** (newer UI) or **Customization → Account Portal / Paths** depending on Clerk version. If you can't find it quickly, pass me a screenshot and I'll point at the exact setting.

## Test plan
- [x] \`npm --workspace mobile run check\` passes.
- [x] \`npx expo export --platform web\` succeeds; bundle emits \`sso-callback\` route.
- [ ] Once merged + deployed (via vercel-deploy-app.yml on push to main), a new user (incognito window, clean cookies) can click "Continue with Google", go through Google, and land signed in at \`app.meetwithoutfear.com/\`.
- [ ] Existing user (you) still signs in cleanly.
- [ ] Native iOS/Android build still uses the popup-native \`useOAuth\` path (no change to \`auth-options.tsx\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)