### PR TITLE
fix(slam-bot): daily-strategy cron to 7 AM / 7 PM Pacific

### DIFF
--- a/scripts/ec2-bot/crontab.txt
+++ b/scripts/ec2-bot/crontab.txt
@@ -23,8 +23,8 @@
 0 11 * * 1  /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled security-audit "Run weekly security audit" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
 0 9 * * 1-5 /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled stale-sweeper "Sweep for stale items" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
 */10 * * * * /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled pr-reviewer "Scan and review open bot PRs" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
-0 11 * * *  /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled daily-strategy "Morning strategy briefing" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
-0 23 * * *  /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled daily-strategy "Evening strategy briefing" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
+0 14 * * *  /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled daily-strategy "Morning strategy briefing" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
+0 2 * * *   /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled daily-strategy "Evening strategy briefing" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
 
 # ── Staging branch sync (keeps bot/staging in sync with main, PRs accumulated work) ──
 0 8,20 * * * /opt/slam-bot/scripts/sync-staging.sh >> /var/log/slam-bot/cron.log 2>&1


### PR DESCRIPTION
## Summary
• PR #168 set daily-strategy schedule to 11:00/23:00 UTC (7 AM / 7 PM Eastern), but Shantam confirmed the intended timezone is Pacific
• Corrected to 14:00/02:00 UTC (7 AM / 7 PM Pacific)
• Live crontab already updated — this PR persists the fix in the repo

## Provenance
• Channel: DM (Shantam)
• Requester: Shantam (U0AD3TF2U7L)
• Message: "But it's supposed to be 7am pacific time."

## Test plan
• Verify crontab.txt has `0 14` and `0 2` for daily-strategy entries
• Next morning run fires at 14:00 UTC (7 AM PT) tomorrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)