### PR TITLE
fix(security): parameterize SQL query & validate linkedPartnerSessionId

### DIFF
--- a/backend/src/controllers/inner-work.ts
+++ b/backend/src/controllers/inner-work.ts
@@ -319,12 +319,8 @@ export const createInnerWorkSession = asyncHandler(
       });
     }
 
-    const { title, initialMessage } = parseResult.data;
-
-    // Extract optional linked session fields (not in shared schema yet)
-    const linkedPartnerSessionId = req.body.linkedPartnerSessionId as string | undefined;
-    const linkedAtStage = req.body.linkedAtStage as number | undefined;
-    const linkedTrigger = req.body.linkedTrigger as string | undefined;
+    const { title, initialMessage, linkedPartnerSessionId, linkedAtStage, linkedTrigger } =
+      parseResult.data;
 
     // If linking to a partner session, verify it exists and user is a participant
     if (linkedPartnerSessionId) {

--- a/backend/src/services/embedding.ts
+++ b/backend/src/services/embedding.ts
@@ -11,6 +11,7 @@
  */
 
 import { logger } from '../lib/logger';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getEmbedding } from '../lib/bedrock';
 
@@ -409,7 +410,7 @@ export async function searchInnerWorkSessionContent(
       s.id,
       s.theme,
       s."contentEmbedding" <=> ${vectorToSql(queryEmbedding)}::vector as distance,
-      ${linkedPartnerSessionId ? `(s."linkedPartnerSessionId" = ${linkedPartnerSessionId})` : 'false'} as is_linked
+      ${linkedPartnerSessionId ? Prisma.sql`(s."linkedPartnerSessionId" = ${linkedPartnerSessionId})` : Prisma.sql`false`} as is_linked
     FROM "InnerWorkSession" s
     WHERE s."userId" = ${userId}
       AND s."contentEmbedding" IS NOT NULL

--- a/shared/src/validation/inner-work.ts
+++ b/shared/src/validation/inner-work.ts
@@ -21,6 +21,12 @@ export const createInnerWorkSessionRequestSchema = z.object({
   title: z.string().max(200).optional(),
   /** Optional initial message - if provided, creates session with user message first (no AI greeting) */
   initialMessage: z.string().min(1).max(10000).optional(),
+  /** Optional linked partner session ID (CUID format) */
+  linkedPartnerSessionId: z.string().cuid().optional(),
+  /** Optional stage at which linking occurred */
+  linkedAtStage: z.number().int().min(0).max(4).optional(),
+  /** Optional trigger that caused the link */
+  linkedTrigger: z.string().max(100).optional(),
 });
 
 export type CreateInnerWorkSessionRequestInput = z.infer<typeof createInnerWorkSessionRequestSchema>;


### PR DESCRIPTION
## Changes
- Fix: Replace JavaScript string interpolation with `Prisma.sql` fragments in `searchInnerWorkSessionContent` raw query, ensuring `linkedPartnerSessionId` is properly parameterized
- Fix: `is_linked` column now returns a proper SQL boolean instead of a string (fixes linked-session similarity boost logic)
- Add: Zod `cuid()` validation for `linkedPartnerSessionId`, `linkedAtStage`, and `linkedTrigger` in the shared schema
- Refactor: Controller now destructures validated fields from Zod parse result instead of casting raw `req.body`

Related to #204

## Provenance
- **Channel:** #security-audit
- **Requested by:** weekly security audit (automated)
- **Original message:** weekly security audit cron
- **Prompt(s) used:** 7-agent parallel security scan — network/app security agent

## Docs updated
No doc changes needed — security fix with no doc-mapped files affected