### PR TITLE
fix(backend): allow CORS from localhost:8082 (e2e Playwright port)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -27,6 +27,7 @@ const corsOrigins: (string | RegExp)[] = [
   'http://localhost:3002',
   'http://localhost:5173',
   'http://localhost:8081',
+  'http://localhost:8082', // e2e Playwright suite uses this port to avoid clashing with local dev on 8081
 ];
 if (process.env.DASHBOARD_URL) {
   corsOrigins.push(process.env.DASHBOARD_URL);


### PR DESCRIPTION
## Summary
The e2e Playwright suite runs Expo Web on port 8082 (per `e2e/playwright.config.ts:24`) so it doesn't clash with local dev on 8081. The backend's CORS allowlist only had 8081, so every API request from the e2e suite was silently blocked at the browser layer.

## Symptom
Trace from a test run shows:
\`\`\`
{"url":"http://localhost:3000/api/sessions/.../compact/sign","status":-1}
"/localhost:3000/api/sessions/.../compact/sign due to access control checks."
\`\`\`

`status: -1` = the request never made it to the backend. The browser blocked it.

This means tests appeared to interact with UI fine — buttons clicked, `onPress` fired — but no state ever advanced because the API requests never reached the backend. Tests timed out at the next step looking for elements that should have appeared after a state change.

## Test plan
- [ ] Run `single-user-journey.spec.ts` after merge — expect compact sign step to advance the UI to the chat input (or the next stale-testID drift, whichever first)
- [ ] No regression in local dev (8081 still allowed)

## Why is this only surfacing now?
Slam-paws is being set up to run e2e tests autonomously on EC2. The first run surfaced the compact-agree-checkbox testID drift (PR #192). The second run surfaced this CORS issue. Each cycle exposes another piece of test-infra rot from the period when no one was running e2e regularly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)