### PR TITLE
fix(backend): add HELD + GAPS_DETECTED empathy state transition

### DIFF
--- a/backend/src/services/__tests__/empathy-state-machine.test.ts
+++ b/backend/src/services/__tests__/empathy-state-machine.test.ts
@@ -13,6 +13,10 @@ describe('empathy-state-machine', () => {
       expect(transition(EmpathyStatus.HELD, 'START_ANALYSIS')).toBe(EmpathyStatus.ANALYZING);
     });
 
+    it('HELD → AWAITING_SHARING on GAPS_DETECTED (skip ANALYZING)', () => {
+      expect(transition(EmpathyStatus.HELD, 'GAPS_DETECTED')).toBe(EmpathyStatus.AWAITING_SHARING);
+    });
+
     it('HELD → READY on MARK_READY (skip analysis)', () => {
       expect(transition(EmpathyStatus.HELD, 'MARK_READY')).toBe(EmpathyStatus.READY);
     });
@@ -120,8 +124,9 @@ describe('empathy-state-machine', () => {
     it('returns correct events for HELD', () => {
       const events = validEventsFor(EmpathyStatus.HELD);
       expect(events).toContain('START_ANALYSIS');
+      expect(events).toContain('GAPS_DETECTED');
       expect(events).toContain('MARK_READY');
-      expect(events).toHaveLength(2);
+      expect(events).toHaveLength(3);
     });
 
     it('returns empty for VALIDATED (terminal)', () => {

--- a/backend/src/services/__tests__/reconciler.test.ts
+++ b/backend/src/services/__tests__/reconciler.test.ts
@@ -198,7 +198,7 @@ describe('Reconciler Service', () => {
     });
 
     it('throws on invalid transition', () => {
-      expect(() => transition(EmpathyStatus.HELD, 'GAPS_DETECTED')).toThrow(
+      expect(() => transition(EmpathyStatus.HELD, 'MUTUAL_REVEAL')).toThrow(
         'Invalid empathy state transition'
       );
     });

--- a/backend/src/services/empathy-state-machine.ts
+++ b/backend/src/services/empathy-state-machine.ts
@@ -7,6 +7,7 @@
  *
  * Valid transitions:
  *   HELD → ANALYZING (reconciler starts comparing)
+ *   HELD → AWAITING_SHARING (gaps detected, skip ANALYZING)
  *   HELD → READY (minor/no gaps, skip sharing)
  *   ANALYZING → AWAITING_SHARING (gaps detected)
  *   ANALYZING → READY (no significant gaps)
@@ -38,6 +39,7 @@ export type EmpathyEvent =
 const TRANSITIONS: Record<string, EmpathyStatus | undefined> = {
   // From HELD
   [`${EmpathyStatus.HELD}:START_ANALYSIS`]: EmpathyStatus.ANALYZING,
+  [`${EmpathyStatus.HELD}:GAPS_DETECTED`]: EmpathyStatus.AWAITING_SHARING,
   [`${EmpathyStatus.HELD}:MARK_READY`]: EmpathyStatus.READY,
 
   // From ANALYZING

--- a/docs/diagrams/reconciler-paths.md
+++ b/docs/diagrams/reconciler-paths.md
@@ -682,7 +682,7 @@ These diagrams are implemented across:
 - **Mobile**: `mobile/src/hooks/useEmpathyActions.ts` (empathy mutations)
 - **Shared**: `shared/src/dto/reconciler.ts` (types and contracts)
 
-> **Note on ANALYZING state:** The `ANALYZING` status and its transitions (`HELD → ANALYZING` via `START_ANALYSIS`, `ANALYZING → READY` via `NO_SIGNIFICANT_GAPS`, `ANALYZING → AWAITING_SHARING` via `GAPS_DETECTED`) are defined in `empathy-state-machine.ts` but are never triggered by the reconciler code. The reconciler in `reconciler/state.ts` updates the database status directly from `HELD` to `READY` or `AWAITING_SHARING`, bypassing the `ANALYZING` state. The state machine definition retains `ANALYZING` for potential future use.
+> **Note on ANALYZING state:** The `ANALYZING` status and its transitions (`HELD → ANALYZING` via `START_ANALYSIS`, `ANALYZING → READY` via `NO_SIGNIFICANT_GAPS`, `ANALYZING → AWAITING_SHARING` via `GAPS_DETECTED`) are defined in `empathy-state-machine.ts` but are never triggered by the reconciler code. The reconciler performs analysis inline and transitions directly from `HELD` — using `HELD + GAPS_DETECTED → AWAITING_SHARING` or `HELD + MARK_READY → READY`. The `ANALYZING` state is retained for potential future use where analysis might be asynchronous.
 
 For detailed specs, see:
 - `docs/archive/specs/when-the-reconciler-responds-with-offeroptional-we-need-to-implement-this.md`


### PR DESCRIPTION
## Changes
- Fix: Add missing `HELD + GAPS_DETECTED → AWAITING_SHARING` transition to the empathy state machine
- Fix: The reconciler performs inline analysis and fires `GAPS_DETECTED` directly from `HELD` status, but only `ANALYZING + GAPS_DETECTED` was defined — causing errors for sessions with significant empathy gaps
- Test: Add test case for the new transition and update `validEventsFor(HELD)` assertion

Related to #142

## Provenance
- **Channel:** GitHub issue
- **Requested by:** health-check audit (2026-04-20)
- **Original message:** Sentry error MWF-BACKEND-6 — `Invalid empathy state transition: HELD + GAPS_DETECTED`

## Docs updated
- `docs/diagrams/reconciler-paths.md` — Updated ANALYZING state note to reflect that the state machine now formally supports direct `HELD → AWAITING_SHARING` transitions