### PR TITLE
fix(mobile): show error toast when AI action fails

### DIFF
--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -56,6 +56,7 @@ import { useSharingStatus } from '../hooks/useSharingStatus';
 import { usePendingActions } from '../hooks/usePendingActions';
 import { useNeedsComparison } from '../hooks/useStages';
 import { deriveIndicators, SessionIndicatorData } from '../utils/chatListSelector';
+import { useToast } from '../contexts/ToastContext';
 import { createStyles } from '../theme/styled';
 import { WaitingBanner } from '../components/WaitingBanner';
 import {
@@ -163,6 +164,7 @@ export function UnifiedSessionScreen({
   const { user, updateUser } = useAuth();
   const { mutate: updateMood } = useUpdateMood();
   const queryClient = useQueryClient();
+  const { showError } = useToast();
 
   // Sharing status for header button
   const sharingStatus = useSharingStatus(sessionId);
@@ -683,7 +685,7 @@ export function UnifiedSessionScreen({
       console.error('[UnifiedSessionScreen] AI error received via Ably:', payload.error);
       // Note: Ghost dots hide automatically because optimistic message is rolled back on error
       handleAIMessageError(sessionId, payload.userMessageId, payload.error, payload.canRetry);
-      // TODO: Show error toast or UI indicator
+      showError('Something went wrong', 'Your message could not be processed. Please try again.');
     },
   });
 


### PR DESCRIPTION
## Changes
- Fix: Wire `useToast().showError()` to the `onAIError` handler in `UnifiedSessionScreen`, replacing the TODO comment
- Users now see a visible toast notification ("Something went wrong") when an AI message fails during a session
- Complements the existing inline retry UI (error-styled message bubble + "Tap to retry")

Related to #176

## Provenance
- **Channel:** GitHub issue
- **Requested by:** daily-strategy bot (code health scan)
- **Original message:** Bug: Missing error toast in UnifiedSessionScreen when action fails
- **Prompt(s) used:** general-pr workspace

## Docs updated
No doc changes needed — 3-line wiring fix using existing toast infrastructure; no new UI patterns or architecture changes.