### PR TITLE
fix(slam-bot): stop clear-stale-locks.sh from deleting main worktree

### DIFF
--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -80,6 +80,38 @@ The socket listener routes messages by channel config. Each monitored channel ma
 
 For `#mwf-sessions`, when `MWF_BACKEND_URL` is set the listener POSTs directly to the backend Bedrock pipeline instead of spawning a Claude Code agent.
 
+### Runbook: repo disappearance
+
+The repo clone at `/home/ubuntu/projects/meet-without-fear/` has vanished four times (2026-04-16, -18, -19, -21), each time breaking the `/opt/slam-bot/scripts` symlink chain. Symptoms: Slack messages stuck on `:eyes:` with no reply, `/var/log/slam-bot/socket-mode.log` crashing on `spawn /opt/slam-bot/scripts/run-claude.sh ENOENT`, `cron.log` flooded with "not found".
+
+**Root cause (identified 2026-04-21)**: the worktree-cleanup loop in `clear-stale-locks.sh` was deleting the main worktree. Its main-worktree guard compared `$WT_PATH` (canonical path from `git worktree list`, e.g. `/home/ubuntu/projects/meet-without-fear`) against `$REPO_ROOT` (symlinked path `/home/ubuntu/meet-without-fear`), which never matched. With the guard bypassed, the `main` branch had no PR → the "no PR + >24h → abandoned" fallback fired → `rm -rf` on the main checkout. Fixed by normalizing both paths with `readlink -f`, adding a `main|master|develop` branch allowlist, and restricting the "no PR" fallback to bot-owned branch patterns.
+
+Persistent auditd watches are installed at `/etc/audit/rules.d/mwf.rules` (keys `mwf_projects`, `mwf_repo`). If the repo disappears again, the first diagnostic is:
+
+```bash
+# ausearch on this host returns nothing even when the log has events — grep the raw log instead.
+ssh slam-bot "sudo grep -hE 'nametype=(DELETE|RENAME).*meet-without-fear' /var/log/audit/audit.log /var/log/audit/audit.log.*"
+```
+
+Pair a matching PATH record with its SYSCALL and PROCTITLE records (same `:NNNNN)` event id) to get the PID, parent chain, and command line. If watches are missing (empty `auditctl -l | grep mwf`), reinstate with `sudo auditctl -R /etc/audit/rules.d/mwf.rules`.
+
+Recovery:
+
+1. `ssh slam-bot 'cd /home/ubuntu/projects && git clone https://github.com/shantamg/meet-without-fear.git'` (skip step if a `.broken` copy exists; remove it first)
+2. `ssh slam-bot 'sudo systemctl restart slam-bot-socket'` (look for a clean startup with no "workspaces missing" warning)
+3. `ssh slam-bot 'rm /opt/slam-bot/state/claims/claimed-<channel>-<ts>.txt'` for each message stuck on `:eyes:`
+
+Slack Socket Mode will not redeliver an acked event. To force the bot to process a stuck message after recovery, invoke `run-claude.sh` directly with the same args the listener would have used:
+
+```bash
+/opt/slam-bot/scripts/run-claude.sh \
+  --workspace slack-triage \
+  --session slack-<channel>-<thread_ts> \
+  '' <prompt_file> <msg_ts>
+```
+
+Set `CHANNEL=<channel>` in the env so the emoji reaction handlers work.
+
 ## Production hosting
 
 - **Backend API**: Render (`meet-without-fear-api` / `srv-d58bj73uibrs73akacd0`), env group `be-heard-api-env`

--- a/scripts/ec2-bot/scripts/clear-stale-locks.sh
+++ b/scripts/ec2-bot/scripts/clear-stale-locks.sh
@@ -244,8 +244,18 @@ while IFS= read -r WT_LINE; do
   WT_PATH=$(echo "$WT_LINE" | awk '{print $1}')
   WT_BRANCH=$(echo "$WT_LINE" | awk '{print $3}' | tr -d '[]')
 
