### PR TITLE
fix(backend): fix premature 'move forward' CTA during empathy stage

### DIFF
--- a/backend/src/__tests__/circuit-breaker-integration.test.ts
+++ b/backend/src/__tests__/circuit-breaker-integration.test.ts
@@ -138,7 +138,7 @@ describe('Circuit Breaker Integration', () => {
       orderBy: { timestamp: 'desc' },
     });
     expect(messages.length).toBeGreaterThanOrEqual(1);
-    expect(messages[0].content).toContain("Let's move forward");
+    expect(messages[0].content).toContain("Your perspective has been received");
     expect(messages[0].content).toContain('Bob');
     // Should NOT contain the normal "quite accurate" message
     expect(messages[0].content).not.toContain('quite accurate');

--- a/backend/src/__tests__/circuit-breaker-integration.test.ts
+++ b/backend/src/__tests__/circuit-breaker-integration.test.ts
@@ -9,7 +9,7 @@ import { runReconcilerForDirection, incrementAttempts } from '../services/reconc
  * runReconcilerForDirection once. Verifies it:
  *   - Skips the AI analysis entirely
  *   - Marks empathy as READY with circuitBreakerTripped=true
- *   - Creates the "Let's move forward" transition message
+ *   - Creates the "Your perspective has been received" transition message
  *   - Calls checkAndRevealBothIfReady (reveals if both directions are READY)
  *
  * Uses real Prisma against the test DB with mocked Ably (realtime) and empathy-status.
