### PR TITLE
fix(slam-bot): don't run duplicate detection on pull requests

### DIFF
--- a/scripts/ec2-bot/scripts/check-duplicates.sh
+++ b/scripts/ec2-bot/scripts/check-duplicates.sh
@@ -31,6 +31,19 @@ log() { echo "[$(date)] $1" >> "$LOGFILE" 2>/dev/null || true; }
 
 ISSUE_NUMBER="${1:?Usage: check-duplicates.sh <issue_number>}"
 
+# ─── Skip pull requests ──────────────────────────────────────────────────────
+# GitHub numbers PRs and issues in the same sequence, and the dispatcher
+# intentionally enumerates both (some bot:* labels are PR-bound, e.g.
+# bot:review-impl). But duplicate detection only makes sense for issues:
+# a bot-opened PR's title usually mirrors the issue it closes, so running
+# the detector on the PR guarantees a 100% match against that issue and
+# auto-closes the PR as a "duplicate" of its own parent. Early-exit here.
+IS_PR=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER" --jq '.pull_request != null' 2>/dev/null || echo "")
+if [ "$IS_PR" = "true" ]; then
+  log "Skipping #$ISSUE_NUMBER — item is a pull request, not an issue"
+  exit 0
+fi
+
 # ─── Fetch the issue ─────────────────────────────────────────────────────────
 
 ISSUE_DATA=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \


### PR DESCRIPTION
## Summary

Discovered while watching #114's bot retry after PR #163 merged.

The bot successfully did the work for issue #114 and opened PR #164 at 04:44:02 UTC. One minute later, the bot's own `check-duplicates.sh` auto-closed #164:

```
[Tue Apr 21 04:45:06 UTC 2026] Duplicate detected: #164 is a duplicate of #114 (score=100%)
[Tue Apr 21 04:45:09 UTC 2026] Auto-closed #164 as duplicate of #114 (score=100%)
```

i.e. the PR was closed as a duplicate of the issue it was meant to close.

### Root cause

GitHub numbers PRs and issues in the same sequence. `workspace-dispatcher.sh:312-315` intentionally enumerates both because some `bot:*` labels are PR-bound (`bot:review-impl`, etc.). `check-duplicates.sh` runs on every enumerated item but was built for issues only: it normalizes titles and searches for open issues with overlapping keywords. A bot-opened PR inherits the parent issue's title verbatim → 100% match against the parent → auto-close fires on the PR.

### Fix

Early-exit in `check-duplicates.sh` when the target number refers to a pull request:

```bash
IS_PR=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER" --jq '.pull_request != null' 2>/dev/null || echo "")
if [ "$IS_PR" = "true" ]; then
  log "Skipping #$ISSUE_NUMBER — item is a pull request, not an issue"
  exit 0
fi
```

`.pull_request` is non-null for PRs and null for issues. One extra API call per dispatch, which is cheap.

Verified empirically:

```
$ gh api repos/shantamg/meet-without-fear/issues/164 --jq '.pull_request != null'
true
$ gh api repos/shantamg/meet-without-fear/issues/114 --jq '.pull_request != null'
false
```

### Other work affected

PR #164 has been manually reopened. Worth a look — the agent produced 11 files across backend / mobile / shared / docs and doc-impact passed. CI was interrupted mid-run by the auto-close; a re-run should complete it.

## Test plan

- [x] `bash -n` clean
- [x] `gh api` PR/issue detection verified on #164 and #114
- [ ] After merge: open a bot PR, confirm `check-duplicates.log` logs "Skipping #N — item is a pull request, not an issue" and the PR survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)