### PR TITLE
fix(backend): stop redundant share suggestions + placeholder AI messages

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1715,20 +1715,6 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       // Clean accumulated text (strip <draft> and <dispatch> tags if they leaked through)
       accumulatedText = parsed.response;
 
-      // Guard: prevent empty AI responses from being saved to DB
-      if (!accumulatedText.trim() && !isDispatchMessage) {
-        logger.error(`[sendMessageStream:${requestId}] Empty AI response after tag stripping — skipping DB save`);
-        // Don't save empty message, but send error event so frontend can retry
-        if (!clientDisconnected) {
-          sendSSE(res, {
-            event: 'error',
-            data: { message: 'Empty AI response — please try again.', retryable: true },
-          });
-        }
-        res.end();
-        return;
-      }
-
       // =========================================================================
       // DISPATCH HANDLING: If dispatch tag detected, get and stream dispatched response
       // Dispatch messages are system responses - skip classifier/embeddings
@@ -1768,6 +1754,18 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
           logger.info(`[sendMessageStream:${requestId}] Unknown dispatch tag "${dispatchTag}" — using original AI response`);
           isDispatchMessage = false;
         }
+      }
+
+      // Guard: empty AI response after parsing + dispatch means the model emitted
+      // content entirely inside tags we couldn't route (e.g. an unknown dispatch
+      // tag, or a stray <draft> with no chat text). Treat as a stream error so
+      // the user message is cleaned up and the client gets a retry prompt —
+      // better than persisting a confusing placeholder or a blank AI message.
+      if (!accumulatedText.trim()) {
+        logger.error(`[sendMessageStream:${requestId}] Empty AI response after tag stripping and dispatch`, {
+          dispatchTag: dispatchTag ?? null,
+        });
+        throw new Error('Empty AI response after tag stripping and dispatch');
       }
 
       finalizeTurnMetrics(turnId);

--- a/backend/src/controllers/reconciler.ts
+++ b/backend/src/controllers/reconciler.ts
@@ -948,6 +948,8 @@ export async function refinementFinalizeHandler(
           sharedContent: content,
           refinedContent: content,
           sharedAt: now,
+          deliveryStatus: 'DELIVERED',
+          deliveredAt: now,
         },
       });
 

--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -34,6 +34,7 @@ import {
   getSharedContextForGuesser,
   generateShareSuggestionForDirection,
   hasContextAlreadyBeenShared,
+  markResultHandledAlreadyShared,
   incrementAttempts,
 } from '../services/reconciler';
 import { isSessionCreator } from '../utils/session';
@@ -133,6 +134,7 @@ async function triggerReconcilerAndUpdateStatuses(sessionId: string): Promise<vo
           `[triggerReconcilerAndUpdateStatuses] Context already shared B→A, skipping AWAITING_SHARING for User A`
         );
         statusA = EmpathyStatus.READY;
+        await markResultHandledAlreadyShared(sessionId, userAId, userBId);
       } else {
         statusA = hasSignificantGapsA ? EmpathyStatus.AWAITING_SHARING : EmpathyStatus.READY;
       }
@@ -193,6 +195,7 @@ async function triggerReconcilerAndUpdateStatuses(sessionId: string): Promise<vo
           `[triggerReconcilerAndUpdateStatuses] Context already shared A→B, skipping AWAITING_SHARING for User B`
         );
         statusB = EmpathyStatus.READY;
+        await markResultHandledAlreadyShared(sessionId, userBId, userAId);
       } else {
         statusB = hasSignificantGapsB ? EmpathyStatus.AWAITING_SHARING : EmpathyStatus.READY;
       }

--- a/backend/src/services/reconciler/circuit-breaker.ts
+++ b/backend/src/services/reconciler/circuit-breaker.ts
@@ -100,3 +100,44 @@ export async function hasContextAlreadyBeenShared(
 
   return false;
 }
