### PR TITLE
Replace Curiosity Compact with brief warm opening framing

### DIFF
--- a/backend/src/controllers/session-state.ts
+++ b/backend/src/controllers/session-state.ts
@@ -249,12 +249,22 @@ export async function getSessionState(req: Request, res: Response): Promise<void
     const myGates = myStage0Record?.gatesSatisfied as CompactGates | null;
     const partnerGates = partnerStage0Record?.gatesSatisfied as CompactGates | null;
 
+    // Check if this is the first session for this relationship
+    const priorResolvedCount = await prisma.session.count({
+      where: {
+        relationshipId: session.relationshipId,
+        id: { not: sessionId },
+        status: 'RESOLVED',
+      },
+    });
+
     const compactResponse = {
       mySigned: myGates?.compactSigned ?? false,
       mySignedAt: myGates?.signedAt ?? null,
       partnerSigned: partnerGates?.compactSigned ?? false,
       partnerSignedAt: partnerGates?.signedAt ?? null,
       canAdvance: (myGates?.compactSigned ?? false) && ((partnerGates?.compactSigned ?? false) || !partnerId),
+      isFirstSession: priorResolvedCount === 0,
     };
 
     // Return consolidated response

--- a/backend/src/controllers/stage0.ts
+++ b/backend/src/controllers/stage0.ts
@@ -309,12 +309,23 @@ export async function getCompactStatus(req: Request, res: Response): Promise<voi
       partnerSignedAt = partner?.gatesSatisfied?.signedAt ?? null;
     }
 
