### PR TITLE
fix(mobile): sign out stale Clerk session before web OAuth so account chooser actually fires

### DIFF
--- a/mobile/app/(public)/auth-options.web.tsx
+++ b/mobile/app/(public)/auth-options.web.tsx
@@ -27,7 +27,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { useSignIn, useSignUp } from '@clerk/clerk-expo';
+import { useClerk, useSignIn, useSignUp } from '@clerk/clerk-expo';
 import { AntDesign } from '@expo/vector-icons';
 import { colors } from '@/theme';
 
@@ -36,6 +36,7 @@ type OAuthStrategy = 'oauth_google' | 'oauth_apple';
 export default function AuthOptionsScreenWeb() {
   const { signIn, isLoaded: signInLoaded } = useSignIn();
   const { isLoaded: signUpLoaded } = useSignUp();
+  const clerk = useClerk();
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [busyProvider, setBusyProvider] = useState<OAuthStrategy | null>(null);
@@ -51,6 +52,20 @@ export default function AuthOptionsScreenWeb() {
       const origin =
         typeof window !== 'undefined' ? window.location.origin : '';
 
+      // If a stale Clerk session cookie is still present (common on mobile
+      // browsers that kept a session from earlier testing), Clerk
+      // short-circuits authenticateWithRedirect server-side and the flow
+      // never reaches Google — so `oidcPrompt` has nothing to apply to and
+      // the user just silently lands back signed in with no chooser. Sign
+      // any existing session out first so OAuth always starts fresh.
+      if (clerk?.session) {
+        try {
+          await clerk.signOut({ redirectUrl: undefined });
+        } catch (signOutErr) {
+          console.warn('[auth-options.web] signOut before OAuth failed (non-fatal):', signOutErr);
+        }
+      }
+
       await signIn.authenticateWithRedirect({
         strategy,
         redirectUrl: `${origin}/sso-callback`,
@@ -58,9 +73,7 @@ export default function AuthOptionsScreenWeb() {
         // Always show the OAuth provider's account chooser. Without this,
         // Google (and Apple) silently return the user if they're already
         // signed in with exactly one account and have previously authorized
-        // the app — no picker, no option to switch accounts. Matches the
-        // native flow where the in-app browser has no pre-existing session
-        // and the chooser always appears.
+        // the app — no picker, no option to switch accounts.
         oidcPrompt: 'select_account',
       });
       // The browser navigates away. Anything below this line only runs if


### PR DESCRIPTION
## Why another sign-in fix
Previous fix added \`oidcPrompt: 'select_account'\` to force Google's account chooser. That works on desktop but not on mobile browsers. Reason: if the browser still carries a valid Clerk session cookie (common on a phone that was used earlier for testing), Clerk short-circuits \`authenticateWithRedirect\` server-side and the browser never reaches Google at all. No Google call → no chance for \`prompt=select_account\` to apply → user silently lands back signed in with no chooser.

## Fix
Before calling \`authenticateWithRedirect\`, check \`clerk.session\`. If a session exists, call \`clerk.signOut()\` first. Benign on fresh browsers (nothing to sign out), fixes mobile. Clicking "Continue with Google" from the welcome screen already implies "I want to start fresh" — no UX regression.

## Test plan
- [x] \`npm --workspace mobile run check\` passes.
- [ ] On mobile browser that was previously signed in: click Continue with Google → lands on Google's account chooser.
- [ ] On fresh browser: click Continue with Google → also lands on chooser (same as before, \`select_account\` handles it).
- [ ] Native iOS: unaffected (\`.web.tsx\` override only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)