+
+// ============================================================================
+// Helper: Mark a reconciler result "handled" via a SKIPPED sentinel share offer
+// ============================================================================
+
+/**
+ * When the context-already-shared shortcut fires, the active reconciler result
+ * still carries "significant gap / OFFER_SHARING" from its analysis. Without a
+ * marker, downstream readers (notably the GET /share-offer fallback in
+ * sharing.ts#generateShareOffer) would happily synthesize yet another redundant
+ * share suggestion.
+ *
+ * Attaching a SKIPPED ReconcilerShareOffer to the active result tells every
+ * reader "this one was handled, do not re-offer" without deleting the analysis
+ * itself (which is still useful data for status/summary endpoints).
+ */
+export async function markResultHandledAlreadyShared(
+  sessionId: string,
+  guesserId: string,
+  subjectId: string
+): Promise<void> {
+  const result = await prisma.reconcilerResult.findFirst({
+    where: { sessionId, guesserId, subjectId, supersededAt: null },
+    select: { id: true },
+  });
+  if (!result) return;
+
+  await prisma.reconcilerShareOffer.upsert({
+    where: { resultId: result.id },
+    create: {
+      resultId: result.id,
+      userId: subjectId,
+      status: 'SKIPPED',
+      skippedAt: new Date(),
+    },
+    update: {
+      status: 'SKIPPED',
+      skippedAt: new Date(),
+    },
+  });
+}

--- a/backend/src/services/reconciler/index.ts
+++ b/backend/src/services/reconciler/index.ts
@@ -28,6 +28,7 @@ export {
   checkAttempts,
   incrementAttempts,
   hasContextAlreadyBeenShared,
+  markResultHandledAlreadyShared,
 } from './circuit-breaker';
 
 // Analysis

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -31,6 +31,7 @@ import {
   dbResultToReconcilerResult,
   getWitnessingContent,
 } from './analysis';
+import { hasContextAlreadyBeenShared } from './circuit-breaker';
 import { checkAndRevealBothIfReady } from './state';
 
 // ============================================================================