-  # Skip the main worktree
-  [ "$WT_PATH" = "$REPO_ROOT" ] && continue
+  # Never delete protected branches — hard guard against rm -rf on the main checkout.
+  # git worktree list reports canonical paths; $REPO_ROOT may be a symlink
+  # (/home/ubuntu/meet-without-fear -> /home/ubuntu/projects/meet-without-fear on EC2),
+  # so a path-only check is not sufficient.
+  case "$WT_BRANCH" in
+    main|master|develop) continue ;;
+  esac
+
+  # Skip the main worktree (normalize symlinks before comparing)
+  WT_CANONICAL=$(readlink -f "$WT_PATH" 2>/dev/null || echo "$WT_PATH")
+  REPO_CANONICAL=$(readlink -f "$REPO_ROOT" 2>/dev/null || echo "$REPO_ROOT")
+  [ "$WT_CANONICAL" = "$REPO_CANONICAL" ] && continue
 
   # Skip worktrees less than 2 hours old (may be actively in use)
   WT_AGE_MIN=$(( ($(date +%s) - $(stat -c %Y "$WT_PATH" 2>/dev/null || echo "$(date +%s)")) / 60 ))
@@ -274,8 +284,12 @@ while IFS= read -r WT_LINE; do
   if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then
     SHOULD_REMOVE=true
   elif [ -z "$PR_STATE" ] && [ "$WT_AGE_MIN" -gt 1440 ]; then
-    # No PR found and worktree is >24h old — likely abandoned
-    SHOULD_REMOVE=true
+    # No PR found and worktree is >24h old — likely abandoned.
+    # Restrict to bot-owned branch patterns so a non-bot worktree (or one that
+    # slipped past the protected-branch guard above) can never be deleted here.
+    case "$WT_BRANCH" in
+      bot/*|feat/*|fix/*|chore/*|feature/*) SHOULD_REMOVE=true ;;
+    esac
   fi
 
   if [ "$SHOULD_REMOVE" = "true" ]; then


### PR DESCRIPTION
## Summary

The slam-bot repo at `/home/ubuntu/projects/meet-without-fear` has vanished four times (2026-04-16, -18, -19, -21) on a ~24h cycle, each time taking the bot offline. Today's occurrence was finally attributed to our own `clear-stale-locks.sh`.

### Root cause

The worktree-cleanup loop's main-worktree guard at line 248 was:

```bash
[ "$WT_PATH" = "$REPO_ROOT" ] && continue
```

- `$WT_PATH` comes from `git worktree list`, which returns the **canonical** path (`/home/ubuntu/projects/meet-without-fear`).
- `$REPO_ROOT` is set in `config.sh:27` to `${HOME}/meet-without-fear`, which on EC2 is a **symlink** to the canonical path.

The guard never matched, so the main worktree fell through to the "no PR + >24h → abandoned" fallback (line 276), which triggered `rm -rf "$WT_PATH"` (line 282).

Auditd captured the kill shot at 02:15:04 UTC:

```
proctitle=rm\0-rf\0/home/ubuntu/projects/meet-without-fear
comm=rm ses=195000 (cron) auid=ubuntu
```

And our own log confirmed intent:

```
/var/log/slam-bot/lock-cleanup.log
[Tue Apr 21 02:15:04 UTC 2026] Removed worktree (): /home/ubuntu/projects/meet-without-fear [main] (1441m old)
```

(`PR_STATE` was empty — hence the blank in parens — and age was 1441 min, one minute over the 1440-min threshold.)

### Fix

Three defenses, narrowest first:

1. **Protected-branch allowlist** — `case "$WT_BRANCH" in main|master|develop) continue ;; esac` before any path comparison. A hard stop that can't be defeated by path/symlink weirdness.
2. **Normalized path comparison** — `readlink -f` on both `$WT_PATH` and `$REPO_ROOT` before comparing, so the original guard works even when they differ syntactically.
3. **Restricted fallback** — the "no PR + >24h → abandoned" branch now only fires for bot-owned branch patterns (`bot/*`, `feat/*`, `fix/*`, `chore/*`, `feature/*`), so a non-bot worktree that slipped past the first two guards still can't be blown away.

### Runbook update

`docs/infrastructure/index.md` is updated to attribute the cause and to note that `ausearch` appears broken on this host — direct `grep` of `/var/log/audit/audit.log*` is the reliable path.

## Test plan

- [x] `bash -n scripts/ec2-bot/scripts/clear-stale-locks.sh` — syntax clean
- [x] Bot recovered and running (slam-bot-socket active as of 03:08 UTC, no "workspaces missing" warning on restart)
- [ ] Watch `/var/log/slam-bot/lock-cleanup.log` over the next 48h — should see no "Removed worktree (): ... [main]" lines
- [ ] Optional: dry-run the guard logic on the host (`bash -x` the worktree section against `git worktree list`) to confirm main is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)