### PR TITLE
fix(docs-audit): correct #agentic-devs channel ID in incremental CONTEXT.md

### DIFF
--- a/bot-workspaces/docs-audit/stages/incremental/CONTEXT.md
+++ b/bot-workspaces/docs-audit/stages/incremental/CONTEXT.md
@@ -17,7 +17,7 @@
 5. **Doc hygiene** on modified docs: valid frontmatter, `updated` date bumped, correct section, referenced from index
 6. **Fix issues**: update drifted docs, create missing docs, fix frontmatter. Commit changes.
 7. **Create PR** if changes made (via `shared/skills/pr.md`)
-8. **Post summary** to #agentic-devs (channel `C0AM2J47R4L`)
+8. **Post summary** to #agentic-devs (channel `C0ATAE7QP3P`)
 
 ## Output
 


### PR DESCRIPTION
## Changes
- Fix: stale Slack channel ID for #agentic-devs in docs-audit incremental stage (`C0AM2J47R4L` → `C0ATAE7QP3P`)

## Provenance
- **Channel:** cron / automated
- **Requested by:** audit-docs bot job
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs incremental — discovered channel_not_found error when posting summary; fixed against .env

## Docs updated
No doc changes needed (this fix IS the bot-workspace config correction)