### PR TITLE
fix(mobile): use Darryl's opening copy on Stage 0 start screen (#114)

### DIFF
--- a/docs/backend/api/stage-0.md
+++ b/docs/backend/api/stage-0.md
@@ -147,7 +147,12 @@ To advance from Stage 0 to Stage 1:
 
 The opening welcome message is served as static content embedded in the mobile app. It replaces the former "Curiosity Compact" formal agreement with a brief, warm AI-spoken message.
 
-- **First session:** "You'll each chat with me privately first. Nothing gets shared without your say. Ready?"
+- **First session:**
+  > "I am here to help you work through conflict—step by step.
+  >
+  > You'll start by sharing what you believe is happening, privately.
+  >
+  > I don't share anything unless you approve it, ever."
 - **Repeat session:** "Welcome back. Same as before — your space is private, nothing shared without your say. Let's pick up where we left off."
 
 The `isFirstSession` field in the compact status response indicates which variant to show. No formal commitments or checkboxes are required — just a "Ready" / "Let's go" button.

--- a/docs/product/stages/stage-0-onboarding.md
+++ b/docs/product/stages/stage-0-onboarding.md
@@ -20,7 +20,11 @@ Welcome users with a brief, warm opening and secure acknowledgment before enteri
 The AI opens with a brief, warm message. The message varies based on whether this is the user's first session with this partner:
 
 **First session:**
-> "You'll each chat with me privately first. Nothing gets shared without your say. Ready?"
+> "I am here to help you work through conflict—step by step.
+>
+> You'll start by sharing what you believe is happening, privately.
+>
+> I don't share anything unless you approve it, ever."
 
 **Repeat session:**
 > "Welcome back. Same as before — your space is private, nothing shared without your say. Let's pick up where we left off."

--- a/mobile/src/components/CompactChatItem.tsx
+++ b/mobile/src/components/CompactChatItem.tsx
@@ -3,9 +3,6 @@
  *
  * Displays a brief, warm AI opening message during onboarding.
  * Replaces the formal Curiosity Compact terms with a conversational welcome.
- *
- * First session: "You'll each chat with me privately first. Nothing gets shared without your say. Ready?"
- * Repeat session: "Welcome back. Same as before — your space is private, nothing shared without your say. Let's pick up where we left off."
  */
 
 import { View } from 'react-native';
@@ -27,7 +24,7 @@ interface CompactChatItemProps {
 // ============================================================================
 
 const FIRST_SESSION_TEXT =
-  "You'll each chat with me privately first. Nothing gets shared without your say. Ready?";
+  "I am here to help you work through conflict\u2014step by step.\n\nYou'll start by sharing what you believe is happening, privately.\n\nI don't share anything unless you approve it, ever.";
 
 const REPEAT_SESSION_TEXT =
   "Welcome back. Same as before \u2014 your space is private, nothing shared without your say. Let's pick up where we left off.";

--- a/mobile/src/components/InlineCompact.tsx
+++ b/mobile/src/components/InlineCompact.tsx
@@ -28,7 +28,7 @@ interface InlineCompactProps {
 // ============================================================================
 
 const FIRST_SESSION_TEXT =
-  "You'll each chat with me privately first. Nothing gets shared without your say. Ready?";
+  "I am here to help you work through conflict\u2014step by step.\n\nYou'll start by sharing what you believe is happening, privately.\n\nI don't share anything unless you approve it, ever.";
 
 const REPEAT_SESSION_TEXT =
   "Welcome back. Same as before \u2014 your space is private, nothing shared without your say. Let's pick up where we left off.";


### PR DESCRIPTION
## Summary
- Replace the first-session opening with the warmer copy Darryl proposed in #114. The previous "You'll each chat with me privately first..." was reported as too vague.
- New first-session copy (three short paragraphs):
  > I am here to help you work through conflict—step by step.
  >
  > You'll start by sharing what you believe is happening, privately.
  >
  > I don't share anything unless you approve it, ever.
- Repeat-session copy is unchanged; the `Ready` / `Let's go` button behavior and backend `signCompact` gate are unchanged.

Updates `mobile/src/components/InlineCompact.tsx`, `mobile/src/components/CompactChatItem.tsx`, and the two stage-0 docs that mirrored the old copy.

Closes #114 once verified.

## Test plan
- [ ] `npm run check` passes (verified locally)
- [ ] `npm run test` for compact components passes (verified locally)
- [ ] After merge, GitHub Actions OTA publish runs
- [ ] Pull the OTA on a device and confirm the start screen shows the new three-line copy on a brand-new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)