### PR TITLE
fix(mobile): add Refine invitation button to invitation panel

### DIFF
--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1980,6 +1980,16 @@ export function UnifiedSessionScreen({
               />
 
               <TouchableOpacity
+                style={styles.refineInvitationButton}
+                onPress={() => setShowInvitationRefine(true)}
+                testID="invitation-refine-button"
+              >
+                <Text style={styles.refineInvitationButtonText}>
+                  Refine invitation
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
                 style={styles.continueButton}
                 onPress={() => {
                   // Track invitation sent
@@ -2754,6 +2764,20 @@ const useStyles = () =>
       marginBottom: t.spacing.sm,
       paddingHorizontal: t.spacing.md,
       lineHeight: 22,
+    },
+    refineInvitationButton: {
+      marginTop: t.spacing.sm,
+      marginHorizontal: t.spacing.lg,
+      paddingVertical: t.spacing.sm,
+      alignItems: 'center',
+      borderWidth: 1,
+      borderColor: t.colors.accent,
+      borderRadius: t.radius.md,
+    },
+    refineInvitationButtonText: {
+      fontSize: t.typography.fontSize.md,
+      color: t.colors.accent,
+      fontWeight: '600' as const,
     },
     continueButton: {
       marginTop: t.spacing.sm,


### PR DESCRIPTION
## Changes
- Add: "Refine invitation" button to the invitation panel between Share and Continue
- The button opens the existing `RefineInvitationDrawer` directly from the panel, giving users a visible path to adjust their invitation text before confirming

Related to #186

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** "It then went to asking questions and if I feel heard without ever sending the invite adjustment"

## Docs updated
No doc changes needed — single UI button addition to existing panel