+    // Check if this is the first session for this relationship
+    const session = sessionCheck.session as { relationshipId: string };
+    const priorResolvedCount = await prisma.session.count({
+      where: {
+        relationshipId: session.relationshipId,
+        id: { not: sessionId },
+        status: 'RESOLVED',
+      },
+    });
+
     successResponse(res, {
       mySigned,
       mySignedAt,
       partnerSigned,
       partnerSignedAt,
       canAdvance: mySigned && partnerSigned,
+      isFirstSession: priorResolvedCount === 0,
     });
   } catch (error) {
     logger.error('[getCompactStatus] Error:', error);

--- a/backend/src/routes/__tests__/stage0.test.ts
+++ b/backend/src/routes/__tests__/stage0.test.ts
@@ -276,6 +276,7 @@ describe('Stage 0 API', () => {
       // Mock: session with relationship
       (prisma.session.findUnique as jest.Mock).mockResolvedValue({
         id: mockSessionId,
+        relationshipId: 'rel-1',
         status: 'ACTIVE',
         relationship: {
           members: [{ userId: mockUser.id }, { userId: mockPartner.id }],
@@ -290,6 +291,9 @@ describe('Stage 0 API', () => {
         stage: 0,
         gatesSatisfied: { compactSigned: true, signedAt: '2024-01-02T00:00:00Z' },
       });
+
+      // Mock: no prior resolved sessions (first session)
+      (prisma.session.count as jest.Mock).mockResolvedValue(0);
 
       const req = createMockRequest({
         user: mockUser,
@@ -321,6 +325,7 @@ describe('Stage 0 API', () => {
       // Mock: session with relationship
       (prisma.session.findUnique as jest.Mock).mockResolvedValue({
         id: mockSessionId,
+        relationshipId: 'rel-1',
         status: 'ACTIVE',
         relationship: {
           members: [{ userId: mockUser.id }, { userId: mockPartner.id }],
@@ -335,6 +340,9 @@ describe('Stage 0 API', () => {
         stage: 0,
         gatesSatisfied: { compactSigned: true, signedAt: '2024-01-02T00:00:00Z' },
       });
+
+      // Mock: no prior resolved sessions
+      (prisma.session.count as jest.Mock).mockResolvedValue(0);
 
       const req = createMockRequest({
         user: mockUser,
@@ -372,6 +380,7 @@ describe('Stage 0 API', () => {
       // Mock: session with relationship
       (prisma.session.findUnique as jest.Mock).mockResolvedValue({
         id: mockSessionId,
+        relationshipId: 'rel-1',
         status: 'ACTIVE',
         relationship: {
           members: [{ userId: mockUser.id }, { userId: mockPartner.id }],
@@ -380,6 +389,9 @@ describe('Stage 0 API', () => {
 
       // Mock: partner has NOT signed
       (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue(null);
+
+      // Mock: no prior resolved sessions
+      (prisma.session.count as jest.Mock).mockResolvedValue(0);
 
       const req = createMockRequest({
         user: mockUser,

--- a/docs/backend/api/stage-0.md
+++ b/docs/backend/api/stage-0.md
@@ -88,6 +88,7 @@ interface CompactStatusResponse {
   partnerSigned: boolean;
   partnerSignedAt: string | null;  // Only visible after user signs
   canAdvance: boolean;
+  isFirstSession: boolean;  // No prior resolved sessions for this relationship
 }
 ```
 
@@ -140,11 +141,14 @@ To advance from Stage 0 to Stage 1:
 
 ---
 
-## Compact Content
+## Opening Framing
 
-The Curiosity Compact text is served as static content, not via API. It should be embedded in the mobile app.
+The opening welcome message is served as static content embedded in the mobile app. It replaces the former "Curiosity Compact" formal agreement with a brief, warm AI-spoken message.
 
-See [Stage 0: Onboarding](../../stages/stage-0-onboarding.md#the-curiosity-compact) for the full text.
+- **First session:** "You'll each chat with me privately first. Nothing gets shared without your say. Ready?"
+- **Repeat session:** "Welcome back. Same as before — your space is private, nothing shared without your say. Let's pick up where we left off."
+
+The `isFirstSession` field in the compact status response indicates which variant to show. No formal commitments or checkboxes are required — just a "Ready" / "Let's go" button.
 
 ---
 

--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -84,15 +84,12 @@ flowchart TB
     subgraph OnboardingChat[Onboarding View]
         Header0[Welcome to Meet Without Fear]
 
-        subgraph Content0[Compact Presentation]
-            Intro[Process explanation]
-            Diagram[Stage overview diagram]
-            Compact[Curiosity Compact text]
+        subgraph Content0[AI Welcome Message]
+            Message[Brief warm opening with typewriter effect]
         end
 
-        subgraph Actions0[Action Buttons]
-            Questions[I have questions]
-            Sign[Sign and Begin]
+        subgraph Actions0[Action Button]
+            Ready[Ready / Let's go]
         end
     end
 ```
@@ -195,9 +192,9 @@ Before the chat list renders, `UnifiedSessionScreen` can swap in a full-screen m
 
 ## Empty States
 
-### Compact-not-signed (onboarding)
+### Opening not acknowledged (onboarding)
 
-If the caller enters a session but hasn't signed the Curiosity Compact, the list replaces its usual empty state with a `CompactChatItem` (the compact text + "Sign and begin" CTA). This is controlled by `isInOnboardingUnsigned` / `customEmptyState`.
+If the caller enters a session but hasn't acknowledged the opening message, the list replaces its usual empty state with a `CompactChatItem` (a brief AI welcome message). A "Ready" button appears above the input via `CompactAgreementBar`. This is controlled by `isInOnboardingUnsigned` / `customEmptyState`.
 
 ### Waiting for Partner
 

--- a/docs/product/stages/stage-0-onboarding.md
+++ b/docs/product/stages/stage-0-onboarding.md
@@ -7,76 +7,43 @@ description: Establish the Process Guardian role and secure commitment from both
 
 ## Purpose
 
-Establish the Process Guardian role and secure commitment from both parties through the Curiosity Compact.
+Welcome users with a brief, warm opening and secure acknowledgment before entering the conversation.
 
 ## AI Goal
 
-- Acknowledge the courage it takes to begin this process
-- Offer to guide both parties through a process of being heard
-- Present the possibility of a win-win outcome
-- Secure explicit agreement to proceed with curiosity rather than judgment
+- Briefly explain the private chat format
+- Reassure users that nothing is shared without consent
+- Get a simple "Ready" acknowledgment to proceed
 
 ## Opening Message
 
-The AI opens with a simple, warm message:
+The AI opens with a brief, warm message. The message varies based on whether this is the user's first session with this partner:
 
-> "Congratulations [Name], you have taken the first step towards strengthening your connections. Are you open to me guiding you and [Partner] through a process where you both can be heard? I think there is a way we can find a win-win here."
+**First session:**
+> "You'll each chat with me privately first. Nothing gets shared without your say. Ready?"
+
+**Repeat session:**
+> "Welcome back. Same as before — your space is private, nothing shared without your say. Let's pick up where we left off."
 
 This message:
-- Celebrates the courage to begin
-- Asks for consent to guide
-- Frames the goal as mutual understanding
-- Offers hope without overpromising
+- Speaks in the AI's first person voice
+- Explains the private chat format
+- Reassures about consent before sharing
+- Asks for a simple acknowledgment to proceed
 
 ## Flow
 
 ```mermaid
 flowchart TD
-    Entry[User enters system] --> Welcome[Simple welcome message]
-    Welcome --> Consent{Open to being guided?}
-    Consent -->|Yes| Compact[Present Curiosity Compact]
-    Consent -->|Questions| Clarify[AI answers questions]
-    Clarify --> Consent
+    Entry[User enters system] --> Welcome[AI welcome message]
+    Welcome --> Ready{User taps Ready?}
+    Ready -->|Yes| Acknowledged[Record acknowledgment]
 
-    Compact --> Review[User reviews terms]
-    Review --> Questions{Questions?}
-    Questions -->|Yes| Clarify[AI clarifies]
-    Clarify --> Review
-    Questions -->|No| Decision{Sign compact?}
-
-    Decision -->|Yes| Signed[Record signature]
-    Decision -->|Not ready| Concerns[Explore concerns]
-    Decision -->|Refuse| CannotProceed[Explain requirements]
-
-    Concerns --> Address[AI addresses concerns]
-    Address --> Decision
-    CannotProceed --> Exit[Exit with resources]
-
-    Signed --> WaitOther{Other signed?}
+    Acknowledged --> WaitOther{Other acknowledged?}
     WaitOther -->|Yes| Advance[Advance to Stage 1]
     WaitOther -->|No| Wait[Waiting room]
-    Wait --> Notify[Notify when other signs]
+    Wait --> Notify[Notify when other acknowledges]
     Notify --> Advance
-```
-
-## The Curiosity Compact
-
-A commitment that both parties make before beginning:
-
-```
-I commit to:
-- Approach this process with curiosity rather than certainty
-- Allow the AI to guide the pace of our work
-- Share honestly within my private space
-- Consider the others perspective when presented
-- Focus on understanding needs rather than winning arguments
-- Take breaks when emotions run high
-
-I understand that:
-- The AI will not judge who is right or wrong
-- My raw thoughts remain private unless I consent to share
-- Progress requires both parties to complete each stage
-- I can pause at any time but cannot skip ahead
 ```
 
 ## Wireframe: Onboarding Screen
@@ -90,27 +57,18 @@ flowchart TB
         end
 
         subgraph Content[Main Content]
-            Title[Welcome to Meet Without Fear]
-            Intro[Brief explanation paragraph]
-            Steps[Visual stage overview]
-        end
-
-        subgraph CompactSection[Curiosity Compact]
-            CompactTitle[Your Commitment]
-            Terms[Scrollable terms]
-            Checkbox[I agree to proceed with curiosity]
+            Message[AI welcome message with typewriter effect]
         end
 
         subgraph Actions[Actions]
-            Questions[I have questions]
-            Sign[Sign and Begin]
+            Ready[Ready / Let's go button]
         end
     end
 ```
 
 ## Success Criteria
 
-Both users must sign the Curiosity Compact.
+Both users must acknowledge the opening message.
 
 ## Failure Paths
 

--- a/mobile/src/components/CompactAgreementBar.tsx
+++ b/mobile/src/components/CompactAgreementBar.tsx
@@ -1,12 +1,11 @@
 /**
  * CompactAgreementBar Component
  *
- * A UI element that appears above the chat input row during onboarding.
- * Contains the checkbox "I agree to proceed with curiosity" and "Sign and Begin" button.
+ * A simple "Ready" button that appears above the chat input during onboarding.
+ * Replaces the previous checkbox + "Sign and Begin" flow with a single tap to proceed.
  */
 
 import { View, Text, TouchableOpacity } from 'react-native';
-import { useState } from 'react';
 import { createStyles } from '../theme/styled';
 
 // ============================================================================
@@ -16,7 +15,8 @@ import { createStyles } from '../theme/styled';
 interface CompactAgreementBarProps {
   onSign: () => void;
   isPending?: boolean;
-  onAskQuestion?: () => void;
+  /** Whether this is the first session (affects button label) */
+  isFirstSession?: boolean;
   testID?: string;
 }
 
@@ -27,57 +27,25 @@ interface CompactAgreementBarProps {
 export function CompactAgreementBar({
   onSign,
   isPending = false,
-  onAskQuestion,
+  isFirstSession = true,
   testID,
 }: CompactAgreementBarProps) {
   const styles = useStyles();
-  const [agreed, setAgreed] = useState(false);
-
-  const handleSign = () => {
-    if (agreed && !isPending) {
-      onSign();
-    }
-  };
 
   return (
     <View style={styles.container} testID={testID || 'compact-agreement-bar'}>
-      <View style={styles.agreementRow}>
-        <TouchableOpacity
-          testID="compact-agree-checkbox"
-          style={styles.checkbox}
-          onPress={() => setAgreed(!agreed)}
-          accessibilityRole="checkbox"
-          accessibilityState={{ checked: agreed }}
-        >
-          <View style={[styles.checkboxBox, agreed && styles.checkboxChecked]}>
-            {agreed && <Text style={styles.checkmark}>&#10003;</Text>}
-          </View>
-          <Text style={styles.checkboxLabel}>I agree to proceed with curiosity</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity
-          style={[styles.signButton, !agreed && styles.signButtonDisabled]}
-          onPress={handleSign}
-          disabled={!agreed || isPending}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: !agreed || isPending }}
-          testID="compact-sign-button"
-        >
-          <Text style={styles.signButtonText}>
-            {isPending ? '...' : 'Begin'}
-          </Text>
-        </TouchableOpacity>
-      </View>
-
-      {onAskQuestion && (
-        <TouchableOpacity
-          style={styles.questionsButton}
-          onPress={onAskQuestion}
-          testID="compact-questions-button"
-        >
-          <Text style={styles.questionsText}>I have questions</Text>
-        </TouchableOpacity>
-      )}
+      <TouchableOpacity
+        style={[styles.readyButton, isPending && styles.readyButtonDisabled]}
+        onPress={onSign}
+        disabled={isPending}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: isPending }}
+        testID="compact-sign-button"
+      >
+        <Text style={styles.readyButtonText}>
+          {isPending ? '...' : isFirstSession ? 'Ready' : "Let's go"}
+        </Text>
+      </TouchableOpacity>
     </View>
   );
 }
@@ -94,66 +62,24 @@ const useStyles = () =>
       backgroundColor: t.colors.bgSecondary,
       borderTopWidth: 1,
       borderTopColor: t.colors.border,
-    },
-    agreementRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: t.spacing.md,
-    },
-    checkbox: {
-      flex: 1,
-      flexDirection: 'row',
       alignItems: 'center',
     },
-    checkboxBox: {
-      width: 22,
-      height: 22,
-      borderRadius: 6,
-      borderWidth: 2,
-      borderColor: t.colors.border,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    checkboxChecked: {
-      backgroundColor: 'rgb(59, 130, 246)', // Blue to match "Compact Signed" indicator
-      borderColor: 'rgb(59, 130, 246)',
-    },
-    checkmark: {
-      color: 'white',
-      fontSize: 12,
-      fontWeight: 'bold',
-    },
-    checkboxLabel: {
-      marginLeft: t.spacing.sm,
-      fontSize: t.typography.fontSize.sm,
-      color: t.colors.textPrimary,
-      flex: 1,
-    },
-    signButton: {
-      backgroundColor: 'rgb(59, 130, 246)', // Blue to match "Compact Signed" indicator
+    readyButton: {
+      backgroundColor: 'rgb(59, 130, 246)',
       paddingVertical: t.spacing.sm,
-      paddingHorizontal: t.spacing.lg,
+      paddingHorizontal: t.spacing.xl,
       borderRadius: t.radius.lg,
       alignItems: 'center',
       justifyContent: 'center',
+      minWidth: 120,
     },
-    signButtonDisabled: {
+    readyButtonDisabled: {
       backgroundColor: t.colors.textMuted,
     },
-    signButtonText: {
+    readyButtonText: {
       color: 'white',
       fontSize: t.typography.fontSize.md,
       fontWeight: '600',
-    },
-    questionsButton: {
-      paddingVertical: t.spacing.sm,
-      paddingHorizontal: t.spacing.md,
-      alignItems: 'center',
-      marginTop: t.spacing.xs,
-    },
-    questionsText: {
-      color: t.colors.accent,
-      fontSize: t.typography.fontSize.sm,
     },
   }));
 

--- a/mobile/src/components/CompactChatItem.tsx
+++ b/mobile/src/components/CompactChatItem.tsx
@@ -1,13 +1,14 @@
 /**
  * CompactChatItem Component
  *
- * Displays the Curiosity Compact with typewriter effects.
- * Shows intro text with typewriter effect, then a button to reveal the compact terms.
- * The compact terms are rendered as structured elements with proper indentation.
+ * Displays a brief, warm AI opening message during onboarding.
+ * Replaces the formal Curiosity Compact terms with a conversational welcome.
+ *
+ * First session: "You'll each chat with me privately first. Nothing gets shared without your say. Ready?"
+ * Repeat session: "Welcome back. Same as before — your space is private, nothing shared without your say. Let's pick up where we left off."
  */
 
-import { useState } from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View } from 'react-native';
 import { TypewriterText } from './TypewriterText';
 import { createStyles } from '../theme/styled';
 
@@ -17,184 +18,37 @@ import { createStyles } from '../theme/styled';
 
 interface CompactChatItemProps {
   testID?: string;
-  /** Whether this is shown after accepting an invitation (adapts intro text) */
-  isAfterInvitationAcceptance?: boolean;
+  /** Whether this is the first session for this relationship */
+  isFirstSession?: boolean;
 }
 
 // ============================================================================
 // Constants
 // ============================================================================
 
-const INTRO_TEXT_NEW_SESSION = "Before we begin, I'd like you to review The Curiosity Compact. These are the commitments you'll both make to ensure a safe and productive conversation.";
+const FIRST_SESSION_TEXT =
+  "You'll each chat with me privately first. Nothing gets shared without your say. Ready?";
 
-const INTRO_TEXT_AFTER_ACCEPTANCE = "Thanks for accepting the invitation! Before we begin, I'd like you to review The Curiosity Compact. These are the commitments you'll both make to ensure a safe and productive conversation.";
-
-const COMMITMENTS = [
-  'Approach this process with curiosity rather than certainty',
-  'Allow the AI to guide the pace of our work',
-  'Share honestly within my private space',
-  "Consider the other's perspective when presented",
-  'Focus on understanding needs rather than winning arguments',
-  'Take breaks when emotions run high',
-];
-
-const UNDERSTANDINGS = [
-  'The AI will not judge who is right or wrong',
-  'My raw thoughts remain private unless I consent to share',
-  'Progress requires both parties to complete each stage',
-  'I can pause at any time but cannot skip ahead',
-];
-
-// ============================================================================
-// Subcomponents
-// ============================================================================
-
-interface CompactSectionProps {
-  title: string;
-  items: string[];
-  startIndex: number;
-  visibleCount: number;
-  currentAnimatingIndex: number;
-  onItemComplete: () => void;
-}
-
-function CompactSection({
-  title,
-  items,
-  startIndex,
-  visibleCount,
-  currentAnimatingIndex,
-  onItemComplete
-}: CompactSectionProps) {
-  const styles = useStyles();
-
-  // Calculate which items in this section should be visible
-  // startIndex is the global index where this section starts
-  // Title counts as 1, then each item counts as 1
-  const titleIndex = startIndex;
-  const titleVisible = visibleCount > startIndex;
-  const visibleItems = Math.max(0, visibleCount - startIndex - 1); // -1 for title
-
-  if (!titleVisible) return null;
-
-  return (
-    <View style={styles.section}>
-      <TypewriterText
-        text={title}
-        style={styles.messageText}
-        skipAnimation={currentAnimatingIndex > titleIndex}
-        onComplete={currentAnimatingIndex === titleIndex ? onItemComplete : undefined}
-      />
-      {items.slice(0, visibleItems).map((item, index) => {
-        const itemIndex = startIndex + 1 + index; // +1 for title
-        return (
-          <View key={index} style={styles.bulletItem}>
-            <Text style={styles.bullet}>-</Text>
-            <View style={styles.bulletTextContainer}>
-              <TypewriterText
-                text={item}
-                style={styles.bulletText}
-                skipAnimation={currentAnimatingIndex > itemIndex}
-                onComplete={currentAnimatingIndex === itemIndex ? onItemComplete : undefined}
-              />
-            </View>
-          </View>
-        );
-      })}
-    </View>
-  );
-}
+const REPEAT_SESSION_TEXT =
+  "Welcome back. Same as before \u2014 your space is private, nothing shared without your say. Let's pick up where we left off.";
 
 // ============================================================================
 // Component
 // ============================================================================
 
-export function CompactChatItem({ testID, isAfterInvitationAcceptance = false }: CompactChatItemProps) {
+export function CompactChatItem({ testID, isFirstSession = true }: CompactChatItemProps) {
   const styles = useStyles();
-  const [introComplete, setIntroComplete] = useState(false);
-  const [showCompact, setShowCompact] = useState(false);
-  const [compactProgress, setCompactProgress] = useState(0);
-  const [currentAnimatingIndex, setCurrentAnimatingIndex] = useState(0);
 
-  const introText = isAfterInvitationAcceptance ? INTRO_TEXT_AFTER_ACCEPTANCE : INTRO_TEXT_NEW_SESSION;
-
-  // Total items: title(1) + commitments title(1) + commitments(6) + understandings title(1) + understandings(4) = 13
-  const totalItems = 1 + 1 + COMMITMENTS.length + 1 + UNDERSTANDINGS.length;
-
-  // Start the compact typewriter sequence
-  const startCompactSequence = () => {
-    setShowCompact(true);
-    setCompactProgress(1); // Show first item (main title)
-    setCurrentAnimatingIndex(0); // Start animating first item
-  };
-
-  // Called when current item finishes its typewriter animation
-  const handleItemComplete = () => {
-    const nextIndex = currentAnimatingIndex + 1;
-    if (nextIndex < totalItems) {
-      setCompactProgress(nextIndex + 1); // Show next item
-      setCurrentAnimatingIndex(nextIndex); // Start animating it
-    }
-  };
+  const messageText = isFirstSession ? FIRST_SESSION_TEXT : REPEAT_SESSION_TEXT;
 
   return (
     <View style={styles.container} testID={testID || 'compact-chat-item'}>
-      {/* AI-style intro with typewriter effect */}
       <View style={styles.messageContainer}>
         <TypewriterText
-          text={introText}
+          text={messageText}
           style={styles.messageText}
-          onComplete={() => setIntroComplete(true)}
         />
       </View>
-
-      {/* Show button after intro completes, hide when compact is shown */}
-      {introComplete && !showCompact && (
-        <View style={styles.buttonContainer}>
-          <TouchableOpacity
-            style={styles.viewButton}
-            onPress={startCompactSequence}
-            testID="view-compact-button"
-          >
-            <Text style={styles.viewButtonText}>View the Compact</Text>
-          </TouchableOpacity>
-        </View>
-      )}
-
-      {/* Compact terms with structured layout and typewriter-like reveal */}
-      {showCompact && (
-        <View style={styles.compactContainer}>
-          {/* Title - index 0 */}
-          {compactProgress >= 1 && (
-            <TypewriterText
-              text="The Curiosity Compact"
-              style={styles.compactTitle}
-              skipAnimation={currentAnimatingIndex > 0}
-              onComplete={currentAnimatingIndex === 0 ? handleItemComplete : undefined}
-            />
-          )}
-
-          {/* I commit to section - starts at index 1 */}
-          <CompactSection
-            title="I commit to:"
-            items={COMMITMENTS}
-            startIndex={1}
-            visibleCount={compactProgress}
-            currentAnimatingIndex={currentAnimatingIndex}
-            onItemComplete={handleItemComplete}
-          />
-
-          {/* I understand that section - starts at index 1 + 1 + COMMITMENTS.length */}
-          <CompactSection
-            title="I understand that:"
-            items={UNDERSTANDINGS}
-            startIndex={2 + COMMITMENTS.length}
-            visibleCount={compactProgress}
-            currentAnimatingIndex={currentAnimatingIndex}
-            onItemComplete={handleItemComplete}
-          />
-        </View>
-      )}
     </View>
   );
 }
@@ -214,55 +68,6 @@ const useStyles = () =>
       paddingHorizontal: t.spacing.lg,
     },
     messageText: {
-      fontSize: t.typography.fontSize.md,
-      lineHeight: 22,
-      color: t.colors.textPrimary,
-      fontFamily: t.typography.fontFamily.regular,
-    },
-    buttonContainer: {
-      alignItems: 'center',
-      marginTop: t.spacing.lg,
-      marginBottom: t.spacing.md,
-    },
-    viewButton: {
-      backgroundColor: 'rgb(59, 130, 246)', // Blue to match "Compact Signed" indicator
-      paddingVertical: t.spacing.sm,
-      paddingHorizontal: t.spacing.xl,
-      borderRadius: t.radius.lg,
-    },
-    viewButtonText: {
-      color: 'white',
-      fontSize: t.typography.fontSize.md,
-      fontWeight: '600',
-    },
-    compactContainer: {
-      paddingHorizontal: t.spacing.lg,
-      marginTop: t.spacing.lg,
-    },
-    compactTitle: {
-      fontSize: t.typography.fontSize.lg,
-      fontWeight: '600',
-      color: t.colors.textPrimary,
-      marginBottom: t.spacing.md,
-    },
-    section: {
-      marginTop: t.spacing.md,
-    },
-    bulletItem: {
-      flexDirection: 'row',
-      paddingLeft: t.spacing.md,
-      marginTop: t.spacing.xs,
-    },
-    bullet: {
-      fontSize: t.typography.fontSize.md,
-      lineHeight: 22,
-      color: t.colors.textPrimary,
-      marginRight: t.spacing.sm,
-    },
-    bulletTextContainer: {
-      flex: 1,
-    },
-    bulletText: {
       fontSize: t.typography.fontSize.md,
       lineHeight: 22,
       color: t.colors.textPrimary,

--- a/mobile/src/components/InlineCompact.tsx
+++ b/mobile/src/components/InlineCompact.tsx
@@ -1,40 +1,37 @@
 /**
  * InlineCompact Component
  *
- * An inline version of the Curiosity Compact for embedding in the chat interface.
- * Styled to match the demo at docs-site/static/demo/index.html.
+ * An inline version of the opening welcome for embedding in the chat interface
+ * as an AI-triggered action. Shows a warm AI message with a "Ready" button.
  */
 
 import { View, Text, TouchableOpacity } from 'react-native';
-import { useState } from 'react';
 import { createStyles } from '../theme/styled';
-import { colors } from '../theme';
 
 // ============================================================================
 // Types
 // ============================================================================
 
 interface InlineCompactProps {
-  /** Callback when compact is signed */
+  /** Callback when user taps Ready */
   onSign: () => void;
   /** Whether signing is in progress */
   isPending?: boolean;
+  /** Whether this is the first session for this relationship */
+  isFirstSession?: boolean;
   /** Test ID for testing */
   testID?: string;
 }
 
 // ============================================================================
-// Compact Terms
+// Constants
 // ============================================================================
 
-const COMPACT_TERMS = [
-  'Approach this process with curiosity rather than certainty',
-  'Allow the AI to guide the pace of our work together',
-  'Share honestly within my private space',
-  'Consider the other perspective when presented',
-  'Focus on understanding needs rather than winning',
-  'Take breaks when emotions run high',
-];
+const FIRST_SESSION_TEXT =
+  "You'll each chat with me privately first. Nothing gets shared without your say. Ready?";
+
+const REPEAT_SESSION_TEXT =
+  "Welcome back. Same as before \u2014 your space is private, nothing shared without your say. Let's pick up where we left off.";
 
 // ============================================================================
 // Component
@@ -43,55 +40,27 @@ const COMPACT_TERMS = [
 export function InlineCompact({
   onSign,
   isPending = false,
+  isFirstSession = true,
   testID = 'inline-compact',
 }: InlineCompactProps) {
   const styles = useStyles();
-  const [agreed, setAgreed] = useState(false);
 
-  const handleSign = () => {
-    if (agreed && !isPending) {
-      onSign();
-    }
-  };
+  const messageText = isFirstSession ? FIRST_SESSION_TEXT : REPEAT_SESSION_TEXT;
 
   return (
     <View style={styles.container} testID={testID}>
-      <Text style={styles.title}>The Curiosity Compact</Text>
-
-      <View style={styles.termsContainer}>
-        {COMPACT_TERMS.map((term, index) => (
-          <View key={index} style={styles.termRow}>
-            <Text style={styles.termBullet}>{'>'}</Text>
-            <Text style={styles.termText}>{term}</Text>
-          </View>
-        ))}
-      </View>
-
-      <TouchableOpacity
-        testID={`${testID}-checkbox`}
-        style={styles.agreeRow}
-        onPress={() => setAgreed(!agreed)}
-        accessibilityRole="checkbox"
-        accessibilityState={{ checked: agreed }}
-      >
-        <View style={[styles.checkbox, agreed && styles.checkboxChecked]}>
-          {agreed && <Text style={styles.checkmark}>&#10003;</Text>}
-        </View>
-        <Text style={styles.agreeLabel}>
-          I commit to approaching this with curiosity
-        </Text>
-      </TouchableOpacity>
+      <Text style={styles.messageText}>{messageText}</Text>
 
       <TouchableOpacity
         testID={`${testID}-sign-button`}
-        style={[styles.signButton, !agreed && styles.signButtonDisabled]}
-        onPress={handleSign}
-        disabled={!agreed || isPending}
+        style={[styles.readyButton, isPending && styles.readyButtonDisabled]}
+        onPress={onSign}
+        disabled={isPending}
         accessibilityRole="button"
-        accessibilityState={{ disabled: !agreed || isPending }}
+        accessibilityState={{ disabled: isPending }}
       >
-        <Text style={styles.signButtonText}>
-          {isPending ? 'Signing...' : 'Sign and Begin'}
+        <Text style={styles.readyButtonText}>
+          {isPending ? '...' : isFirstSession ? 'Ready' : "Let's go"}
         </Text>
       </TouchableOpacity>
     </View>
@@ -112,77 +81,23 @@ const useStyles = () =>
       borderWidth: 1,
       borderColor: t.colors.border,
     },
-    title: {
-      fontSize: t.typography.fontSize.xl,
-      fontWeight: '600',
-      color: t.colors.textPrimary,
-      textAlign: 'center',
-      marginBottom: t.spacing.lg,
-    },
-    termsContainer: {
-      marginBottom: t.spacing.lg,
-    },
-    termRow: {
-      flexDirection: 'row',
-      paddingVertical: t.spacing.sm,
-      borderBottomWidth: 1,
-      borderBottomColor: t.colors.border,
-    },
-    termBullet: {
-      color: colors.accent,
-      fontWeight: 'bold',
-      marginRight: t.spacing.md,
-      fontSize: t.typography.fontSize.md,
-    },
-    termText: {
-      flex: 1,
+    messageText: {
       fontSize: t.typography.fontSize.md,
       lineHeight: 22,
       color: t.colors.textPrimary,
-    },
-    agreeRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      backgroundColor: t.colors.bgTertiary,
-      borderRadius: t.radius.sm,
-      padding: t.spacing.md,
       marginBottom: t.spacing.lg,
     },
-    checkbox: {
-      width: 22,
-      height: 22,
-      borderRadius: t.radius.sm,
-      borderWidth: 2,
-      borderColor: t.colors.border,
-      alignItems: 'center',
-      justifyContent: 'center',
-      marginRight: t.spacing.md,
-    },
-    checkboxChecked: {
-      backgroundColor: 'rgb(59, 130, 246)', // Blue to match "Compact Signed" indicator
-      borderColor: 'rgb(59, 130, 246)',
-    },
-    checkmark: {
-      color: 'white',
-      fontSize: 14,
-      fontWeight: 'bold',
-    },
-    agreeLabel: {
-      flex: 1,
-      fontSize: t.typography.fontSize.md,
-      color: t.colors.textPrimary,
-    },
-    signButton: {
-      backgroundColor: 'rgb(59, 130, 246)', // Blue to match "Compact Signed" indicator
+    readyButton: {
+      backgroundColor: 'rgb(59, 130, 246)',
       paddingVertical: t.spacing.lg,
       paddingHorizontal: t.spacing.xl,
       borderRadius: t.radius.sm,
       alignItems: 'center',
     },
-    signButtonDisabled: {
+    readyButtonDisabled: {
       backgroundColor: t.colors.bgTertiary,
     },
-    signButtonText: {
+    readyButtonText: {
       color: 'white',
       fontSize: t.typography.fontSize.md,
       fontWeight: '600',

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1579,11 +1579,11 @@ export function UnifiedSessionScreen({
   // Memoized Empty State Element (prevents typewriter restart on re-render)
   // -------------------------------------------------------------------------
   // Use useMemo to create a stable element reference, not a render function
-  // Adapt intro text for invitees who accepted the invitation
-  const isInvitee = invitation && !invitation.isInviter;
+  // Pass isFirstSession from compact data to show appropriate welcome message
+  const isFirstSession = compactData?.isFirstSession ?? true;
   const compactEmptyStateElement = useMemo(() => {
-    return <CompactChatItem testID="inline-compact" isAfterInvitationAcceptance={isInvitee} />;
-  }, [isInvitee]);
+    return <CompactChatItem testID="inline-compact" isFirstSession={isFirstSession} />;
+  }, [isFirstSession]);
 
   // -------------------------------------------------------------------------
   // Render Overlays
@@ -1829,6 +1829,7 @@ export function UnifiedSessionScreen({
               handleSignCompact(() => onStageComplete?.(Stage.ONBOARDING));
             }}
             isPending={isSigningCompact}
+            isFirstSession={isFirstSession}
             testID="compact-agreement-bar"
           />
         );
@@ -2112,6 +2113,7 @@ export function UnifiedSessionScreen({
     sessionId,
     invitation?.isInviter,
     isSigningCompact,
+    isFirstSession,
     isTypewriterAnimating,
     isConfirmingFeelHeard,
     isSharingEmpathy,

--- a/shared/src/dto/stage.ts
+++ b/shared/src/dto/stage.ts
@@ -139,6 +139,8 @@ export interface CompactStatusResponse {
   partnerSigned: boolean;
   partnerSignedAt: string | null;
   canAdvance: boolean;
+  /** Whether this is the first session for this relationship (no prior resolved sessions) */
+  isFirstSession: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Changes
- Replace formal Curiosity Compact agreement screen (scrollable terms, checkboxes, "Sign and Begin") with a brief AI-spoken welcome message
- First session: "You'll each chat with me privately first. Nothing gets shared without your say. Ready?"
- Repeat session: "Welcome back. Same as before — your space is private, nothing shared without your say. Let's pick up where we left off."
- Add `isFirstSession` field to `CompactStatusResponse` DTO (counts prior resolved sessions per relationship)
- Simplify `CompactAgreementBar` to a single "Ready" / "Let's go" button (no checkbox)
- Simplify `CompactChatItem` to show AI welcome message with typewriter effect
- Simplify `InlineCompact` to show AI message + button (no terms)
- Backend `signCompact` endpoint unchanged — still records acknowledgment as Stage 0 → 1 gate

Related to #114

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr (U0ASRE7NZL7), with direction from Shantam (U0AD3TF2U7L)
- **Original message:** What do you think about replacing the compact in the beginning with a very brief overview of the process? We can include guidelines if necessary. Just thinking something warmer, less preachy?

## Docs updated
- `docs/backend/api/stage-0.md` — Updated CompactStatusResponse with `isFirstSession`, replaced compact content section with opening framing
- `docs/product/stages/stage-0-onboarding.md` — Replaced formal Curiosity Compact with warm opening message, updated flow diagram and wireframe
- `docs/mobile/wireframes/chat-interface.md` — Updated onboarding wireframe and empty state description