### PR TITLE
feat(slam-bot): monitor #most-important-thing in real-time

### DIFF
--- a/bot-workspaces/slack-triage/CLAUDE.md
+++ b/bot-workspaces/slack-triage/CLAUDE.md
@@ -1,6 +1,6 @@
 # Slack Triage Workspace (L1)
 
-Triage actionable messages from any Slack channel (DMs, #pmf1, #agentic-devs, #slam-paws, #bugs-and-requests). Classify each message and dispatch the appropriate action. **All substantive work must flow through GitHub issues with `bot:*` labels** — Slack is an intake channel, GitHub is where work happens visibly.
+Triage actionable messages from any Slack channel (DMs, #pmf1, #agentic-devs, #slam-paws, #bugs-and-requests, #most-important-thing). Classify each message and dispatch the appropriate action. **All substantive work must flow through GitHub issues with `bot:*` labels** — Slack is an intake channel, GitHub is where work happens visibly.
 
 ## What to Load
 
@@ -55,6 +55,14 @@ Adapt tone based on the source channel:
 - Keep it non-technical: no file paths, function names, stack traces
 - Acknowledge the report, link to the GitHub issue you filed
 - Warm and brief — mirror #pmf1 tone
+
+**#most-important-thing** — Twice-daily strategy briefing channel. Shantam and Darryl respond here.
+- Messages are typically responses to the daily strategy briefing (agree, defer, questions)
+- Acknowledge their response briefly — formal processing happens at the next scheduled run
+- If they agree to an item, confirm you've noted it
+- If they defer with a reason, confirm you'll document it at the next run
+- If they ask a question, answer it directly
+- Be concise — this channel is about quick decisions, not long discussions
 
 **DMs** — Direct conversation with a team member.
 - Match their tone and technical level

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -24,6 +24,7 @@
  *   AGENTIC_DEVS_CHANNEL_ID — Channel ID for the #agentic-devs channel
  *   SLAM_BOT_CHANNEL_ID — Channel ID for the #slam-paws channel
  *   BUGS_AND_REQUESTS_CHANNEL_ID — Channel ID for the #bugs-and-requests channel
+ *   MOST_IMPORTANT_THING_CHANNEL_ID — Channel ID for the #most-important-thing channel
  *   MWF_SESSIONS_CHANNEL_ID — Channel ID for the #mwf-sessions channel
  */
 
@@ -45,6 +46,7 @@ const SHANTAM_DM = process.env.SHANTAM_SLACK_DM;
 const SLAM_BOT_CHANNEL = process.env.SLAM_BOT_CHANNEL_ID;
 const AGENTIC_DEVS_CHANNEL = process.env.AGENTIC_DEVS_CHANNEL_ID;
 const BUGS_AND_REQUESTS_CHANNEL = process.env.BUGS_AND_REQUESTS_CHANNEL_ID;
+const MOST_IMPORTANT_THING_CHANNEL = process.env.MOST_IMPORTANT_THING_CHANNEL_ID;
 const MWF_SESSIONS_CHANNEL = process.env.MWF_SESSIONS_CHANNEL_ID;
 
 // Backend endpoint that owns MWF sessions (Bedrock engine, same as mobile).
@@ -162,6 +164,17 @@ if (BUGS_AND_REQUESTS_CHANNEL) {
     logName: 'check-bugs-and-requests',
     channelName: '#bugs-and-requests',
     commandSlug: 'bugs-and-requests-reply',
+    workspace: 'slack-triage',
+    contextCount: 10,
+  };
+}
+
+// #most-important-thing channel — daily strategy briefing responses
+if (MOST_IMPORTANT_THING_CHANNEL) {
+  CHANNEL_CONFIG[MOST_IMPORTANT_THING_CHANNEL] = {
+    logName: 'check-most-important-thing',
+    channelName: '#most-important-thing',
+    commandSlug: 'most-important-thing-reply',
     workspace: 'slack-triage',
     contextCount: 10,
   };


### PR DESCRIPTION
## Summary

• Add `#most-important-thing` (C0AU9Q3DENQ) to the socket-mode listener so the bot can acknowledge strategy briefing replies immediately instead of waiting for the next 12h scheduled run
• Route through `slack-triage` workspace with dedicated tone guidance for the channel
• `MOST_IMPORTANT_THING_CHANNEL_ID` env var already set on the instance

After merge, the socket-mode service will pick up the change on next git-pull cycle and restart.

## Provenance

- **Channel**: #bugs-and-requests
- **Requester**: Shantam (U0AD3TF2U7L)
- **Original message**: "Yes please" (in response to offering real-time monitoring for #most-important-thing)

## Test plan

• [ ] After merge + service restart, post a message in #most-important-thing and verify the bot reacts with :eyes: and responds
• [ ] Verify the bot acknowledges "agree" / "defer" replies appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)