### PR TITLE
docs: fix drift from 24h code changes (2026-04-27)

### DIFF
--- a/docs/architecture/backend-overview.md
+++ b/docs/architecture/backend-overview.md
@@ -3,7 +3,7 @@ title: Architecture
 sidebar_position: 2
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-04-20
+updated: 2026-04-27
 status: living
 ---
 # Architecture
@@ -132,7 +132,7 @@ status: living
 **Backend API Server:**
 - Location: `backend/src/app.ts` (middleware + route mounting) and `backend/src/server.ts` (HTTP + WebSocket listener)
 - Triggers: `npm run dev:api` in development; PORT=3000 (default) in production
-- Responsibilities: Initializes Express app with middleware; mounts all route modules under both `/api` and `/api/v1` (dual-prefix for compatibility); attaches the `/realtime` WebSocket for real-time transcription via `attachRealtimeWebSocket(server)`; handles errors consistently
+- Responsibilities: Initializes Express app with middleware; mounts all route modules under both `/api` and `/api/v1` (dual-prefix for compatibility); attaches the `/realtime` WebSocket for real-time transcription via `attachRealtimeWebSocket(server)` (requires Clerk JWT via `?token=` query parameter on upgrade); handles errors consistently
 - Compression: the compression middleware is explicitly disabled for `/messages/stream` paths to prevent SSE buffering
 
 **Mobile App Entry:**

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -99,7 +99,9 @@ The reconciler runs when one user confirms "feel heard" (completing Stage 1) and
 >
 > **Message de-duplication:** `markEmpathyReady()` in `state.ts` checks whether the alignment message it would post is identical to the last AI message the Guesser already saw. If so, it updates the empathy status without creating a redundant chat line — preventing duplicate messages during multi-cycle refinement runs.
 >
-> **Redundant share-suggestion guard:** `generateShareOffer()` in `sharing.ts` calls `hasContextAlreadyBeenShared()` before generating a new suggestion. If context was already shared in that direction, it returns `null` and `markResultHandledAlreadyShared()` is called to mark the reconciler result handled — preventing the Guesser from seeing repeated offer messages.
+> **Redundant share-suggestion guard (API endpoint):** `generateShareOffer()` in `sharing.ts` calls `hasContextAlreadyBeenShared()` before generating a suggestion. If context was already shared in that direction, it returns `null`, and the API responds with `hasSuggestion: false` — preventing the Guesser from seeing a repeated offer message.
+>
+> **Reconciler processing guard:** `triggerReconcilerAndUpdateStatuses()` in `stage2.ts` independently calls `hasContextAlreadyBeenShared()`. If context was already shared, it calls `markResultHandledAlreadyShared()` and sets the guesser's status directly to `READY`, bypassing the `AWAITING_SHARING` step.
 
 ### Reconciler Decision Tree
 

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -3,7 +3,7 @@ title: "Stage 2: Perspective Stretch - Empathy Exchange Flow"
 sidebar_position: 6
 description: This document describes the empathy exchange flow in Stage 2, including the reconciler system that analyzes empathy accuracy and manages the sharing of addit...
 created: 2026-03-11
-updated: 2026-04-18
+updated: 2026-04-27
 status: living
 ---
 # Stage 2: Perspective Stretch - Empathy Exchange Flow
@@ -96,6 +96,10 @@ The reconciler runs when one user confirms "feel heard" (completing Stage 1) and
 > - `index.ts` — Barrel re-exports.
 >
 > Status transitions are formally validated by `backend/src/services/empathy-state-machine.ts` which enforces a strict transition table.
+>
+> **Message de-duplication:** `markEmpathyReady()` in `state.ts` checks whether the alignment message it would post is identical to the last AI message the Guesser already saw. If so, it updates the empathy status without creating a redundant chat line — preventing duplicate messages during multi-cycle refinement runs.
+>
+> **Redundant share-suggestion guard:** `generateShareOffer()` in `sharing.ts` calls `hasContextAlreadyBeenShared()` before generating a new suggestion. If context was already shared in that direction, it returns `null` and `markResultHandledAlreadyShared()` is called to mark the reconciler result handled — preventing the Guesser from seeing repeated offer messages.
 
 ### Reconciler Decision Tree
 

--- a/docs/e2e-testing/architecture.md
+++ b/docs/e2e-testing/architecture.md
@@ -3,7 +3,7 @@ title: E2E Testing Architecture
 sidebar_position: 2
 description: This document describes the end-to-end testing approach used in Meet Without Fear.
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-04-27
 status: living
 ---
 # E2E Testing Architecture
