### PR TITLE
fix(slam-bot): use conversations.replies for thread-reply cancellation check

### DIFF
--- a/scripts/ec2-bot/scripts/process-queue.sh
+++ b/scripts/ec2-bot/scripts/process-queue.sh
@@ -89,30 +89,49 @@ if [ -z "$COMMAND_SLUG" ]; then
 fi
 
 # --- Cancellation check (#562) ---
-# Before processing, verify the message hasn't been cancelled (deleted or ❌ reacted)
+# Before processing, verify the message hasn't been cancelled (deleted or ❌ reacted).
+# conversations.history does NOT return threaded replies — fetching a thread reply
+# via that endpoint always returns 0 messages, which previously caused the script
+# to falsely conclude the message was deleted and cancel without removing the
+# hourglass. Use conversations.replies for thread replies so they're actually found.
 if [ -n "$SLACK_CHANNEL" ] && [ -n "$SLACK_TS" ]; then
   # Secrets already loaded by config.sh
   if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
-    # Check if the original message still exists
-    MSG_CHECK=$(curl -s -X GET \
-      "https://slack.com/api/conversations.history?channel=${SLACK_CHANNEL}&oldest=${SLACK_TS}&latest=${SLACK_TS}&inclusive=true&limit=1" \
-      -H "Authorization: Bearer $SLACK_BOT_TOKEN" 2>/dev/null || echo '{}')
+    if [ -n "$THREAD_TS" ] && [ "$THREAD_TS" != "$SLACK_TS" ]; then
+      # Threaded reply — pin the window to SLACK_TS so we don't pull the entire thread
+      MSG_CHECK=$(curl -s -X GET \
+        "https://slack.com/api/conversations.replies?channel=${SLACK_CHANNEL}&ts=${THREAD_TS}&oldest=${SLACK_TS}&latest=${SLACK_TS}&inclusive=true&limit=1" \
+        -H "Authorization: Bearer $SLACK_BOT_TOKEN" 2>/dev/null || echo '{}')
+    else
+      # Top-level message
+      MSG_CHECK=$(curl -s -X GET \
+        "https://slack.com/api/conversations.history?channel=${SLACK_CHANNEL}&oldest=${SLACK_TS}&latest=${SLACK_TS}&inclusive=true&limit=1" \
+        -H "Authorization: Bearer $SLACK_BOT_TOKEN" 2>/dev/null || echo '{}')
+    fi
 
-    MSG_COUNT=$(echo "$MSG_CHECK" | jq -r '.messages | length // 0' 2>/dev/null || echo "0")
+    # Find the message whose ts matches SLACK_TS exactly. conversations.replies
+    # always echoes the thread parent in addition to the requested message, so a
+    # ts-equality filter is required to avoid false matches.
+    TARGET_MSG=$(echo "$MSG_CHECK" | jq --arg ts "$SLACK_TS" 'first(.messages[]? | select(.ts == $ts))' 2>/dev/null)
 
-    if [ "$MSG_COUNT" = "0" ] || [ "$MSG_COUNT" = "null" ]; then
+    if [ -z "$TARGET_MSG" ] || [ "$TARGET_MSG" = "null" ]; then
       echo "[$(date)] CANCELLED $COMMAND_SLUG — original message deleted (channel=$SLACK_CHANNEL ts=$SLACK_TS)" >> "$LOGFILE"
+      # Always remove the hourglass on cancel — otherwise the user sees a stuck
+      # :hourglass_flowing_sand: indicating queued work that will never run.
+      curl -s -X POST https://slack.com/api/reactions.remove \
+        -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg ch "$SLACK_CHANNEL" --arg ts "$SLACK_TS" \
+          '{channel: $ch, timestamp: $ts, name: "hourglass_flowing_sand"}')" > /dev/null 2>&1 || true
       rm -f "$OLDEST"
       exit 0
     fi
 
     # Check if the message has a ❌ (x) reaction — user wants to cancel
-    REACTIONS=$(echo "$MSG_CHECK" | jq -r '.messages[0].reactions // []' 2>/dev/null)
-    HAS_CANCEL=$(echo "$REACTIONS" | jq -r '[.[] | select(.name == "x")] | length' 2>/dev/null || echo "0")
+    HAS_CANCEL=$(echo "$TARGET_MSG" | jq -r '[(.reactions // [])[] | select(.name == "x")] | length' 2>/dev/null || echo "0")
 
     if [ "$HAS_CANCEL" != "0" ] && [ "$HAS_CANCEL" != "null" ]; then
       echo "[$(date)] CANCELLED $COMMAND_SLUG — ❌ reaction found (channel=$SLACK_CHANNEL ts=$SLACK_TS)" >> "$LOGFILE"
-      # Remove the hourglass emoji to indicate cancellation
       curl -s -X POST https://slack.com/api/reactions.remove \
         -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
         -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- The bot's `process-queue.sh` cancellation check used `conversations.history` to verify a queued Slack message still existed. That endpoint does **not** return threaded replies, so any thread reply queued for the bot was always seen as deleted, the queue entry was cancelled, and the `:hourglass_flowing_sand:` reaction was never removed.
- Reported live by Shantam in #bugs-and-requests: a reply to a bot post got an hourglass that never went away because no follow-up was actually queued.

## Concrete repro from logs
Shantam's reply at ts `1777226188.464609` in thread `1777223415.592969` (#bugs-and-requests):
- 17:56:32 — dispatched
- 17:56:32.927 — agent exited code 0 in 0.7s (couldn't find the message)
- 17:57:03 — `process-queue.log`: `CANCELLED ws-slack-triage — original message deleted (channel=C0ATK0V09JM ts=1777226188.464609)`
- Message was not deleted; it was a thread reply.
- Hourglass stayed on Shantam's message indefinitely.

The same bug also blocked Darryl's reply at ts `1777226582.540179` in #daily-summary thread `1777212523.532069` from getting any response.

## Changes
- When `THREAD_TS` is set and differs from `SLACK_TS`, use `conversations.replies?ts=THREAD_TS` instead of `conversations.history` to find the message.
- Filter the response by ts equality so the thread parent (which `replies` always returns) doesn't false-match.
- Always remove the hourglass on cancel — both the "deleted" and "❌ reaction" branches now call `reactions.remove`. Previously only the ❌ branch removed it, so even *legit* cancels left a stuck hourglass.

Producer side already populates `thread_ts` via `shared.sh:131`, so no changes needed there.

## Test plan
- [x] `bash -n scripts/ec2-bot/scripts/process-queue.sh` — syntax ok
- [ ] After deploy: post a thread reply to a bot message in #bugs-and-requests, observe queue log: should NOT log `CANCELLED ... original message deleted`
- [ ] After deploy: hourglass should be removed when the agent picks the work up (existing path at line 207) OR when it's cancelled (new path at line 110)
- [ ] After deploy: existing top-level cancellation flow (e.g. user reacts ❌ on a top-level #bugs-and-requests message) still works

## Deployment note
This file is also at `/opt/slam-bot/scripts/process-queue.sh` on the EC2 host (verified identical to the repo copy before this PR). After merge, the deploy script that syncs `scripts/ec2-bot/` to `/opt/slam-bot/` will pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)