### PR TITLE
fix(backend): unflake time-language tests across timezones

### DIFF
--- a/backend/src/utils/__tests__/time-language.test.ts
+++ b/backend/src/utils/__tests__/time-language.test.ts
@@ -6,12 +6,32 @@ import {
   getTimeContext,
   formatMessageWithTimeContext,
   getRecencyGuidance,
-  type TimeContext,
 } from '../time-language';
 
 describe('time-language utilities', () => {
-  // Use current time for consistent testing
-  const NOW = new Date();
+  // Pin the wall clock to a fixed local midday. Two reasons:
+  //
+  // 1. `getTimeContext` buckets via local-calendar-day (`isSameDay` uses
+  //    `getDate`/`getMonth`/`getYear`). Under `new Date()` + UTC CI, any run
+  //    between 00:00–04:00 UTC made `NOW - 4h` cross the previous UTC midnight,
+  //    bucketing "earlier same day" content as 'yesterday'.
+  //
+  // 2. `getRecencyGuidance` calls `getTimeContext(t)` without passing `now`,
+  //    so production code falls back to `new Date()`. Pinning only a local
+  //    `NOW` constant would desync it from production's real clock. Fake
+  //    timers mock `Date` globally so both sides see the same instant.
+  //
+  // Noon gives every `NOW - Xh` case here enough headroom to stay on the
+  // same local day, in any timezone.
+  const NOW = new Date('2026-04-15T12:00:00');
+
+  beforeAll(() => {
+    jest.useFakeTimers({ now: NOW, doNotFake: ['setTimeout', 'setImmediate', 'setInterval'] });
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   describe('getTimeContext', () => {
     it('should identify just_now for content < 1 hour old', () => {


### PR DESCRIPTION
## Summary

`backend/src/utils/__tests__/time-language.test.ts` was failing PR #160's CI today. Not #160's fault — the test is time-of-day and timezone sensitive, and has been silently flaky for a while.

### Root cause

The suite used `const NOW = new Date()` and built expected times with `NOW - Nh`. `getTimeContext` buckets via **local-calendar-day** (`isSameDay` compares `getDate`/`getMonth`/`getYear`). Under `TZ=UTC` + CI:

- Anywhere from 00:00–04:00 UTC, `NOW - 4h` crosses the previous UTC midnight.
- The "earlier same day" case then buckets as `'yesterday'` → test fails.
- Roughly 4 of every 24 hours → ~17% of runs. Today's #160 run at 03:25 UTC hit it.

### Why the obvious fix didn't work

My first pass pinned a local `NOW = new Date('2026-04-15T12:00:00')` and called it done. That made the original case pass but broke two other tests:

- `getRecencyGuidance` internally calls `getTimeContext(t)` **without** passing `now`, so production code falls back to `new Date()` (real wall clock).
- Test inputs were built from a 2026-04-15 `NOW`, but production classified them against the real current date (2026-04-21), shifting every bucket.

### Actual fix

`jest.useFakeTimers({ now: NOW })` — mocks `Date` globally so the implementation and test see the same instant. `NOW` set to a fixed local noon gives every `NOW - Xh` case in this file enough headroom to stay on the same local calendar day in any timezone. `setTimeout`/`setImmediate`/`setInterval` are not faked so async helpers in the suite keep working.

## Test plan

- [x] `TZ=UTC npx jest src/utils/__tests__/time-language.test.ts` — 17/17 pass
- [x] `TZ=America/Los_Angeles npx jest ...` — 17/17 pass
- [x] `npm run check` clean

Once this merges, #160's CI should go green on the next run (or rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)