### PR TITLE
fix(slam-bot): stop triage-killing agents via wrong log-file path

### DIFF
--- a/scripts/ec2-bot/scripts/clear-stale-locks.sh
+++ b/scripts/ec2-bot/scripts/clear-stale-locks.sh
@@ -17,6 +17,12 @@ source "$SCRIPT_DIR/lib/config.sh"
 
 LOGFILE="${BOT_LOG_DIR}/lock-cleanup.log"
 
+# On-disk prefix for bot-owned paths (lockfiles, temp files, worktree dirs).
+# Differs from $BOT_NAME after the slam-bot → slam-paws rename:
+#   BOT_NAME is the identity ("slam-paws"), but LOCK_PREFIX is still "/tmp/slam-bot"
+#   and files on disk still use the "slam-bot-" prefix. Match on this, not BOT_NAME.
+BOT_DISK_PREFIX="${LOCK_PREFIX##*/}"
+
 mkdir -p "$HEARTBEAT_DIR" 2>/dev/null || true
 
 # Clean up any leftover rate limit state files from the removed rate limiting infrastructure
@@ -26,7 +32,7 @@ rm -f "${LOCK_PREFIX}-rate-limited.flag" "${LOCK_PREFIX}-rate-limit-snapshot.txt
 for LOCK in ${LOCK_PREFIX}-*.lock; do
   [ -f "$LOCK" ] || continue
 
-  SLUG=$(basename "$LOCK" | sed "s/^${BOT_NAME}-//; s/\.lock$//")
+  SLUG=$(basename "$LOCK" | sed "s/^${BOT_DISK_PREFIX}-//; s/\.lock$//")
   PID=$(cat "$LOCK" 2>/dev/null)
   LOCK_AGE_MIN=$(( ($(date +%s) - $(stat -c %Y "$LOCK")) / 60 ))
 
@@ -181,9 +187,9 @@ if [ -d "$CLAIMS_DIR" ]; then
 fi
 
 # Clean up temp prompt/context files (>1 hour old)
-find /tmp -maxdepth 1 -name "${BOT_NAME}-prompt-*" -mmin +60 -delete 2>/dev/null
-find /tmp -maxdepth 1 -name "${BOT_NAME}-context-*" -mmin +60 -delete 2>/dev/null
-find /tmp -maxdepth 1 -name "${BOT_NAME}-thread-replies-*" -mmin +60 -delete 2>/dev/null
+find /tmp -maxdepth 1 -name "${BOT_DISK_PREFIX}-prompt-*" -mmin +60 -delete 2>/dev/null
+find /tmp -maxdepth 1 -name "${BOT_DISK_PREFIX}-context-*" -mmin +60 -delete 2>/dev/null
+find /tmp -maxdepth 1 -name "${BOT_DISK_PREFIX}-thread-replies-*" -mmin +60 -delete 2>/dev/null
 
 # Clean up legacy directories (one-time removal)
 rm -rf "${BOT_STATE_DIR}/pmf1-claims" 2>/dev/null
@@ -224,14 +230,14 @@ fi
 # ── Clean up orphaned worktrees (from hard kills where trap didn't run) ───────
 cd "$REPO_ROOT" 2>/dev/null && git worktree prune 2>/dev/null
 # Remove stale worktree temp dirs
-find /tmp -maxdepth 1 -name "${BOT_NAME}-worktree-*" -mmin +20 -exec rm -rf {} \; 2>/dev/null
+find /tmp -maxdepth 1 -name "${BOT_DISK_PREFIX}-worktree-*" -mmin +20 -exec rm -rf {} \; 2>/dev/null
 
 # ── Clean up worktrees whose PRs are merged/closed ──────────────────────────
 # Bot workspaces (general-pr, docs-audit, etc.) create worktrees that persist
 # after their PRs are merged/closed. Without cleanup these accumulate and fill
 # the disk. Only check worktrees older than 2 hours to avoid touching active work.
 # Rate-limit: only run this check once per hour (uses gh API calls per worktree).
-WT_CLEANUP_MARKER="/tmp/${BOT_NAME}-worktree-cleanup-last"
+WT_CLEANUP_MARKER="/tmp/${BOT_DISK_PREFIX}-worktree-cleanup-last"
 WT_CLEANUP_AGE=999
 if [ -f "$WT_CLEANUP_MARKER" ]; then
   WT_CLEANUP_AGE=$(( ($(date +%s) - $(stat -c %Y "$WT_CLEANUP_MARKER" 2>/dev/null || echo 0)) / 60 ))
@@ -263,12 +269,12 @@ while IFS= read -r WT_LINE; do
 
   # Skip if there's an active lock file with a running process
   SKIP=false
-  for LOCK in /tmp/${BOT_NAME}-*.lock; do
+  for LOCK in /tmp/${BOT_DISK_PREFIX}-*.lock; do
     [ -f "$LOCK" ] || continue
     LOCK_PID=$(cat "$LOCK" 2>/dev/null)
     if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
       # Check if the lock slug matches the worktree branch
-      LOCK_SLUG=$(basename "$LOCK" | sed "s/^${BOT_NAME}-//; s/\\.lock\$//")
+      LOCK_SLUG=$(basename "$LOCK" | sed "s/^${BOT_DISK_PREFIX}-//; s/\\.lock\$//")
       if echo "$WT_BRANCH" | grep -q "$LOCK_SLUG" 2>/dev/null; then
         SKIP=true
         break

