### PR TITLE
docs: fix ausearch runbook — redirect stdin over ssh

### DIFF
--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -89,8 +89,10 @@ The repo clone at `/home/ubuntu/projects/meet-without-fear/` has vanished four t
 Persistent auditd watches are installed at `/etc/audit/rules.d/mwf.rules` (keys `mwf_projects`, `mwf_repo`). If the repo disappears again, the first diagnostic is:
 
 ```bash
-# ausearch on this host returns nothing even when the log has events — grep the raw log instead.
-ssh slam-bot "sudo grep -hE 'nametype=(DELETE|RENAME).*meet-without-fear' /var/log/audit/audit.log /var/log/audit/audit.log.*"
+# The `</dev/null` is required. ausearch reads from stdin when stdin isn't a tty,
+# and non-interactive ssh makes stdin a pipe, so without redirection it silently
+# returns `<no matches>` for every query.
+ssh slam-bot "sudo ausearch -k mwf_projects </dev/null | grep -E 'rename|delete|unlink|comm='"
 ```
 
 Pair a matching PATH record with its SYSCALL and PROCTITLE records (same `:NNNNN)` event id) to get the PID, parent chain, and command line. If watches are missing (empty `auditctl -l | grep mwf`), reinstate with `sudo auditctl -R /etc/audit/rules.d/mwf.rules`.


### PR DESCRIPTION
## Summary

Follow-up to #159. The runbook I added yesterday told future-me to run:

```bash
ssh slam-bot "sudo ausearch -k mwf_projects -ts today"
```

…which always returns `<no matches>`, even when the audit log clearly contains matching events.

### Why

`ausearch` is designed to be used two ways — reading from its configured log file (`/var/log/audit/audit.log`) **or** from stdin as part of an `audispd | ausearch` pipeline. It picks between them by `fstat`-ing stdin. When stdin is a tty, it reads the log file. When stdin is a pipe/FIFO, it reads stdin.

Non-interactive ssh (`ssh host "cmd"`) always gives the remote process a pipe for stdin, so ausearch reads from stdin, gets immediate EOF, and exits with `<no matches>`. This is why `sudo grep` on the raw log worked during today's incident but `ausearch` did not.

Confirmed with strace — in the failing case ausearch never reads from `/var/log/audit/audit.log` at all; the only `read(...)` on the audit fd is a zero-byte read from stdin (fd 0, `S_IFIFO`).

### Fix

Append `</dev/null` to the command. That makes stdin a regular file with immediate EOF at the "I have no events to feed you" layer, which is apparently enough for ausearch's detection to fall through to reading the configured log file:

```bash
ssh slam-bot "sudo ausearch -k mwf_projects </dev/null | grep -E 'rename|delete|unlink|comm='"
```

Verified working — returns the full event stream for the watched keys.

## Test plan

- [x] `ssh slam-bot 'sudo ausearch -k mwf_projects </dev/null' | head` returns records
- [x] Without `</dev/null`, returns `<no matches>` — reproduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)