### PR TITLE
fix(reconciler): replace premature 'move forward' CTA with waiting language

### DIFF
--- a/backend/src/__tests__/circuit-breaker-integration.test.ts
+++ b/backend/src/__tests__/circuit-breaker-integration.test.ts
@@ -9,7 +9,7 @@ import { runReconcilerForDirection, incrementAttempts } from '../services/reconc
  * runReconcilerForDirection once. Verifies it:
  *   - Skips the AI analysis entirely
  *   - Marks empathy as READY with circuitBreakerTripped=true
- *   - Creates the "Let's move forward" transition message
+ *   - Creates the waiting-state transition message
  *   - Calls checkAndRevealBothIfReady (reveals if both directions are READY)
  *
  * Uses real Prisma against the test DB with mocked Ably (realtime) and empathy-status.
@@ -138,7 +138,7 @@ describe('Circuit Breaker Integration', () => {
       orderBy: { timestamp: 'desc' },
     });
     expect(messages.length).toBeGreaterThanOrEqual(1);
-    expect(messages[0].content).toContain("Let's move forward");
+    expect(messages[0].content).toContain("you'll both see what each other shared");
     expect(messages[0].content).toContain('Bob');
     // Should NOT contain the normal "quite accurate" message
     expect(messages[0].content).not.toContain('quite accurate');
@@ -155,7 +155,7 @@ describe('Circuit Breaker Integration', () => {
       sessionId,
       userAId,
       expect.objectContaining({
-        content: expect.stringContaining("Let's move forward"),
+        content: expect.stringContaining("you'll both see what each other shared"),
       }),
       expect.anything()
     );

--- a/backend/src/services/reconciler/state.ts
+++ b/backend/src/services/reconciler/state.ts
@@ -51,8 +51,8 @@ async function markEmpathyReady(
 
   // Choose message based on whether circuit breaker tripped
   const alignmentMessage = circuitBreakerTripped
-    ? `You've shared your perspective on what ${subjectName} might be experiencing. Let's move forward — ${subjectName} is also reflecting on your perspective.`
-    : `${subjectName} has felt heard. The reconciler reports your attempt to imagine what they're feeling was quite accurate. ${subjectName} is now considering your perspective, and once they do, you'll both see what each other shared.`;
+    ? `You've shared your perspective on what ${subjectName} might be experiencing. ${subjectName} is also reflecting on your perspective — once they're done, you'll both see what each other shared.`
+    : `${subjectName} has felt heard. Your attempt to imagine what they're feeling was quite accurate. ${subjectName} is now considering your perspective, and once they're done, you'll both see what each other shared.`;
 
   // De-dup guard: reconciliation iterates every time either side refines, so
   // the shortcut path can fire several times in a row with the same message
@@ -264,8 +264,8 @@ export async function runReconcilerForDirection(
   if (contextAlreadyShared) {
     logger.info('Context already shared, skipping AWAITING_SHARING and marking READY', { subjectId, guesserId });
     // Context was already shared but gaps remain after resubmission.
-    // Mark READY to prevent infinite loop, but use the honest "let's move forward"
-    // message instead of the false "quite accurate" claim.
+    // Mark READY to prevent infinite loop, using the circuit breaker message
+    // (neutral waiting language) instead of the false "quite accurate" claim.
     await markEmpathyReady(sessionId, guesserId, subjectInfo.name, true);
 
     // Mark the reconciler result "handled" so the GET /share-offer fallback

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -521,7 +521,7 @@ If user tries to validate partner's empathy before reconciler finishes:
 ### Case 5: User Responds Before Fetching Share Offer
 If user accepts/declines before the GET endpoint marks offer as `OFFERED`:
 - `respondToShareSuggestion` accepts both `PENDING` and `OFFERED` status, and supports three actions: `accept`, `decline`, and `refine` (re-runs suggestion generation with `refinedContent` feedback from the user)
-- After the circuit-breaker trips, the Guesser's alignment message is softened from the default "your attempt to imagine what they're feeling was quite accurate" to the more honest "You've shared your perspective… Let's move forward" to avoid overclaiming accuracy when refinement was exhausted or context was already shared
+- After the circuit-breaker trips, the Guesser's alignment message uses neutral waiting language ("You've shared your perspective… [Partner] is also reflecting on your perspective — once they're done, you'll both see what each other shared") instead of the normal "quite accurate" feedback, to avoid overclaiming accuracy when refinement was exhausted or context was already shared
 - Marks as `OFFERED` before processing for proper audit trail
 
 ## Debugging Tips

--- a/docs/diagrams/reconciler-paths.md
+++ b/docs/diagrams/reconciler-paths.md
@@ -562,7 +562,7 @@ stateDiagram-v2
 
 ## 6. Acceptance Check (Guesser Declines to Refine)
 
-When the guesser receives shared context or feedback but chooses not to refine their empathy statement, the backend transitions the attempt to `READY` with a **hardcoded** alignment message — there is no AI call at this junction. The message is chosen from two templates based on whether the circuit breaker tripped: either "`<subjectName>` has felt heard…" (normal path) or "You've shared your perspective… Let's move forward" (circuit-breaker / already-shared-context path).
+When the guesser receives shared context or feedback but chooses not to refine their empathy statement, the backend transitions the attempt to `READY` with a **hardcoded** alignment message — there is no AI call at this junction. The message is chosen from two templates based on whether the circuit breaker tripped: either "`<subjectName>` has felt heard… Your attempt to imagine what they're feeling was quite accurate…" (normal path) or "You've shared your perspective… [Partner] is also reflecting on your perspective — once they're done, you'll both see what each other shared" (circuit-breaker / already-shared-context path).
 
 ### 6.1 Guesser Perspective (Acceptance Check)
 

--- a/e2e/tests/two-browser-circuit-breaker.spec.ts
+++ b/e2e/tests/two-browser-circuit-breaker.spec.ts
@@ -15,7 +15,7 @@
  * - Reconciler returns OFFER_SHARING again → Subject shares → Guesser refines (attempt 3)
  * - Reconciler returns OFFER_SHARING again → Subject shares → Guesser refines (attempt 4)
  * - Circuit breaker trips on 4th attempt → Reconciler skipped → READY forced
- * - Guesser sees circuit breaker transition message ("Let's move forward")
+ * - Guesser sees circuit breaker transition message (waiting-state language)
  * - Both users see empathy revealed
  *
  * SUCCESS CRITERIA:


### PR DESCRIPTION
## Changes
- Fix: Replace misleading "Let's move forward" circuit breaker message with neutral waiting-state language that matches the waiting-status banner
- Fix: Remove "The reconciler reports" internal system language from the normal alignment message
- Update: Test assertions and doc references to reflect new message text

Related to #156

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** The app told me to move forward when we couldn't move forward

## Docs updated
- `docs/backend/reconciler-flow.md` — updated circuit breaker message description
- `docs/diagrams/reconciler-paths.md` — updated alignment message template description