### PR TITLE
fix(mobile): route incomplete Clerk sign-ups to Account Portal + surface missing fields

### DIFF
--- a/mobile/app/sso-callback.web.tsx
+++ b/mobile/app/sso-callback.web.tsx
@@ -15,12 +15,22 @@
 import { useEffect, useRef, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet, TouchableOpacity } from 'react-native';
 import { useRouter } from 'expo-router';
-import { useClerk } from '@clerk/clerk-expo';
+import { useClerk, useSignIn, useSignUp } from '@clerk/clerk-expo';
 
 import { colors } from '@/theme';
 
+// Clerk's hosted sign-up continuation UI. Lives under the Account Portal
+// subdomain that ships with every Clerk instance; we don't have to host it.
+// When a Google OAuth sign-up completes but Clerk requires a field Google
+// didn't supply (phone / username / etc.), Clerk redirects here and the
+// Account Portal prompts the user for the remaining field before finalizing
+// the session.
+const CONTINUE_SIGN_UP_URL = 'https://accounts.meetwithoutfear.com/sign-up/continue';
+
 export default function SsoCallbackScreen() {
   const clerk = useClerk();
+  const { signIn } = useSignIn();
+  const { signUp } = useSignUp();
   const router = useRouter();
   const started = useRef(false);
   const [error, setError] = useState<string | null>(null);
@@ -35,10 +45,45 @@ export default function SsoCallbackScreen() {
           redirectUrl: '/sso-callback',
           afterSignInUrl: '/',
           afterSignUpUrl: '/',
+          // If the OAuth return leaves a signUp in `missing_requirements`
+          // (Clerk instance requires a field Google didn't supply), Clerk
+          // will navigate the browser here to collect it. Without this,
+          // handleRedirectCallback silently returns with no session and the
+          // user gets bounced back to the welcome screen with no explanation.
+          continueSignUpUrl: CONTINUE_SIGN_UP_URL,
         });
-        // handleRedirectCallback typically triggers navigation on its own.
-        // Belt-and-braces: if we're still here 200ms later, route manually.
-        setTimeout(() => router.replace('/'), 200);
+
+        // Log the post-callback state so we can see exactly what Clerk did.
+        // Useful for debugging when the session doesn't materialize.
+        console.log('[sso-callback] post-callback state', {
+          clerkSession: !!clerk.session,
+          signInStatus: signIn?.status,
+          signUpStatus: signUp?.status,
+          signUpMissingFields: signUp?.missingFields,
+          signUpUnverifiedFields: signUp?.unverifiedFields,
+        });
+
+        // Only fall back if we actually have a session — otherwise letting
+        // Clerk's own navigation (including continueSignUpUrl) complete.
+        if (clerk.session) {
+          setTimeout(() => router.replace('/'), 200);
+          return;
+        }
+
+        // No session and no navigation — surface whatever Clerk knows.
+        const missing =
+          signUp?.missingFields?.join(', ') ||
+          signUp?.unverifiedFields?.join(', ');
+        const status = signUp?.status || signIn?.status;
+        if (missing) {
+          setError(
+            `Sign-up couldn't complete: missing ${missing}. If this doesn't finish on its own, check your Clerk dashboard's required fields.`,
+          );
+        } else if (status) {
+          setError(`Sign-in ended in status "${status}" without a session.`);
+        } else {
+          setError('Sign-in didn\'t complete. Please try again.');
+        }
       } catch (err) {
         console.error('[sso-callback] handleRedirectCallback failed:', err);
         const message =
@@ -48,7 +93,7 @@ export default function SsoCallbackScreen() {
         setError(message);
       }
     })();
-  }, [clerk, router]);
+  }, [clerk, router, signIn, signUp]);
 
   if (error) {
     return (


### PR DESCRIPTION
## Symptom
New users complete Google OAuth on app.meetwithoutfear.com and silently loop back to the "Get Started" welcome screen. No \`User\` row created in our DB — the flow dies before we see them. Returning users (you) sign in fine, which is what made this look account-specific.

## Likely cause
Classic Clerk pattern: OAuth succeeds but the resulting \`signUp\` object is in \`missing_requirements\` state because a required field in the Clerk instance (phone number / username / name) isn't supplied by Google. Our previous callback returned from \`handleRedirectCallback\` with no session, the 200ms safety fallback routed to \`/\`, and \`(auth)/_layout.tsx\` bounced the user back to \`(public)\` because \`isSignedIn\` was still false.

## Fix (three parts)

1. **Route incomplete sign-ups to the Account Portal.** Pass
   \`continueSignUpUrl: 'https://accounts.meetwithoutfear.com/sign-up/continue'\`
   to \`handleRedirectCallback\`. Clerk's hosted Account Portal will prompt the user for the missing field and finalize the session — no custom form, no dashboard changes needed.

2. **Only run the 200ms safety fallback when a session actually exists.** The old code fell through to \`router.replace('/')\` regardless, which is what masked the real problem.

3. **Surface diagnostic state.** On return, read \`signUp.status\` / \`signUp.missingFields\` / \`signUp.unverifiedFields\` and log them + show a user-facing error message when no session materialized. So next time this happens, the friend sees *why* instead of an inscrutable bounce, and you can see the exact fields in the browser console.

## Context from checks
- Sentry mobile: no issues in the last 2h.
- Production DB: zero new \`User\` records in 24h — friend never got far enough to make an authenticated request, confirming the bug is in the pre-session callback path, not backend.

## Test plan
- [x] \`npm --workspace mobile run check\` passes.
- [ ] After deploy, friend can sign up on a fresh browser:
  - Happy path: Clerk doesn't need extra fields → session created, lands at \`/\` signed in.
  - Missing-fields path: Clerk redirects to the Account Portal, friend fills in the missing field, comes back signed in.
  - Worst case: if it still fails, the browser console now logs \`[sso-callback] post-callback state\` with \`signUpStatus\` + \`signUpMissingFields\` so we can see exactly what Clerk is returning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)