@@ -1046,6 +1047,25 @@ export async function generateShareOffer(
 
   // If share offer already exists and was processed, return null
   if (result.shareOffer && result.shareOffer.status !== 'NOT_OFFERED') {
+    return null;
+  }
+
+  // If the subject has already shared context in this direction, don't synthesize
+  // another suggestion. The asymmetric reconciler shortcuts to READY in this case
+  // (state.ts hasContextAlreadyBeenShared branch), but the GET /share-offer
+  // fallback would otherwise keep re-drafting near-identical share suggestions
+  // every time the guesser refines, making the UX feel redundant and stuck.
+  const contextAlreadyShared = await hasContextAlreadyBeenShared(
+    sessionId,
+    result.guesserId,
+    subjectId
+  );
+  if (contextAlreadyShared) {
+    logger.info('generateShareOffer: context already shared, skipping redundant suggestion', {
+      sessionId,
+      guesserId: result.guesserId,
+      subjectId,
+    });
     return null;
   }
 

--- a/backend/src/services/reconciler/state.ts
+++ b/backend/src/services/reconciler/state.ts
@@ -28,7 +28,7 @@ import {
   getWitnessingContent,
   analyzeEmpathyGap,
 } from './analysis';
-import { checkAttempts, hasContextAlreadyBeenShared } from './circuit-breaker';
+import { checkAttempts, hasContextAlreadyBeenShared, markResultHandledAlreadyShared } from './circuit-breaker';
 import { generateShareSuggestion } from './sharing';
 
 // ============================================================================
@@ -54,6 +54,17 @@ async function markEmpathyReady(
     ? `You've shared your perspective on what ${subjectName} might be experiencing. Let's move forward — ${subjectName} is also reflecting on your perspective.`
     : `${subjectName} has felt heard. The reconciler reports your attempt to imagine what they're feeling was quite accurate. ${subjectName} is now considering your perspective, and once they do, you'll both see what each other shared.`;
 
+  // De-dup guard: reconciliation iterates every time either side refines, so
+  // the shortcut path can fire several times in a row with the same message
+  // content. If the last AI message to this guesser already says the same
+  // thing, just update the empathy status without re-posting the chat line.
+  const lastAiMessageForGuesser = await prisma.message.findFirst({
+    where: { sessionId, forUserId: guesserId, role: 'AI' },
+    orderBy: { timestamp: 'desc' },
+    select: { content: true },
+  });
+  const alreadyPosted = lastAiMessageForGuesser?.content?.trim() === alignmentMessage.trim();
+
   // Wrap state transition + status update + message creation in a transaction
   // to ensure atomicity — a partial write here could leave the attempt READY
   // without a corresponding alignment message, or vice versa.
@@ -72,6 +83,10 @@ async function markEmpathyReady(
       data: { status: 'READY', statusVersion: { increment: 1 } },
     });
 
+    if (alreadyPosted) {
+      return null;
+    }
+
     // Create alignment message
     const msg = await tx.message.create({
       data: {
@@ -86,6 +101,13 @@ async function markEmpathyReady(
 
     return msg;
   });
+
+  if (!savedMessage) {
+    logger.info('Skipping duplicate alignment message', { guesserId });
+    // Still need to check mutual reveal after the status update above.
+    await checkAndRevealBothIfReady(sessionId);
+    return;
+  }
 
   logger.debug('Created alignment message', { guesserId, alignmentMessage });
 
@@ -245,6 +267,10 @@ export async function runReconcilerForDirection(
     // Mark READY to prevent infinite loop, but use the honest "let's move forward"
     // message instead of the false "quite accurate" claim.
     await markEmpathyReady(sessionId, guesserId, subjectInfo.name, true);
+
+    // Mark the reconciler result "handled" so the GET /share-offer fallback
+    // (and any other downstream reader) won't synthesize a redundant suggestion.
+    await markResultHandledAlreadyShared(sessionId, guesserId, subjectId);
 
     return {
       result,

--- a/backend/src/utils/__tests__/micro-tag-parser.test.ts
+++ b/backend/src/utils/__tests__/micro-tag-parser.test.ts
@@ -181,5 +181,30 @@ Response after multiple newlines.`;
       const result = parseMicroTagResponse(raw);
       expect(result.response).toBe('Response after multiple newlines.');
     });
+
+    it('returns empty response (no placeholder) when content is entirely inside thinking', () => {
+      // Regression: previously returned "[AI processing — please continue the conversation]"
+      // which was then saved as the user-facing message. Caller should see empty and decide.
+      const raw = `<thinking>Mode:Witness | FeelHeardCheck:N</thinking>`;
+      const result = parseMicroTagResponse(raw);
+      expect(result.response).toBe('');
+      expect(result.thinking).toContain('Mode:Witness');
+    });
+
+    it('returns empty response (no placeholder) when only dispatch tag is present', () => {
+      // This is the exact shape that caused the "[AI processing...]" message in prod:
+      // model emitted <thinking>...</thinking><dispatch>TAG</dispatch> with no visible text.
+      const raw = `<thinking>User asking for impasse handling</thinking>\n<dispatch>HANDLE_DENIAL_IMPASSE</dispatch>`;
+      const result = parseMicroTagResponse(raw);
+      expect(result.response).toBe('');
+      expect(result.dispatchTag).toBe('HANDLE_DENIAL_IMPASSE');
+    });
+
+    it('returns empty response (no placeholder) when only draft is present', () => {
+      const raw = `<thinking>Mode:Empathy</thinking>\n<draft>A proposed empathy statement.</draft>`;
+      const result = parseMicroTagResponse(raw);
+      expect(result.response).toBe('');
+      expect(result.draft).toBe('A proposed empathy statement.');
+    });
   });
 });

--- a/backend/src/utils/micro-tag-parser.ts
+++ b/backend/src/utils/micro-tag-parser.ts
@@ -49,10 +49,16 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
     .replace(/<dispatch>[\s\S]*?<\/dispatch>/gi, '')
     .trim();
 
-  // 3. Fallback: if all content ended up inside tags, don't return empty
-  if (!responseText && thinking) {
-    logger.warn('[micro-tag-parser] Empty response after tag stripping — using thinking fallback');
-    responseText = '[AI processing — please continue the conversation]';
+  // If everything landed inside tags, leave response empty and let the caller
+  // decide what to do. A dispatch handler may still fill it in; otherwise the
+  // streaming endpoint should send an SSE error and ask the user to retry,
+  // rather than persisting a confusing "AI processing…" placeholder message.
+  if (!responseText && (thinking || draft || dispatchTag)) {
+    logger.warn('[micro-tag-parser] Empty response after tag stripping', {
+      hasThinking: !!thinking,
+      hasDraft: !!draft,
+      dispatchTag: dispatchTag ?? null,
+    });
   }
 
   // 3. Extract flags from thinking string (no JSON needed!)


### PR DESCRIPTION
## Summary
- Stops the redundant "share more about X" suggestions that kept regenerating every time a partner refined their empathy statement (reproduced live in a Stage-2 session with @piet).
- Stops the `[AI processing — please continue the conversation]` placeholder from ever reaching the chat; treats empty-response-after-dispatch as a retryable error instead.
- Fixes `ReconcilerShareOffer.deliveryStatus` staying `PENDING` forever when offers are accepted via the refinement path.
- De-dups the "Let's move forward — {partner} is also reflecting on your perspective" chat line that fired verbatim on every refinement cycle.

## Surfaced by
Real prod session `cmo6ki8bf000gon1xonjuwwpt`. Both partners ended up in the refinement loop; the "sharing suggestion" panel kept regenerating a substantively identical "I feel guilty about not responding…" draft three times because the `GET /reconciler/share-offer` fallback (`generateShareOffer`) didn't run the `hasContextAlreadyBeenShared` check that the asymmetric reconciler path does.

## What's in here
1. `micro-tag-parser.ts` — no more placeholder fallback (+ 3 regression tests).
2. `controllers/messages.ts` — empty-response guard moved after dispatch handling; routes through `streamError` cleanup so the client gets a proper retry prompt.
3. `controllers/reconciler.ts` (`refinementFinalizeHandler`) — sets `deliveryStatus=DELIVERED` + `deliveredAt` on accept, mirroring `respondToShareSuggestion`.
4. `reconciler/sharing.ts` (`generateShareOffer`) — runs `hasContextAlreadyBeenShared` before synthesizing a new suggestion.
5. `reconciler/circuit-breaker.ts` — new `markResultHandledAlreadyShared` helper that attaches a `SKIPPED` sentinel share-offer to the reconciler result whenever the shortcut fires.
6. `reconciler/state.ts` + `controllers/stage2.ts` (both symmetric branches) — use the helper so every downstream reader, not just the patched fallback, sees "this result was handled, don't re-offer."
7. `reconciler/state.ts` (`markEmpathyReady`) — de-dups the alignment chat message against the most recent AI message to the guesser.

Also ran a one-off SQL on prod to mark the stuck `OFFERED` share-offer in that session as `SKIPPED` so the UI cleared immediately.

## Not in this PR (next design round)
- Impasse off-ramp for cases where the two partners fundamentally can't engage in good faith (e.g. factual contradictions, one side performative). The reconciler currently treats each partner's Stage-1 content as ground truth with no epistemic check, and the dispatch-handler has no `IMPASSE` handler — the AI freelanced `HANDLE_DENIAL_IMPASSE` and `HANDLE_DIRECT_CONTACT_REQUEST` in the session, both of which landed as `Unknown tag ignored` warnings.

## Test plan
- [x] `npm run check` clean across all workspaces
- [x] `npx jest` — 61 suites, 1162 tests passing
- [ ] Manual: verify prod session no longer regenerates "I feel guilty about messages piling up" share suggestion after piet refines
- [ ] Manual: trigger an unknown dispatch tag (or force an empty-response case) and confirm client sees a retry prompt instead of `[AI processing…]`
- [ ] Manual: verify the "Let's move forward" message posts at most once per session state

🤖 Generated with [Claude Code](https://claude.com/claude-code)