### PR TITLE
fix(security): strip PII from prompt logging and BrainActivity storage

### DIFF
--- a/backend/src/lib/bedrock.ts
+++ b/backend/src/lib/bedrock.ts
@@ -78,8 +78,8 @@ function logPromptToFile(params: {
   sessionId?: string;
   turnId?: string;
 }): string | null {
-  // Skip if env var is set to disable
-  if (process.env.DISABLE_PROMPT_LOGGING === 'true') {
+  // Opt-in: only log when explicitly enabled AND not in production
+  if (process.env.ENABLE_PROMPT_LOGGING !== 'true' || process.env.NODE_ENV === 'production') {
     return null;
   }
 
@@ -137,7 +137,7 @@ function logPromptToFile(params: {
  */
 function logResponseToFile(promptFilepath: string | null, response: string | null): void {
   if (!promptFilepath || !response) return;
-  if (process.env.DISABLE_PROMPT_LOGGING === 'true') return;
+  if (process.env.ENABLE_PROMPT_LOGGING !== 'true' || process.env.NODE_ENV === 'production') return;
 
   try {
     // Replace .txt with _response.txt
@@ -401,7 +401,7 @@ export async function getModelCompletion(
     turnId: options.turnId,
     activityType: ActivityType.LLM_CALL,
     model: modelId,
-    input: { systemPrompt: systemPromptText, messages, operation },
+    input: { operation, messageCount: messages.length, systemPromptLength: systemPromptText.length },
     metadata: { maxTokens },
     callType: options.callType,
   });
@@ -605,7 +605,7 @@ export async function getEmbedding(text: string, options?: { sessionId?: string;
           turnId: options?.turnId,
           activityType: ActivityType.EMBEDDING,
           model: BEDROCK_TITAN_EMBED_MODEL_ID,
-          input: { text: truncatedText },
+          input: { textLength: truncatedText.length },
         });
       } catch (logError) {
         logger.warn('[Bedrock] Failed to log embedding activity (continuing without logging):', (logError as Error).message);
@@ -796,9 +796,9 @@ export async function* getSonnetStreamingResponse(
     activityType: ActivityType.LLM_CALL,
     model: BEDROCK_SONNET_MODEL_ID,
     input: {
-      systemPrompt: systemPromptText,
-      messages,
       operation: options.operation,
+      messageCount: messages.length,
+      systemPromptLength: systemPromptText.length,
       streaming: true,
     },
     metadata: {

--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -46,7 +46,7 @@ status: living
   - Cost attribution: `CompletionOptions.sessionId` / `.turnId` are optional at the type level (`sessionId?: string`) but required in practice — `SonnetStreamingOptions.sessionId` is non-optional, and call sites/telemetry assume both are present for `BrainActivity` attribution.
   - Haiku JSON retry: `getHaikuJson()` retries once with operation suffix `-retry` if the first response fails JSON parsing, before returning `null`.
   - Legacy model support: `PRICING` still includes entries for `claude-sonnet-4-6`, `claude-3-5-sonnet-20241022-v2:0`, and `claude-3-5-haiku-20241022-v1:0`, and a legacy `BEDROCK_MODEL_ID` export aliases Sonnet. Safe to reference when resurrecting old calls; new call sites should use the named constants.
-  - Prompt debug logging (local dev only): every Bedrock prompt + response is written to `backend/tmp/prompts/` as paired `<stem>.txt` / `<stem>_response.txt` files unless `DISABLE_PROMPT_LOGGING=true`. Directory is gitignored.
+  - Prompt debug logging (local dev only): every Bedrock prompt + response is written to `backend/tmp/prompts/` as paired `<stem>.txt` / `<stem>_response.txt` files when `ENABLE_PROMPT_LOGGING=true` **and** `NODE_ENV !== 'production'`. Disabled by default. Directory is gitignored.
 
 **Real-time Communication:**
 - Ably - WebSocket-based pub/sub messaging
@@ -211,7 +211,7 @@ status: living
 - `MOCK_LLM=true` - Toggle mock LLM responses for E2E testing
 - `E2E_AUTH_BYPASS=true` - Bypass auth for E2E tests
 - `E2E_FIXTURE_ID` - Use pre-canned responses for E2E tests
-- `DISABLE_PROMPT_LOGGING` - Disable prompt debug logging
+- `ENABLE_PROMPT_LOGGING` - Enable prompt debug logging (dev only, blocked in production)
 - `ENABLE_AUDIT_STREAM` - Enable AI audit stream channel for monitoring
 - `BEDROCK_TITAN_EMBED_MODEL_ID` - Override Titan embedding model ID
 - `OPENAI_API_KEY` - OpenAI API key (for voice preview generation in `tts.ts` and `generate-voice-previews.ts`)

--- a/docs/backend/prompt-caching.md
+++ b/docs/backend/prompt-caching.md
@@ -64,7 +64,7 @@ We use `@anthropic-ai/bedrock-sdk`. As of Feb 2026, **automatic caching** (top-l
 | `BEDROCK_SONNET_MODEL_ID` | `global.anthropic.claude-sonnet-4-5-20250929-v1:0` | Override Sonnet model ID |
 | `BEDROCK_HAIKU_MODEL_ID` | `global.anthropic.claude-haiku-4-5-20251001-v1:0` | Override Haiku model ID |
 | `BEDROCK_TITAN_EMBED_MODEL_ID` | `amazon.titan-embed-text-v2:0` | Override Titan embedding model ID |
-| `DISABLE_PROMPT_LOGGING` | `false` | Disable prompt debug logging to filesystem |
+| `ENABLE_PROMPT_LOGGING` | `false` | Enable prompt debug logging to filesystem (dev only, blocked in production) |
 | `ENABLE_AUDIT_STREAM` | `false` | Enable AI audit stream channel for monitoring |
 
 ### Cross-User Caching

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -150,7 +150,7 @@ Optional variables include Twilio SMS credentials, Neural Monitor dashboard sett
 | Variable | Purpose |
 |----------|---------|
 | `SENTRY_DSN` | Sentry error tracking DSN |
-| `DISABLE_PROMPT_LOGGING` | Disable prompt/completion logging (boolean) |
+| `ENABLE_PROMPT_LOGGING` | Enable prompt debug logging (dev only, blocked in production) |
 
 ## Documents
 


### PR DESCRIPTION
## Changes
- Fix: Flip prompt file logging from opt-out (`DISABLE_PROMPT_LOGGING`) to opt-in (`ENABLE_PROMPT_LOGGING=true`) with a `NODE_ENV !== 'production'` guard — logging is now disabled by default and blocked in production
- Fix: Replace full `systemPrompt` + `messages` in `BrainActivity.input` with metadata only (`operation`, `messageCount`, `systemPromptLength`) — eliminates PII from the database
- Fix: Strip embedding text from `BrainActivity.input` (store `textLength` only)
- Docs: Update `integrations.md`, `prompt-caching.md`, and `deployment/index.md` to reflect the new env var name and behavior

Related to #206

## Provenance
- **Channel:** #security-audit
- **Requested by:** weekly security audit (automated)
- **Original message:** weekly security audit cron
- **Prompt(s) used:** 7-agent parallel security scan — data security & PII, logging/monitoring agents

## Docs updated
- `docs/architecture/integrations.md` — updated env var name and description
- `docs/backend/prompt-caching.md` — updated env var table entry
- `docs/deployment/index.md` — updated env var table entry