### PR TITLE
fix(e2e): update single-user-journey waiting-status copy assertion

### DIFF
--- a/e2e/tests/single-user-journey.spec.ts
+++ b/e2e/tests/single-user-journey.spec.ts
@@ -283,9 +283,10 @@ test.describe('Single User Journey', () => {
     console.log(`${elapsed()} Empathy shared indicator is visible`);
 
     // Step 19b: Assert waiting status panel is visible
-    // After sharing empathy, user should see "Waiting for Test Partner to feel heard"
+    // After sharing empathy, user should see "<Partner> is working on their perspective"
+    // (copy was previously "Waiting for <Partner> to feel heard"; updated to lower stakes)
     console.log(`${elapsed()} Step 19b: Verifying waiting status panel...`);
-    const waitingStatus = page.getByText(/Waiting for Darryl to feel heard/i);
+    const waitingStatus = page.getByText(/Darryl is working on their perspective/i);
     await expect(waitingStatus).toBeVisible({ timeout: 5000 });
     console.log(`${elapsed()} Waiting status panel is visible`);
 


### PR DESCRIPTION
## Summary
The copy on the post-empathy-shared waiting panel was changed at some point from \"Waiting for <Partner> to feel heard\" to \"<Partner> is working on their perspective\" (less anxious framing). Test was still asserting the old copy and timing out at the very end of the flow.

## Verified
On slam-bot the test now runs cleanly through Stage 0 (compact), Stage 1 (witness, feel-heard, invite), Stage 2 (empathy share). The screenshot at the failure point clearly shows \"Darryl is working on their perspective.\" rendered.

This is the third in a chain of test-drift fixes (#192 testID + bundle mode, #193 CORS allowlist, this one) needed before slam-paws can run \`single-user-journey.spec.ts\` autonomously on EC2 as a regression baseline.

## Test plan
- [ ] After merge, re-run on slam-bot — expect green
- [ ] No effect on local dev runs (still uses the same partner-name seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)