### PR TITLE
fix(slam-bot): daily-strategy briefings at 7 AM / 7 PM ET with budget guard

### DIFF
--- a/.claude/config/services.json
+++ b/.claude/config/services.json
@@ -29,12 +29,16 @@
     }
   },
   "slack": {
-    "channels": {},
+    "channels": {
+      "most-important-thing": "C0AU9Q3DENQ"
+    },
     "bot_user_id": ""
   },
   "github": {
     "repo": "shantamg/meet-without-fear",
-    "pr_reviewers": ["shantamg"],
+    "pr_reviewers": [
+      "shantamg"
+    ],
     "slack_to_github_users": {}
   }
 }

--- a/scripts/ec2-bot/crontab.txt
+++ b/scripts/ec2-bot/crontab.txt
@@ -23,7 +23,8 @@
 0 11 * * 1  /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled security-audit "Run weekly security audit" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
 0 9 * * 1-5 /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled stale-sweeper "Sweep for stale items" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
 */10 * * * * /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled pr-reviewer "Scan and review open bot PRs" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
-0 16 * * *  /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled daily-strategy "Compile proactive daily strategy briefing" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
+0 11 * * *  /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled daily-strategy "Morning strategy briefing" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
+0 23 * * *  /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled daily-strategy "Evening strategy briefing" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
 
 # ── Staging branch sync (keeps bot/staging in sync with main, PRs accumulated work) ──
 0 8,20 * * * /opt/slam-bot/scripts/sync-staging.sh >> /var/log/slam-bot/cron.log 2>&1

--- a/scripts/ec2-bot/scripts/daily-strategy-precheck.sh
+++ b/scripts/ec2-bot/scripts/daily-strategy-precheck.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# daily-strategy-precheck.sh — Pre-check for scheduled daily-strategy workspace.
+#
+# Convention: exit 0 = work found (dispatcher invokes Claude),
+#             exit 1 = nothing to do (dispatcher skips Claude).
+#
+# Daily strategy always has work to do (scheduled briefings), so this
+# precheck only gates on GitHub API budget. If the remaining rate limit
+# is too low for the 10 parallel sub-agents, posts a fallback notice to
+# #most-important-thing and exits 1 (skip Claude).
+#
+# Minimum thresholds: 200 GraphQL points, 200 REST calls. The daily-strategy
+# workspace typically uses ~150 GraphQL points and ~100 REST calls per run
+# across its 10 sub-agents.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/config.sh"
+
+LOGFILE="$BOT_LOG_DIR/daily-strategy.log"
+log() { echo "[$(date)] $*" >> "$LOGFILE" 2>/dev/null || true; }
+
+MIN_GRAPHQL=200
+MIN_REST=200
+
+# ── Check rate limit ─────────────────────────────────────────────────────
+RAW=$(gh api rate_limit 2>&1)
+RC=$?
+if [ $RC -ne 0 ]; then
+  log "ERROR: gh api rate_limit failed (rc=$RC) — skipping daily-strategy"
+  # Can't check budget → post fallback and skip
+  CHANNEL_ID="${MOST_IMPORTANT_THING_CHANNEL_ID:-}"
+  if [ -n "$CHANNEL_ID" ] && [ -n "${SLACK_BOT_TOKEN:-}" ]; then
+    curl -s -X POST https://slack.com/api/chat.postMessage \
+      -H "Authorization: Bearer $SLACK_BOT_TOKEN" -H "Content-Type: application/json" \
+      -d "$(jq -n --arg ch "$CHANNEL_ID" \
+         --arg text ":warning: Strategy briefing skipped — GitHub API unavailable. Check bot logs." \
+         '{channel: $ch, text: $text}')" > /dev/null 2>&1 || true
+  fi
+  exit 1
+fi
+
+GRAPHQL_REMAINING=$(echo "$RAW" | jq -r '.resources.graphql.remaining // 0' 2>/dev/null || echo "0")
+REST_REMAINING=$(echo "$RAW" | jq -r '.resources.core.remaining // 0' 2>/dev/null || echo "0")
+
+log "Budget check: graphql=$GRAPHQL_REMAINING (min $MIN_GRAPHQL), rest=$REST_REMAINING (min $MIN_REST)"
+
+if [ "$GRAPHQL_REMAINING" -lt "$MIN_GRAPHQL" ] || [ "$REST_REMAINING" -lt "$MIN_REST" ]; then
+  log "Insufficient API budget — posting fallback notice"
+
+  CHANNEL_ID="${MOST_IMPORTANT_THING_CHANNEL_ID:-}"
+  if [ -n "$CHANNEL_ID" ] && [ -n "${SLACK_BOT_TOKEN:-}" ]; then
+    curl -s -X POST https://slack.com/api/chat.postMessage \
+      -H "Authorization: Bearer $SLACK_BOT_TOKEN" -H "Content-Type: application/json" \
+      -d "$(jq -n --arg ch "$CHANNEL_ID" \
+         --arg text ":warning: Strategy briefing skipped — GitHub API budget low (GraphQL: ${GRAPHQL_REMAINING} remaining, REST: ${REST_REMAINING} remaining). Will retry next scheduled run." \
+         '{channel: $ch, text: $text}')" > /dev/null 2>&1 || true
+    log "Fallback notice posted to #most-important-thing"
+  else
+    log "WARNING: No MOST_IMPORTANT_THING_CHANNEL_ID or SLACK_BOT_TOKEN — cannot post fallback notice"
+  fi
+
+  exit 1
+fi
+
+log "Budget sufficient — proceeding with daily-strategy"
+echo "budget_ok graphql=$GRAPHQL_REMAINING rest=$REST_REMAINING"
+exit 0


### PR DESCRIPTION
## Changes
- Fix: update crontab from single 16:00 UTC entry to two entries at 11:00 UTC (7 AM EDT) and 23:00 UTC (7 PM EDT)
- Add: `daily-strategy-precheck.sh` that checks GitHub API rate limits before running — posts fallback notice to #most-important-thing if budget is insufficient instead of failing silently
- Fix: add `most-important-thing` channel ID (`C0AU9Q3DENQ`) to `services.json` so the workspace can resolve it as documented

Related to #167

## Provenance
- **Channel:** #most-important-thing
- **Requested by:** Darryl Finkton Jr (U0ASRE7NZL7)
- **Original message:** "What's happening with this thread @Slam Paws? Are you not posting these daily at 7 am and 7pm for us to review?"

## Docs updated
No doc changes needed — infrastructure/config-only PR with no docs mappings.