### PR TITLE
fix(ec2-bot): auto-clear waiting-human markers on non-bot reply

### DIFF
--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -38,7 +38,7 @@ The crontab (installed by `deploy.sh`) covers roughly the following categories. 
 | every 1 min | `workspace-dispatcher.sh` | Drive label-based workspace dispatch |
 | every 1 min | `process-queue.sh` | Drain queued work items |
 | every 1 min | `api-budget-monitor.sh` | Track Claude API spend per workspace |
-| every 5 min | `clear-stale-locks.sh` | Unblock wedged dispatcher runs |
+| every 5 min | `clear-stale-locks.sh` | Unblock wedged dispatcher runs; auto-clear `waiting-human` markers when a non-bot reply is detected |
 | every 5 min | `check-socket-mode.sh` | Restart socket listener if Slack disconnects |
 | every 10 min | `pipeline-monitor.sh` | Watch PR / workflow state |
 | every 30 min | `thread-tracker.sh` | Reconcile Slack threads with GitHub activity |

--- a/scripts/ec2-bot/scripts/clear-stale-locks.sh
+++ b/scripts/ec2-bot/scripts/clear-stale-locks.sh
@@ -184,6 +184,50 @@ if [ -d "$CLAIMS_DIR" ]; then
   # waiting for human input. 7 days matches the spec-builder stale threshold.
   WAITING_CLEANED=$(find "$CLAIMS_DIR" -name "waiting-human-*.txt" -mmin +10080 -delete -print 2>/dev/null | wc -l)
   [ "$WAITING_CLEANED" -gt 0 ] && echo "[$(date)] Cleaned $WAITING_CLEANED stale waiting-human markers" >> "$LOGFILE"
+
+  # Auto-clear waiting-human markers when a non-bot user has replied on the issue.
+  # Without this, the bot stays deaf to human replies once a marker is written
+  # (pipeline-monitor Check 7 only runs while a bot:milestone-builder issue is open).
+  # Gate on github-state.json updatedAt to avoid unnecessary API calls.
+  # Refs: #150, #151, #152, #169, #173
+  GITHUB_STATE_FILE="${GITHUB_STATE_FILE:-${BOT_STATE_DIR}/github-state.json}"
+  for MARKER in "$CLAIMS_DIR"/waiting-human-*.txt; do
+    [ -f "$MARKER" ] || continue
+    ISSUE_NUM=$(basename "$MARKER" | sed 's/^waiting-human-//; s/\.txt$//')
+    [ -z "$ISSUE_NUM" ] && continue
+
+    # Gate: only check if the issue has been updated since the marker was written
+    MARKER_EPOCH=$(stat -c %Y "$MARKER" 2>/dev/null || echo 0)
+    if [ -f "$GITHUB_STATE_FILE" ]; then
+      UPDATED_AT=$(jq -r --arg n "$ISSUE_NUM" '.issues[$n].updatedAt // empty' "$GITHUB_STATE_FILE" 2>/dev/null)
+      if [ -n "$UPDATED_AT" ]; then
+        UPDATED_EPOCH=$(date -d "$UPDATED_AT" +%s 2>/dev/null || echo 0)
+        if [ "$UPDATED_EPOCH" -le "$MARKER_EPOCH" ]; then
+          continue  # Issue not updated since marker — skip API call
+        fi
+      fi
+    fi
+
+    # Fetch the latest comment on the issue
+    LATEST_COMMENT=$(gh api "repos/${GITHUB_REPO}/issues/${ISSUE_NUM}/comments?per_page=1&direction=desc" 2>/dev/null | jq '.[0] // empty' 2>/dev/null)
+    [ -z "$LATEST_COMMENT" ] && continue
+
+    COMMENT_AUTHOR=$(echo "$LATEST_COMMENT" | jq -r '.user.login // empty')
+    COMMENT_DATE=$(echo "$LATEST_COMMENT" | jq -r '.created_at // empty')
+    [ -z "$COMMENT_AUTHOR" ] || [ -z "$COMMENT_DATE" ] && continue
+
+    # Skip if the latest comment is from the bot itself
+    if [ "$COMMENT_AUTHOR" = "$BOT_NAME" ] || [ "$COMMENT_AUTHOR" = "slam-paws" ]; then
+      continue
+    fi
+
+    # Only clear if the comment was posted after the marker was written
+    COMMENT_EPOCH=$(date -d "$COMMENT_DATE" +%s 2>/dev/null || echo 0)
+    if [ "$COMMENT_EPOCH" -gt "$MARKER_EPOCH" ]; then
+      rm -f "$MARKER"
+      echo "[$(date)] Auto-cleared waiting-human-${ISSUE_NUM} — human reply from $COMMENT_AUTHOR at $COMMENT_DATE" >> "$LOGFILE"
+    fi
+  done
 fi
 
 # Clean up temp prompt/context files (>1 hour old)


### PR DESCRIPTION
## Summary

- Extends `clear-stale-locks.sh` to auto-clear `waiting-human-${N}.txt` markers when a non-bot user has commented on the issue since the marker was written
- Gates on `github-state.json` `updatedAt` field to avoid per-issue API calls when nothing has changed
- Only fetches `gh api .../comments?per_page=1&direction=desc` when the issue was updated after the marker was written
- Removes the marker if the latest comment's author is not `slam-paws` and its `created_at` is newer than the marker's mtime

## Motivation

Once PR #179 writes `waiting-human` markers, the bot goes deaf to non-`@MwfBot` replies. The existing cleanup for this (pipeline-monitor Check 7) only runs while a `bot:milestone-builder` issue is open. This fix makes `clear-stale-locks.sh` (which runs every 5 minutes via cron) handle this unconditionally.

Motivating cases: #150, #151, #152, #169, #173

## Test plan

- [ ] Verify script parses correctly: `bash -n scripts/ec2-bot/scripts/clear-stale-locks.sh`
- [ ] Manually create a test marker, post a human comment on the issue, and confirm the marker is cleared on the next cron run
- [ ] Confirm that markers for issues with only bot comments are NOT cleared
- [ ] Confirm that markers for issues not updated since marker creation are skipped (no API call made)

## Provenance

- Channel: #slam-paws
- Requester: Shantam (U0AD3TF2U7L)
- Follow-up to PR #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)