### PR TITLE
docs: fix drift from 24h incremental audit (2026-04-26)

### DIFF
--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -2,6 +2,8 @@
 title: Chat Interface
 sidebar_position: 3
 description: The primary conversation interface where users interact with the AI.
+updated: 2026-04-26
+status: living
 ---
 # Chat Interface
 
@@ -55,6 +57,7 @@ Characteristics:
 - Subtle background color
 - AI avatar/icon
 - A typing indicator ("ghost dots") appears while the user is waiting for the AI's reply — it's derived from cache state (the last message role is `USER`, meaning the AI hasn't answered yet) and from pending mutations like `isFetchingInitialMessage` / `isConfirmingFeelHeard` / `isSharingEmpathy` / `isConfirmingInvitation`. Dots hide as soon as the first AI chunk arrives via SSE / Ably.
+- **AI error feedback**: when an Ably `onAIError` event arrives (e.g. the backend failed to process the user's message), the optimistic message is rolled back (dots hide automatically) and a toast is shown: *"Something went wrong — Your message could not be processed. Please try again."* This is triggered via `useToast().showError` in `UnifiedSessionScreen`.
 
 ### User Message
 


### PR DESCRIPTION
## Changes
- Add: document AI error toast behaviour in `docs/mobile/wireframes/chat-interface.md` — `onAIError` Ably event now shows a toast ("Something went wrong / Your message could not be processed. Please try again.") after rolling back the optimistic message (#177)
- Fix: add `updated: 2026-04-26` and `status: living` frontmatter to chat-interface.md

## Provenance
- **Channel:** cron / audit-docs
- **Requested by:** automated nightly incremental audit
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs

## Docs updated
- `docs/mobile/wireframes/chat-interface.md`