### PR TITLE
fix(backend): require Clerk JWT auth for /realtime WebSocket

### DIFF
--- a/backend/src/services/__tests__/realtime-transcription.test.ts
+++ b/backend/src/services/__tests__/realtime-transcription.test.ts
@@ -1,0 +1,110 @@
+import { attachRealtimeWebSocket } from '../realtime-transcription';
+import { EventEmitter } from 'events';
+
+// Self-contained ws mock — instances are accessed via jest.requireMock after setup
+jest.mock('ws', () => {
+  const Server = jest.fn().mockImplementation(() => ({
+    handleUpgrade: jest.fn(),
+    on: jest.fn(),
+    emit: jest.fn(),
+  }));
+  const WS = function () {} as any;
+  WS.Server = Server;
+  return { __esModule: true, default: WS };
+});
+
+// Mock @clerk/express (intercepts both static and dynamic imports)
+jest.mock('@clerk/express', () => ({
+  verifyToken: jest.fn(),
+}));
+
+function makeRequest(url: string) {
+  return { url, headers: { host: 'localhost' } };
+}
+
+function makeSocket() {
+  return { write: jest.fn(), destroy: jest.fn() };
+}
+
+describe('attachRealtimeWebSocket — JWT auth', () => {
+  let server: EventEmitter;
+  let wssInstance: { handleUpgrade: jest.Mock; on: jest.Mock; emit: jest.Mock };
+  let mockVerifyToken: jest.Mock;
+
+  beforeEach(() => {
+    server = new EventEmitter();
+    process.env.CLERK_SECRET_KEY = 'test-clerk-key';
+
+    // Clear mock state before each test
+    const MockServer = jest.requireMock('ws').default.Server as jest.Mock;
+    MockServer.mockClear();
+
+    mockVerifyToken = jest.requireMock('@clerk/express').verifyToken as jest.Mock;
+    mockVerifyToken.mockReset();
+
+    attachRealtimeWebSocket(server as any);
+
+    // Capture the wss instance created inside attachRealtimeWebSocket
+    wssInstance = MockServer.mock.results[0].value as typeof wssInstance;
+  });
+
+  afterEach(() => {
+    delete process.env.CLERK_SECRET_KEY;
+  });
+
+  it('rejects upgrade without ?token= with HTTP 401', () => {
+    const socket = makeSocket();
+    server.emit('upgrade', makeRequest('/realtime'), socket, Buffer.alloc(0));
+
+    // No-token path is synchronous — no async needed
+    expect(socket.write).toHaveBeenCalledWith('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    expect(socket.destroy).toHaveBeenCalled();
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+    expect(wssInstance.handleUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('rejects upgrade with an invalid/expired token with HTTP 401', async () => {
+    mockVerifyToken.mockRejectedValue(new Error('Token verification failed'));
+    const socket = makeSocket();
+
+    const destroyPromise = new Promise<void>((resolve) => {
+      socket.destroy.mockImplementation(resolve);
+    });
+
+    server.emit('upgrade', makeRequest('/realtime?token=bad-token'), socket, Buffer.alloc(0));
+    await destroyPromise;
+
+    expect(socket.write).toHaveBeenCalledWith('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    expect(socket.destroy).toHaveBeenCalled();
+    expect(wssInstance.handleUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('allows upgrade with a valid Clerk JWT', async () => {
+    mockVerifyToken.mockResolvedValue({ sub: 'user_abc123' });
+    const socket = makeSocket();
+    const head = Buffer.alloc(0);
+
+    const handleUpgradePromise = new Promise<void>((resolve) => {
+      wssInstance.handleUpgrade.mockImplementation(resolve);
+    });
+
+    server.emit('upgrade', makeRequest('/realtime?token=valid-clerk-jwt'), socket, head);
+    await handleUpgradePromise;
+
+    expect(socket.write).not.toHaveBeenCalled();
+    expect(socket.destroy).not.toHaveBeenCalled();
+    expect(mockVerifyToken).toHaveBeenCalledWith('valid-clerk-jwt', expect.any(Object));
+    expect(wssInstance.handleUpgrade).toHaveBeenCalled();
+  });
+
+  it('ignores non-/realtime upgrade requests without touching the socket', async () => {
+    const socket = makeSocket();
+    server.emit('upgrade', makeRequest('/other-path'), socket, Buffer.alloc(0));
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(socket.write).not.toHaveBeenCalled();
+    expect(socket.destroy).not.toHaveBeenCalled();
+    expect(wssInstance.handleUpgrade).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/realtime-transcription.ts
+++ b/backend/src/services/realtime-transcription.ts
@@ -23,6 +23,7 @@ import { Server, IncomingMessage } from 'http';
 import { Socket } from 'net';
 import { logger } from '../lib/logger';
 
+const CLERK_SECRET_KEY = process.env.CLERK_SECRET_KEY;
 const ASSEMBLYAI_API_KEY = process.env.ASSEMBLYAI_API_KEY;
 const ASSEMBLYAI_TOKEN_URL = 'https://streaming.assemblyai.com/v3/token?expires_in_seconds=300';
 const ASSEMBLYAI_WS_BASE = 'wss://streaming.assemblyai.com/v3/ws';
@@ -37,15 +38,39 @@ const MIN_CHUNK_SIZE = 1600;
 export function attachRealtimeWebSocket(server: Server): void {
   const wss = new WebSocket.Server({ noServer: true });
 
-  server.on('upgrade', (request: IncomingMessage, socket, head: Buffer) => {
-    const pathname = new URL(request.url || '', `http://${request.headers.host}`).pathname;
+  server.on('upgrade', async (request: IncomingMessage, socket, head: Buffer) => {
+    const url = new URL(request.url || '', `http://${request.headers.host}`);
 
-    if (pathname === '/realtime') {
-      wss.handleUpgrade(request, socket as Socket, head, (ws: WebSocket) => {
-        wss.emit('connection', ws, request);
-      });
+    if (url.pathname !== '/realtime') {
+      // Non-/realtime upgrades are ignored (other middleware may handle them)
+      return;
     }
-    // Non-/realtime upgrades are ignored (other middleware may handle them)
+
+    // Verify Clerk JWT before accepting the WebSocket upgrade
+    const token = url.searchParams.get('token');
+    if (!token) {
+      logger.warn('[Realtime] WebSocket upgrade rejected: no token provided');
+      (socket as Socket).write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+      (socket as Socket).destroy();
+      return;
+    }
+
+    try {
+      const { verifyToken } = await import('@clerk/express');
+      const session = await verifyToken(token, {
+        secretKey: CLERK_SECRET_KEY!,
+      });
+      logger.info('[Realtime] Authenticated WebSocket upgrade for user:', session.sub);
+    } catch (error) {
+      logger.warn('[Realtime] WebSocket upgrade rejected: invalid token', error);
+      (socket as Socket).write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+      (socket as Socket).destroy();
+      return;
+    }
+
+    wss.handleUpgrade(request, socket as Socket, head, (ws: WebSocket) => {
+      wss.emit('connection', ws, request);
+    });
   });
 
   wss.on('connection', async (clientWs: WebSocket, request: import('http').IncomingMessage) => {

--- a/docs/backend/index.md
+++ b/docs/backend/index.md
@@ -3,7 +3,7 @@ title: Backend Documentation
 sidebar_position: 1
 description: Backend-specific documentation for the Express + Prisma API server.
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-04-20
 status: living
 ---
 # Backend Documentation
@@ -60,7 +60,7 @@ These rules are constitutional and must never be compromised:
 - **AI Models**: AWS Bedrock (Haiku for mechanics, Sonnet for facilitation)
 - **Auth**: Clerk (JWT validation, account deletion handoff)
 - **Email**: Resend (transactional; not outbound invitation delivery)
-- **Voice**: AssemblyAI Universal Streaming (real-time transcription via `realtime-transcription.ts`)
+- **Voice**: AssemblyAI Universal Streaming (real-time transcription via `realtime-transcription.ts`; WebSocket upgrade requires Clerk JWT via `?token=` param)
 - **Infrastructure**: Render.com (Web Service + Managed Postgres)
 
 ## Dual-Layer Data Strategy


### PR DESCRIPTION
## Changes
- Add Clerk JWT verification before accepting WebSocket upgrade on `/realtime`
- Reject unauthenticated connections with HTTP 401 before the upgrade completes
- Extract auth token from `?token=` query parameter (standard pattern for WebSocket auth)
- Follow the same `verifyToken()` pattern used by all HTTP route middleware

Related to #147

## Provenance
- **Channel:** #security-audit
- **Requested by:** weekly security audit (automated)
- **Original message:** weekly security audit cron
- **Prompt(s) used:** Network & Application Security agent scan

## Docs updated
No doc changes needed — security fix to existing endpoint with no docs mapping