### PR TITLE
docs: fix drift from 24h incremental audit (2026-04-21)

### DIFF
--- a/bot-workspaces/CLAUDE.md
+++ b/bot-workspaces/CLAUDE.md
@@ -9,6 +9,7 @@ Route each bot job to its workspace and entry stage. The workspace `CLAUDE.md` (
 | `dm-reply` | `slack-triage/` | `1-fetch-and-classify` |
 | `slam-paws-reply` | `slack-triage/` | `1-fetch-and-classify` |
 | `bugs-and-requests-reply` | `slack-triage/` | `1-fetch-and-classify` |
+| `most-important-thing-reply` | `slack-triage/` | `1-fetch-and-classify` |
 | `mwf-session-reply` | `mwf-session/` | `route` |
 | `respond-github` | `github-respond/` | `respond` |
 | `review-pr` | `github-respond/` | `review` |

--- a/docs/backend/api/stage-0.md
+++ b/docs/backend/api/stage-0.md
@@ -1,16 +1,16 @@
 ---
 title: "Stage 0 API: Onboarding"
 sidebar_position: 5
-description: Endpoints for the Curiosity Compact signing flow.
+description: Endpoints for the Stage 0 onboarding acknowledgment flow.
 slug: /backend/api/stage-0
 ---
 # Stage 0 API: Onboarding
 
-Endpoints for the Curiosity Compact signing flow.
+Endpoints for the Stage 0 onboarding acknowledgment flow.
 
-## Sign Curiosity Compact
+## Sign Compact
 
-Sign the Curiosity Compact to commit to the process.
+Record acknowledgment of the opening welcome message to proceed.
 
 ```
 POST /api/v1/sessions/:id/compact/sign
@@ -106,7 +106,8 @@ interface CompactStatusResponse {
     "mySignedAt": "2024-01-16T14:30:00Z",
     "partnerSigned": false,
     "partnerSignedAt": null,
-    "canAdvance": false
+    "canAdvance": false,
+    "isFirstSession": true
   }
 }
 ```
@@ -121,7 +122,8 @@ interface CompactStatusResponse {
     "mySignedAt": "2024-01-16T14:30:00Z",
     "partnerSigned": true,
     "partnerSignedAt": "2024-01-16T14:45:00Z",
-    "canAdvance": true
+    "canAdvance": true,
+    "isFirstSession": false
   }
 }
 ```

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -24,7 +24,7 @@ Operational infrastructure for Meet Without Fear.
 
 | Service | Purpose |
 |---|---|
-| `slam-bot-socket.service` | Socket Mode listener for real-time Slack events. Routes incoming messages by channel: DMs and `#slam-paws`/`#agentic-devs`/`#bugs-and-requests` go to the `slack-triage` workspace; `#mwf-sessions` messages go to the `mwf-session` workspace (or, when `MWF_BACKEND_URL` is set, forward directly to the backend Bedrock pipeline). |
+| `slam-bot-socket.service` | Socket Mode listener for real-time Slack events. Routes incoming messages by channel: DMs and `#slam-paws`/`#agentic-devs`/`#bugs-and-requests`/`#most-important-thing` go to the `slack-triage` workspace; `#mwf-sessions` messages go to the `mwf-session` workspace (or, when `MWF_BACKEND_URL` is set, forward directly to the backend Bedrock pipeline). |
 | `slam-bot-state-scanner.service` | GitHub state scanner daemon (`github-state-scanner.sh` loop). Hardened with `MemoryMax=256M` and `TasksMax=64` to prevent runaway resource use. |
 
 ### Cron jobs
@@ -53,7 +53,7 @@ Local operator scripts live at `scripts/ec2-bot/`:
 | `provision.sh` | One-shot AWS provisioning (security group, EIP, instance, SSH config entry) |
 | `setup.sh` | First-time bootstrap of a fresh instance (Node, gh, claude, directories) |
 | `deploy.sh` | Symlink scripts, install systemd units + crontab + logrotate |
