### PR TITLE
docs: fix drift from 24h incremental audit (2026-04-20)

### DIFF
--- a/docs/backend/prompting-architecture.md
+++ b/docs/backend/prompting-architecture.md
@@ -3,12 +3,12 @@ title: Backend Prompting Architecture Audit
 sidebar_position: 5
 description: "Last Updated: 2026-03-11"
 created: 2026-03-11
-updated: 2026-04-18
+updated: 2026-04-20
 status: living
 ---
 # Backend Prompting Architecture Audit
 
-**Last Updated:** 2026-04-18
+**Last Updated:** 2026-04-20
 
 This document provides a comprehensive overview of how prompting works in the Meet Without Fear backend, including prompt construction, model usage, parallel vs sequential operations, and memory handling.
 
@@ -484,7 +484,7 @@ graph TD
    When `PromptContext.invitedSessionNudge` is set (non-null), its content is appended to the dynamic block as `OPERATIONAL NUDGE:`. This signals the AI to weave in an invite-expiry reminder. Only used for Slack-originated `INVITED` sessions approaching their 7-day TTL.
 
 5. **Dynamic Elements:**
-   - Turn count
+   - **Stage turn count** (`stageTurnCount`) — counts only messages in the *current stage*, not the session total. This ensures stage-specific guards (e.g. `earlyStage3`, feel-heard timing) fire correctly regardless of how many turns occurred in prior stages.
    - Emotional intensity
    - Surfacing style
    - Stage transition acknowledgments
@@ -924,7 +924,7 @@ The `buildBudgetedContext()` function in `backend/src/utils/token-budget.ts` man
 - `backend/src/services/reconciler/` - Empathy gap analysis (modular: `analysis.ts`, `state.ts`, `sharing.ts`, `circuit-breaker.ts`)
 - `backend/src/services/crisis-detector.ts` - Pattern-based safety detection (additive safety net alongside LLM prompts)
 - `backend/src/services/input-sanitizer.ts` - Prompt injection defense (XML delimiters + pattern detection)
-- `backend/src/services/needs.ts` - Need extraction
+- `backend/src/services/needs.ts` - Need extraction + Stage 3 safety-net extraction (`runStage3SafetyNetExtraction`, fires at `stageTurnCount ≥ 6` if no needs identified yet) + shared extraction lock (`isExtractionRunning` / `acquireExtractionLock` / `releaseExtractionLock`)
 
 ---
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -3,7 +3,7 @@ title: Deployment
 sidebar_position: 1
 description: Production deployment targets and distribution options for the Meet Without Fear platform.
 created: 2026-03-11
-updated: 2026-04-16
+updated: 2026-04-20
 status: living
 ---
 # Deployment
