### PR TITLE
fix(mobile): add error handling to WebBrowser.openBrowserAsync calls

### DIFF
--- a/mobile/app/(auth)/settings/help.tsx
+++ b/mobile/app/(auth)/settings/help.tsx
@@ -62,7 +62,9 @@ export default function HelpSupportScreen() {
   };
 
   const handleOpenDocs = () => {
-    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/docs');
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/docs').catch(() => {
+      Alert.alert('Error', 'Could not open documentation');
+    });
   };
 
   const handleFeedback = () => {

--- a/mobile/app/(auth)/settings/privacy.tsx
+++ b/mobile/app/(auth)/settings/privacy.tsx
@@ -12,6 +12,7 @@ import {
   ScrollView,
   Switch,
   TouchableOpacity,
+  Alert,
 } from 'react-native';
 import { Stack } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
@@ -26,11 +27,15 @@ export default function PrivacySettingsScreen() {
   const [shareAnonymousAnalytics, setShareAnonymousAnalytics] = useState(true);
 
   const handlePrivacyPolicyPress = () => {
-    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/privacy');
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/privacy').catch(() => {
+      Alert.alert('Error', 'Could not open Privacy Policy');
+    });
   };
 
   const handleTermsPress = () => {
-    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/terms');
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/terms').catch(() => {
+      Alert.alert('Error', 'Could not open Terms of Service');
+    });
   };
 
   return (

--- a/mobile/app/(public)/index.tsx
+++ b/mobile/app/(public)/index.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView, Alert } from 'react-native';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { colors } from '@/theme';
@@ -16,11 +16,15 @@ export default function WelcomeScreen() {
   };
 
   const handleTerms = () => {
-    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/terms');
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/terms').catch(() => {
+      Alert.alert('Error', 'Could not open Terms of Service');
+    });
   };
 
   const handlePrivacy = () => {
-    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/privacy');
+    WebBrowser.openBrowserAsync('https://meetwithoutfear.com/privacy').catch(() => {
+      Alert.alert('Error', 'Could not open Privacy Policy');
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- Adds `.catch()` to all `WebBrowser.openBrowserAsync` calls in mobile (welcome screen, privacy settings, help screen) to fix the Sentry crashes from #107
- Shows an `Alert` on failure instead of an unhandled promise rejection
- Cherry-picked from PR #120 — only the mobile portion. The website terms/privacy pages on #120 are bot-generated boilerplate making substantive false-promise claims (encryption-at-rest, no-AI-training, 30-day deletion SLA) and need human/legal review before merging. This PR ships the mobile crash fix immediately so #120 can stay open until the legal text is sorted.

Refs #107.

## Test plan
- [x] `npx tsc --noEmit` clean in mobile workspace
- [ ] Manual: airplane mode → tap Terms / Privacy / Docs → see an Alert (not a silent failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)