### PR TITLE
docs(deployment): document OPENAI_API_KEY for TTS

### DIFF
--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -34,6 +34,7 @@ All required environment variables for Meet Without Fear services.
 | `RATE_LIMIT_WINDOW_MS` | Rate limit window | `60000` |
 | `RATE_LIMIT_MAX` | Max requests per window | `100` |
 | `EXPO_ACCESS_TOKEN` | Expo push notification token | (optional) |
+| `OPENAI_API_KEY` | OpenAI key for TTS (`/api/tts` → `tts-1` / `tts-1-hd`). Without it, TTS returns 500 and meditation/gratitude/chat read-aloud features are broken. | (none) |
 
 ## JWT Configuration
 


### PR DESCRIPTION
## Summary
- Adds `OPENAI_API_KEY` to the Optional section of `docs/deployment/environment-variables.md`
- Notes that TTS (`/api/tts`) returns 500 without it, breaking meditation / gratitude / chat read-aloud

## Why
Closes #155. TTS prod outage (Sentry MWF-BACKEND-8, 2026-04-20) traced to `OPENAI_API_KEY` missing from the Render env group `be-heard-api-env`. The variable was in `backend/.env.example` but absent from this deployment doc, so it slipped through provisioning. Documenting it here is the code-fixable half of the issue; the env var itself was added in Render manually.

## Test plan
- [ ] Confirm `OPENAI_API_KEY` is now listed in `docs/deployment/environment-variables.md` under Backend API → Optional
- [ ] Confirm prod TTS works after Render redeploy (separate verification, not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)