### PR TITLE
fix(mobile): deduplicate network error tracking

### DIFF
--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -260,7 +260,6 @@ apiClient.interceptors.response.use(
 
     // Network error or timeout
     if (error.code === 'ECONNABORTED') {
-      trackError('network', 'TIMEOUT', error.config?.url || 'unknown');
       return Promise.reject(
         new ApiClientError(
           { code: ErrorCode.SERVICE_UNAVAILABLE, message: 'Request timed out' },
@@ -269,7 +268,6 @@ apiClient.interceptors.response.use(
       );
     }
 
-    trackError('network', 'NETWORK_ERROR', error.config?.url || 'unknown');
     return Promise.reject(
       new ApiClientError(
         { code: ErrorCode.SERVICE_UNAVAILABLE, message: 'Network error' },

--- a/mobile/src/providers/QueryProvider.tsx
+++ b/mobile/src/providers/QueryProvider.tsx
@@ -6,11 +6,16 @@
 
 import React, { type PropsWithChildren, useState } from 'react';
 import {
+  QueryCache,
   QueryClient,
   QueryClientProvider,
+  MutationCache,
   focusManager,
 } from '@tanstack/react-query';
 import { AppState, AppStateStatus, Platform } from 'react-native';
+import { ApiClientError } from '../lib/api';
+import { trackError } from '../services/analytics';
+import { ErrorCode } from '@meet-without-fear/shared';
 
 // ============================================================================
 // App Focus Management
@@ -38,8 +43,21 @@ function setupFocusManager(): () => void {
 // Query Client Configuration
 // ============================================================================
 
+function trackNetworkError(error: unknown): void {
+  if (error instanceof ApiClientError && error.code === ErrorCode.SERVICE_UNAVAILABLE) {
+    const errorCode = error.message === 'Request timed out' ? 'TIMEOUT' : 'NETWORK_ERROR';
+    trackError('network', errorCode);
+  }
+}
+
 function createQueryClient(): QueryClient {
   return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error) => trackNetworkError(error),
+    }),
+    mutationCache: new MutationCache({
+      onError: (error) => trackNetworkError(error),
+    }),
     defaultOptions: {
       queries: {
         // Data considered fresh for 30 seconds


### PR DESCRIPTION
## Changes
- Remove `trackError` calls for TIMEOUT and NETWORK_ERROR from the Axios response interceptor in `mobile/src/lib/api.ts` — these fire on every HTTP attempt including React Query retries, inflating error counts ~4x
- Add `QueryCache` and `MutationCache` `onError` callbacks in `mobile/src/providers/QueryProvider.tsx` that call `trackError` once per logical failure (only after all retries are exhausted)
- Network error tracking now accurately reflects actual failures instead of retry attempts

Related to #98

## Provenance
- **Channel:** #health-check (automated daily audit)
- **Requested by:** slam-paws health-check bot
- **Original message:** Scheduled health check 2026-04-17
- **Prompt(s) used:** Cross-referenced Mixpanel errors with Render logs and Sentry issues

## Docs updated
No doc changes needed — internal error tracking change with no architectural impact