### PR TITLE
docs: align stage docs with Darryl's gold flow

### DIFF
--- a/docs/backend/api/index.md
+++ b/docs/backend/api/index.md
@@ -120,7 +120,7 @@ Emotional tracking across all stages.
 | `GET` | `/sessions/:id/emotions` | Get emotional history |
 | `POST` | `/sessions/:id/exercises/complete` | Log exercise completion |
 
-### [Stage 3: Need Mapping](./stage-3.md)
+### [Stage 3: What Matters](./stage-3.md)
 Need synthesis and common ground discovery.
 
 | Method | Endpoint | Description |

--- a/docs/backend/api/stage-3.md
+++ b/docs/backend/api/stage-3.md
@@ -1,10 +1,10 @@
 ---
-title: "Stage 3 API: Need Mapping"
+title: "Stage 3 API: What Matters"
 sidebar_position: 10
 description: Endpoints for identifying needs, confirming them, and discovering common ground.
 slug: /backend/api/stage-3
 ---
-# Stage 3 API: Need Mapping
+# Stage 3 API: What Matters
 
 Endpoints for identifying needs, confirming them, and discovering common ground.
 
@@ -404,7 +404,7 @@ See [Retrieval Contracts: Stage 3](../state-machine/retrieval-contracts.md#stage
 
 ## Related Documentation
 
-- [Stage 3: Need Mapping](../../stages/stage-3-need-mapping.md)
+- [Stage 3: What Matters](../../stages/stage-3-need-mapping.md)
 - [Need Extraction Prompt](../prompts/need-extraction.md)
 - [Universal Needs Framework](../../stages/stage-3-need-mapping.md#universal-needs-framework)
 

--- a/docs/backend/prompt-caching.md
+++ b/docs/backend/prompt-caching.md
@@ -150,7 +150,7 @@ All stages exceed Sonnet's 1,024-token caching threshold (measured Feb 2026, see
 | Stage 1 (Witnessing) | ~1,410 tok | ~70 tok | ~1,480 tok | YES |
 | Stage 2 (Perspective Stretch) | ~1,678 tok | ~10 tok | ~1,688 tok | YES |
 | Stage 2B (Informed Empathy) | ~1,415 tok | ~10 tok | ~1,425 tok | YES |
-| Stage 3 (Need Mapping) | ~1,219 tok | ~10 tok | ~1,229 tok | YES |
+| Stage 3 (What Matters) | ~1,219 tok | ~10 tok | ~1,229 tok | YES |
 | Stage 4 (Strategic Repair) | ~1,269 tok | ~10 tok | ~1,279 tok | YES |
 
 > Dynamic-block sizes above reflect a typical turn. On stage-transition turns, `buildStagePromptString` prepends a `transitionInjection` (6–8 sentences for the Stage 1→2 boundary) and may append a `postShareSection` after a partner share — those transitions temporarily push the dynamic block well above the steady-state numbers without changing the cached static block.

--- a/docs/backend/prompts/index.md
+++ b/docs/backend/prompts/index.md
@@ -22,7 +22,7 @@ Meet Without Fear uses Claude models via AWS Bedrock:
 | **User-facing responses (default)** | **Claude Sonnet 4.5** | Empathy, nuance, safety |
 | User-facing responses (low-signal turns) | Claude Haiku 4.5 via `routeModel()` | Cost/latency optimization |
 | Reconciler / empathy-gap analysis | Claude Sonnet 4.5 | Complex reasoning over partner state |
-| Need / need-mapping responses | Claude Sonnet 4.5 | Integrated into Stage 3 prompt |
+| Need / what-matters responses | Claude Sonnet 4.5 | Integrated into Stage 3 prompt |
 | Content transformation (consent shareable text) | Claude Sonnet 4.5 | Preserving meaning, removing heat |
 
 > Emotional intensity and current stage are **pre-calculated** in the orchestrator context (intensity from `EmotionalReading` rows, stage from session state) — they are not detected by an LLM during orchestration, even though a dedicated Haiku path exists for other classification tasks.
@@ -37,7 +37,7 @@ Meet Without Fear uses Claude models via AWS Bedrock:
 | [Stage 1: Witnessing](./stage-1-witnessing.md) | 1 | Deep listening and reflection |
 | [Stage 2: Perspective](./stage-2-perspective.md) | 2 | Building empathy guess; also hosts the `MIRROR` mode (redirect judgment) and other internal modes as branches of `buildStage2Prompt` |
 | Stage 2B: Informed Empathy | 21 (internal code) | Refining empathy after receiving partner's shared context (`buildStage2BPrompt`) |
-| [Stage 3: Need Mapping](./stage-3-needs.md) | 3 | Validating needs, extracting universal needs from venting, and surfacing common ground (need extraction lives inside `buildStage3Prompt`) |
+| [Stage 3: What Matters](./stage-3-needs.md) | 3 | Validating needs, extracting universal needs from venting, and surfacing common ground (need extraction lives inside `buildStage3Prompt`) |
 | [Stage 4: Strategic Repair](./stage-4-repair.md) | 4 | Collaborative strategy creation |
 
 ### Cross-Stage

--- a/docs/backend/prompts/need-extraction.md
+++ b/docs/backend/prompts/need-extraction.md
@@ -199,7 +199,7 @@ Stage 3 should:
 
 ## Related
 
-- [Stage 3: Need Mapping](../../stages/stage-3-need-mapping.md)
+- [Stage 3: What Matters](../../stages/stage-3-need-mapping.md)
 - [Stage 3 Prompt](./stage-3-needs.md)
 - [Universal Needs Framework](../../stages/stage-3-need-mapping.md#universal-needs-framework)
 

--- a/docs/backend/prompts/stage-2-transition.md
+++ b/docs/backend/prompts/stage-2-transition.md
@@ -15,12 +15,12 @@ Generates transition messages when users complete the empathy exchange.
 
 - Both users have shared empathy statements
 - Both users have validated their partner's empathy (or agreed to differ)
-- Goal: Celebrate the milestone and bridge to Stage 3 (Need Mapping)
+- Goal: Celebrate the milestone and bridge to Stage 3 (What Matters)
 
 ## System Prompt
 
 ```
-You are Meet Without Fear, a Process Guardian transitioning users from the "Perspective Stretch" stage to the "Need Mapping" stage.
+You are Meet Without Fear, a Process Guardian transitioning users from the "Perspective Stretch" stage to the "What Matters" stage.
 
 Both users have successfully:
 1. Shared what they imagined the other was feeling.

--- a/docs/backend/prompts/stage-3-needs.md
+++ b/docs/backend/prompts/stage-3-needs.md
@@ -1,5 +1,5 @@
 ---
-title: "Stage 3: Need Mapping Prompt"
+title: "Stage 3: What Matters Prompt"
 sidebar_position: 12
 description: Guiding users to validate synthesized needs and discover common ground.
 slug: /backend/prompts/stage-3-needs
@@ -7,7 +7,7 @@ model: sonnet
 temperature: 0.6
 max_tokens: 800
 ---
-# Stage 3: Need Mapping Prompt
+# Stage 3: What Matters Prompt
 
 Guiding users to validate synthesized needs and discover common ground.
 
@@ -20,7 +20,7 @@ Guiding users to validate synthesized needs and discover common ground.
 ## System Prompt
 
 ```
-You are Meet Without Fear, a Process Guardian in the Need Mapping stage. Your role is to help {{user_name}} understand and validate the needs that have emerged from their sharing.
+You are Meet Without Fear, a Process Guardian in the What Matters stage. Your role is to help {{user_name}} explore what truly matters to them — in their own words, not as analysis of the other person.
 
 CRITICAL RULES:
 - Present needs as observations, not diagnoses
@@ -181,7 +181,7 @@ You are right that your needs are different in some ways. [Partner] needs more s
 
 ## Related
 
-- [Stage 3: Need Mapping](../../stages/stage-3-need-mapping.md)
+- [Stage 3: What Matters](../../stages/stage-3-need-mapping.md)
 - [Need Extraction Prompt](./need-extraction.md)
 - [Universal Needs Framework](../../stages/stage-3-need-mapping.md#universal-needs-framework)
 

--- a/docs/backend/state-machine/index.md
+++ b/docs/backend/state-machine/index.md
@@ -76,7 +76,7 @@ stateDiagram-v2
 | 0 (Onboarding) | `compactSigned`, `partnerCompactSigned` | User signed, partner signed |
 | 1 (Witness) | `feelHeardConfirmed` | User posts feel-heard true |
 | 2 (Perspective) | `empathyDraftReady`, `empathyConsented`, `partnerConsented`, `partnerValidated` | Draft marked ready, user consents to share, partner consents, partner validates (or user accepts feedback path) |
-| 3 (Need Mapping) | `needsConfirmed`, `partnerNeedsConfirmed`, `commonGroundConfirmed` | User confirms needs, partner confirms theirs, both confirm common ground |
+| 3 (What Matters) | `needsConfirmed`, `partnerNeedsConfirmed`, `commonGroundConfirmed` | User confirms needs, partner confirms theirs, both confirm common ground |
 | 4 (Strategic Repair) | `strategiesSubmitted`, `rankingsSubmitted`, `overlapIdentified`, `agreementCreated` | Both submitted strategies (or declared none), both rankings in, overlap revealed, Agreement saved |
 
 Advancement rule: a user can advance when all gate keys for their current stage are true AND any stage-level preconditions (e.g., Stage 4 only after both Stage 3 complete). WAITING state is derived when one user satisfies gates and the other has not.

--- a/docs/backend/state-machine/retrieval-contracts.md
+++ b/docs/backend/state-machine/retrieval-contracts.md
@@ -331,9 +331,9 @@ WHERE cc."sharedVesselId" = $sharedVesselId
 
 ---
 
-## Stage 3: Need Mapping
+## Stage 3: What Matters
 
-**Purpose**: Identify universal needs and find common ground. See [Stage 3 Documentation](../../stages/stage-3-need-mapping.md).
+**Purpose**: Help each user explore what truly matters to them. See [Stage 3 Documentation](../../stages/stage-3-need-mapping.md).
 
 ### Retrieval Contract
 
@@ -536,7 +536,7 @@ function determineMemoryIntent(
 
 - [Stage 1: The Witness](../../stages/stage-1-witness.md)
 - [Stage 2: Perspective Stretch](../../stages/stage-2-perspective-stretch.md)
-- [Stage 3: Need Mapping](../../stages/stage-3-need-mapping.md)
+- [Stage 3: What Matters](../../stages/stage-3-need-mapping.md)
 - [Stage 4: Strategic Repair](../../stages/stage-4-strategic-repair.md)
 - [Vessel Model](../../privacy/vessel-model.md)
 - [Consensual Bridge](../../mechanisms/consensual-bridge.md)

--- a/docs/canonical-facts.json
+++ b/docs/canonical-facts.json
@@ -27,7 +27,7 @@
       { "n": 0, "name": "Onboarding",          "doc": "docs/product/stages/stage-0-onboarding.md" },
       { "n": 1, "name": "Witness",             "doc": "docs/product/stages/stage-1-witness.md" },
       { "n": 2, "name": "Perspective Stretch", "doc": "docs/product/stages/stage-2-perspective-stretch.md" },
-      { "n": 3, "name": "Need Mapping",        "doc": "docs/product/stages/stage-3-need-mapping.md" },
+      { "n": 3, "name": "What Matters",         "doc": "docs/product/stages/stage-3-need-mapping.md" },
       { "n": 4, "name": "Strategic Repair",    "doc": "docs/product/stages/stage-4-strategic-repair.md" }
     ]
   },

--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -138,11 +138,11 @@ flowchart TB
     end
 ```
 
-### Stage 3: Need Mapping Chat
+### Stage 3: What Matters Chat
 
 ```mermaid
 flowchart TB
-    subgraph NeedChat[Need Mapping View]
+    subgraph NeedChat[What Matters View]
         Header3[Stage 3: Finding Common Ground]
 
         subgraph NeedPanels[Need Panels]

--- a/docs/mobile/wireframes/stage-controls.md
+++ b/docs/mobile/wireframes/stage-controls.md
@@ -54,7 +54,7 @@ flowchart TB
 
         subgraph Stage3Box[Stage 3]
             S3Icon[Lock]
-            S3Label[Need Mapping]
+            S3Label[What Matters]
             S3Status[Locked]
         end
     end
@@ -186,7 +186,7 @@ flowchart TB
 flowchart TB
     subgraph LockedHeader[Locked Stage Header]
         LockedBadge[Upcoming]
-        LockedTitle[Stage 3: Need Mapping]
+        LockedTitle[Stage 3: What Matters]
         LockedDesc[Finding common ground]
         LockedNote[Complete Stage 2 to unlock]
     end

--- a/docs/product/mechanisms/guardrails.md
+++ b/docs/product/mechanisms/guardrails.md
@@ -103,6 +103,24 @@ flowchart TD
     Regulate --> Check
 ```
 
+### 6. Needs Redirection
+
+**The AI continually redirects from judgments and strategies to universal human needs** (aligned with Rosenberg's Nonviolent Communication framework).
+
+When a user expresses a judgment ("they're selfish") or a strategy ("they need to stop doing X"), the AI redirects to the underlying need. This applies across all stages.
+
+### 7. Need Independence
+
+**Valid needs do not depend on a specific person acting a specific way.**
+
+A need like "I need them to apologize" is a strategy, not a need. The AI helps users find the universal need underneath (e.g., "I need acknowledgment"). This ensures needs can be met in multiple ways, not just through one person's specific behavior.
+
+### 8. Suggestions, Not Corrections
+
+**The AI offers interpretations and language as suggestions to confirm or refine — never as corrections.**
+
+The user always has the final word on what they are feeling and needing. The AI proposes; the user decides.
+
 ## Enforcement Hierarchy
 
 When guardrails conflict, follow this priority:

--- a/docs/product/mechanisms/mirror-intervention.md
+++ b/docs/product/mechanisms/mirror-intervention.md
@@ -177,7 +177,7 @@ flowchart TD
 ## Related Documents
 
 - [Stage 2: Perspective Stretch](../stages/stage-2-perspective-stretch.md)
-- [Stage 3: Need Mapping](../stages/stage-3-need-mapping.md)
+- [Stage 3: What Matters](../stages/stage-3-need-mapping.md)
 - [System Guardrails](./guardrails.md)
 
 ---

--- a/docs/product/source-material/conflict-resolution.md
+++ b/docs/product/source-material/conflict-resolution.md
@@ -42,7 +42,7 @@ AI-Facilitated Conflict Metabolism System
 | 0 | Onboarding | Establish Process Guardian authority; explain stages | Both users sign Curiosity Compact |
 | 1 | The Witness | Deep reflection (parallel) | User confirms: “I feel fully heard by the AI” |
 | 2 | Perspective Stretch | Empathy training (parallel) | User can accurately state the other’s needs without judgment |
-| 3 | Need Mapping | Transition from stories → universal needs | Identification of at least one common-ground need (e.g., “Safety”) |
+| 3 | What Matters | User-driven exploration of what truly matters | User-confirmed universal needs |
 | 4 | Strategic Repair | Propose small, reversible actions | Mutual agreement on one Micro-Experiment |
 
 ---

--- a/docs/product/stages/index.md
+++ b/docs/product/stages/index.md
@@ -13,7 +13,7 @@ Meet Without Fear guides users through a structured five-stage process. Each sta
 flowchart LR
     S0[Stage 0\nOnboarding] --> S1[Stage 1\nThe Witness]
     S1 --> S2[Stage 2\nPerspective Stretch]
-    S2 --> S3[Stage 3\nNeed Mapping]
+    S2 --> S3[Stage 3\nWhat Matters]
     S3 --> S4[Stage 4\nStrategic Repair]
 ```
 
@@ -24,7 +24,7 @@ flowchart LR
 | [Stage 0](./stage-0-onboarding.md) | Onboarding | Establish trust and process | Both sign Curiosity Compact |
 | [Stage 1](./stage-1-witness.md) | The Witness | Deep reflection and being heard | Both feel fully heard |
 | [Stage 2](./stage-2-perspective-stretch.md) | Perspective Stretch | Build empathy for other view | Can state other needs accurately; feels accurately reflected |
-| [Stage 3](./stage-3-need-mapping.md) | Need Mapping | Identify universal needs | Common ground identified |
+| [Stage 3](./stage-3-need-mapping.md) | What Matters | Explore what truly matters to each user | User-confirmed universal needs |
 | [Stage 4](./stage-4-strategic-repair.md) | Strategic Repair | Commit to action | Agree on micro-experiment |
 
 ## Parallel vs Sequential Work
@@ -39,7 +39,7 @@ flowchart TD
     subgraph Parallel[Parallel - Independent Work]
         S1[Stage 1: The Witness]
         S2[Stage 2: Perspective Stretch]
-        S3[Stage 3: Need Mapping]
+        S3[Stage 3: What Matters]
     end
 ```
 

--- a/docs/product/stages/stage-0-onboarding.md
+++ b/docs/product/stages/stage-0-onboarding.md
@@ -20,20 +20,16 @@ Welcome users with a brief, warm opening and secure acknowledgment before enteri
 The AI opens with a brief, warm message. The message varies based on whether this is the user's first session with this partner:
 
 **First session:**
-> "I am here to help you work through conflict—step by step.
->
-> You'll start by sharing what you believe is happening, privately.
->
-> I don't share anything unless you approve it, ever."
+> "I am here to help you work through conflict — step by step. You'll start by sharing what you believe is happening, privately. I won't share anything you've said unless you explicitly approve it."
 
 **Repeat session:**
-> "Welcome back. Same as before — your space is private, nothing shared without your say. Let's pick up where we left off."
+> "Welcome back. Same as before — everything stays private unless you approve sharing. Let's pick up where we left off."
 
 This message:
 - Speaks in the AI's first person voice
+- Sets expectation of a step-by-step process
 - Explains the private chat format
 - Reassures about consent before sharing
-- Asks for a simple acknowledgment to proceed
 
 ## Flow
 

--- a/docs/product/stages/stage-1-witness.md
+++ b/docs/product/stages/stage-1-witness.md
@@ -16,6 +16,10 @@ Provide each user with the experience of being deeply and fully heard by the AI,
 - Help users articulate feelings they may not have words for
 - Continue until the user genuinely feels heard
 
+## Neutrality Constraint
+
+The AI does **not** accept the user's narrative as truth, criticize the other person, or show agreement with contempt or blame. The AI's role is to hear and reflect — not to take sides or validate a one-sided story. Listening does not equal agreeing.
+
 ## Open-Ended Design
 
 Stage 1 is intentionally **open-ended with no suggested prompts or options**. This design choice:

--- a/docs/product/stages/stage-2-perspective-stretch.md
+++ b/docs/product/stages/stage-2-perspective-stretch.md
@@ -71,8 +71,15 @@ flowchart TD
     Ready --> Consent1{Consent to share attempt?}
     Consent1 -->|No| MoreTime[More time to refine]
     MoreTime --> Attempt
-    Consent1 -->|Yes| WaitExchange[Wait for partner]
+    Consent1 -->|Yes| PostShare[Post-sharing message]
+    PostShare --> WaitExchange[Wait for partner]
 ```
+
+### Post-Sharing Message
+
+Once a user consents to share their empathy attempt, the AI delivers:
+
+> "You've done something difficult — thank you for staying with it. You've completed your part for now. We'll notify you when [partner] has completed their side. Then you'll each see the other's attempt to understand."
 
 ### Phase 2: Mutual Exchange
 
@@ -126,7 +133,7 @@ flowchart TD
 
     subgraph Example[Example Exchange]
         User[User: They are just happy I am miserable]
-        AI[AI: I hear how painful that is. When we are hurting this much it can feel like the other person must be causing it on purpose. What fear might be driving their behavior?]
+        AI[AI: I hear how painful that is. When we are hurting this much it can feel like the other person must be causing it on purpose. What do you think might be going on for them underneath that?]
     end
 
     Reflect --> Example
@@ -150,7 +157,7 @@ The [Consensual Bridge](../mechanisms/consensual-bridge.md) mechanism controls t
 
 ## The Empathy Attempt
 
-Each user builds their best guess at what their partner is experiencing:
+Each user builds their best guess at what their partner is experiencing. The AI frames this as exploring **possibilities**, not making assertions:
 
 ```
 AI: [After listening] "What do you imagine [Partner] might be
@@ -158,8 +165,12 @@ AI: [After listening] "What do you imagine [Partner] might be
 
 User: [Builds their attempt - open-ended, not steered]
 
-AI: [Reflects, helps refine without telling them what to think]
+AI: [Offers possibilities to consider, not assertions]
+    "One possibility is that they might be feeling... Does that
+    resonate, or does something else feel closer?"
 ```
+
+The AI helps the user explore what their partner *might* be experiencing without asserting what the partner *is* experiencing. All suggestions are framed as possibilities the user can confirm, adjust, or reject.
 
 **Readiness criteria:**
 - User feels they have put together their best guess
@@ -277,7 +288,7 @@ flowchart TB
 ## Related Documents
 
 - [Previous: Stage 1 - The Witness](./stage-1-witness.md)
-- [Next: Stage 3 - Need Mapping](./stage-3-need-mapping.md)
+- [Next: Stage 3 - What Matters](./stage-3-need-mapping.md)
 - [Mirror Intervention](../mechanisms/mirror-intervention.md)
 - [Consensual Bridge](../mechanisms/consensual-bridge.md)
 

--- a/docs/product/stages/stage-3-need-mapping.md
+++ b/docs/product/stages/stage-3-need-mapping.md
@@ -1,97 +1,99 @@
 ---
-title: "Stage 3: Need Mapping"
+title: "Stage 3: What Matters"
 sidebar_position: 6
-description: Transition from surface-level stories and complaints to identifying universal human needs that both parties share.
+description: Help each user explore what truly matters to them in the conflict — in terms of their own needs, not what is wrong with the other person.
 ---
-# Stage 3: Need Mapping
+# Stage 3: What Matters
 
 ## Purpose
 
-Transition from surface-level stories and complaints to identifying universal human needs that both parties share.
+Help each user explore what truly matters to them in the conflict — in terms of their own needs, not what is wrong with the other person.
 
 ## AI Goal
 
-- Synthesize underlying needs from each users sharing
-- Translate complaints and positions into needs language
-- Identify at least one common-ground need
-- Reframe accusations into I-statements and needs
+- Facilitate **user-driven exploration** of underlying needs
+- Redirect other-focused answers back to the user's own experience
+- Offer language as suggestions for the user to confirm or refine — never as corrections
+- Ensure identified needs are universal and do not depend on a specific person acting a specific way
+- Help users move from surface complaints to what genuinely matters
 
-## Visual Design: Gentle and Soft
+## Opening
 
-Stage 3 uses **softer colors** to create a gentle, calming feel that supports the reflective nature of this work:
+The AI opens Stage 3 with:
 
-- Soft blues and teals for need cards
-- Gentle greens for common ground elements
-- Rounded corners and generous padding
-- **Side-by-side layout is key** - users see both sets of needs simultaneously
+> "What's this really about for you? Answer in terms of what matters to you — not what's wrong with them."
 
-The visual juxtaposition of both parties' needs creates the insight moment where users recognize shared humanity.
+This framing sets the tone: Stage 3 is about self-exploration, not analysis of the other person.
+
+## Redirect for Other-Focused Answers
+
+When a user answers in terms of what the other person is doing wrong, the AI gently redirects:
+
+> "Let me bring it back to you — what feels important or missing for you?"
+
+The redirect is warm and non-judgmental. The user may need several redirects before shifting from "they always..." to "what matters to me is..."
 
 ## Flow
 
 ```mermaid
 flowchart TD
-    Enter[Enter Stage 3] --> Intro[AI introduces needs work]
-    Intro --> Review[Review what has been shared]
+    Enter[Enter Stage 3] --> Open[AI: What is this really about for you?]
 
-    subgraph Translation[Complaint to Need Translation]
-        C1[Surface complaint] --> E1[Underlying emotion]
-        E1 --> N1[Core need]
-    end
+    Open --> Response{User response}
 
-    Review --> Translation
-    Translation --> Present[Present needs map to user]
+    Response -->|Self-focused| Explore[AI explores deeper]
+    Response -->|Other-focused| Redirect[AI: What feels important or missing for you?]
+    Redirect --> Response
 
-    Present --> Validate{User validates?}
-    Validate -->|Adjustments| Refine[Refine understanding]
-    Refine --> Present
-    Validate -->|Confirmed| Compare[Compare both maps]
+    Explore --> Suggest[AI offers language as suggestion]
+    Suggest --> Check{User confirms?}
 
-    Compare --> Search[Search for overlap]
-    Search --> Found{Common need?}
+    Check -->|Adjusts| Refine[User refines in own words]
+    Refine --> Suggest
+    Check -->|Confirms| Deeper{More to explore?}
 
-    Found -->|Yes| Highlight[Highlight shared need]
-    Found -->|Not obvious| Deeper[Dig to deeper needs]
-    Deeper --> Search
+    Deeper -->|Yes| Open2[AI: What else matters here?]
+    Open2 --> Response
+    Deeper -->|No| Validate[Validate needs are universal]
 
-    Highlight --> Confirm{Both confirm?}
-    Confirm -->|Yes| Complete[Stage 3 complete]
-    Confirm -->|Disagreement| Explore[Explore the difference]
-    Explore --> Search
+    Validate --> Independent{Needs independent of specific behavior?}
+    Independent -->|No| Reframe[AI suggests reframe as suggestion]
+    Reframe --> Check
+    Independent -->|Yes| Confirm[User confirms final needs]
 
+    Confirm --> Complete[Stage 3 complete]
     Complete --> Advance[Advance to Stage 4]
 ```
 
-## From Stories to Needs
+## Key Constraints
 
-```mermaid
-flowchart LR
-    subgraph Stories[Surface Level]
-        S1[They never listen to me]
-        S2[They always criticize]
-        S3[They work too much]
-    end
+### Needs Must Be Universal
 
-    subgraph Emotions[Emotional Layer]
-        E1[Feeling unimportant]
-        E2[Feeling inadequate]
-        E3[Feeling lonely]
-    end
+A valid need does not depend on a specific person acting a specific way. The AI checks for this:
 
-    subgraph Needs[Universal Needs]
-        N1[Need for recognition]
-        N2[Need for acceptance]
-        N3[Need for connection]
-    end
+| Not a universal need | Universal need |
+|---------------------|----------------|
+| "I need them to stop criticizing me" | "I need acceptance" |
+| "I need them to come home earlier" | "I need connection and quality time" |
+| "I need them to agree with me" | "I need to feel heard and respected" |
 
-    S1 --> E1 --> N1
-    S2 --> E2 --> N2
-    S3 --> E3 --> N3
+### Language as Suggestion, Not Correction
+
+The AI offers reframes as possibilities, not corrections:
+
 ```
+User: "I just need them to listen to me for once."
+
+AI: "It sounds like being heard really matters to you. Would you
+    say this is about needing to feel that your voice counts —
+    or does it feel like something else?"
+```
+
+The user always has the final word on what their needs are. The AI suggests; the user decides.
 
 ## Universal Needs Framework
 
-The AI maps to universal human needs:
+The AI maps to universal human needs (aligned with Rosenberg's framework):
 
 | Category | Example Needs |
 |----------|---------------|
@@ -102,96 +104,50 @@ The AI maps to universal human needs:
 | **Meaning** | Purpose, contribution, growth, significance |
 | **Fairness** | Justice, equality, reciprocity, balance |
 
-## Accusation Reframing
-
-The AI transforms accusatory language:
-
-| Original Statement | Reframed to Needs |
-|--------------------|-------------------|
-| "You never help around the house" | "I have a need for partnership and shared responsibility" |
-| "You always take their side" | "I need to feel like you are on my team" |
-| "You care more about work than me" | "I need quality time and to feel prioritized" |
-
-## Wireframe: Need Mapping Interface
+## Wireframe: What Matters Interface
 
 ```mermaid
 flowchart TB
-    subgraph Screen[Need Mapping Screen]
+    subgraph Screen[What Matters Screen]
         subgraph Header[Header]
             Logo[Meet Without Fear]
-            Stage[Stage 3: Need Mapping]
-            Status[Finding common ground]
-        end
-
-        subgraph YourNeeds[Your Identified Needs]
-            Title1[What you need most]
-            Need1[Safety - feeling secure in the relationship]
-            Need2[Recognition - being seen for your efforts]
-            Edit[Adjust these?]
-        end
-
-        subgraph CommonGround[Common Ground]
-            Title2[Shared Needs Discovered]
-            Shared1[Both need: Safety]
-            Shared2[Both need: Connection]
-            Insight[You both want to feel secure together]
+            Stage[Stage 3: What Matters]
+            Status[Exploring what matters]
         end
 
         subgraph Chat[Exploration Chat]
-            AI1[AI explores and refines needs]
-            User1[User clarifies]
+            AI1[AI: What is this really about for you?]
+            User1[User shares freely]
+            AI2[AI offers language as suggestion]
+            User2[User refines or confirms]
         end
 
-        subgraph Confirm[Confirmation]
-            Question[Does this capture what you need?]
-            Yes[Yes this is right]
-            Adjust[I want to adjust]
+        subgraph Input[Input Area]
+            TextBox[Type your thoughts...]
+            Send[Send]
         end
     end
 ```
 
 ## Success Criteria
 
-At least one common-ground need is identified and confirmed by both parties.
-
-## Common Ground Discovery
-
-```mermaid
-flowchart TD
-    subgraph UserA[User A Needs]
-        A1[Safety]
-        A2[Recognition]
-        A3[Autonomy]
-    end
-
-    subgraph UserB[User B Needs]
-        B1[Connection]
-        B2[Safety]
-        B3[Fairness]
-    end
-
-    A1 --- Common{Common: Safety}
-    B2 --- Common
-
-    Common --> Highlight[Both need Safety]
-    Highlight --> Build[Build on this foundation]
-```
+User has identified at least one universal need in their own words, confirmed by the user (not imposed by the AI).
 
 ## Failure Paths
 
 | Scenario | AI Response |
 |----------|-------------|
-| No obvious overlap | Dig deeper - surface needs often share deeper roots |
-| User rejects need synthesis | Refine and re-present; ask clarifying questions |
-| Accusatory language persists | Apply reframing; return to Stage 2 if needed |
-| One user dominates narrative | Balance attention; ensure both needs are mapped |
+| User stays other-focused | Gentle, repeated redirects back to self |
+| User rejects AI suggestion | Accept gracefully; ask user to describe in their own words |
+| Accusatory language persists | Redirect to needs; return to Stage 2 if needed |
+| User struggles to articulate | Offer multiple framings as possibilities to try on |
 
 ## Data Captured
 
-- Identified needs for each user
-- Common ground discovered
-- Reframing transformations applied
-- Confirmation of accuracy
+- User's self-described needs (in their own words)
+- AI suggestions offered and user responses
+- Redirect interactions
+- Confirmation of final needs
 
 ---
 

--- a/docs/product/stages/stage-4-strategic-repair.md
+++ b/docs/product/stages/stage-4-strategic-repair.md
@@ -74,10 +74,8 @@ flowchart TD
 
     Discuss --> Document[Document micro-experiment]
 
-    Document --> FollowUp{Schedule check-in?}
-    FollowUp -->|Yes| Schedule[Set follow-up date]
-    FollowUp -->|No| Complete[Stage 4 complete]
-    Schedule --> Complete
+    Document --> Schedule[Schedule follow-up check-in]
+    Schedule --> Complete[Stage 4 complete]
 
     Complete --> Resolution[Resolution achieved]
 ```
@@ -92,14 +90,14 @@ flowchart TB
         G1[Specific: One 15-min check-in per day]
         G2[Time-bounded: For the next week]
         G3[Reversible: Can adjust or stop]
-        G4[Measurable: Did we do it? How did it feel?]
+        G4[Observable: Did we do it? How did it feel?]
     end
 
     subgraph Bad[Too Big - Not a Micro-Experiment]
         B1[Vague: Communicate better]
         B2[Permanent: Always do X]
         B3[High stakes: Major life change]
-        B4[Unmeasurable: Be more supportive]
+        B4[Not observable: Be more supportive]
     end
 ```
 
@@ -224,7 +222,7 @@ flowchart TB
 
 ## Success Criteria
 
-Mutual agreement on at least one micro-experiment.
+Mutual agreement on at least one micro-experiment with an observable outcome and a scheduled follow-up check-in.
 
 ## Agreement Documentation
 
@@ -238,9 +236,9 @@ Date agreed: [Date]
 
 Experiment: [Specific description]
 Duration: [Time period]
-Success measure: [How to know if it worked]
+Observable outcome: [How both parties will know if it worked]
 
-Check-in scheduled: [Date/time if applicable]
+Check-in scheduled: [Date/time — required]
 ```
 
 ## Failure Paths
@@ -252,9 +250,9 @@ Check-in scheduled: [Date/time if applicable]
 | Proposals too ambitious | Help scope down; emphasize "small and reversible" |
 | One party uncooperative | Acknowledge difficulty; explore barriers |
 
-## Follow-Up Support
+## Follow-Up Check-In (Required)
 
-If users schedule a check-in:
+Every micro-experiment includes a scheduled follow-up check-in. This is not optional — accountability is part of the repair process.
 
 ```mermaid
 flowchart TD
@@ -290,7 +288,7 @@ flowchart TD
 
 ## Related Documents
 
-- [Previous: Stage 3 - Need Mapping](./stage-3-need-mapping.md)
+- [Previous: Stage 3 - What Matters](./stage-3-need-mapping.md)
 - [User Journey](../overview/user-journey.md)
 - [System Guardrails](../mechanisms/guardrails.md)
 

--- a/docs/product/user-journey.md
+++ b/docs/product/user-journey.md
@@ -25,13 +25,12 @@ flowchart TD
 
     Stage0 --> Stage1[Stage 1: The Witness]
     Stage1 --> Stage2[Stage 2: Perspective Stretch]
-    Stage2 --> Stage3[Stage 3: Need Mapping]
+    Stage2 --> Stage3[Stage 3: What Matters]
     Stage3 --> Stage4[Stage 4: Strategic Repair]
     Stage4 --> Resolution[Resolution achieved]
 
-    Resolution --> Followup{Future check-in?}
-    Followup -->|Yes| CheckIn[Scheduled follow-up]
-    Followup -->|No| Complete[Session complete]
+    Resolution --> CheckIn[Scheduled follow-up check-in]
+    CheckIn --> Complete[Session complete]
 ```
 
 ## Detailed Stage Flow with Success/Failure Loops
@@ -137,7 +136,7 @@ flowchart TD
 
 ---
 
-### Stage 3: Need Mapping
+### Stage 3: What Matters
 
 ```mermaid
 flowchart TD
@@ -282,7 +281,7 @@ stateDiagram-v2
 - [Stage 0: Onboarding](../stages/stage-0-onboarding.md)
 - [Stage 1: The Witness](../stages/stage-1-witness.md)
 - [Stage 2: Perspective Stretch](../stages/stage-2-perspective-stretch.md)
-- [Stage 3: Need Mapping](../stages/stage-3-need-mapping.md)
+- [Stage 3: What Matters](../stages/stage-3-need-mapping.md)
 - [Stage 4: Strategic Repair](../stages/stage-4-strategic-repair.md)
 - [Emotional Barometer](../mechanisms/emotional-barometer.md)
 


### PR DESCRIPTION
## Changes
- Update Stage 0 opening message to emphasize step-by-step process and privacy
- Add Stage 1 neutrality constraint: AI doesn't accept narrative as truth or validate blame
- Add Stage 2 post-sharing message, use "possibilities" not assertions in Building mode, make Mirror mode open-ended
- Rename Stage 3 from "Need Mapping" to "What Matters" — rewrite as user-driven exploration with redirect for other-focused answers
- Make Stage 4 follow-up check-in required (not optional), change "measurable" to "observable"
- Add three new guardrails: needs redirection, need independence, suggestions-not-corrections
- Update all cross-references across 22 living docs and canonical-facts.json

Related to #196

## Provenance
- **Channel:** #daily-summary
- **Requested by:** Darryl Finkton Jr
- **Original message:** "Please do both" (re: updating docs + creating PR for gold flow alignment)
- **Prompt(s) used:** Darryl's authoritative gold flow posted in #daily-summary thread

## Docs updated
- `docs/product/stages/stage-0-onboarding.md` — new opening message
- `docs/product/stages/stage-1-witness.md` — added neutrality constraint
- `docs/product/stages/stage-2-perspective-stretch.md` — post-sharing message, possibilities language, open-ended mirror
- `docs/product/stages/stage-3-need-mapping.md` — full rewrite as "What Matters"
- `docs/product/stages/stage-4-strategic-repair.md` — required follow-up, observable criteria
- `docs/product/stages/index.md` — updated stage name and description
- `docs/product/mechanisms/guardrails.md` — three new system principles
- `docs/product/mechanisms/mirror-intervention.md` — updated link text
- `docs/product/user-journey.md` — stage name, required follow-up
- `docs/product/source-material/conflict-resolution.md` — stage name
- `docs/canonical-facts.json` — stage 3 name
- `docs/backend/api/index.md`, `docs/backend/api/stage-3.md` — stage name
- `docs/backend/state-machine/index.md`, `docs/backend/state-machine/retrieval-contracts.md` — stage name
- `docs/backend/prompts/index.md`, `docs/backend/prompts/stage-3-needs.md`, `docs/backend/prompts/need-extraction.md`, `docs/backend/prompts/stage-2-transition.md` — stage name
- `docs/backend/prompt-caching.md` — stage name
- `docs/mobile/wireframes/chat-interface.md`, `docs/mobile/wireframes/stage-controls.md` — stage name