### PR TITLE
fix(slam-bot): stop needs-info re-dispatch loop

### DIFF
--- a/bot-workspaces/needs-info/CLAUDE.md
+++ b/bot-workspaces/needs-info/CLAUDE.md
@@ -2,6 +2,15 @@
 
 Structured interview loop for vague or incomplete requests. Asks clarifying questions, polls for responses, and graduates the issue when enough context is gathered.
 
+## Modes
+
+The dispatcher always invokes this workspace at `entry_stage: 01-create-issue` because there is no per-issue stage state in the registry. Determine the actual current stage from the issue's bot comments before loading a stage CONTEXT.md:
+
+- **No bot comment with `<!-- bot:needs-info-meta` metadata exists** → fresh issue, load `stages/01-create-issue/CONTEXT.md`.
+- **A bot comment with `<!-- bot:needs-info-meta` metadata exists** → re-entry, load `stages/02-interview/CONTEXT.md` directly. Do NOT exit early expecting a "next tick" to handle stage 02 — the next tick will re-enter at stage 01 again, producing an infinite re-dispatch loop (every 30 min, while `bot:needs-info` carries `keep_label: true`).
+
+The `waiting-human-${ISSUE_NUMBER}.txt` marker file in the claims dir is the only signal that gates re-dispatch. Whichever stage runs MUST leave that marker present on every exit path that does not graduate or close the issue.
+
 ## What to Load
 
 | Resource | When | Why |

--- a/bot-workspaces/needs-info/stages/01-create-issue/CONTEXT.md
+++ b/bot-workspaces/needs-info/stages/01-create-issue/CONTEXT.md
@@ -31,7 +31,9 @@ Any other `gh` read call indicates a bug.
 ## Process
 
 1. **Confirm the label** via the state file helper `github_state_issue_has_label`. Then **read the issue body** via `gh issue view <number>`.
-2. **Check for existing bot comments** on the issue. If the bot has already posted an initial comment, skip to stage 02 (this is a re-entry).
+2. **Detect re-entry**: check for existing bot comments on the issue.
+   - **If a bot comment with `<!-- bot:needs-info-meta` metadata already exists**, this is a re-entry. The dispatcher always invokes this workspace at stage 01 because there is no per-issue stage state. Do NOT exit. Instead, **read `stages/02-interview/CONTEXT.md` and execute its Process section in this same invocation** — that's where response handling, follow-ups, nudges, and the waiting-human marker live. After running stage 02's logic, exit.
+   - **If no prior bot comment exists**, this is a first run — continue with steps 3–5 below.
 3. **Classify the request category**:
    - `bug` — user describes something broken but lacks specifics
    - `feature` — user wants something new but scope is unclear
@@ -44,12 +46,25 @@ Any other `gh` read call indicates a bug.
    ```
    <!-- bot:needs-info-meta: {"questions_asked": 1, "category": "<category>", "created": "<ISO>"} -->
    ```
+6. **Write the waiting-human marker** so the dispatcher does not re-fire on every cooldown expiry (every 30 min) while waiting for the user's first response:
+   ```bash
+   date -Iseconds > "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+   ```
 
 ## Output
 
-- Initial interview comment posted on the GitHub issue
-- Category classification stored in metadata
+- Initial interview comment posted on the GitHub issue (first run only)
+- Category classification stored in metadata (first run only)
+- `waiting-human-${ISSUE_NUMBER}.txt` marker present in claims dir on every exit path
+
+## Failsafe
+
+If, for any reason, this stage exits without having executed stage 02's logic AND without having posted a fresh bot comment, write the marker before exiting:
+```bash
+date -Iseconds > "${CLAIMS_DIR:-/opt/slam-bot/state/claims}/waiting-human-${ISSUE_NUMBER}.txt"
+```
+This prevents an infinite re-dispatch loop if the LLM misroutes the re-entry path.
 
 ## Completion
 
-Proceed to `stages/02-interview/` on the next dispatcher tick.
+A single invocation handles either the first-run interview (steps 3–5) or the re-entry by inlining stage 02. There is no "next tick" handoff — the marker file is the only signal that gates re-dispatch.


### PR DESCRIPTION
## Summary

- Five `bot:needs-info` issues (#150, #151, #152, #169, #173) were burning Claude Code credits every 30 min — ~936 Sonnet runs over 6 days, with daily volume climbing 76→231 as more issues fell into the trap.
- Root cause: `stages/01-create-issue/CONTEXT.md` told the LLM to *"skip to stage 02 on the next dispatcher tick"* on re-entry. But the dispatcher always re-enters at stage 01 (the registry has no per-issue stage state), so stage 02 (where the `waiting-human-${N}.txt` marker that gates re-dispatch is written) was never reached. Result: every 30-min cooldown expiry → another Sonnet fire → repeat forever.
- Fix: route on re-entry from `needs-info/CLAUDE.md` based on the bot-comment meta tag (same pattern `spec-builder/CLAUDE.md` and `research/CLAUDE.md` already use). Stage 01 inlines stage 02's logic on re-entry instead of deferring, and writes the marker as a failsafe on every exit path.
- Already shipped manually before this PR: wrote `waiting-human-{150,151,152,169,173}.txt` on EC2 to halt the live loop. The dispatcher saw the markers on the next tick and stopped firing on those issues.

## Why the bug bit only `needs-info`

`bot:spec-builder` and `bot:research` both have L1 `CLAUDE.md` instructions to determine the current stage from the meta tag at the top of each invocation. `bot:needs-info` was missing that pattern, so it relied on stage 01 to detect re-entry and route — but stage 01's instruction said "exit and let the next tick do it," which never worked because the next tick was identical.

## Damage

| Issue | Cycles | Days looping |
|---|---|---|
| #150 | 262 | 6 |
| #151 | 263 | 6 |
| #152 | 263 | 6 |
| #169 | 98 | 2 |
| #173 | 50 | 1 |

## Out of scope (followups)

- **Marker auto-clearing on human reply.** `pipeline-monitor.sh`'s Check 7 (the only thing that clears markers when a non-bot user comments) only runs while a `bot:milestone-builder` issue is open. With this PR's marker reliably written, the bot won't re-engage on a non-`@MwfBot` reply unless the human removes/re-adds the label. The cleanest fix is probably extending `clear-stale-locks.sh` to scan markers, compare to the state file's `updatedAt`, and fetch comments only when the issue has changed since the marker was written.
- **Empirical audit of `bot:spec-builder`** — its L1 routing should keep it out of this trap, but no harm in a quick check.

## Test plan

- [ ] Verify the 5 stuck issues stay quiet after this lands (no new `bot:in-progress` label cycling)
- [ ] Trigger a fresh `bot:needs-info` flow end-to-end: confirm marker is written on first run, dispatcher skips on subsequent ticks
- [ ] Reply on a `bot:needs-info` issue with `@MwfBot` and confirm `check-github.sh` still routes correctly (independent of this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)