@@ -155,7 +155,7 @@ describe('Circuit Breaker Integration', () => {
       sessionId,
       userAId,
       expect.objectContaining({
-        content: expect.stringContaining("Let's move forward"),
+        content: expect.stringContaining("Your perspective has been received"),
       }),
       expect.anything()
     );

--- a/backend/src/services/__tests__/empathy-state-machine.test.ts
+++ b/backend/src/services/__tests__/empathy-state-machine.test.ts
@@ -72,6 +72,12 @@ describe('empathy-state-machine', () => {
     });
 
     // ===== Invalid transitions throw =====
+    it('throws on HELD + GAPS_DETECTED (must go through ANALYZING first)', () => {
+      expect(() => transition(EmpathyStatus.HELD, 'GAPS_DETECTED')).toThrow(
+        'Invalid empathy state transition: HELD + GAPS_DETECTED'
+      );
+    });
+
     it('throws on HELD + VALIDATE (skip to end)', () => {
       expect(() => transition(EmpathyStatus.HELD, 'VALIDATE')).toThrow(
         'Invalid empathy state transition: HELD + VALIDATE'

--- a/backend/src/services/__tests__/reconciler.test.ts
+++ b/backend/src/services/__tests__/reconciler.test.ts
@@ -1338,8 +1338,8 @@ describe('Reconciler Service', () => {
 
       // The empathyAttempt.findFirst is called multiple times:
       // 1. getEmpathyData (for the guesser's empathy statement) — needs content
-      // 2. For AWAITING_SHARING transition validation — needs status ANALYZING
-      //    (because analyzeEmpathyGap runs first, implicitly the status should be ANALYZING)
+      // 2. For AWAITING_SHARING transition validation — still HELD in the DB
+      //    (the code validates HELD→START_ANALYSIS then ANALYZING→GAPS_DETECTED)
       (prisma.empathyAttempt.findFirst as jest.Mock)
         .mockResolvedValueOnce({
           id: 'attempt-1',
@@ -1353,7 +1353,7 @@ describe('Reconciler Service', () => {
           id: 'attempt-1',
           sessionId,
           sourceUserId: guesserId,
-          status: EmpathyStatus.ANALYZING,
+          status: EmpathyStatus.HELD,
         });
 
       // Mock reconciler result creation — need it for generateShareSuggestion

--- a/backend/src/services/reconciler/state.ts
+++ b/backend/src/services/reconciler/state.ts
@@ -51,7 +51,7 @@ async function markEmpathyReady(
 
   // Choose message based on whether circuit breaker tripped
   const alignmentMessage = circuitBreakerTripped
-    ? `You've shared your perspective on what ${subjectName} might be experiencing. Let's move forward — ${subjectName} is also reflecting on your perspective.`
+    ? `Your perspective has been received. ${subjectName} is also reflecting on yours — once they're done, you'll both see what each other shared.`
     : `${subjectName} has felt heard. The reconciler reports your attempt to imagine what they're feeling was quite accurate. ${subjectName} is now considering your perspective, and once they do, you'll both see what each other shared.`;
 
   // Wrap state transition + status update + message creation in a transaction
@@ -284,7 +284,8 @@ export async function runReconcilerForDirection(
       where: { sessionId, sourceUserId: guesserId },
     });
     if (attemptForAwait) {
-      transition(attemptForAwait.status as EmpathyStatus, 'GAPS_DETECTED');
+      transition(attemptForAwait.status as EmpathyStatus, 'START_ANALYSIS');
+      transition(EmpathyStatus.ANALYZING, 'GAPS_DETECTED');
     }
     await tx.empathyAttempt.updateMany({
       where: { sessionId, sourceUserId: guesserId },

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -3,7 +3,7 @@ title: "Stage 2: Perspective Stretch - Empathy Exchange Flow"
 sidebar_position: 6
 description: This document describes the empathy exchange flow in Stage 2, including the reconciler system that analyzes empathy accuracy and manages the sharing of addit...
 created: 2026-03-11
-updated: 2026-04-18
+updated: 2026-04-20
 status: living
 ---
 # Stage 2: Perspective Stretch - Empathy Exchange Flow
@@ -521,7 +521,7 @@ If user tries to validate partner's empathy before reconciler finishes:
 ### Case 5: User Responds Before Fetching Share Offer
 If user accepts/declines before the GET endpoint marks offer as `OFFERED`:
 - `respondToShareSuggestion` accepts both `PENDING` and `OFFERED` status, and supports three actions: `accept`, `decline`, and `refine` (re-runs suggestion generation with `refinedContent` feedback from the user)
-- After the circuit-breaker trips, the Guesser's alignment message is softened from the default "your attempt to imagine what they're feeling was quite accurate" to the more honest "You've shared your perspective… Let's move forward" to avoid overclaiming accuracy when refinement was exhausted or context was already shared
+- After the circuit-breaker trips, the Guesser's alignment message is softened from the default "your attempt to imagine what they're feeling was quite accurate" to the more honest "Your perspective has been received. [Partner] is also reflecting on yours — once they're done, you'll both see what each other shared." to avoid overclaiming accuracy when refinement was exhausted or context was already shared
 - Marks as `OFFERED` before processing for proper audit trail
 
 ## Debugging Tips

--- a/docs/diagrams/reconciler-paths.md
+++ b/docs/diagrams/reconciler-paths.md
@@ -3,7 +3,7 @@ title: Reconciler Outcome Paths - State Diagrams
 sidebar_position: 4
 description: This document provides state diagrams for all reconciler outcome paths from both user perspectives (guesser and subject). These diagrams document the complet...
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-04-20
 status: living
 ---
 # Reconciler Outcome Paths - State Diagrams
@@ -306,7 +306,7 @@ stateDiagram-v2
 
 ## 4. Refinement Loop (One Cycle)
 
-When the subject shares additional context, the guesser can refine their empathy attempt. The reconciler re-runs each cycle. A circuit breaker (`refinement-circuit-breaker.ts`) caps this at **3 attempts per direction** — beyond that, the reconciler is skipped and the attempt is forced into `READY` with the softer "let's move forward" alignment message.
+When the subject shares additional context, the guesser can refine their empathy attempt. The reconciler re-runs each cycle. A circuit breaker (`refinement-circuit-breaker.ts`) caps this at **3 attempts per direction** — beyond that, the reconciler is skipped and the attempt is forced into `READY` with a softer waiting-state alignment message ("Your perspective has been received…").
 
 ### 4.1 Guesser Perspective (Refinement)
 
@@ -562,7 +562,7 @@ stateDiagram-v2
 
 ## 6. Acceptance Check (Guesser Declines to Refine)
 
-When the guesser receives shared context or feedback but chooses not to refine their empathy statement, the backend transitions the attempt to `READY` with a **hardcoded** alignment message — there is no AI call at this junction. The message is chosen from two templates based on whether the circuit breaker tripped: either "`<subjectName>` has felt heard…" (normal path) or "You've shared your perspective… Let's move forward" (circuit-breaker / already-shared-context path).
+When the guesser receives shared context or feedback but chooses not to refine their empathy statement, the backend transitions the attempt to `READY` with a **hardcoded** alignment message — there is no AI call at this junction. The message is chosen from two templates based on whether the circuit breaker tripped: either "`<subjectName>` has felt heard…" (normal path) or "Your perspective has been received. `<subjectName>` is also reflecting on yours…" (circuit-breaker / already-shared-context path).
 
 ### 6.1 Guesser Perspective (Acceptance Check)
 


### PR DESCRIPTION
## Changes
- Fix: Replace misleading "Let's move forward" circuit breaker message with waiting-state language ("Your perspective has been received…") that doesn't prompt the user to act while their partner is still reflecting
- Fix: Add missing `START_ANALYSIS` intermediate state transition before `GAPS_DETECTED` in the empathy reconciler — the state machine requires `HELD → ANALYZING → AWAITING_SHARING`, but the code was calling `transition(HELD, GAPS_DETECTED)` directly, causing Sentry error MWF-BACKEND-6
- Test: Add explicit test for invalid `HELD + GAPS_DETECTED` transition; update reconciler test mock to reflect correct `HELD` status (was incorrectly mocking `ANALYZING`)

Related to #156

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** "The app told me to move forward when we couldn't move forward"

## Docs updated
- `docs/backend/reconciler-flow.md` — updated circuit breaker message text
- `docs/diagrams/reconciler-paths.md` — updated circuit breaker message references