-| `configure-slack.sh` | Write Slack tokens + channel IDs (`SLAM_BOT_CHANNEL_ID` for `#slam-paws`, `AGENTIC_DEVS_CHANNEL_ID` for `#agentic-devs`, `BUGS_AND_REQUESTS_CHANNEL_ID` for `#bugs-and-requests`, `MWF_SESSIONS_CHANNEL_ID` for `#mwf-sessions`) to `/opt/slam-bot/.env` and start the socket service |
+| `configure-slack.sh` | Write Slack tokens + channel IDs (`SLAM_BOT_CHANNEL_ID` for `#slam-paws`, `AGENTIC_DEVS_CHANNEL_ID` for `#agentic-devs`, `BUGS_AND_REQUESTS_CHANNEL_ID` for `#bugs-and-requests`, `MOST_IMPORTANT_THING_CHANNEL_ID` for `#most-important-thing`, `MWF_SESSIONS_CHANNEL_ID` for `#mwf-sessions`) to `/opt/slam-bot/.env` and start the socket service |
 | `configure-mixpanel.sh` | Write Mixpanel service-account credentials |
 | `configure-db.sh` | Create/rotate `slam_bot_readonly` role on the Render Postgres |
 
@@ -76,6 +76,7 @@ The socket listener routes messages by channel config. Each monitored channel ma
 | `#slam-paws` | `slack-triage` | `slam-paws-reply` |
 | `#agentic-devs` | `slack-triage` | `agentic-devs-reply` |
 | `#bugs-and-requests` | `slack-triage` | `bugs-and-requests-reply` |
+| `#most-important-thing` | `slack-triage` | `most-important-thing-reply` |
 | `#mwf-sessions` | `mwf-session` | `mwf-session-reply` |
 
 For `#mwf-sessions`, when `MWF_BACKEND_URL` is set the listener POSTs directly to the backend Bedrock pipeline instead of spawning a Claude Code agent.

--- a/docs/product/stages/stage-0-onboarding.md
+++ b/docs/product/stages/stage-0-onboarding.md
@@ -1,7 +1,7 @@
 ---
 title: "Stage 0: Onboarding"
 sidebar_position: 3
-description: Establish the Process Guardian role and secure commitment from both parties through the Curiosity Compact.
+description: Welcome both parties with a brief warm opening and secure acknowledgment before entering the conversation.
 ---
 # Stage 0: Onboarding
 
@@ -75,13 +75,13 @@ Both users must acknowledge the opening message.
 | Scenario | AI Response |
 |----------|-------------|
 | User has concerns | Explore concerns; provide reassurance |
-| User refuses to sign | Explain this is required; offer resources for other options |
+| User refuses to proceed | Explore concerns; explain the format is required; offer resources for other options |
 | Other party not responding | Send reminders; offer to resend invitation |
 | Invitation expires | Allow session creator to send new invitation |
 
 ## Data Captured
 
-- Signature timestamp for each user
+- Acknowledgment timestamp for each user
 - Any concerns raised (for improving onboarding)
 - Invitation/acceptance timing
 
@@ -94,7 +94,7 @@ Both users must acknowledge the opening message.
 
 ### Backend Implementation
 
-- [Stage 0 API](../backend/api/stage-0.md) - Compact signing endpoints
+- [Stage 0 API](../backend/api/stage-0.md) - Onboarding acknowledgment endpoints
 - [Stage 0 Prompt](../backend/prompts/stage-0-opening.md) - Opening message template
 - [Retrieval Contracts](../backend/state-machine/retrieval-contracts.md#stage-0-onboarding)
 


### PR DESCRIPTION
## Changes
- Fix: `docs/backend/api/stage-0.md` — remove stale "Curiosity Compact signing flow" terminology; add `isFirstSession` to both `CompactStatusResponse` examples
- Fix: `docs/product/stages/stage-0-onboarding.md` — update description and failure-path language ("refuses to sign" → "refuses to proceed"); "Signature timestamp" → "Acknowledgment timestamp"; related link label updated
- Add: `docs/infrastructure/index.md` — add `#most-important-thing` to channel routing table, systemd service description, and `configure-slack.sh` env-var list (`MOST_IMPORTANT_THING_CHANNEL_ID`)
- Add: `bot-workspaces/CLAUDE.md` — add `most-important-thing-reply` routing entry (`slack-triage` / `1-fetch-and-classify`)

## Provenance
- **Channel:** cron / nightly audit
- **Requested by:** automated (audit-docs)
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** `/audit-docs` — git-history-aware incremental docs audit

## Docs updated
- `docs/backend/api/stage-0.md`
- `docs/product/stages/stage-0-onboarding.md`
- `docs/infrastructure/index.md`
- `bot-workspaces/CLAUDE.md`