### PR TITLE
fix(mobile): add base-name sibling for sso-callback so web bundle loads

### DIFF
--- a/mobile/app/sso-callback.tsx
+++ b/mobile/app/sso-callback.tsx
@@ -1,0 +1,18 @@
+/**
+ * Native fallback for the `/sso-callback` route.
+ *
+ * The real implementation lives in `sso-callback.web.tsx` — it handles the
+ * browser's return from Clerk's OAuth redirect flow (web-only). Native
+ * builds use the popup-native `useOAuth` + expo-web-browser path and never
+ * land on this route, but Expo Router's route resolver requires every
+ * `.web.tsx` file to have a base-name sibling to register the route. This
+ * stub satisfies that requirement; if native somehow navigates here
+ * (deep-link misconfiguration, etc.) we bounce straight back to the public
+ * auth screen rather than rendering a broken blank view.
+ */
+
+import { Redirect } from 'expo-router';
+
+export default function SsoCallbackNative() {
+  return <Redirect href="/(public)" />;
+}


### PR DESCRIPTION
## Summary
PR #133 shipped \`sso-callback.web.tsx\` without a \`sso-callback.tsx\` sibling. Expo Router requires every platform-specific route file to have a base-name fallback, and crashed the entire web app bundle on load:

\`\`\`
Uncaught Error: The file ./sso-callback.web.tsx does not have a
fallback sibling file without a platform extension.
\`\`\`

That meant the fix in #133 was worse than the symptom it was meant to cure — no user could load app.meetwithoutfear.com at all.

## Fix
Add \`mobile/app/sso-callback.tsx\` as a native no-op that redirects to \`/(public)\`. Native builds use the popup-native \`useOAuth\` + expo-web-browser flow and never land on \`/sso-callback\`; this stub exists purely so Expo Router's route resolver is happy.

Hotfix — merge + ship as fast as possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)