@@ -310,8 +310,10 @@ export default defineConfig({
       },
     },
     {
-      command: 'cd ../mobile && EXPO_PUBLIC_E2E_MODE=true EXPO_PUBLIC_API_URL=http://localhost:3000 npx expo start --web --port 8082',
+      // --no-dev forces a production-mode bundle for deterministic rendering on slow hardware (EC2).
+      command: 'cd ../mobile && EXPO_PUBLIC_E2E_MODE=true EXPO_PUBLIC_API_URL=http://localhost:3000 npx expo start --web --port 8082 --no-dev',
       port: 8082,
+      timeout: 300000, // 300s for cold production bundle compilation
     },
   ],
 });

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -3,7 +3,7 @@ title: Infrastructure
 sidebar_position: 1
 description: Slam bot (EC2), Render hosting, Vercel deploys, GitHub automation.
 created: 2026-03-11
-updated: 2026-04-25
+updated: 2026-04-27
 status: living
 ---
 
@@ -53,7 +53,7 @@ Local operator scripts live at `scripts/ec2-bot/`:
 | `provision.sh` | One-shot AWS provisioning (security group, EIP, instance, SSH config entry) |
 | `setup.sh` | First-time bootstrap of a fresh instance (Node, gh, claude, directories) |
 | `deploy.sh` | Symlink scripts, install systemd units + crontab + logrotate |
-| `configure-slack.sh` | Write Slack tokens + channel IDs (`SLAM_BOT_CHANNEL_ID` for `#slam-paws`, `AGENTIC_DEVS_CHANNEL_ID` for `#agentic-devs`, `BUGS_AND_REQUESTS_CHANNEL_ID` for `#bugs-and-requests`, `MOST_IMPORTANT_THING_CHANNEL_ID` for `#most-important-thing`, `MWF_SESSIONS_CHANNEL_ID` for `#mwf-sessions`) to `/opt/slam-bot/.env` and start the socket service |
+| `configure-slack.sh` | Write Slack tokens + channel IDs (`SLAM_BOT_CHANNEL_ID` for `#slam-paws`, `AGENTIC_DEVS_CHANNEL_ID` for `#agentic-devs`, `BUGS_AND_REQUESTS_CHANNEL_ID` for `#bugs-and-requests`, `MOST_IMPORTANT_THING_CHANNEL_ID` for `#most-important-thing`, `DAILY_SUMMARY_CHANNEL_ID` for `#daily-summary`, `MWF_SESSIONS_CHANNEL_ID` for `#mwf-sessions`) to `/opt/slam-bot/.env` and start the socket service |
 | `configure-mixpanel.sh` | Write Mixpanel service-account credentials |
 | `configure-db.sh` | Create/rotate `slam_bot_readonly` role on the Render Postgres |
 
@@ -77,6 +77,7 @@ The socket listener routes messages by channel config. Each monitored channel ma
 | `#agentic-devs` | `slack-triage` | `agentic-devs-reply` |
 | `#bugs-and-requests` | `slack-triage` | `bugs-and-requests-reply` |
 | `#most-important-thing` | `slack-triage` | `most-important-thing-reply` |
+| `#daily-summary` | `slack-triage` | `daily-summary-reply` |
 | `#mwf-sessions` | `mwf-session` | `mwf-session-reply` |
 
 For `#mwf-sessions`, when `MWF_BACKEND_URL` is set the listener POSTs directly to the backend Bedrock pipeline instead of spawning a Claude Code agent.


### PR DESCRIPTION
## Changes
- Add `#daily-summary` channel to infrastructure routing table and `DAILY_SUMMARY_CHANNEL_ID` to `configure-slack.sh` description
- Add `--no-dev` flag and `timeout: 300000` to Playwright `webServer` config example in e2e-testing architecture doc
- Note Clerk JWT requirement (`?token=` param) on `/realtime` WebSocket upgrade in backend-overview
- Document message de-dup guard in `markEmpathyReady()` and redundant share-suggestion prevention guard in reconciler-flow doc
- Bump `updated` frontmatter to 2026-04-27 on all four docs

## Provenance
- **Channel:** cron / nightly audit-docs
- **Requested by:** automated
- **Trigger:** `audit-docs` job — 24h incremental lookback
- **Commits covered:** dba92c2, 2c0382e, 8507b6c, 250d0d7, 698caab, 66655df, 191cd5e, 1897f93

## Docs updated
- `docs/infrastructure/index.md`
- `docs/e2e-testing/architecture.md`
- `docs/architecture/backend-overview.md`
- `docs/backend/reconciler-flow.md`