### PR TITLE
fix(backend): load empathy draft in regular Stage 2 for editing context

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1383,6 +1383,16 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
         // Fetch shared context from partner
         const sharedContextResult = await getSharedContextForGuesser(sessionId, user.id);
         stage2BSharedContext = sharedContextResult.content;
+      } else {
+        // Regular Stage 2 — load empathy draft so AI can see/edit the current draft
+        const currentEmpathyDraft = await prisma.empathyDraft.findUnique({
+          where: { sessionId_userId: { sessionId, userId: user.id } },
+          select: { content: true },
+        });
+        if (currentEmpathyDraft) {
+          empathyDraftContent = currentEmpathyDraft.content;
+          logger.info(`[sendMessageStream:${requestId}] Stage 2: found existing empathy draft (${empathyDraftContent.length} chars)`);
+        }
       }
     }
 


### PR DESCRIPTION
## Changes
- Fix: Load empathy draft from database during regular Stage 2 (not just Stage 2B/REFINING flow)
- This ensures the AI has context about the current empathy draft when the user requests edits
- Without this fix, `empathyDraftContent` stayed `null` in regular Stage 2, causing the AI to generate blank content

Related to #188

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** "I tried to edit the message at the end of stage 2 and hit this bug"

## Docs updated
No doc changes needed — bug fix to runtime behavior, no API or architecture changes