### PR TITLE
fix(mobile): Sign Out button works on web (Alert.alert is no-op in react-native-web)

### DIFF
--- a/mobile/app/(auth)/settings/index.tsx
+++ b/mobile/app/(auth)/settings/index.tsx
@@ -5,6 +5,7 @@ import {
   ScrollView,
   TouchableOpacity,
   Alert,
+  Platform,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import {
@@ -32,6 +33,29 @@ export default function SettingsScreen() {
   const { signOut: clerkSignOut } = useClerk();
 
   const handleSignOut = () => {
+    const performSignOut = async () => {
+      try {
+        // Sign out from Clerk first (clears OAuth session)
+        await clerkSignOut();
+        // Then clear local auth state
+        await signOut();
+        router.replace('/(public)');
+      } catch (error) {
+        console.error('Sign out failed:', error);
+      }
+    };
+
+    // Alert.alert is a no-op in react-native-web, so the native confirmation
+    // flow never fires on web and the button appears inert. Fall back to the
+    // browser-native confirm() dialog on web — same two-button shape, works
+    // everywhere.
+    if (Platform.OS === 'web') {
+      if (typeof window !== 'undefined' && window.confirm('Are you sure you want to sign out?')) {
+        void performSignOut();
+      }
+      return;
+    }
+
     Alert.alert(
       'Sign Out',
       'Are you sure you want to sign out?',
@@ -40,17 +64,7 @@ export default function SettingsScreen() {
         {
           text: 'Sign Out',
           style: 'destructive',
-          onPress: async () => {
-            try {
-              // Sign out from Clerk first (clears OAuth session)
-              await clerkSignOut();
-              // Then clear local auth state
-              await signOut();
-              router.replace('/(public)');
-            } catch (error) {
-              console.error('Sign out failed:', error);
-            }
-          },
+          onPress: performSignOut,
         },
       ]
     );


### PR DESCRIPTION
## Symptom
Clicking **Sign Out** in Settings does nothing on \`app.meetwithoutfear.com\`. Works fine on native iOS/Android.

## Cause
\`Alert.alert()\` from React Native is **not implemented in react-native-web** — it's a silent no-op. The current handler only calls \`Alert.alert(...)\` to show a confirmation modal; since the modal never renders on web, the destructive "Sign Out" \`onPress\` handler that actually calls \`clerkSignOut()\` is never invoked. The button looks inert but it's actually just waiting for a user confirmation that can never happen.

## Fix
In \`settings/index.tsx\`, branch on \`Platform.OS === 'web'\` and use the browser-native \`window.confirm()\` dialog on web. Native keeps using \`Alert.alert\`. The sign-out body (Clerk signOut → local signOut → route to /(public)) is hoisted into a shared \`performSignOut()\` so there's no divergence.

## Out of scope (follow-up)
\`settings/account.tsx\` has the same pattern for the delete-account confirmation and for error \`Alert.alert\` toasts. Those are also silently broken on web but less urgent — will fix in a follow-up PR once this unsticks anyone currently wedged on the web build.

## Test plan
- [x] \`npm --workspace mobile run check\` passes.
- [ ] After deploy: on \`app.meetwithoutfear.com\` in a signed-in browser, click Sign Out → confirm dialog appears → click OK → land on the public welcome screen, signed out.
- [ ] On native iOS, Sign Out still shows the native alert and still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)