--- a/scripts/ec2-bot/scripts/triage-stuck-process.sh
+++ b/scripts/ec2-bot/scripts/triage-stuck-process.sh
@@ -18,9 +18,13 @@ PID="${2:-0}"
 AGE_MIN="${3:-0}"
 LOGFILE="${4:-}"
 
-# If no log file or it doesn't exist, can't triage — default to kill
+# If no log file or it doesn't exist, we can't evaluate the process — escalate
+# rather than kill. A missing log most often means the caller passed the wrong
+# path (e.g., a prefix mismatch bug in the slug derivation), not that the
+# process is actually broken. Defaulting to kill here silently terminated
+# legitimate long-running agents; "alert" routes to a human without data loss.
 if [ -z "$LOGFILE" ] || [ ! -f "$LOGFILE" ]; then
-  echo '{"verdict":"kill","reason":"No log file found — cannot determine process state"}'
+  echo "{\"verdict\":\"alert\",\"reason\":\"No log file found at expected path (${LOGFILE:-unset}) — cannot evaluate; escalating instead of killing\"}"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Issue #114 has a `bot:failed` label. The agent's log shows it was doing real work (designing and implementing the Curiosity Compact replacement, edits across `shared/`, `backend/`, and `mobile/`) and was mid-test-run when it died. Two separate agents got SIGKILL'd (exit 137) the same way, ~13–15 min into their runs.

### Smoking gun

`/var/log/slam-bot/lock-cleanup.log`:

```
[Mon Apr 20 19:20:02 UTC 2026] Triaging idle slam-bot-ws-general-pr-issue-114 (PID 487680, age 12m, idle 12m)
[Mon Apr 20 19:20:02 UTC 2026] Triage verdict for slam-bot-ws-general-pr-issue-114: kill — No log file found — cannot determine process state
[Mon Apr 20 19:20:05 UTC 2026] Killed stuck slam-bot-ws-general-pr-issue-114 (PID 487680, 12m old, idle 12m)
...
[Mon Apr 20 19:50:02 UTC 2026] Triaging idle slam-bot-ws-general-pr-issue-114 (PID 520095, age 14m, idle 14m)
[Mon Apr 20 19:50:02 UTC 2026] Triage verdict for slam-bot-ws-general-pr-issue-114: kill — No log file found — cannot determine process state
```

Notice the slug: `slam-bot-ws-general-pr-issue-114`. That's the lockfile basename *with the `slam-bot-` still attached*. It should have been stripped.

### Root cause

`clear-stale-locks.sh:29` derived `SLUG` by stripping `${BOT_NAME}-`:

```bash
SLUG=$(basename "$LOCK" | sed "s/^${BOT_NAME}-//; s/\.lock$//")
```

After the slam-bot → slam-paws rename, `BOT_NAME` became `slam-paws` — but the on-disk lockfile prefix stayed `slam-bot` (baked into `LOCK_PREFIX=/tmp/slam-bot`, and the comment in `config.sh:15` explicitly says the rename was identity-only). The sed no-oped. `SLUG` kept the leading `slam-bot-`, so:

```
LOG_CANDIDATE = /var/log/slam-bot/slam-bot-ws-general-pr-issue-114.log  ← doesn't exist
actual file    = /var/log/slam-bot/ws-general-pr-issue-114.log          ← full transcript
```

`triage-stuck-process.sh` saw the nonexistent file and, per its own logic, defaulted to `{"verdict":"kill"}` — "when in doubt, terminate." Anything that went quiet for >5 min (e.g. during `npm test`) got SIGKILL'd. #114's two attempts both died that way.

### Fix (two layers)

1. **`clear-stale-locks.sh`** — derive the on-disk prefix from `LOCK_PREFIX` (authoritative), not `BOT_NAME`:

    ```bash
    BOT_DISK_PREFIX="${LOCK_PREFIX##*/}"  # "slam-bot"
    ```

    Applied to `SLUG` and the four other `${BOT_NAME}-*` glob patterns in the same file that had the same latent defect:
    - tmp prompt/context/thread-replies cleanup
    - tmp worktree cleanup
    - worktree cleanup marker
    - inner lock-match loop for active worktree protection

    These were silently no-ops before (leaking tmp files, worktree dirs, etc.). Now they actually match.

2. **`triage-stuck-process.sh`** — change missing-log default from `kill` to `alert`. A missing log means we can't evaluate; that's a reason to escalate, not to silently terminate a working agent. Kill-as-default masked this path-derivation bug for weeks and destroyed real work.

### Impact beyond #114

The same SIGKILL pattern (exit 137, "No log file found" verdict, 10–45m old idle) will be visible in lock-cleanup.log for any recent bot workspace run on an issue where the agent paused for tests, long edits, or any quiet phase >5 min. Worth a scan after this merges.

## Test plan

- [x] `bash -n` both scripts — syntax clean
- [x] Manually verified slug derivation: input `slam-bot-ws-general-pr-issue-114.lock`, `BOT_DISK_PREFIX=slam-bot`, output `ws-general-pr-issue-114` ✓
- [ ] After merge: remove `bot:failed` from #114 and re-add `bot:pr` to kick the dispatcher; verify the agent survives past the 5-min idle threshold without being triage-killed
- [ ] Watch `lock-cleanup.log` for the next 24h — no `No log file found` kill verdicts should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)