### PR TITLE
fix(mobile): force Google account chooser on web OAuth (oidcPrompt=select_account)

### DIFF
--- a/mobile/app/(public)/auth-options.web.tsx
+++ b/mobile/app/(public)/auth-options.web.tsx
@@ -55,6 +55,13 @@ export default function AuthOptionsScreenWeb() {
         strategy,
         redirectUrl: `${origin}/sso-callback`,
         redirectUrlComplete: `${origin}/`,
+        // Always show the OAuth provider's account chooser. Without this,
+        // Google (and Apple) silently return the user if they're already
+        // signed in with exactly one account and have previously authorized
+        // the app — no picker, no option to switch accounts. Matches the
+        // native flow where the in-app browser has no pre-existing session
+        // and the chooser always appears.
+        oidcPrompt: 'select_account',
       });
       // The browser navigates away. Anything below this line only runs if
       // the redirect was blocked somehow.


### PR DESCRIPTION
## Summary
The new web redirect flow silently returns you to the app if Google already has an active session with one account that's previously authorized MWF — no chooser, no way to switch accounts. On native, the in-app browser has no pre-existing Google session so the chooser always appears.

Clerk's \`authenticateWithRedirect\` accepts \`oidcPrompt\` directly. Passing \`'select_account'\` forces Google (and Apple) to always present the account chooser, matching the mobile experience.

## Test plan
- [x] \`npm --workspace mobile run check\` passes.
- [ ] On \`app.meetwithoutfear.com\` in a browser already signed into Google: clicking "Continue with Google" should now land on Google's account chooser instead of silently signing in.
- [ ] Picking the existing account from the chooser still signs in normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)