@@ -58,9 +58,19 @@ Build profiles are defined in `mobile/eas.json`. Most profiles set `EXPO_PUBLIC_
 
 | Target | Workspace | Deploy Command |
 |--------|-----------|----------------|
-| Website | `website/` | `npm run website:deploy` (runs `cd website && vercel --prod`) |
+| Website (`meetwithoutfear.com`) | `website/` | `npm run website:deploy` (runs `cd website && vercel --prod`) |
 | Docs site | `docs-site/` | `npm run docs:deploy` (runs Vercel deploy in docs-site workspace) |
 | Status dashboard | `tools/status-dashboard/` | `npm run deploy:status` (runs `cd tools/status-dashboard && vercel --prod`) |
+
+### Web App: Vercel (Expo Web)
+
+The Expo mobile codebase also bundles for web and is served at `app.meetwithoutfear.com`.
+
+- **Vercel project**: `mwf-app` (Root Directory: `mobile/`)
+- **Deploy trigger**: `.github/workflows/vercel-deploy-app.yml` — fires automatically on pushes to `main` that touch `mobile/**` or `shared/**`; also supports `workflow_dispatch`
+- **Build**: `expo export --platform web` (run by `vercel build --prod`)
+- **Env vars / secrets**: `VERCEL_ORG_ID`, `VERCEL_APP_PROJECT_ID` (repo vars), `VERCEL_TOKEN` (repo secret)
+- **Web shims**: Platform-specific overrides live in `mobile/src/shims/` (Clerk token cache, SecureStore, Sentry) and `mobile/src/hooks/*.web.ts` (speech, voice input, OTA, biometrics)
 
 ## CI/CD Pipeline
 
@@ -87,6 +97,19 @@ The pipeline uses a dedicated test database (`meetwithoutfear_test`) with `NODE_
 Runs on push to `main`. A `dorny/paths-filter` step restricts deploys to pushes that actually change `backend/`, `shared/`, the lockfile, `render.yaml`, or the workflow itself. On a match, the workflow `curl -X POST`s the Render **deploy hook** stored in repo secret `RENDER_DEPLOY_HOOK`.
 
 > Render's built-in "auto-deploy on push" must be **off** for the `meet-without-fear-api` service — GitHub Actions is the only deploy trigger. This prevents docs-only pushes from rebuilding the backend.
+
+### `.github/workflows/vercel-deploy-app.yml` — Expo Web deploy on main
+Runs on push to `main` when `mobile/**` or `shared/**` changes (also `workflow_dispatch`). Builds the Expo Web bundle via `vercel build --prod` and deploys it to `app.meetwithoutfear.com` (Vercel project `mwf-app`). Uses repo vars `VERCEL_ORG_ID` / `VERCEL_APP_PROJECT_ID` and secret `VERCEL_TOKEN`.
+
+### `.github/workflows/vercel-deploy-website.yml` — marketing site deploy on main
+Runs on push to `main` when `website/**` changes. Deploys `website/` to Vercel (`meetwithoutfear.com`).
+
+### `.github/workflows/ota-update.yml` — OTA update for iOS
+Runs on push to `main` when `mobile/**` or `shared/**` changes (also `workflow_dispatch` with optional message). Publishes an Expo OTA update to the `production` EAS branch (iOS only) using `eas update`. Uses secret `EXPO_TOKEN`.
+
+- OTA updates are picked up on next app launch — no App Store review required
+- Roll back a bad update: `eas update:list --branch production --non-interactive --json` → `eas update:delete <group-id> --non-interactive`
+- `cancel-in-progress: false` — in-flight EAS update jobs are never cancelled (a partial publish can crash the app)
 
 ## Key Environment Variables
 

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -3,7 +3,7 @@ title: Infrastructure
 sidebar_position: 1
 description: Slam bot (EC2), Render hosting, Vercel deploys, GitHub automation.
 created: 2026-03-11
-updated: 2026-04-19
+updated: 2026-04-20
 status: living
 ---
 
@@ -85,7 +85,8 @@ For `#mwf-sessions`, when `MWF_BACKEND_URL` is set the listener POSTs directly t
 - **Backend API**: Render (`meet-without-fear-api` / `srv-d58bj73uibrs73akacd0`), env group `be-heard-api-env`
 - **Database**: Render Postgres (`be-heard-db` / `dpg-d58660shg0os73bkkpmg-a`), Oregon region
 - **Docs site (this one)**: Vercel
-- **Marketing site**: Vercel
+- **Marketing site**: Vercel (`website/`)
+- **Web app** (`app.meetwithoutfear.com`): Vercel — Expo Web build of `mobile/`, Vercel project `mwf-app`. Deployed via `.github/workflows/vercel-deploy-app.yml` on pushes to `main` that touch `mobile/**` or `shared/**`.
 
 See [deployment](../deployment/index.md) for release procedures and env var reference.
 
@@ -94,3 +95,6 @@ See [deployment](../deployment/index.md) for release procedures and env var refe
 - `.github/workflows/docs-impact.yml` — PR-time check that code changes and their mapped docs are updated together. Mapping rules in `docs/code-to-docs-mapping.json`.
 - `.github/workflows/ci.yml` — PR-time CI: spins up a Postgres 15 service container, installs deps (`npm ci`), generates the Prisma client, runs `npm run check`, migrates the test DB, and runs `npm run test`. Skipped for docs-only changes via `dorny/paths-filter`. A `ci-success` gate job is the single required status check for branch protection.
 - `.github/workflows/render-deploy.yml` — Push-to-`main` backend deploy: filters to pushes that touch `backend/`, `shared/`, the lockfile, `render.yaml`, or the workflow itself, then POSTs the Render deploy hook (stored in repo secret `RENDER_DEPLOY_HOOK`). Render's built-in auto-deploy must be **off** — this workflow is the sole deploy trigger.
+- `.github/workflows/vercel-deploy-app.yml` — Push-to-`main` Expo Web deploy: filters to pushes touching `mobile/**` or `shared/**`, builds the Expo Web bundle, and deploys to `app.meetwithoutfear.com` via Vercel (`mwf-app` project). Also supports `workflow_dispatch`.
+- `.github/workflows/vercel-deploy-website.yml` — Push-to-`main` marketing site deploy: filters to pushes touching `website/**`, deploys to Vercel.
+- `.github/workflows/ota-update.yml` — Push-to-`main` OTA update: publishes an Expo OTA update to the `production` EAS branch for iOS whenever `mobile/**` or `shared/**` changes on `main`. Also supports `workflow_dispatch` with a custom message. Uses `EXPO_TOKEN` secret. Roll back a bad update with `eas update:delete <group-id> --non-interactive`.


### PR DESCRIPTION
## Changes
- Update: `docs/infrastructure/index.md` — add `app.meetwithoutfear.com` (Expo Web on Vercel) to production hosting; document `vercel-deploy-app.yml`, `vercel-deploy-website.yml`, and `ota-update.yml` GitHub workflows
- Update: `docs/deployment/index.md` — add "Web App: Vercel (Expo Web)" section covering `app.meetwithoutfear.com`, web shims, and CI/CD secrets; document new OTA update workflow with rollback procedure
- Fix: `docs/backend/prompting-architecture.md` — clarify that turn count passed to `buildStagePrompt` is stage-scoped (`stageTurnCount`), not session-wide; document Stage 3 safety-net extraction and shared extraction lock in `needs.ts`

## Provenance
- **Channel:** cron / nightly audit-docs
- **Requested by:** @slam-paws (automated)
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** `/audit-docs` — git-history-aware incremental docs audit covering PRs #116–#140

## Docs updated
- `docs/infrastructure/index.md`
- `docs/deployment/index.md`
- `docs/backend/prompting-architecture.md`