### PR TITLE
feat(test-dashboard): Phase 1A scaffold — browsable test-run dashboard

### DIFF
--- a/.github/workflows/vercel-deploy-test-dashboard.yml
+++ b/.github/workflows/vercel-deploy-test-dashboard.yml
@@ -1,0 +1,66 @@
+name: Vercel Deploy — Test Dashboard
+
+# Deploys the Vite SPA + Vercel serverless functions in `tools/test-dashboard/`
+# to Vercel. Triggers on changes to tools/test-dashboard/** on main, or manual dispatch.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tools/test-dashboard/**'
+      - '.github/workflows/vercel-deploy-test-dashboard.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: vercel-deploy-test-dashboard-${{ github.sha }}
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      test_dashboard: ${{ steps.filter.outputs.test_dashboard }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        # workflow_dispatch should always deploy
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            test_dashboard:
+              - 'tools/test-dashboard/**'
+              - '.github/workflows/vercel-deploy-test-dashboard.yml'
+
+  test_dashboard:
+    name: Deploy Test Dashboard (Vite)
+    needs: changes
+    if: needs.changes.outputs.test_dashboard == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/test-dashboard
+    env:
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_TEST_DASHBOARD_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      # Standard Vite + Vercel functions setup builds cleanly on Vercel's own
+      # build environment, so skip the `vercel build` / `deploy --prebuilt`
+      # dance that the Expo Web app needs.
+      - name: Deploy to Vercel
+        run: vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}

--- a/e2e/tests/single-user-journey.spec.ts
+++ b/e2e/tests/single-user-journey.spec.ts
@@ -283,9 +283,10 @@ test.describe('Single User Journey', () => {
     console.log(`${elapsed()} Empathy shared indicator is visible`);
 
     // Step 19b: Assert waiting status panel is visible
-    // After sharing empathy, user should see "Waiting for Test Partner to feel heard"
+    // After sharing empathy, user should see "<Partner> is working on their perspective"
+    // (copy was previously "Waiting for <Partner> to feel heard"; updated to lower stakes)
     console.log(`${elapsed()} Step 19b: Verifying waiting status panel...`);
-    const waitingStatus = page.getByText(/Waiting for Darryl to feel heard/i);
+    const waitingStatus = page.getByText(/Darryl is working on their perspective/i);
     await expect(waitingStatus).toBeVisible({ timeout: 5000 });
     console.log(`${elapsed()} Waiting status panel is visible`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "e2e"
       ],
       "dependencies": {
+        "@vercel/blob": "^0.27.3",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },
@@ -9286,7 +9287,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -19695,20 +19695,31 @@
       }
     },
     "node_modules/@vercel/blob": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.0.tgz",
-      "integrity": "sha512-oYWiJbWRQ7gz9Mj0X/NHFJ3OcLMOBzq/2b3j6zeNrQmtFo6dHwU8FAwNpxVIYddVMd+g8eqEi7iRueYx8FtM0Q==",
-      "dev": true,
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-0.27.3.tgz",
+      "integrity": "sha512-WizeAxzOTmv0JL7wOaxvLIU/KdBcrclM1ZUOdSlIZAxsTTTe1jsyBthStLby0Ueh7FnmKYAjLz26qRJTk5SDkQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "async-retry": "^1.3.3",
         "is-buffer": "^2.0.5",
         "is-node-process": "^1.2.0",
         "throttleit": "^2.1.0",
-        "undici": "^6.23.0"
+        "undici": "^5.28.4"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@vercel/build-utils": {
@@ -22700,7 +22711,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "retry": "0.13.1"
@@ -22710,7 +22720,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -31796,7 +31805,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -32132,7 +32140,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-npm": {
@@ -46803,7 +46810,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
       "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -48679,6 +48685,23 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/vercel/node_modules/@vercel/blob": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.0.tgz",
+      "integrity": "sha512-oYWiJbWRQ7gz9Mj0X/NHFJ3OcLMOBzq/2b3j6zeNrQmtFo6dHwU8FAwNpxVIYddVMd+g8eqEi7iRueYx8FtM0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/vercel/node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "concurrently": "^9.2.1"
   },
   "dependencies": {
+    "@vercel/blob": "^0.27.3",
     "react": "19.1.0",
     "react-dom": "19.1.0"
   },

--- a/scripts/ec2-bot/scripts/write-test-result.README.md
+++ b/scripts/ec2-bot/scripts/write-test-result.README.md
@@ -14,11 +14,10 @@ Set them in the bot's systemd unit or `.env` (sourced before the script runs).
 
 ## Install
 
-The bot already has `tsx` available (or run via `npx tsx`). Required npm deps in the working directory:
+`@vercel/blob` is declared in the repo-root `package.json`, so a normal `npm install` at the repo root makes it resolvable from this script's path. If `tsx` isn't already on the bot, install it once:
 
 ```
-npm i -D tsx
-npm i @vercel/blob
+npm install -g tsx
 ```
 
 ## Invocation

--- a/scripts/ec2-bot/scripts/write-test-result.README.md
+++ b/scripts/ec2-bot/scripts/write-test-result.README.md
@@ -33,12 +33,14 @@ tsx scripts/ec2-bot/scripts/write-test-result.ts \
   --failed-test-line 87
 ```
 
-Full pass with screenshots + transcript:
+Full pass with screenshots + transcript + real test timing:
 
 ```bash
 tsx scripts/ec2-bot/scripts/write-test-result.ts \
   --scenario single-user-journey \
   --status pass \
+  --started-at 2026-04-26T18:30:12.000Z \
+  --finished-at 2026-04-26T18:34:48.000Z \
   --screenshots-dir /tmp/playwright/screenshots/run-2026-04-26 \
   --transcript-file /tmp/playwright/transcripts/run-2026-04-26.txt \
   --starting-snapshot-id 01HXY... \
@@ -46,6 +48,8 @@ tsx scripts/ec2-bot/scripts/write-test-result.ts \
   --final-stage 4 \
   --trigger-source cron
 ```
+
+Always pass `--started-at` (and ideally `--finished-at` or `--duration-ms`) from the runner — without them, `duration_ms` only covers the writer's upload phase and the dashboard misreports test latency.
 
 Update an existing queued run (when the dashboard's web UI enqueued it):
 
@@ -74,4 +78,6 @@ Use `NN-short-description.png`, e.g. `01-opens-app.png`, `02-types-message.png`,
 
 ## Failure handling
 
-Any HTTP failure exits non-zero with the API response body printed. The bot's process supervisor decides whether to retry.
+- Missing optional inputs (no `--screenshots-dir`, dir not found, transcript file not found) → warning, script continues.
+- Once an artifact upload starts, any failure (Vercel Blob 5xx, `/api/artifacts` non-2xx, file read error) propagates and the script exits non-zero.
+- Before re-throwing, the script makes a best-effort PATCH to set the run's status to `error` with `error_message: "writer failure: ..."`. This prevents stuck-at-`running` rows in the dashboard when the writer dies mid-upload.

--- a/scripts/ec2-bot/scripts/write-test-result.README.md
+++ b/scripts/ec2-bot/scripts/write-test-result.README.md
@@ -1,0 +1,78 @@
+# write-test-result.ts
+
+CLI script the EC2 bot calls after each Playwright e2e run. Pushes a row + screenshots + transcript to the test-dashboard.
+
+## Required environment variables
+
+| Var | Where it comes from |
+|---|---|
+| `TEST_DASHBOARD_API_URL` | Vercel deployment URL of `tools/test-dashboard/`, e.g. `https://test-dashboard.meetwithoutfear.com` |
+| `BOT_WRITER_TOKEN` | Long random string. Must equal the same env var set on the Vercel project. |
+| `BLOB_READ_WRITE_TOKEN` | Vercel Blob token (auto-issued by the Blob integration). Only needed when uploading screenshots. |
+
+Set them in the bot's systemd unit or `.env` (sourced before the script runs).
+
+## Install
+
+The bot already has `tsx` available (or run via `npx tsx`). Required npm deps in the working directory:
+
+```
+npm i -D tsx
+npm i @vercel/blob
+```
+
+## Invocation
+
+Minimal — failed run, no artifacts:
+
+```bash
+tsx scripts/ec2-bot/scripts/write-test-result.ts \
+  --scenario two-browser-stage-2 \
+  --status fail \
+  --error-message "timeout waiting for stage 2 transition" \
+  --failed-test-file e2e/two-browser-stage-2.spec.ts \
+  --failed-test-line 87
+```
+
+Full pass with screenshots + transcript:
+
+```bash
+tsx scripts/ec2-bot/scripts/write-test-result.ts \
+  --scenario single-user-journey \
+  --status pass \
+  --screenshots-dir /tmp/playwright/screenshots/run-2026-04-26 \
+  --transcript-file /tmp/playwright/transcripts/run-2026-04-26.txt \
+  --starting-snapshot-id 01HXY... \
+  --ending-snapshot-id 01HXZ... \
+  --final-stage 4 \
+  --trigger-source cron
+```
+
+Update an existing queued run (when the dashboard's web UI enqueued it):
+
+```bash
+tsx scripts/ec2-bot/scripts/write-test-result.ts \
+  --run-id 01HXY... \
+  --scenario two-browser-stage-2 \
+  --status pass \
+  --screenshots-dir /tmp/playwright/screenshots/run-2026-04-26
+```
+
+## Behaviour
+
+1. If `--run-id` is omitted, POSTs `/api/runs` to create a new row, then PATCHes status to `running`.
+2. If `--run-id` is provided, PATCHes the row to `running` (used by the queue-poller path).
+3. For each PNG/JPG/WebP in `--screenshots-dir` (sorted naturally by filename), uploads to Vercel Blob and POSTs `/api/artifacts` with `type=screenshot`.
+   - Step index is parsed from the leading digits of the filename (`01-foo.png` -> step 1, `step-12_login.jpg` -> step 12), falling back to file order.
+   - Caption is derived from the filename (numeric prefix stripped, dashes/underscores replaced with spaces).
+4. If `--transcript-file` exists, POSTs `/api/artifacts` with `type=transcript` and the file contents inline.
+5. Final PATCH `/api/runs/:id` with status, `finished_at`, `duration_ms`, and any failure fields.
+6. Prints the run id + the dashboard URL on completion.
+
+## Screenshot filename convention
+
+Use `NN-short-description.png`, e.g. `01-opens-app.png`, `02-types-message.png`, `03-shows-stage-2.png`. The leading number sets `step_index`, the suffix becomes the caption.
+
+## Failure handling
+
+Any HTTP failure exits non-zero with the API response body printed. The bot's process supervisor decides whether to retry.

--- a/scripts/ec2-bot/scripts/write-test-result.ts
+++ b/scripts/ec2-bot/scripts/write-test-result.ts
@@ -228,6 +228,7 @@ async function main() {
       status: 'running',
       started_at: new Date(startedAtMs).toISOString(),
       code_sha: codeSha,
+      trigger_source: triggerSource,
     });
   }
 

--- a/scripts/ec2-bot/scripts/write-test-result.ts
+++ b/scripts/ec2-bot/scripts/write-test-result.ts
@@ -1,0 +1,339 @@
+#!/usr/bin/env tsx
+/**
+ * write-test-result.ts
+ *
+ * After a Playwright e2e run finishes on the EC2 bot, this script:
+ *   1. Creates (or updates) a test_runs row in the test-dashboard Postgres.
+ *   2. Uploads each screenshot in --screenshots-dir to Vercel Blob.
+ *   3. Posts a run_artifacts row per screenshot + transcript.
+ *   4. PATCHes the run with final status, finished_at, duration_ms, failure fields.
+ *
+ * Required env vars:
+ *   TEST_DASHBOARD_API_URL   e.g. https://test-dashboard.meetwithoutfear.com
+ *   BOT_WRITER_TOKEN         must match what the dashboard has configured
+ *   BLOB_READ_WRITE_TOKEN    Vercel Blob token (rw)
+ *
+ * See ./write-test-result.README.md for examples.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { basename, extname, join } from 'node:path';
+import { put } from '@vercel/blob';
+
+type Status = 'queued' | 'running' | 'pass' | 'fail' | 'error' | 'cancelled';
+type TriggerSource = 'slack' | 'cron' | 'web' | 'manual';
+
+interface Args {
+  runId?: string;
+  scenario?: string;
+  status?: Status;
+  screenshotsDir?: string;
+  transcriptFile?: string;
+  startingSnapshotId?: string;
+  endingSnapshotId?: string;
+  codeSha?: string;
+  triggerSource?: TriggerSource;
+  triggeredBy?: string;
+  finalStage?: number;
+  errorMessage?: string;
+  failedAssertion?: string;
+  failedTestFile?: string;
+  failedTestLine?: number;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const next = argv[i + 1];
+    const take = () => {
+      if (next === undefined) throw new Error(`missing value for ${flag}`);
+      i++;
+      return next;
+    };
+    switch (flag) {
+      case '--run-id':              args.runId              = take(); break;
+      case '--scenario':            args.scenario           = take(); break;
+      case '--status':              args.status             = take() as Status; break;
+      case '--screenshots-dir':     args.screenshotsDir     = take(); break;
+      case '--transcript-file':     args.transcriptFile     = take(); break;
+      case '--starting-snapshot-id':args.startingSnapshotId = take(); break;
+      case '--ending-snapshot-id':  args.endingSnapshotId   = take(); break;
+      case '--code-sha':            args.codeSha            = take(); break;
+      case '--trigger-source':      args.triggerSource      = take() as TriggerSource; break;
+      case '--triggered-by':        args.triggeredBy        = take(); break;
+      case '--final-stage':         args.finalStage         = Number(take()); break;
+      case '--error-message':       args.errorMessage       = take(); break;
+      case '--failed-assertion':    args.failedAssertion    = take(); break;
+      case '--failed-test-file':    args.failedTestFile     = take(); break;
+      case '--failed-test-line':    args.failedTestLine     = Number(take()); break;
+      case '--help':
+      case '-h':
+        printHelpAndExit();
+        break;
+      default:
+        if (flag.startsWith('--')) {
+          throw new Error(`unknown flag: ${flag}`);
+        }
+    }
+  }
+  return args;
+}
+
+function printHelpAndExit(): never {
+  console.log(`Usage: tsx write-test-result.ts [flags]
+
+Required:
+  --scenario <name>            scenario name (e.g. two-browser-stage-2)
+  --status <pass|fail|error>   final status
+
+Optional:
+  --run-id <id>                  update existing run instead of creating one
+  --screenshots-dir <path>       dir of PNG/JPG screenshots
+  --transcript-file <path>       path to transcript text file
+  --starting-snapshot-id <id>
+  --ending-snapshot-id <id>
+  --code-sha <sha>               defaults to \`git rev-parse HEAD\`
+  --trigger-source <slack|cron|web|manual>   defaults to 'manual'
+  --triggered-by <id>            slack user id or email
+  --final-stage <0..4>
+  --error-message <msg>
+  --failed-assertion <text>
+  --failed-test-file <path>
+  --failed-test-line <n>
+`);
+  process.exit(0);
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`ERROR: env var ${name} is required`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function gitSha(): string | null {
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function apiFetch(
+  baseUrl: string,
+  token: string,
+  path: string,
+  method: 'GET' | 'POST' | 'PATCH',
+  body?: unknown
+): Promise<unknown> {
+  const url = `${baseUrl.replace(/\/$/, '')}${path}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-bot-token': token,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    parsed = text;
+  }
+  if (!res.ok) {
+    throw new Error(
+      `${method} ${path} -> ${res.status}: ${
+        typeof parsed === 'string' ? parsed : JSON.stringify(parsed)
+      }`
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Try to extract a step index from a filename like "01-opens-app.png" or
+ * "step-12_login.jpg". Returns null if no leading number is found.
+ */
+function extractStepIndex(filename: string): number | null {
+  const m = filename.match(/^(?:step[-_])?(\d{1,4})/i);
+  if (!m) return null;
+  return Number(m[1]);
+}
+
+function captionFromFilename(filename: string): string {
+  const noExt = filename.replace(/\.(png|jpg|jpeg|webp)$/i, '');
+  // Drop a leading numeric step prefix.
+  const stripped = noExt.replace(/^(?:step[-_])?\d{1,4}[-_]?/i, '');
+  return stripped.replace(/[-_]+/g, ' ').trim() || noExt;
+}
+
+function listScreenshots(dir: string): string[] {
+  const entries = readdirSync(dir);
+  return entries
+    .filter((f) => /\.(png|jpe?g|webp)$/i.test(f))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.scenario) {
+    console.error('ERROR: --scenario is required');
+    process.exit(1);
+  }
+  if (!args.status) {
+    console.error('ERROR: --status is required');
+    process.exit(1);
+  }
+
+  const apiBase = requireEnv('TEST_DASHBOARD_API_URL');
+  const botToken = requireEnv('BOT_WRITER_TOKEN');
+  // BLOB_READ_WRITE_TOKEN only needed if we have screenshots to upload.
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN;
+
+  const codeSha = args.codeSha ?? gitSha();
+  const triggerSource: TriggerSource = args.triggerSource ?? 'manual';
+
+  // 1. Create or mark-running.
+  const startedAtMs = Date.now();
+  let runId: string;
+
+  if (args.runId) {
+    runId = args.runId;
+    await apiFetch(apiBase, botToken, `/api/runs/${runId}`, 'PATCH', {
+      status: 'running',
+      started_at: new Date(startedAtMs).toISOString(),
+      code_sha: codeSha,
+      starting_snapshot_id: args.startingSnapshotId,
+      triggered_by: args.triggeredBy,
+    });
+    console.log(`[write-test-result] reusing run ${runId} -> running`);
+  } else {
+    const created = (await apiFetch(apiBase, botToken, '/api/runs', 'POST', {
+      scenario: args.scenario,
+      starting_snapshot_id: args.startingSnapshotId,
+      triggered_by: args.triggeredBy,
+    })) as { id: string };
+    runId = created.id;
+    console.log(`[write-test-result] created run ${runId}`);
+
+    // The POST endpoint forces trigger_source='web' & status='queued', so
+    // immediately PATCH to the real values for non-web triggers.
+    await apiFetch(apiBase, botToken, `/api/runs/${runId}`, 'PATCH', {
+      status: 'running',
+      started_at: new Date(startedAtMs).toISOString(),
+      code_sha: codeSha,
+    });
+  }
+
+  // 2. Upload screenshots and post artifact rows.
+  if (args.screenshotsDir) {
+    if (!blobToken) {
+      console.warn(
+        '[write-test-result] BLOB_READ_WRITE_TOKEN missing — skipping screenshot uploads'
+      );
+    } else {
+      try {
+        const stat = statSync(args.screenshotsDir);
+        if (!stat.isDirectory()) {
+          console.warn(
+            `[write-test-result] --screenshots-dir is not a directory: ${args.screenshotsDir}`
+          );
+        } else {
+          const files = listScreenshots(args.screenshotsDir);
+          console.log(
+            `[write-test-result] uploading ${files.length} screenshot(s) from ${args.screenshotsDir}`
+          );
+          for (let i = 0; i < files.length; i++) {
+            const filename = files[i];
+            const path = join(args.screenshotsDir, filename);
+            const data = readFileSync(path);
+            const ext = extname(filename).toLowerCase();
+            const contentType =
+              ext === '.png'
+                ? 'image/png'
+                : ext === '.webp'
+                ? 'image/webp'
+                : 'image/jpeg';
+
+            const blobKey = `runs/${runId}/${String(i).padStart(3, '0')}-${basename(filename)}`;
+            const uploaded = await put(blobKey, data, {
+              access: 'public',
+              contentType,
+              token: blobToken,
+            });
+
+            const stepIndex = extractStepIndex(filename) ?? i;
+            const caption = captionFromFilename(filename);
+
+            await apiFetch(apiBase, botToken, '/api/artifacts', 'POST', {
+              run_id: runId,
+              type: 'screenshot',
+              blob_url: uploaded.url,
+              caption,
+              step_index: stepIndex,
+            });
+            console.log(
+              `[write-test-result]   step ${stepIndex} (${caption}) -> ${uploaded.url}`
+            );
+          }
+        }
+      } catch (err) {
+        console.warn(
+          `[write-test-result] screenshot processing failed: ${(err as Error).message}`
+        );
+      }
+    }
+  }
+
+  // 3. Transcript artifact.
+  if (args.transcriptFile) {
+    try {
+      const text = readFileSync(args.transcriptFile, 'utf8');
+      await apiFetch(apiBase, botToken, '/api/artifacts', 'POST', {
+        run_id: runId,
+        type: 'transcript',
+        inline_text: text,
+        caption: basename(args.transcriptFile),
+        step_index: 9999, // sort transcript last
+      });
+      console.log(`[write-test-result] transcript posted (${text.length} chars)`);
+    } catch (err) {
+      console.warn(
+        `[write-test-result] transcript read failed: ${(err as Error).message}`
+      );
+    }
+  }
+
+  // 4. Final PATCH with status + timing + failure metadata.
+  const finishedAtMs = Date.now();
+  const durationMs = finishedAtMs - startedAtMs;
+
+  await apiFetch(apiBase, botToken, `/api/runs/${runId}`, 'PATCH', {
+    status: args.status,
+    finished_at: new Date(finishedAtMs).toISOString(),
+    duration_ms: durationMs,
+    final_stage: args.finalStage ?? null,
+    ending_snapshot_id: args.endingSnapshotId,
+    error_message: args.errorMessage ?? null,
+    failed_assertion: args.failedAssertion ?? null,
+    failed_test_file: args.failedTestFile ?? null,
+    failed_test_line: args.failedTestLine ?? null,
+  });
+
+  const dashboardUrl = `${apiBase.replace(/\/$/, '')}/run/${runId}`;
+  console.log('');
+  console.log(`[write-test-result] DONE: ${args.status} in ${durationMs}ms`);
+  console.log(`[write-test-result] run id:  ${runId}`);
+  console.log(`[write-test-result] view:    ${dashboardUrl}`);
+}
+
+main().catch((err) => {
+  console.error('[write-test-result] FAILED:', err);
+  process.exit(1);
+});

--- a/scripts/ec2-bot/scripts/write-test-result.ts
+++ b/scripts/ec2-bot/scripts/write-test-result.ts
@@ -39,6 +39,9 @@ interface Args {
   failedAssertion?: string;
   failedTestFile?: string;
   failedTestLine?: number;
+  startedAt?: string;
+  finishedAt?: string;
+  durationMs?: number;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -67,6 +70,9 @@ function parseArgs(argv: string[]): Args {
       case '--failed-assertion':    args.failedAssertion    = take(); break;
       case '--failed-test-file':    args.failedTestFile     = take(); break;
       case '--failed-test-line':    args.failedTestLine     = Number(take()); break;
+      case '--started-at':          args.startedAt          = take(); break;
+      case '--finished-at':         args.finishedAt         = take(); break;
+      case '--duration-ms':         args.durationMs         = Number(take()); break;
       case '--help':
       case '-h':
         printHelpAndExit();
@@ -101,6 +107,9 @@ Optional:
   --failed-assertion <text>
   --failed-test-file <path>
   --failed-test-line <n>
+  --started-at <ISO>             real test start time (defaults to script start — under-reports)
+  --finished-at <ISO>            real test end time (defaults to now)
+  --duration-ms <n>              overrides finished_at - started_at
 `);
   process.exit(0);
 }
@@ -199,19 +208,31 @@ async function main() {
   const codeSha = args.codeSha ?? gitSha();
   const triggerSource: TriggerSource = args.triggerSource ?? 'manual';
 
+  // Real test timing comes from the runner via flags. Falling back to script
+  // time means duration only reflects the upload phase — useless for analysis.
+  if (!args.startedAt) {
+    console.warn(
+      '[write-test-result] WARN: --started-at not provided; duration will only cover the writer\'s execution, not the test run'
+    );
+  }
+  const scriptStartMs = Date.now();
+  const startedAtIso = args.startedAt ?? new Date(scriptStartMs).toISOString();
+
   // 1. Create or mark-running.
-  const startedAtMs = Date.now();
   let runId: string;
 
   if (args.runId) {
     runId = args.runId;
-    await apiFetch(apiBase, botToken, `/api/runs/${runId}`, 'PATCH', {
+    // Don't clobber the row's started_at unless the caller passed one — for a
+    // queued run, started_at was set when the user enqueued it.
+    const reusePatch: Record<string, unknown> = {
       status: 'running',
-      started_at: new Date(startedAtMs).toISOString(),
       code_sha: codeSha,
       starting_snapshot_id: args.startingSnapshotId,
       triggered_by: args.triggeredBy,
-    });
+    };
+    if (args.startedAt) reusePatch.started_at = args.startedAt;
+    await apiFetch(apiBase, botToken, `/api/runs/${runId}`, 'PATCH', reusePatch);
     console.log(`[write-test-result] reusing run ${runId} -> running`);
   } else {
     const created = (await apiFetch(apiBase, botToken, '/api/runs', 'POST', {
@@ -226,11 +247,52 @@ async function main() {
     // immediately PATCH to the real values for non-web triggers.
     await apiFetch(apiBase, botToken, `/api/runs/${runId}`, 'PATCH', {
       status: 'running',
-      started_at: new Date(startedAtMs).toISOString(),
+      started_at: startedAtIso,
       code_sha: codeSha,
       trigger_source: triggerSource,
     });
   }
+
+  // From here on, any failure should leave the row marked `error` rather
+  // than stuck `running` — otherwise the dashboard misreports state.
+  try {
+    await uploadArtifactsAndFinalize({
+      apiBase,
+      botToken,
+      blobToken,
+      runId,
+      args,
+      startedAtIso,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[write-test-result] artifact/finalize phase failed: ${msg}`);
+    try {
+      await apiFetch(apiBase, botToken, `/api/runs/${runId}`, 'PATCH', {
+        status: 'error',
+        finished_at: new Date().toISOString(),
+        error_message: `writer failure: ${msg}`,
+      });
+    } catch (recoverErr) {
+      console.error(
+        `[write-test-result] failed to mark run as error: ${(recoverErr as Error).message}`
+      );
+    }
+    throw err;
+  }
+}
+
+interface FinalizeCtx {
+  apiBase: string;
+  botToken: string;
+  blobToken: string | undefined;
+  runId: string;
+  args: Args;
+  startedAtIso: string;
+}
+
+async function uploadArtifactsAndFinalize(ctx: FinalizeCtx): Promise<void> {
+  const { apiBase, botToken, blobToken, runId, args, startedAtIso } = ctx;
 
   // 2. Upload screenshots and post artifact rows.
   if (args.screenshotsDir) {
@@ -239,62 +301,75 @@ async function main() {
         '[write-test-result] BLOB_READ_WRITE_TOKEN missing — skipping screenshot uploads'
       );
     } else {
+      // Probe existence as a warning case (missing optional dir is fine).
+      // Once we know the dir is real, upload errors propagate — losing
+      // screenshots silently would defeat the point of the dashboard.
+      let isDir = false;
       try {
-        const stat = statSync(args.screenshotsDir);
-        if (!stat.isDirectory()) {
-          console.warn(
-            `[write-test-result] --screenshots-dir is not a directory: ${args.screenshotsDir}`
-          );
-        } else {
-          const files = listScreenshots(args.screenshotsDir);
-          console.log(
-            `[write-test-result] uploading ${files.length} screenshot(s) from ${args.screenshotsDir}`
-          );
-          for (let i = 0; i < files.length; i++) {
-            const filename = files[i];
-            const path = join(args.screenshotsDir, filename);
-            const data = readFileSync(path);
-            const ext = extname(filename).toLowerCase();
-            const contentType =
-              ext === '.png'
-                ? 'image/png'
-                : ext === '.webp'
-                ? 'image/webp'
-                : 'image/jpeg';
-
-            const blobKey = `runs/${runId}/${String(i).padStart(3, '0')}-${basename(filename)}`;
-            const uploaded = await put(blobKey, data, {
-              access: 'public',
-              contentType,
-              token: blobToken,
-            });
-
-            const stepIndex = extractStepIndex(filename) ?? i;
-            const caption = captionFromFilename(filename);
-
-            await apiFetch(apiBase, botToken, '/api/artifacts', 'POST', {
-              run_id: runId,
-              type: 'screenshot',
-              blob_url: uploaded.url,
-              caption,
-              step_index: stepIndex,
-            });
-            console.log(
-              `[write-test-result]   step ${stepIndex} (${caption}) -> ${uploaded.url}`
-            );
-          }
-        }
-      } catch (err) {
+        isDir = statSync(args.screenshotsDir).isDirectory();
+      } catch {
+        // ENOENT etc. — treat as warning below.
+      }
+      if (!isDir) {
         console.warn(
-          `[write-test-result] screenshot processing failed: ${(err as Error).message}`
+          `[write-test-result] --screenshots-dir not found or not a directory: ${args.screenshotsDir}`
         );
+      } else {
+        const files = listScreenshots(args.screenshotsDir);
+        console.log(
+          `[write-test-result] uploading ${files.length} screenshot(s) from ${args.screenshotsDir}`
+        );
+        for (let i = 0; i < files.length; i++) {
+          const filename = files[i];
+          const path = join(args.screenshotsDir, filename);
+          const data = readFileSync(path);
+          const ext = extname(filename).toLowerCase();
+          const contentType =
+            ext === '.png'
+              ? 'image/png'
+              : ext === '.webp'
+              ? 'image/webp'
+              : 'image/jpeg';
+
+          const blobKey = `runs/${runId}/${String(i).padStart(3, '0')}-${basename(filename)}`;
+          const uploaded = await put(blobKey, data, {
+            access: 'public',
+            contentType,
+            token: blobToken,
+          });
+
+          const stepIndex = extractStepIndex(filename) ?? i;
+          const caption = captionFromFilename(filename);
+
+          await apiFetch(apiBase, botToken, '/api/artifacts', 'POST', {
+            run_id: runId,
+            type: 'screenshot',
+            blob_url: uploaded.url,
+            caption,
+            step_index: stepIndex,
+          });
+          console.log(
+            `[write-test-result]   step ${stepIndex} (${caption}) -> ${uploaded.url}`
+          );
+        }
       }
     }
   }
 
-  // 3. Transcript artifact.
+  // 3. Transcript artifact. Same split: missing-file is a warning, read/post
+  // failures propagate.
   if (args.transcriptFile) {
+    let exists = false;
     try {
+      exists = statSync(args.transcriptFile).isFile();
+    } catch {
+      // ENOENT etc. — warn below.
+    }
+    if (!exists) {
+      console.warn(
+        `[write-test-result] --transcript-file not found: ${args.transcriptFile}`
+      );
+    } else {
       const text = readFileSync(args.transcriptFile, 'utf8');
       await apiFetch(apiBase, botToken, '/api/artifacts', 'POST', {
         run_id: runId,
@@ -304,20 +379,22 @@ async function main() {
         step_index: 9999, // sort transcript last
       });
       console.log(`[write-test-result] transcript posted (${text.length} chars)`);
-    } catch (err) {
-      console.warn(
-        `[write-test-result] transcript read failed: ${(err as Error).message}`
-      );
     }
   }
 
   // 4. Final PATCH with status + timing + failure metadata.
-  const finishedAtMs = Date.now();
-  const durationMs = finishedAtMs - startedAtMs;
+  // Real timing comes from the runner; if not provided, we have to lie a bit.
+  const finishedAtIso = args.finishedAt ?? new Date().toISOString();
+  const computedDuration =
+    args.durationMs ??
+    (Date.parse(finishedAtIso) - Date.parse(startedAtIso));
+  const durationMs = Number.isFinite(computedDuration)
+    ? Math.max(0, computedDuration)
+    : 0;
 
   await apiFetch(apiBase, botToken, `/api/runs/${runId}`, 'PATCH', {
     status: args.status,
-    finished_at: new Date(finishedAtMs).toISOString(),
+    finished_at: finishedAtIso,
     duration_ms: durationMs,
     final_stage: args.finalStage ?? null,
     ending_snapshot_id: args.endingSnapshotId,

--- a/tools/test-dashboard/.env.example
+++ b/tools/test-dashboard/.env.example
@@ -13,3 +13,8 @@ ABLY_KEY=
 
 # Frontend behaviour
 VITE_USE_REAL_API=true
+
+# Phase 1B: flip to "true" once user auth is wired on POST /api/runs.
+# Until then the queue/requeue buttons stay disabled with a Phase 1A banner,
+# matching the API which already rejects anon POSTs.
+VITE_WEB_QUEUEING_ENABLED=false

--- a/tools/test-dashboard/.env.example
+++ b/tools/test-dashboard/.env.example
@@ -1,0 +1,15 @@
+# Pulled from Vercel after `vercel env pull`
+POSTGRES_URL=
+POSTGRES_PRISMA_URL=
+POSTGRES_URL_NON_POOLING=
+BLOB_READ_WRITE_TOKEN=
+
+# Bot auth (any random token; same value goes on EC2 bot)
+BOT_WRITER_TOKEN=
+
+# Optional — for live updates from running tests
+VITE_ABLY_KEY=
+ABLY_KEY=
+
+# Frontend behaviour
+VITE_USE_REAL_API=true

--- a/tools/test-dashboard/.gitignore
+++ b/tools/test-dashboard/.gitignore
@@ -3,3 +3,4 @@ dist
 .vercel
 .env.local
 *.log
+.env*.local

--- a/tools/test-dashboard/.gitignore
+++ b/tools/test-dashboard/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.vercel
+.env.local
+*.log

--- a/tools/test-dashboard/README.md
+++ b/tools/test-dashboard/README.md
@@ -1,0 +1,40 @@
+# MWF Test Dashboard
+
+A web UI for browsing Playwright e2e test runs, screenshots, and snapshots — replacing Slack screenshot threads as the primary "browse all runs" surface.
+
+See the plan: [`/.planning/TEST_DASHBOARD_PLAN.md`](../../.planning/TEST_DASHBOARD_PLAN.md).
+
+## Dev
+
+```bash
+npm install
+npm run dev          # Vite dev server on :3003 (mock data fallback if API down)
+npm run dev:vercel   # vercel dev — runs api/* serverless functions on :3000 + Vite
+npm run check        # tsc
+npm run build        # production build
+npm run deploy       # vercel --prod
+```
+
+## Env vars
+
+Create `.env.local`:
+
+```
+# Optional — enables live updates from the slam-bot
+VITE_ABLY_KEY=
+
+# Optional — flip to "1" to disable mock fallback in dev
+VITE_USE_REAL_API=
+
+# Phase 1B+ (Clerk auth, before sharing with Darryl)
+# VITE_CLERK_PUBLISHABLE_KEY=
+```
+
+## Architecture
+
+- **Frontend**: React 19 + Vite + react-router-dom v7
+- **API routes**: `tools/test-dashboard/api/*.ts` (Vercel serverless, owned by a separate agent)
+- **Storage**: Vercel Postgres (run/snapshot metadata) + Vercel Blob (screenshots)
+- **Realtime**: Ably channel `test-runs:updates`
+
+In dev, if no API is running, the fetch helpers fall back to `src/services/mock.ts` so the UI is fully browsable without backend.

--- a/tools/test-dashboard/SETUP.md
+++ b/tools/test-dashboard/SETUP.md
@@ -1,0 +1,174 @@
+# Test Dashboard — Operator Setup
+
+Step-by-step guide for provisioning the `mwf-test-dashboard` Vercel project and wiring it into GitHub Actions + the EC2 bot.
+
+## Prerequisites
+
+- **Vercel CLI** installed locally and logged in:
+  ```bash
+  npm i -g vercel    # or use `npx vercel`
+  vercel login
+  ```
+- **GitHub CLI** authenticated:
+  ```bash
+  gh auth status
+  ```
+
+## Step 1 — Create the Vercel project
+
+From the repo root:
+
+```bash
+cd tools/test-dashboard
+vercel link
+```
+
+Answer the prompts:
+- **Scope**: `Shantam's Projects`
+- **Project name**: `mwf-test-dashboard`
+- **Root directory**: `tools/test-dashboard`
+
+Or via CLI:
+
+```bash
+vercel projects add mwf-test-dashboard
+vercel link
+```
+
+Note the **project ID** — it lands in `tools/test-dashboard/.vercel/project.json` after `vercel link`.
+
+## Step 2 — Provision Vercel Postgres
+
+```bash
+vercel storage create postgres mwf-test-dashboard-db --region iad1
+```
+
+(If the CLI sub-command isn't available, use the dashboard: **Storage → Create → Postgres**.)
+
+Connect the database to the project:
+- Vercel dashboard → **Storage** tab → select `mwf-test-dashboard-db`
+- **Connect Project** → choose `mwf-test-dashboard` → select **all environments** (Production, Preview, Development)
+
+This auto-injects the following env vars into the project:
+
+- `POSTGRES_URL`
+- `POSTGRES_PRISMA_URL`
+- `POSTGRES_URL_NON_POOLING`
+- `POSTGRES_USER`
+- `POSTGRES_HOST`
+- `POSTGRES_PASSWORD`
+- `POSTGRES_DATABASE`
+
+## Step 3 — Provision Vercel Blob
+
+```bash
+vercel storage create blob mwf-test-dashboard-blob
+```
+
+(Or via dashboard: **Storage → Create → Blob**.)
+
+Connect to the project the same way as Step 2. This auto-injects:
+
+- `BLOB_READ_WRITE_TOKEN`
+
+## Step 4 — Pull env locally and run migrations
+
+```bash
+cd tools/test-dashboard
+vercel env pull .env.local
+npm install
+npx tsx db/migrate.ts
+```
+
+`vercel env pull` writes the Postgres + Blob env vars into `.env.local`. The migration script creates the schema.
+
+## Step 5 — Set bot writer token
+
+Generate a token:
+
+```bash
+openssl rand -hex 32
+```
+
+Add it to all three Vercel environments:
+
+```bash
+vercel env add BOT_WRITER_TOKEN production
+# paste token
+vercel env add BOT_WRITER_TOKEN preview
+# paste same token
+vercel env add BOT_WRITER_TOKEN development
+# paste same token
+```
+
+**Save the token** — the EC2 bot needs the same value (Step 7).
+
+## Step 6 — Wire GitHub Actions
+
+Add the project ID as a repo variable:
+
+```bash
+gh variable set VERCEL_TEST_DASHBOARD_PROJECT_ID --body "<project-id-from-.vercel/project.json>"
+```
+
+Confirm `VERCEL_ORG_ID` (variable) and `VERCEL_TOKEN` (secret) already exist — they're shared with the other Vercel deploys (`mobile/` app, `website/`):
+
+```bash
+gh variable list | grep VERCEL_ORG_ID
+gh secret list | grep VERCEL_TOKEN
+```
+
+Trigger the first deploy by pushing a change in `tools/test-dashboard/` to `main`, or run manually:
+
+```bash
+gh workflow run vercel-deploy-test-dashboard.yml
+```
+
+## Step 7 — Configure EC2 bot
+
+SSH in:
+
+```bash
+ssh ec2-user@52.88.216.17
+```
+
+Add to `~/.bashrc` (or wherever the bot reads its env from):
+
+```bash
+export TEST_DASHBOARD_API_URL=https://mwf-test-dashboard.vercel.app   # or custom domain
+export BOT_WRITER_TOKEN=<token-from-step-5>
+export BLOB_READ_WRITE_TOKEN=<from-step-3>
+```
+
+Reload: `source ~/.bashrc`.
+
+Make sure the repo is present (it likely already is at `~/projects/meet-without-fear/`):
+
+```bash
+cd ~/projects/meet-without-fear && git pull
+```
+
+Smoke test the writer:
+
+```bash
+cd ~/projects/meet-without-fear
+npx tsx scripts/ec2-bot/scripts/write-test-result.ts \
+  --scenario test \
+  --status pass \
+  --screenshots-dir /tmp/empty-dir
+```
+
+## Step 8 — Optional: Custom domain
+
+```bash
+vercel domains add test-dashboard.meetwithoutfear.com mwf-test-dashboard
+```
+
+Add the CNAME record per Vercel's instructions, then update `TEST_DASHBOARD_API_URL` on the EC2 bot to the new domain.
+
+## Troubleshooting
+
+- **`vercel storage` subcommand not available**: your CLI version is older than the storage commands. Use the Vercel dashboard for Postgres and Blob provisioning instead.
+- **Migrations fail with auth error**: confirm `.env.local` has `POSTGRES_URL` (not just `POSTGRES_PRISMA_URL`). Re-run `vercel env pull .env.local` after the storage is connected to the project in **all** environments.
+- **GitHub Actions deploy fails**: check the variable name matches exactly: `VERCEL_TEST_DASHBOARD_PROJECT_ID` (case sensitive). Run `gh variable list` to verify.
+- **First deploy succeeds but functions 500**: check that the Postgres + Blob storage is connected to the **Production** environment, not just Preview/Development. Vercel dashboard → project → Settings → Environment Variables.

--- a/tools/test-dashboard/SETUP.md
+++ b/tools/test-dashboard/SETUP.md
@@ -137,10 +137,10 @@ export BLOB_READ_WRITE_TOKEN=<from-step-3>
 
 Reload: `source ~/.bashrc`.
 
-Make sure the repo is present (it likely already is at `~/projects/meet-without-fear/`):
+Make sure the repo is present (it likely already is at `~/projects/meet-without-fear/`) and that root deps are installed (`@vercel/blob` is declared at the repo root so the bot script can resolve it):
 
 ```bash
-cd ~/projects/meet-without-fear && git pull
+cd ~/projects/meet-without-fear && git pull && npm install
 ```
 
 Smoke test the writer:
@@ -163,6 +163,13 @@ vercel domains add test-dashboard.meetwithoutfear.com mwf-test-dashboard
 ```
 
 Add the CNAME record per Vercel's instructions, then update `TEST_DASHBOARD_API_URL` on the EC2 bot to the new domain.
+
+## Auth model (Phase 1A)
+
+- `GET /api/runs`, `GET /api/runs/:id`, `GET /api/snapshots`, `GET /api/snapshots/:id` — **public read**. Anyone with the URL can browse runs.
+- `POST /api/runs`, `PATCH /api/runs/:id`, `POST /api/snapshots`, `POST /api/artifacts` — **bot-token only**. Requires `x-bot-token: <BOT_WRITER_TOKEN>` header.
+
+This means the dashboard's "New Run" page **does not work in production** until Phase 1B wires Clerk-based user auth. The form is staged but the server rejects unauthenticated POSTs. To queue a run today, use the EC2 writer script directly. This was a deliberate choice — leaving POST open on a public deployment lets anyone enqueue work that the EC2 bot will execute.
 
 ## Troubleshooting
 

--- a/tools/test-dashboard/SETUP.md
+++ b/tools/test-dashboard/SETUP.md
@@ -2,6 +2,8 @@
 
 Step-by-step guide for provisioning the `mwf-test-dashboard` Vercel project and wiring it into GitHub Actions + the EC2 bot.
 
+> **Heads up — Postgres provider:** Vercel deprecated `@vercel/postgres` in late 2025; new Postgres databases are provisioned through the **Neon** marketplace integration. The `@vercel/postgres` npm package still works against a Neon database (it just proxies to the Neon serverless driver), so the existing API code is unchanged. If you'd rather migrate to `@neondatabase/serverless` directly later, the SQL stays the same.
+
 ## Prerequisites
 
 - **Vercel CLI** installed locally and logged in:
@@ -14,73 +16,66 @@ Step-by-step guide for provisioning the `mwf-test-dashboard` Vercel project and 
   gh auth status
   ```
 
-## Step 1 — Create the Vercel project
+## Step 1 — Link the Vercel project
 
-From the repo root:
+The project `mwf-test-dashboard` already exists (auto-created during initial scaffold). Re-link if `.vercel/` is missing:
 
 ```bash
 cd tools/test-dashboard
-vercel link
+vercel link --yes --project mwf-test-dashboard
 ```
 
-Answer the prompts:
-- **Scope**: `Shantam's Projects`
-- **Project name**: `mwf-test-dashboard`
-- **Root directory**: `tools/test-dashboard`
+The project ID is in `tools/test-dashboard/.vercel/project.json` after linking. **Note it down — you'll need it for Step 6.**
 
-Or via CLI:
+## Step 2 — Provision Postgres (via Neon)
+
+Easiest path is the Vercel dashboard:
+
+1. https://vercel.com/dashboard → select **`mwf-test-dashboard`** project
+2. **Storage** tab → **Create Database** → **Neon (Postgres)**
+3. Name: `mwf-test-dashboard-db`, region: `iad1` (closest to existing infra)
+4. **Connect** to `mwf-test-dashboard` and select **all three environments** (Production, Preview, Development)
+
+This auto-injects:
+- `DATABASE_URL`
+- `DATABASE_URL_UNPOOLED`
+- `POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`, `POSTGRES_USER`, `POSTGRES_HOST`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE` (Neon-shimmed for backward compatibility)
+
+CLI alternative (interactive — needs operator confirmation):
 
 ```bash
-vercel projects add mwf-test-dashboard
-vercel link
+vercel integration add neon
+# Follow the prompts to install the Neon integration into the Shantam scope
+# Then connect the resulting database to mwf-test-dashboard via the dashboard
 ```
-
-Note the **project ID** — it lands in `tools/test-dashboard/.vercel/project.json` after `vercel link`.
-
-## Step 2 — Provision Vercel Postgres
-
-```bash
-vercel storage create postgres mwf-test-dashboard-db --region iad1
-```
-
-(If the CLI sub-command isn't available, use the dashboard: **Storage → Create → Postgres**.)
-
-Connect the database to the project:
-- Vercel dashboard → **Storage** tab → select `mwf-test-dashboard-db`
-- **Connect Project** → choose `mwf-test-dashboard` → select **all environments** (Production, Preview, Development)
-
-This auto-injects the following env vars into the project:
-
-- `POSTGRES_URL`
-- `POSTGRES_PRISMA_URL`
-- `POSTGRES_URL_NON_POOLING`
-- `POSTGRES_USER`
-- `POSTGRES_HOST`
-- `POSTGRES_PASSWORD`
-- `POSTGRES_DATABASE`
 
 ## Step 3 — Provision Vercel Blob
 
+The Blob store `mwf-test-dashboard-blob` was already created during scaffold (store ID `store_Odn0ZYAqSWIiTLTk`). It just needs to be **connected** to the project:
+
+1. Vercel dashboard → **`mwf-test-dashboard`** → **Storage**
+2. Click **Connect Store** → select `mwf-test-dashboard-blob` → all environments
+
+This auto-injects `BLOB_READ_WRITE_TOKEN`.
+
+If the store doesn't exist (e.g. fresh clone), recreate:
+
 ```bash
-vercel storage create blob mwf-test-dashboard-blob
+cd tools/test-dashboard
+vercel blob store add mwf-test-dashboard-blob
+# answer Y to link
 ```
-
-(Or via dashboard: **Storage → Create → Blob**.)
-
-Connect to the project the same way as Step 2. This auto-injects:
-
-- `BLOB_READ_WRITE_TOKEN`
 
 ## Step 4 — Pull env locally and run migrations
 
 ```bash
 cd tools/test-dashboard
 vercel env pull .env.local
-npm install
-npx tsx db/migrate.ts
+npm install   # already done if you've been developing
+npm run migrate
 ```
 
-`vercel env pull` writes the Postgres + Blob env vars into `.env.local`. The migration script creates the schema.
+`vercel env pull` writes Postgres + Blob env vars into `.env.local`. The migration script reads `POSTGRES_URL` (or `DATABASE_URL`) and applies `db/schema.sql`.
 
 ## Step 5 — Set bot writer token
 
@@ -90,7 +85,7 @@ Generate a token:
 openssl rand -hex 32
 ```
 
-Add it to all three Vercel environments:
+Add to all three Vercel environments:
 
 ```bash
 vercel env add BOT_WRITER_TOKEN production
@@ -108,10 +103,10 @@ vercel env add BOT_WRITER_TOKEN development
 Add the project ID as a repo variable:
 
 ```bash
-gh variable set VERCEL_TEST_DASHBOARD_PROJECT_ID --body "<project-id-from-.vercel/project.json>"
+gh variable set VERCEL_TEST_DASHBOARD_PROJECT_ID --body "$(jq -r .projectId tools/test-dashboard/.vercel/project.json)"
 ```
 
-Confirm `VERCEL_ORG_ID` (variable) and `VERCEL_TOKEN` (secret) already exist — they're shared with the other Vercel deploys (`mobile/` app, `website/`):
+Confirm `VERCEL_ORG_ID` (variable) and `VERCEL_TOKEN` (secret) already exist — they're shared with the existing `mobile/` and `website/` deploys:
 
 ```bash
 gh variable list | grep VERCEL_ORG_ID
@@ -152,11 +147,14 @@ Smoke test the writer:
 
 ```bash
 cd ~/projects/meet-without-fear
+mkdir -p /tmp/empty-screenshots
 npx tsx scripts/ec2-bot/scripts/write-test-result.ts \
-  --scenario test \
+  --scenario smoke-test \
   --status pass \
-  --screenshots-dir /tmp/empty-dir
+  --screenshots-dir /tmp/empty-screenshots
 ```
+
+You should see a `https://mwf-test-dashboard.vercel.app/run/<id>` URL printed. Click it — the run should appear in the dashboard.
 
 ## Step 8 — Optional: Custom domain
 
@@ -168,7 +166,16 @@ Add the CNAME record per Vercel's instructions, then update `TEST_DASHBOARD_API_
 
 ## Troubleshooting
 
-- **`vercel storage` subcommand not available**: your CLI version is older than the storage commands. Use the Vercel dashboard for Postgres and Blob provisioning instead.
-- **Migrations fail with auth error**: confirm `.env.local` has `POSTGRES_URL` (not just `POSTGRES_PRISMA_URL`). Re-run `vercel env pull .env.local` after the storage is connected to the project in **all** environments.
+- **Migrations fail with auth error**: confirm `.env.local` has `POSTGRES_URL` or `DATABASE_URL`. Re-run `vercel env pull .env.local` after the storage is connected to the project in **all** environments.
 - **GitHub Actions deploy fails**: check the variable name matches exactly: `VERCEL_TEST_DASHBOARD_PROJECT_ID` (case sensitive). Run `gh variable list` to verify.
-- **First deploy succeeds but functions 500**: check that the Postgres + Blob storage is connected to the **Production** environment, not just Preview/Development. Vercel dashboard → project → Settings → Environment Variables.
+- **First deploy succeeds but functions 500**: check that Postgres + Blob storage is connected to the **Production** environment, not just Preview/Development. Vercel dashboard → project → Settings → Environment Variables.
+- **`@vercel/postgres` deprecation warning at install**: harmless. The package still works against Neon databases. Migration to `@neondatabase/serverless` is a future cleanup, not a blocker.
+
+## What's already done (autonomously)
+
+- Vercel project `mwf-test-dashboard` created and linked (`.vercel/project.json` present)
+- Vercel Blob store `mwf-test-dashboard-blob` (store ID `store_Odn0ZYAqSWIiTLTk`) created — needs project link in Step 3
+- All scaffold + API + GitHub Actions workflow committed
+- npm deps installed; build + typecheck pass
+
+Operator (you) needs to: provision Neon Postgres (Step 2), confirm Blob link (Step 3), pull env + migrate (Step 4), set bot token (Step 5), set GH variable (Step 6), configure EC2 (Step 7).

--- a/tools/test-dashboard/api/REQUIRED_DEPS.txt
+++ b/tools/test-dashboard/api/REQUIRED_DEPS.txt
@@ -1,0 +1,40 @@
+Test Dashboard — npm dependencies the API + migrate script need
+================================================================
+
+Add these to tools/test-dashboard/package.json (the frontend agent owns
+that file). The Vercel build resolves serverless function deps from the
+project-root package.json, so no separate api/package.json is required.
+
+dependencies:
+  @vercel/postgres   (sql template-tag client used by every API route)
+  @vercel/blob       (used by scripts/ec2-bot/scripts/write-test-result.ts; not directly by API routes, but kept here in case the API ever proxies uploads)
+  pg                 (used by db/migrate.ts only — Vercel API routes use @vercel/postgres)
+  ulid               (NOT required at runtime; api/_lib/db.ts ships its own ulid generator. Listed for reference if you prefer to swap in the official lib later.)
+
+devDependencies:
+  @vercel/node       (TypeScript types: `import type { VercelRequest, VercelResponse } from '@vercel/node'`)
+  @types/pg          (types for the pg client used in migrate.ts)
+  tsx                (run db/migrate.ts and bot scripts: `npx tsx db/migrate.ts`)
+
+Suggested package.json additions:
+  "dependencies": {
+    "@vercel/postgres": "^0.10.0",
+    "@vercel/blob": "^0.27.0",
+    "pg": "^8.13.0"
+  },
+  "devDependencies": {
+    "@vercel/node": "^3.2.0",
+    "@types/pg": "^8.11.10",
+    "tsx": "^4.19.0"
+  }
+
+Suggested scripts:
+  "scripts": {
+    "migrate": "tsx db/migrate.ts"
+  }
+
+Environment variables (Vercel project settings → Environment Variables):
+  POSTGRES_URL              — auto-set by Vercel Postgres integration
+  POSTGRES_URL_NON_POOLING  — auto-set; used by migrate
+  BOT_WRITER_TOKEN          — long random string; required by PATCH /api/runs/:id, POST /api/snapshots, POST /api/artifacts
+  BLOB_READ_WRITE_TOKEN     — auto-set by Vercel Blob integration; needed by the EC2 bot writer script (NOT by the API)

--- a/tools/test-dashboard/api/_lib/db.ts
+++ b/tools/test-dashboard/api/_lib/db.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared helpers for serverless API routes.
+ */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,PATCH,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, x-bot-token',
+  'Access-Control-Max-Age': '86400',
+};
+
+export function applyCors(res: VercelResponse) {
+  for (const [k, v] of Object.entries(CORS_HEADERS)) {
+    res.setHeader(k, v);
+  }
+}
+
+export function handleOptions(req: VercelRequest, res: VercelResponse): boolean {
+  if (req.method === 'OPTIONS') {
+    applyCors(res);
+    res.status(204).end();
+    return true;
+  }
+  return false;
+}
+
+export function jsonError(res: VercelResponse, status: number, message: string) {
+  applyCors(res);
+  res.setHeader('Content-Type', 'application/json');
+  res.status(status).json({ error: message });
+}
+
+export function json(res: VercelResponse, status: number, body: unknown) {
+  applyCors(res);
+  res.setHeader('Content-Type', 'application/json');
+  res.status(status).json(body);
+}
+
+/**
+ * Throws a 401-style error if the x-bot-token header is missing or wrong.
+ * Caller should catch and convert to a JSON 401 response.
+ */
+export class BotAuthError extends Error {
+  status = 401;
+}
+
+export function requireBotToken(req: VercelRequest): void {
+  const expected = process.env.BOT_WRITER_TOKEN;
+  if (!expected) {
+    throw new BotAuthError('BOT_WRITER_TOKEN not configured on server');
+  }
+  const got = req.headers['x-bot-token'];
+  const value = Array.isArray(got) ? got[0] : got;
+  if (!value || value !== expected) {
+    throw new BotAuthError('invalid or missing x-bot-token');
+  }
+}
+
+/**
+ * Vercel Node runtime auto-parses JSON when Content-Type is application/json,
+ * but for safety we accept either an already-parsed object or a string body.
+ */
+export function parseJsonBody<T = unknown>(req: VercelRequest): T {
+  const body = req.body;
+  if (body == null) return {} as T;
+  if (typeof body === 'string') {
+    if (body.trim() === '') return {} as T;
+    try {
+      return JSON.parse(body) as T;
+    } catch (err) {
+      throw new Error(`Invalid JSON body: ${(err as Error).message}`);
+    }
+  }
+  return body as T;
+}
+
+/**
+ * Generate a ulid-like id: 10 chars Crockford-base32 timestamp + 16 chars random.
+ * 26 chars total, lexicographically sortable by creation time.
+ *
+ * We avoid the `ulid` npm dep to keep cold starts small; this implementation
+ * matches the ulid spec closely enough for our uses (ids are opaque to clients).
+ */
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+function encodeBase32(value: number, length: number): string {
+  let out = '';
+  let v = value;
+  for (let i = length - 1; i >= 0; i--) {
+    out = CROCKFORD[v % 32] + out;
+    v = Math.floor(v / 32);
+  }
+  return out;
+}
+
+function randomBase32(length: number): string {
+  let out = '';
+  for (let i = 0; i < length; i++) {
+    out += CROCKFORD[Math.floor(Math.random() * 32)];
+  }
+  return out;
+}
+
+export function generateId(): string {
+  const ts = Date.now();
+  // Date.now() fits in 48 bits; encode as 10 base32 chars (50 bits of space).
+  // We encode high 25 bits and low 25 bits separately to avoid float precision loss.
+  const high = Math.floor(ts / 0x2000000); // top bits
+  const low = ts % 0x2000000;
+  const tsPart = (encodeBase32(high, 5) + encodeBase32(low, 5));
+  return tsPart + randomBase32(16);
+}
+
+export function pick<T extends object, K extends keyof T>(
+  obj: T,
+  keys: readonly K[]
+): Partial<T> {
+  const out: Partial<T> = {};
+  for (const k of keys) {
+    if (obj[k] !== undefined) out[k] = obj[k];
+  }
+  return out;
+}

--- a/tools/test-dashboard/api/artifacts/index.ts
+++ b/tools/test-dashboard/api/artifacts/index.ts
@@ -1,0 +1,84 @@
+/**
+ * POST /api/artifacts
+ *   Body: { run_id, type, caption?, step_index, blob_url? OR inline_text? }
+ *   Auth: header `x-bot-token: <BOT_WRITER_TOKEN>`.
+ *
+ * Screenshot binaries themselves are uploaded to Vercel Blob *by the bot* via
+ * `@vercel/blob`'s `put()` (using BLOB_READ_WRITE_TOKEN). The bot then calls this
+ * endpoint with the resulting blob_url. This endpoint never handles file bytes.
+ */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { sql } from '@vercel/postgres';
+import {
+  BotAuthError,
+  generateId,
+  handleOptions,
+  json,
+  jsonError,
+  parseJsonBody,
+  requireBotToken,
+} from '../_lib/db.js';
+
+export const config = { runtime: 'nodejs' };
+
+const VALID_TYPES = new Set(['screenshot', 'transcript', 'page_error', 'console']);
+
+interface CreateArtifactBody {
+  run_id?: string;
+  type?: string;
+  caption?: string | null;
+  step_index?: number;
+  blob_url?: string | null;
+  inline_text?: string | null;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res)) return;
+
+  if (req.method !== 'POST') {
+    return jsonError(res, 405, `Method ${req.method} not allowed`);
+  }
+
+  try {
+    requireBotToken(req);
+    const body = parseJsonBody<CreateArtifactBody>(req);
+
+    if (!body.run_id) return jsonError(res, 400, 'run_id is required');
+    if (!body.type || !VALID_TYPES.has(body.type)) {
+      return jsonError(res, 400, `invalid type: ${body.type}`);
+    }
+    if (!body.blob_url && !body.inline_text) {
+      return jsonError(res, 400, 'either blob_url or inline_text must be provided');
+    }
+
+    // Confirm run exists (FK is CASCADE; this gives a friendlier 404 than a constraint err).
+    const runExists = await sql`SELECT id FROM test_runs WHERE id = ${body.run_id}`;
+    if (runExists.rows.length === 0) {
+      return jsonError(res, 404, 'run_id does not exist');
+    }
+
+    const id = generateId();
+    const stepIndex = Number.isFinite(body.step_index) ? Number(body.step_index) : 0;
+    const caption = body.caption ?? null;
+    const blobUrl = body.blob_url ?? null;
+    const inlineText = body.inline_text ?? null;
+
+    const result = await sql`
+      INSERT INTO run_artifacts (
+        id, run_id, type, blob_url, inline_text, caption, step_index
+      )
+      VALUES (
+        ${id}, ${body.run_id}, ${body.type}, ${blobUrl}, ${inlineText}, ${caption}, ${stepIndex}
+      )
+      RETURNING *
+    `;
+
+    return json(res, 201, result.rows[0]);
+  } catch (err) {
+    if (err instanceof BotAuthError) {
+      return jsonError(res, err.status, err.message);
+    }
+    console.error('[api/artifacts] error:', err);
+    return jsonError(res, 500, (err as Error).message);
+  }
+}

--- a/tools/test-dashboard/api/runs/[id].ts
+++ b/tools/test-dashboard/api/runs/[id].ts
@@ -1,0 +1,150 @@
+/**
+ * GET   /api/runs/:id  — RunDetail (run + artifacts + starting/ending snapshots)
+ * PATCH /api/runs/:id  — bot writer updates status / timing / failure fields.
+ *                        Requires header `x-bot-token: <BOT_WRITER_TOKEN>`.
+ */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { sql } from '@vercel/postgres';
+import {
+  BotAuthError,
+  handleOptions,
+  json,
+  jsonError,
+  parseJsonBody,
+  requireBotToken,
+} from '../_lib/db.js';
+
+export const config = { runtime: 'nodejs' };
+
+const VALID_STATUSES = new Set([
+  'queued',
+  'running',
+  'pass',
+  'fail',
+  'error',
+  'cancelled',
+]);
+
+const PATCHABLE_FIELDS = [
+  'status',
+  'started_at',
+  'finished_at',
+  'duration_ms',
+  'final_stage',
+  'starting_snapshot_id',
+  'ending_snapshot_id',
+  'code_sha',
+  'triggered_by',
+  'error_message',
+  'failed_assertion',
+  'failed_test_file',
+  'failed_test_line',
+  'notes',
+] as const;
+
+type PatchableField = (typeof PATCHABLE_FIELDS)[number];
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res)) return;
+
+  const id = typeof req.query.id === 'string' ? req.query.id : '';
+  if (!id) return jsonError(res, 400, 'missing :id');
+
+  try {
+    if (req.method === 'GET') {
+      return await getRun(id, res);
+    }
+    if (req.method === 'PATCH') {
+      requireBotToken(req);
+      return await patchRun(id, req, res);
+    }
+    return jsonError(res, 405, `Method ${req.method} not allowed`);
+  } catch (err) {
+    if (err instanceof BotAuthError) {
+      return jsonError(res, err.status, err.message);
+    }
+    console.error('[api/runs/:id] error:', err);
+    return jsonError(res, 500, (err as Error).message);
+  }
+}
+
+async function getRun(id: string, res: VercelResponse) {
+  const runResult = await sql`SELECT * FROM test_runs WHERE id = ${id}`;
+  const run = runResult.rows[0];
+  if (!run) {
+    return jsonError(res, 404, 'run not found');
+  }
+
+  const artifactsResult = await sql`
+    SELECT * FROM run_artifacts
+    WHERE run_id = ${id}
+    ORDER BY step_index ASC, created_at ASC
+  `;
+
+  let startingSnapshot = null;
+  if (run.starting_snapshot_id) {
+    const r = await sql`SELECT * FROM snapshots WHERE id = ${run.starting_snapshot_id}`;
+    startingSnapshot = r.rows[0] ?? null;
+  }
+
+  let endingSnapshot = null;
+  if (run.ending_snapshot_id) {
+    const r = await sql`SELECT * FROM snapshots WHERE id = ${run.ending_snapshot_id}`;
+    endingSnapshot = r.rows[0] ?? null;
+  }
+
+  return json(res, 200, {
+    run,
+    artifacts: artifactsResult.rows,
+    starting_snapshot: startingSnapshot,
+    ending_snapshot: endingSnapshot,
+  });
+}
+
+async function patchRun(id: string, req: VercelRequest, res: VercelResponse) {
+  const body = parseJsonBody<Record<string, unknown>>(req);
+
+  // Whitelist patchable fields and validate enums.
+  const updates: Partial<Record<PatchableField, unknown>> = {};
+  for (const key of PATCHABLE_FIELDS) {
+    if (key in body) {
+      updates[key] = body[key];
+    }
+  }
+
+  if (
+    typeof updates.status === 'string' &&
+    !VALID_STATUSES.has(updates.status)
+  ) {
+    return jsonError(res, 400, `invalid status: ${updates.status}`);
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return jsonError(res, 400, 'no patchable fields supplied');
+  }
+
+  // Confirm row exists.
+  const exists = await sql`SELECT id FROM test_runs WHERE id = ${id}`;
+  if (exists.rows.length === 0) {
+    return jsonError(res, 404, 'run not found');
+  }
+
+  // Build a parameterized UPDATE manually (sql tag doesn't support dynamic columns).
+  const cols = Object.keys(updates) as PatchableField[];
+  const setClauses = cols.map((c, i) => `${c} = $${i + 1}`).join(', ');
+  const values = cols.map((c) => updates[c]);
+  values.push(id);
+
+  // Use the underlying client via @vercel/postgres' `db` export.
+  const { db } = await import('@vercel/postgres');
+  const client = await db.connect();
+  try {
+    const result = await client.query(
+      `UPDATE test_runs SET ${setClauses} WHERE id = $${values.length} RETURNING *`,
+      values
+    );
+    return json(res, 200, result.rows[0]);
+  } finally {
+    client.release();
+  }
+}

--- a/tools/test-dashboard/api/runs/[id].ts
+++ b/tools/test-dashboard/api/runs/[id].ts
@@ -25,6 +25,8 @@ const VALID_STATUSES = new Set([
   'cancelled',
 ]);
 
+const VALID_TRIGGER_SOURCES = new Set(['slack', 'cron', 'web', 'manual']);
+
 const PATCHABLE_FIELDS = [
   'status',
   'started_at',
@@ -34,6 +36,7 @@ const PATCHABLE_FIELDS = [
   'starting_snapshot_id',
   'ending_snapshot_id',
   'code_sha',
+  'trigger_source',
   'triggered_by',
   'error_message',
   'failed_assertion',
@@ -94,7 +97,7 @@ async function getRun(id: string, res: VercelResponse) {
   }
 
   return json(res, 200, {
-    run,
+    ...run,
     artifacts: artifactsResult.rows,
     starting_snapshot: startingSnapshot,
     ending_snapshot: endingSnapshot,
@@ -117,6 +120,17 @@ async function patchRun(id: string, req: VercelRequest, res: VercelResponse) {
     !VALID_STATUSES.has(updates.status)
   ) {
     return jsonError(res, 400, `invalid status: ${updates.status}`);
+  }
+
+  if (
+    typeof updates.trigger_source === 'string' &&
+    !VALID_TRIGGER_SOURCES.has(updates.trigger_source)
+  ) {
+    return jsonError(
+      res,
+      400,
+      `invalid trigger_source: ${updates.trigger_source}`
+    );
   }
 
   if (Object.keys(updates).length === 0) {

--- a/tools/test-dashboard/api/runs/[id].ts
+++ b/tools/test-dashboard/api/runs/[id].ts
@@ -144,21 +144,16 @@ async function patchRun(id: string, req: VercelRequest, res: VercelResponse) {
   }
 
   // Build a parameterized UPDATE manually (sql tag doesn't support dynamic columns).
+  // Note: we use sql.query (the function form) instead of db.connect() because
+  // the Neon HTTP driver doesn't support TCP-pooled connections.
   const cols = Object.keys(updates) as PatchableField[];
   const setClauses = cols.map((c, i) => `${c} = $${i + 1}`).join(', ');
   const values = cols.map((c) => updates[c]);
   values.push(id);
 
-  // Use the underlying client via @vercel/postgres' `db` export.
-  const { db } = await import('@vercel/postgres');
-  const client = await db.connect();
-  try {
-    const result = await client.query(
-      `UPDATE test_runs SET ${setClauses} WHERE id = $${values.length} RETURNING *`,
-      values
-    );
-    return json(res, 200, result.rows[0]);
-  } finally {
-    client.release();
-  }
+  const result = await sql.query(
+    `UPDATE test_runs SET ${setClauses} WHERE id = $${values.length} RETURNING *`,
+    values
+  );
+  return json(res, 200, result.rows[0]);
 }

--- a/tools/test-dashboard/api/runs/index.ts
+++ b/tools/test-dashboard/api/runs/index.ts
@@ -11,6 +11,7 @@ import {
   json,
   jsonError,
   parseJsonBody,
+  requireBotToken,
 } from '../_lib/db.js';
 
 export const config = { runtime: 'nodejs' };
@@ -32,6 +33,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return await listRuns(req, res);
     }
     if (req.method === 'POST') {
+      // Phase 1A: queueing is bot-only (the EC2 writer + cron + future
+      // bot-mediated Slack flow). The web "New run" page is staged for
+      // Phase 1B and gets locked behind Clerk auth then. Until then the
+      // public deployment must not let anonymous clients enqueue work
+      // that the EC2 bot will execute.
+      requireBotToken(req);
       return await createRun(req, res);
     }
     return jsonError(res, 405, `Method ${req.method} not allowed`);

--- a/tools/test-dashboard/api/runs/index.ts
+++ b/tools/test-dashboard/api/runs/index.ts
@@ -1,0 +1,104 @@
+/**
+ * GET  /api/runs?status=fail   — list latest 100 runs
+ * POST /api/runs                — enqueue a new run from the web UI
+ */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { sql } from '@vercel/postgres';
+import {
+  BotAuthError,
+  generateId,
+  handleOptions,
+  json,
+  jsonError,
+  parseJsonBody,
+} from '../_lib/db.js';
+
+export const config = { runtime: 'nodejs' };
+
+const VALID_STATUSES = new Set([
+  'queued',
+  'running',
+  'pass',
+  'fail',
+  'error',
+  'cancelled',
+]);
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res)) return;
+
+  try {
+    if (req.method === 'GET') {
+      return await listRuns(req, res);
+    }
+    if (req.method === 'POST') {
+      return await createRun(req, res);
+    }
+    return jsonError(res, 405, `Method ${req.method} not allowed`);
+  } catch (err) {
+    if (err instanceof BotAuthError) {
+      return jsonError(res, err.status, err.message);
+    }
+    console.error('[api/runs] error:', err);
+    return jsonError(res, 500, (err as Error).message);
+  }
+}
+
+async function listRuns(req: VercelRequest, res: VercelResponse) {
+  const statusFilter = typeof req.query.status === 'string' ? req.query.status : undefined;
+
+  let result;
+  if (statusFilter) {
+    if (!VALID_STATUSES.has(statusFilter)) {
+      return jsonError(res, 400, `invalid status filter: ${statusFilter}`);
+    }
+    result = await sql`
+      SELECT * FROM test_runs
+      WHERE status = ${statusFilter}
+      ORDER BY created_at DESC
+      LIMIT 100
+    `;
+  } else {
+    result = await sql`
+      SELECT * FROM test_runs
+      ORDER BY created_at DESC
+      LIMIT 100
+    `;
+  }
+
+  return json(res, 200, result.rows);
+}
+
+interface CreateRunBody {
+  scenario?: string;
+  starting_snapshot_id?: string | null;
+  notes?: string | null;
+  triggered_by?: string | null;
+}
+
+async function createRun(req: VercelRequest, res: VercelResponse) {
+  const body = parseJsonBody<CreateRunBody>(req);
+  const scenario = body.scenario?.trim();
+  if (!scenario) {
+    return jsonError(res, 400, 'scenario is required');
+  }
+
+  const id = generateId();
+  const startingSnapshotId = body.starting_snapshot_id ?? null;
+  const notes = body.notes ?? null;
+  const triggeredBy = body.triggered_by ?? null;
+
+  const result = await sql`
+    INSERT INTO test_runs (
+      id, scenario, status, trigger_source,
+      starting_snapshot_id, notes, triggered_by
+    )
+    VALUES (
+      ${id}, ${scenario}, 'queued', 'web',
+      ${startingSnapshotId}, ${notes}, ${triggeredBy}
+    )
+    RETURNING *
+  `;
+
+  return json(res, 201, result.rows[0]);
+}

--- a/tools/test-dashboard/api/snapshots/[id].ts
+++ b/tools/test-dashboard/api/snapshots/[id].ts
@@ -1,0 +1,60 @@
+/**
+ * GET /api/snapshots/:id
+ *   Returns: { snapshot, parent, children: Snapshot[], runs: TestRun[] }
+ *     - parent  = snapshot whose id == snapshot.parent_id (or null)
+ *     - children = snapshots where parent_id = :id
+ *     - runs    = runs where starting_snapshot_id = :id (newest first)
+ */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { sql } from '@vercel/postgres';
+import { handleOptions, json, jsonError } from '../_lib/db.js';
+
+export const config = { runtime: 'nodejs' };
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res)) return;
+
+  if (req.method !== 'GET') {
+    return jsonError(res, 405, `Method ${req.method} not allowed`);
+  }
+
+  const id = typeof req.query.id === 'string' ? req.query.id : '';
+  if (!id) return jsonError(res, 400, 'missing :id');
+
+  try {
+    const snapResult = await sql`SELECT * FROM snapshots WHERE id = ${id}`;
+    const snapshot = snapResult.rows[0];
+    if (!snapshot) {
+      return jsonError(res, 404, 'snapshot not found');
+    }
+
+    let parent = null;
+    if (snapshot.parent_id) {
+      const r = await sql`SELECT * FROM snapshots WHERE id = ${snapshot.parent_id}`;
+      parent = r.rows[0] ?? null;
+    }
+
+    const childrenResult = await sql`
+      SELECT * FROM snapshots
+      WHERE parent_id = ${id}
+      ORDER BY created_at ASC
+    `;
+
+    const runsResult = await sql`
+      SELECT * FROM test_runs
+      WHERE starting_snapshot_id = ${id}
+      ORDER BY created_at DESC
+      LIMIT 200
+    `;
+
+    return json(res, 200, {
+      snapshot,
+      parent,
+      children: childrenResult.rows,
+      runs: runsResult.rows,
+    });
+  } catch (err) {
+    console.error('[api/snapshots/:id] error:', err);
+    return jsonError(res, 500, (err as Error).message);
+  }
+}

--- a/tools/test-dashboard/api/snapshots/index.ts
+++ b/tools/test-dashboard/api/snapshots/index.ts
@@ -1,0 +1,101 @@
+/**
+ * GET  /api/snapshots  — flat list of all snapshots, each augmented with `run_count`.
+ *                        Frontend builds the tree by linking child.parent_id → parent.id.
+ * POST /api/snapshots  — bot writer creates a new snapshot row.
+ *                        Requires header `x-bot-token: <BOT_WRITER_TOKEN>`.
+ */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { sql } from '@vercel/postgres';
+import {
+  BotAuthError,
+  generateId,
+  handleOptions,
+  json,
+  jsonError,
+  parseJsonBody,
+  requireBotToken,
+} from '../_lib/db.js';
+
+export const config = { runtime: 'nodejs' };
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res)) return;
+
+  try {
+    if (req.method === 'GET') {
+      return await listSnapshots(res);
+    }
+    if (req.method === 'POST') {
+      requireBotToken(req);
+      return await createSnapshot(req, res);
+    }
+    return jsonError(res, 405, `Method ${req.method} not allowed`);
+  } catch (err) {
+    if (err instanceof BotAuthError) {
+      return jsonError(res, err.status, err.message);
+    }
+    console.error('[api/snapshots] error:', err);
+    return jsonError(res, 500, (err as Error).message);
+  }
+}
+
+async function listSnapshots(res: VercelResponse) {
+  // Flat array; frontend assembles the tree from parent_id.
+  // run_count = number of runs that started from this snapshot.
+  const result = await sql`
+    SELECT
+      s.*,
+      COALESCE(rc.run_count, 0)::int AS run_count
+    FROM snapshots s
+    LEFT JOIN (
+      SELECT starting_snapshot_id, COUNT(*) AS run_count
+      FROM test_runs
+      WHERE starting_snapshot_id IS NOT NULL
+      GROUP BY starting_snapshot_id
+    ) rc ON rc.starting_snapshot_id = s.id
+    ORDER BY s.created_at ASC
+  `;
+
+  return json(res, 200, result.rows);
+}
+
+interface CreateSnapshotBody {
+  name?: string;
+  description?: string | null;
+  parent_id?: string | null;
+  file_path?: string;
+  db_state_summary?: unknown;
+  created_by_run_id?: string | null;
+}
+
+async function createSnapshot(req: VercelRequest, res: VercelResponse) {
+  const body = parseJsonBody<CreateSnapshotBody>(req);
+
+  const name = body.name?.trim();
+  const filePath = body.file_path?.trim();
+  if (!name) return jsonError(res, 400, 'name is required');
+  if (!filePath) return jsonError(res, 400, 'file_path is required');
+
+  const id = generateId();
+  const description = body.description ?? null;
+  const parentId = body.parent_id ?? null;
+  const createdByRunId = body.created_by_run_id ?? null;
+  const dbStateSummary =
+    body.db_state_summary === undefined
+      ? null
+      : JSON.stringify(body.db_state_summary);
+
+  const result = await sql`
+    INSERT INTO snapshots (
+      id, name, description, parent_id, file_path,
+      db_state_summary, created_by_run_id
+    )
+    VALUES (
+      ${id}, ${name}, ${description}, ${parentId}, ${filePath},
+      ${dbStateSummary}::jsonb, ${createdByRunId}
+    )
+    RETURNING *
+  `;
+
+  return json(res, 201, result.rows[0]);
+}

--- a/tools/test-dashboard/db/migrate.ts
+++ b/tools/test-dashboard/db/migrate.ts
@@ -2,19 +2,58 @@
  * Run db/schema.sql against the configured Postgres instance.
  *
  * Usage:
+ *   npm run migrate                                # auto-loads .env.local
  *   POSTGRES_URL=postgres://... npx tsx db/migrate.ts
- *   # or DATABASE_URL=...
+ *   DATABASE_URL=postgres://... npx tsx db/migrate.ts
  *
  * Idempotent — safe to run repeatedly. Logs each statement as it executes.
  */
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from 'pg';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Minimal `.env.local` loader so the documented `vercel env pull` →
+ * `npm run migrate` flow works without an extra dotenv dep. Existing
+ * process.env values win, so CI / explicit shell exports still take
+ * precedence.
+ */
+function loadDotEnvLocal(): void {
+  const candidates = [
+    join(__dirname, '..', '.env.local'),
+    join(process.cwd(), '.env.local'),
+  ];
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    const content = readFileSync(path, 'utf8');
+    for (const rawLine of content.split('\n')) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let value = line.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (process.env[key] === undefined) {
+        process.env[key] = value;
+      }
+    }
+    console.log(`[migrate] loaded env from ${path}`);
+    return;
+  }
+}
+
 async function main() {
+  loadDotEnvLocal();
+
   const connectionString =
     process.env.POSTGRES_URL ||
     process.env.DATABASE_URL ||
@@ -22,7 +61,7 @@ async function main() {
 
   if (!connectionString) {
     console.error(
-      'ERROR: set POSTGRES_URL (or DATABASE_URL) in the environment before running migrate.'
+      'ERROR: no Postgres URL found. Either run `vercel env pull .env.local` first, or set POSTGRES_URL / DATABASE_URL in the environment before running migrate.'
     );
     process.exit(1);
   }

--- a/tools/test-dashboard/db/migrate.ts
+++ b/tools/test-dashboard/db/migrate.ts
@@ -1,0 +1,83 @@
+/**
+ * Run db/schema.sql against the configured Postgres instance.
+ *
+ * Usage:
+ *   POSTGRES_URL=postgres://... npx tsx db/migrate.ts
+ *   # or DATABASE_URL=...
+ *
+ * Idempotent — safe to run repeatedly. Logs each statement as it executes.
+ */
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from 'pg';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  const connectionString =
+    process.env.POSTGRES_URL ||
+    process.env.DATABASE_URL ||
+    process.env.POSTGRES_URL_NON_POOLING;
+
+  if (!connectionString) {
+    console.error(
+      'ERROR: set POSTGRES_URL (or DATABASE_URL) in the environment before running migrate.'
+    );
+    process.exit(1);
+  }
+
+  const schemaPath = join(__dirname, 'schema.sql');
+  const sql = readFileSync(schemaPath, 'utf8');
+
+  const client = new Client({ connectionString });
+  await client.connect();
+
+  try {
+    // Naive splitter that respects DO $$ ... $$ blocks. Statements are separated by
+    // semicolons at the end of a line, but we treat $$-quoted blocks as single units.
+    const statements = splitSqlStatements(sql);
+
+    for (const [i, stmt] of statements.entries()) {
+      const trimmed = stmt.trim();
+      if (!trimmed) continue;
+      const preview = trimmed.replace(/\s+/g, ' ').slice(0, 80);
+      console.log(`[migrate] (${i + 1}/${statements.length}) ${preview}`);
+      await client.query(trimmed);
+    }
+
+    const { rows } = await client.query(
+      'SELECT version, applied_at FROM schema_migrations ORDER BY version'
+    );
+    console.log('[migrate] schema_migrations:', rows);
+    console.log('[migrate] OK');
+  } finally {
+    await client.end();
+  }
+}
+
+function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let buf = '';
+  let inDollar = false;
+  const lines = sql.split('\n');
+
+  for (const line of lines) {
+    const stripped = line.replace(/--.*$/, '');
+    // Toggle on $$ occurrences
+    const dollarCount = (stripped.match(/\$\$/g) || []).length;
+    for (let i = 0; i < dollarCount; i++) inDollar = !inDollar;
+    buf += line + '\n';
+    if (!inDollar && /;\s*$/.test(stripped)) {
+      statements.push(buf);
+      buf = '';
+    }
+  }
+  if (buf.trim()) statements.push(buf);
+  return statements;
+}
+
+main().catch((err) => {
+  console.error('[migrate] FAILED:', err);
+  process.exit(1);
+});

--- a/tools/test-dashboard/db/schema.sql
+++ b/tools/test-dashboard/db/schema.sql
@@ -1,0 +1,117 @@
+-- Test Dashboard schema (Vercel Postgres)
+-- Idempotent: safe to re-run.
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  version TEXT PRIMARY KEY,
+  applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- snapshots: a captured DB state on EC2 (a `.sql` file) that runs can branch from.
+CREATE TABLE IF NOT EXISTS snapshots (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  parent_id TEXT,
+  file_path TEXT NOT NULL,
+  db_state_summary JSONB,
+  created_by_run_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- test_runs: one execution of a Playwright scenario.
+CREATE TABLE IF NOT EXISTS test_runs (
+  id TEXT PRIMARY KEY,
+  scenario TEXT NOT NULL,
+  status TEXT NOT NULL,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  finished_at TIMESTAMPTZ,
+  duration_ms INTEGER,
+  final_stage SMALLINT,
+  starting_snapshot_id TEXT,
+  ending_snapshot_id TEXT,
+  code_sha TEXT,
+  trigger_source TEXT NOT NULL,
+  triggered_by TEXT,
+  error_message TEXT,
+  failed_assertion TEXT,
+  failed_test_file TEXT,
+  failed_test_line INTEGER,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT test_runs_status_check
+    CHECK (status IN ('queued', 'running', 'pass', 'fail', 'error', 'cancelled')),
+  CONSTRAINT test_runs_trigger_source_check
+    CHECK (trigger_source IN ('slack', 'cron', 'web', 'manual')),
+  CONSTRAINT test_runs_final_stage_check
+    CHECK (final_stage IS NULL OR (final_stage >= 0 AND final_stage <= 4))
+);
+
+-- run_artifacts: screenshots, transcripts, page errors, console logs.
+CREATE TABLE IF NOT EXISTS run_artifacts (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  blob_url TEXT,
+  inline_text TEXT,
+  caption TEXT,
+  step_index INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT run_artifacts_type_check
+    CHECK (type IN ('screenshot', 'transcript', 'page_error', 'console'))
+);
+
+-- Foreign keys (added separately so re-running is safe; we drop+re-add via DO block).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'test_runs_starting_snapshot_id_fkey'
+  ) THEN
+    ALTER TABLE test_runs
+      ADD CONSTRAINT test_runs_starting_snapshot_id_fkey
+      FOREIGN KEY (starting_snapshot_id) REFERENCES snapshots(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'test_runs_ending_snapshot_id_fkey'
+  ) THEN
+    ALTER TABLE test_runs
+      ADD CONSTRAINT test_runs_ending_snapshot_id_fkey
+      FOREIGN KEY (ending_snapshot_id) REFERENCES snapshots(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'snapshots_parent_id_fkey'
+  ) THEN
+    ALTER TABLE snapshots
+      ADD CONSTRAINT snapshots_parent_id_fkey
+      FOREIGN KEY (parent_id) REFERENCES snapshots(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'snapshots_created_by_run_id_fkey'
+  ) THEN
+    ALTER TABLE snapshots
+      ADD CONSTRAINT snapshots_created_by_run_id_fkey
+      FOREIGN KEY (created_by_run_id) REFERENCES test_runs(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'run_artifacts_run_id_fkey'
+  ) THEN
+    ALTER TABLE run_artifacts
+      ADD CONSTRAINT run_artifacts_run_id_fkey
+      FOREIGN KEY (run_id) REFERENCES test_runs(id) ON DELETE CASCADE;
+  END IF;
+END
+$$;
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS test_runs_created_at_idx ON test_runs (created_at DESC);
+CREATE INDEX IF NOT EXISTS test_runs_status_idx ON test_runs (status);
+CREATE INDEX IF NOT EXISTS test_runs_scenario_idx ON test_runs (scenario);
+CREATE INDEX IF NOT EXISTS test_runs_starting_snapshot_id_idx ON test_runs (starting_snapshot_id);
+CREATE INDEX IF NOT EXISTS snapshots_parent_id_idx ON snapshots (parent_id);
+CREATE INDEX IF NOT EXISTS run_artifacts_run_id_step_idx ON run_artifacts (run_id, step_index);
+
+INSERT INTO schema_migrations (version) VALUES ('001')
+ON CONFLICT (version) DO NOTHING;

--- a/tools/test-dashboard/index.html
+++ b/tools/test-dashboard/index.html
@@ -3,9 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
     <title>MWF Test Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Fira+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
-  <body style="margin:0; background:#0a0e1a; color:#f1f5f9; font-family:'Inter', system-ui, -apple-system, sans-serif;">
+  <body style="margin:0; background:#020617; color:#f1f5f9;">
     <div id="app"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/tools/test-dashboard/index.html
+++ b/tools/test-dashboard/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MWF Test Dashboard</title>
+  </head>
+  <body style="margin:0; background:#0a0e1a; color:#f1f5f9; font-family:'Inter', system-ui, -apple-system, sans-serif;">
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/tools/test-dashboard/package-lock.json
+++ b/tools/test-dashboard/package-lock.json
@@ -1,0 +1,4886 @@
+{
+  "name": "test-dashboard",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-dashboard",
+      "dependencies": {
+        "@clerk/clerk-react": "^5.61.1",
+        "@vercel/blob": "^0.27.0",
+        "@vercel/postgres": "^0.10.0",
+        "ably": "^2.16.0",
+        "pg": "^8.13.0",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
+        "react-router-dom": "^7.12.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "@types/pg": "^8.11.10",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@vercel/node": "^3.2.0",
+        "@vitejs/plugin-react": "^5.1.2",
+        "tsx": "^4.19.0",
+        "typescript": "^5.9.3",
+        "vite": "^7.3.0"
+      }
+    },
+    "node_modules/@ably/msgpack-js": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@ably/msgpack-js/-/msgpack-js-0.4.1.tgz",
+      "integrity": "sha512-Sjxj6SOr17hExAVrsycN7u6oV4PhZcK7Z2S8dM71CH/butgO47cSo/TL6FJPCXUyDAzKkOWjMUpJGyZkEpyu4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bops": "^1.0.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "5.61.6",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.6.tgz",
+      "integrity": "sha512-OiyBlrnkRr9IhZtPd7EwlzhYScBpvNKJ8lgg7Uw6JElzJYz854IeQaez5mAfpiib3LcW/Dn53E2PQhagcuLJ3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.47.5",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
+      "integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@edge-runtime/format": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.2.1.tgz",
+      "integrity": "sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/node-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.3.0.tgz",
+      "integrity": "sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/ponyfill": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/ponyfill/-/ponyfill-2.4.2.tgz",
+      "integrity": "sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/primitives": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.1.0.tgz",
+      "integrity": "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/vm": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
+      "integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@edge-runtime/primitives": "4.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@neondatabase/serverless": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.9.5.tgz",
+      "integrity": "sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "8.11.6"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/@types/pg": {
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/pg-types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.1.0.tgz",
+      "integrity": "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
+      "integrity": "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react/node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vercel/blob": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-0.27.3.tgz",
+      "integrity": "sha512-WizeAxzOTmv0JL7wOaxvLIU/KdBcrclM1ZUOdSlIZAxsTTTe1jsyBthStLby0Ueh7FnmKYAjLz26qRJTk5SDkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@vercel/build-utils": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-8.7.0.tgz",
+      "integrity": "sha512-ofZX+ABiW76u5khIyYyH5xK5KSuiAteqRu5hz2k1a2WHLwF7VpeBg8gdFR+HwbVnNkHtkMA64ya5Dd/lNoABkw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/error-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.0.3.tgz",
+      "integrity": "sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/nft": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.27.3.tgz",
+      "integrity": "sha512-oySTdDSzUAFDXpsSLk9Q943o+/Yu/+TCFxnehpFQEf/3khi2stMpTHPVNwFdvZq/Z4Ky93lE+MGHpXCRpMkSCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.5",
+        "@rollup/pluginutils": "^4.0.0",
+        "acorn": "^8.6.0",
+        "acorn-import-attributes": "^1.9.5",
+        "async-sema": "^3.1.1",
+        "bindings": "^1.4.0",
+        "estree-walker": "2.0.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.2",
+        "node-gyp-build": "^4.2.2",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "nft": "out/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@vercel/node": {
+      "version": "3.2.29",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-3.2.29.tgz",
+      "integrity": "sha512-WRVYidBqtRyYUw36v/WyUB2v97PsiV2+LepUiOPWcW9UpszQGGT2DAzsXOYqWveXMJKFhx0aETR6Nn6i+Yps1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@edge-runtime/node-utils": "2.3.0",
+        "@edge-runtime/primitives": "4.1.0",
+        "@edge-runtime/vm": "3.2.0",
+        "@types/node": "16.18.11",
+        "@vercel/build-utils": "8.7.0",
+        "@vercel/error-utils": "2.0.3",
+        "@vercel/nft": "0.27.3",
+        "@vercel/static-config": "3.0.0",
+        "async-listen": "3.0.0",
+        "cjs-module-lexer": "1.2.3",
+        "edge-runtime": "2.5.9",
+        "es-module-lexer": "1.4.1",
+        "esbuild": "0.14.47",
+        "etag": "1.8.1",
+        "node-fetch": "2.6.9",
+        "path-to-regexp": "6.2.1",
+        "ts-morph": "12.0.0",
+        "ts-node": "10.9.1",
+        "typescript": "4.9.5",
+        "undici": "5.28.4"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@types/node": {
+      "version": "16.18.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
+      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vercel/node/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@vercel/postgres": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@vercel/postgres/-/postgres-0.10.0.tgz",
+      "integrity": "sha512-fSD23DxGND40IzSkXjcFcxr53t3Tiym59Is0jSYIFpG4/0f0KO9SGtcp1sXiebvPaGe7N/tU05cH4yt2S6/IPg==",
+      "deprecated": "@vercel/postgres is deprecated. If you are setting up a new database, you can choose an alternate storage solution from the Vercel Marketplace. If you had an existing Vercel Postgres database, it should have been migrated to Neon as a native Vercel integration. You can find more details and the guide to migrate to Neon's SDKs here: https://neon.com/docs/guides/vercel-postgres-transition-guide",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@neondatabase/serverless": "^0.9.3",
+        "bufferutil": "^4.0.8",
+        "ws": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=18.14"
+      }
+    },
+    "node_modules/@vercel/static-config": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.0.0.tgz",
+      "integrity": "sha512-2qtvcBJ1bGY0dYGYh3iM7yGKkk971FujLEDXzuW5wcZsPr1GSEjO/w2iSr3qve6nDDtBImsGoDEnus5FI4+fIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "8.6.3",
+        "json-schema-to-ts": "1.6.4",
+        "ts-morph": "12.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ably": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/ably/-/ably-2.21.0.tgz",
+      "integrity": "sha512-Zgs3O/hqhnTEoXeV1WxoQeLaww58JbnDVFbVeEDj2kCHeuLPeavTbyf2NQBkxAM3jooN5mILaP0PDm79NOcpKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ably/msgpack-js": "^0.4.0",
+        "dequal": "^2.0.3",
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "got": "^11.8.5",
+        "ulid": "^2.3.0",
+        "ws": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-listen": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.0.tgz",
+      "integrity": "sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/async-sema": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+      "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz",
+      "integrity": "sha512-ZXBDPMt/v/8fsIqn+Z5VwrhdR6jVka0bYobHdGia0Nxi7BJ9i/Uvml3AocHIBtIIBhZjBw5MR0aR4ROs/8+SNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.23",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
+      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bops": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bops/-/bops-1.0.1.tgz",
+      "integrity": "sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.0.2",
+        "to-utf8": "0.0.1"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/convert-hrtime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
+      "integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/edge-runtime": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.9.tgz",
+      "integrity": "sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@edge-runtime/format": "2.2.1",
+        "@edge-runtime/ponyfill": "2.4.2",
+        "@edge-runtime/vm": "3.2.0",
+        "async-listen": "3.0.1",
+        "mri": "1.2.0",
+        "picocolors": "1.0.0",
+        "pretty-ms": "7.0.1",
+        "signal-exit": "4.0.2",
+        "time-span": "4.0.0"
+      },
+      "bin": {
+        "edge-runtime": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/edge-runtime/node_modules/async-listen": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.1.tgz",
+      "integrity": "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/edge-runtime/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.47.tgz",
+      "integrity": "sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "esbuild-android-64": "0.14.47",
+        "esbuild-android-arm64": "0.14.47",
+        "esbuild-darwin-64": "0.14.47",
+        "esbuild-darwin-arm64": "0.14.47",
+        "esbuild-freebsd-64": "0.14.47",
+        "esbuild-freebsd-arm64": "0.14.47",
+        "esbuild-linux-32": "0.14.47",
+        "esbuild-linux-64": "0.14.47",
+        "esbuild-linux-arm": "0.14.47",
+        "esbuild-linux-arm64": "0.14.47",
+        "esbuild-linux-mips64le": "0.14.47",
+        "esbuild-linux-ppc64le": "0.14.47",
+        "esbuild-linux-riscv64": "0.14.47",
+        "esbuild-linux-s390x": "0.14.47",
+        "esbuild-netbsd-64": "0.14.47",
+        "esbuild-openbsd-64": "0.14.47",
+        "esbuild-sunos-64": "0.14.47",
+        "esbuild-windows-32": "0.14.47",
+        "esbuild-windows-64": "0.14.47",
+        "esbuild-windows-arm64": "0.14.47"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz",
+      "integrity": "sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz",
+      "integrity": "sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz",
+      "integrity": "sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz",
+      "integrity": "sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz",
+      "integrity": "sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz",
+      "integrity": "sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz",
+      "integrity": "sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz",
+      "integrity": "sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz",
+      "integrity": "sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz",
+      "integrity": "sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz",
+      "integrity": "sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz",
+      "integrity": "sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz",
+      "integrity": "sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz",
+      "integrity": "sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz",
+      "integrity": "sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz",
+      "integrity": "sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz",
+      "integrity": "sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz",
+      "integrity": "sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz",
+      "integrity": "sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz",
+      "integrity": "sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gauge/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-1.6.4.tgz",
+      "integrity": "sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.6",
+        "ts-toolbelt": "^6.15.5"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "license": "MIT"
+    },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/time-span": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-4.0.0.tgz",
+      "integrity": "sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/to-utf8": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+      "integrity": "sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ts-morph": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.0.0.tgz",
+      "integrity": "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.11.0",
+        "code-block-writer": "^10.1.1"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
+      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "bin/cli.js"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/tools/test-dashboard/package.json
+++ b/tools/test-dashboard/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "test-dashboard",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "dev:vercel": "vercel dev",
+    "build": "tsc && vite build",
+    "check": "tsc",
+    "deploy": "vercel --prod",
+    "migrate": "tsx db/migrate.ts"
+  },
+  "dependencies": {
+    "@clerk/clerk-react": "^5.61.1",
+    "@vercel/blob": "^0.27.0",
+    "@vercel/postgres": "^0.10.0",
+    "ably": "^2.16.0",
+    "pg": "^8.13.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "react-router-dom": "^7.12.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@types/pg": "^8.11.10",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vercel/node": "^3.2.0",
+    "@vitejs/plugin-react": "^5.1.2",
+    "tsx": "^4.19.0",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.0"
+  }
+}

--- a/tools/test-dashboard/src/App.tsx
+++ b/tools/test-dashboard/src/App.tsx
@@ -1,0 +1,23 @@
+import { Routes, Route } from 'react-router-dom';
+import { Layout } from './components/Layout';
+import { RunsFeedPage } from './pages/RunsFeedPage';
+import { RunDetailPage } from './pages/RunDetailPage';
+import { SnapshotsTreePage } from './pages/SnapshotsTreePage';
+import { SnapshotDetailPage } from './pages/SnapshotDetailPage';
+import { NewRunPage } from './pages/NewRunPage';
+import { NotFoundPage } from './pages/NotFoundPage';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route path="/" element={<RunsFeedPage />} />
+        <Route path="/run/:id" element={<RunDetailPage />} />
+        <Route path="/snapshots" element={<SnapshotsTreePage />} />
+        <Route path="/snapshot/:id" element={<SnapshotDetailPage />} />
+        <Route path="/new-run" element={<NewRunPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/tools/test-dashboard/src/components/Layout.tsx
+++ b/tools/test-dashboard/src/components/Layout.tsx
@@ -1,0 +1,24 @@
+import { NavLink, Outlet } from 'react-router-dom';
+
+export function Layout() {
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <div className="app-brand">
+          <span className="brand-dot" />
+          <h1>MWF Test Dashboard</h1>
+        </div>
+        <nav className="app-nav">
+          <NavLink to="/" end>
+            Runs
+          </NavLink>
+          <NavLink to="/snapshots">Snapshots</NavLink>
+          <NavLink to="/new-run">New Run</NavLink>
+        </nav>
+      </header>
+      <main className="app-main">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/tools/test-dashboard/src/components/Layout.tsx
+++ b/tools/test-dashboard/src/components/Layout.tsx
@@ -5,10 +5,13 @@ export function Layout() {
     <div className="app-shell">
       <header className="app-header">
         <div className="app-brand">
-          <span className="brand-dot" />
+          <span className="brand-dot" aria-hidden="true" />
           <h1>MWF Test Dashboard</h1>
+          <span className="env-tag" title="Phase 1A — read-only baseline">
+            phase 1a
+          </span>
         </div>
-        <nav className="app-nav">
+        <nav className="app-nav" aria-label="Primary">
           <NavLink to="/" end>
             Runs
           </NavLink>
@@ -19,6 +22,25 @@ export function Layout() {
       <main className="app-main">
         <Outlet />
       </main>
+      <footer className="app-footer">
+        <span>mwf-test-dashboard</span>
+        <span>·</span>
+        <a
+          href="https://github.com/shantamg/meet-without-fear/blob/main/.planning/TEST_DASHBOARD_PLAN.md"
+          target="_blank"
+          rel="noreferrer"
+        >
+          plan
+        </a>
+        <span>·</span>
+        <a
+          href="https://github.com/shantamg/meet-without-fear/tree/main/tools/test-dashboard"
+          target="_blank"
+          rel="noreferrer"
+        >
+          source
+        </a>
+      </footer>
     </div>
   );
 }

--- a/tools/test-dashboard/src/hooks/useAbly.ts
+++ b/tools/test-dashboard/src/hooks/useAbly.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+import Ably from 'ably';
+
+// WARNING: VITE_ABLY_KEY exposes the Ably API key in the client bundle.
+// In production, swap to token auth via a backend endpoint (see
+// tools/status-dashboard/src/hooks/useAblyConnection.ts for the pattern).
+// Only set VITE_ABLY_KEY for local development.
+const ablyKey = import.meta.env.VITE_ABLY_KEY as string | undefined;
+
+const TEST_RUNS_CHANNEL = 'test-runs:updates';
+
+export type TestRunsEvent = {
+  type: 'run.queued' | 'run.started' | 'run.updated' | 'run.finished';
+  run_id?: string;
+  [key: string]: unknown;
+};
+
+type Callback = (event: TestRunsEvent) => void;
+
+/**
+ * Subscribe to the `test-runs:updates` Ably channel.
+ * No-op if VITE_ABLY_KEY is not set — UI still works, it just won't get
+ * realtime nudges. Callers can fall back to manual refresh.
+ */
+export function useTestRunsChannel(onMessage: Callback): void {
+  const cbRef = useRef(onMessage);
+  cbRef.current = onMessage;
+
+  useEffect(() => {
+    if (!ablyKey) {
+      // eslint-disable-next-line no-console
+      console.info(
+        '[useTestRunsChannel] VITE_ABLY_KEY not set — live updates disabled.'
+      );
+      return;
+    }
+
+    const client = new Ably.Realtime({ key: ablyKey });
+    const channel = client.channels.get(TEST_RUNS_CHANNEL);
+
+    const handler = (msg: Ably.Message) => {
+      const data = msg.data as TestRunsEvent | undefined;
+      if (!data) return;
+      cbRef.current(data);
+    };
+
+    channel.subscribe(handler);
+
+    return () => {
+      channel.unsubscribe(handler);
+      client.close();
+    };
+  }, []);
+}

--- a/tools/test-dashboard/src/main.tsx
+++ b/tools/test-dashboard/src/main.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './style.css';
+
+// NOTE: No Clerk wrapper for Phase 1A.
+// Add ClerkProvider here (with VITE_CLERK_PUBLISHABLE_KEY) before sharing with Darryl.
+
+const rootEl = document.getElementById('app');
+if (!rootEl) {
+  throw new Error('Root element #app not found');
+}
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/tools/test-dashboard/src/pages/NewRunPage.tsx
+++ b/tools/test-dashboard/src/pages/NewRunPage.tsx
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Snapshot } from '../types';
 import { listSnapshotsFlat, queueRun } from '../services/api';
+import {
+  QUEUEING_DISABLED_MESSAGE,
+  WEB_QUEUEING_ENABLED,
+} from '../services/featureFlags';
 
 // Hardcoded list of e2e specs (mirrored in SnapshotDetailPage).
 // In Phase 1B the API can return the canonical list.
@@ -74,9 +78,11 @@ export function NewRunPage() {
         </div>
       </div>
 
-      <div className="error-banner" style={{ background: '#1f2937', borderColor: '#fbbf24', color: '#fbbf24' }}>
-        Phase 1A: this form is staged. Production deploys reject web POSTs until Phase 1B wires user auth — use the EC2 writer script to queue runs for now.
-      </div>
+      {!WEB_QUEUEING_ENABLED && (
+        <div className="error-banner" style={{ background: '#1f2937', borderColor: '#fbbf24', color: '#fbbf24' }}>
+          {QUEUEING_DISABLED_MESSAGE}
+        </div>
+      )}
 
       {error && <div className="error-banner">Error: {error}</div>}
 
@@ -134,7 +140,10 @@ export function NewRunPage() {
           <button
             type="submit"
             className="btn btn-primary"
-            disabled={busy || !scenario}
+            disabled={busy || !scenario || !WEB_QUEUEING_ENABLED}
+            title={
+              WEB_QUEUEING_ENABLED ? undefined : QUEUEING_DISABLED_MESSAGE
+            }
           >
             {busy ? 'Queueing…' : 'Queue run'}
           </button>

--- a/tools/test-dashboard/src/pages/NewRunPage.tsx
+++ b/tools/test-dashboard/src/pages/NewRunPage.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { Snapshot } from '../types';
+import { listSnapshotsFlat, queueRun } from '../services/api';
+
+// Hardcoded list of e2e specs (mirrored in SnapshotDetailPage).
+// In Phase 1B the API can return the canonical list.
+const SCENARIOS = [
+  'single-user-journey',
+  'partner-journey',
+  'two-browser-smoke',
+  'two-browser-stage-0',
+  'two-browser-stage-1',
+  'two-browser-stage-2',
+  'two-browser-stage-3',
+  'two-browser-stage-4',
+  'two-browser-full-flow',
+  'two-browser-circuit-breaker',
+  'two-browser-reconciler-offer-optional',
+  'two-browser-reconciler-offer-sharing-refinement',
+  'stage-3-4-complete',
+  'live-ai-full-flow',
+];
+
+export function NewRunPage() {
+  const navigate = useNavigate();
+  const [scenario, setScenario] = useState<string>(SCENARIOS[0] ?? '');
+  const [snapshotId, setSnapshotId] = useState<string>('');
+  const [notes, setNotes] = useState<string>('');
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    listSnapshotsFlat()
+      .then(setSnapshots)
+      .catch((err: unknown) => {
+        // Non-fatal: form still works without snapshot select.
+        // eslint-disable-next-line no-console
+        console.warn('Failed to load snapshots for select:', err);
+      });
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!scenario) return;
+      setBusy(true);
+      setError(null);
+      try {
+        const created = await queueRun({
+          scenario,
+          ...(snapshotId ? { starting_snapshot_id: snapshotId } : {}),
+          ...(notes.trim() ? { notes: notes.trim() } : {}),
+        });
+        navigate(`/run/${created.id}`);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Failed to queue run');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [scenario, snapshotId, notes, navigate]
+  );
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h2>Queue a new run</h2>
+          <div className="page-subtitle">
+            The slam-bot picks queued runs every minute.
+          </div>
+        </div>
+      </div>
+
+      {error && <div className="error-banner">Error: {error}</div>}
+
+      <form onSubmit={handleSubmit} className="form">
+        <div className="form-field">
+          <label htmlFor="new-run-scenario">Scenario</label>
+          <select
+            id="new-run-scenario"
+            value={scenario}
+            onChange={(e) => setScenario(e.target.value)}
+            required
+          >
+            {SCENARIOS.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <div className="hint">
+            Maps to a file in <span className="mono">e2e/tests/</span>.
+          </div>
+        </div>
+
+        <div className="form-field">
+          <label htmlFor="new-run-snapshot">Starting snapshot (optional)</label>
+          <select
+            id="new-run-snapshot"
+            value={snapshotId}
+            onChange={(e) => setSnapshotId(e.target.value)}
+          >
+            <option value="">— Fresh DB (no snapshot) —</option>
+            {snapshots.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <div className="hint">
+            If set, the bot resets the DB to this snapshot before running.
+          </div>
+        </div>
+
+        <div className="form-field">
+          <label htmlFor="new-run-notes">Notes (optional)</label>
+          <textarea
+            id="new-run-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={3}
+            placeholder="Why are you running this?"
+          />
+        </div>
+
+        <div>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={busy || !scenario}
+          >
+            {busy ? 'Queueing…' : 'Queue run'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/tools/test-dashboard/src/pages/NewRunPage.tsx
+++ b/tools/test-dashboard/src/pages/NewRunPage.tsx
@@ -74,6 +74,10 @@ export function NewRunPage() {
         </div>
       </div>
 
+      <div className="error-banner" style={{ background: '#1f2937', borderColor: '#fbbf24', color: '#fbbf24' }}>
+        Phase 1A: this form is staged. Production deploys reject web POSTs until Phase 1B wires user auth — use the EC2 writer script to queue runs for now.
+      </div>
+
       {error && <div className="error-banner">Error: {error}</div>}
 
       <form onSubmit={handleSubmit} className="form">

--- a/tools/test-dashboard/src/pages/NotFoundPage.tsx
+++ b/tools/test-dashboard/src/pages/NotFoundPage.tsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom';
+
+export function NotFoundPage() {
+  return (
+    <div className="empty">
+      <p>Not found.</p>
+      <p>
+        <Link to="/">Back to runs</Link>
+      </p>
+    </div>
+  );
+}

--- a/tools/test-dashboard/src/pages/RunDetailPage.tsx
+++ b/tools/test-dashboard/src/pages/RunDetailPage.tsx
@@ -93,8 +93,10 @@ export function RunDetailPage() {
       <div className="page-header">
         <div>
           <h2>
-            <span className={`status-badge status-${run.status}`}>{run.status}</span>{' '}
-            {run.scenario}
+            <span className={`status-badge status-${run.status}`}>{run.status}</span>
+            <span className="mono" style={{ fontWeight: 600 }}>
+              {run.scenario}
+            </span>
           </h2>
           <div className="page-subtitle">
             Started {formatTimestamp(run.started_at)} · Finished{' '}
@@ -246,7 +248,9 @@ export function RunDetailPage() {
       )}
 
       <section className="detail-section">
-        <h3>Screenshots ({screenshots.length})</h3>
+        <h3>
+          Screenshots <span className="count">{screenshots.length}</span>
+        </h3>
         {screenshots.length === 0 ? (
           <div className="empty" style={{ padding: '1rem' }}>
             No screenshots.
@@ -262,7 +266,9 @@ export function RunDetailPage() {
 
       {pageErrors.length > 0 && (
         <section className="detail-section">
-          <h3>Page errors ({pageErrors.length})</h3>
+          <h3>
+            Page errors <span className="count">{pageErrors.length}</span>
+          </h3>
           {pageErrors.map((a) => (
             <pre key={a.id} className="log-block error">
               {a.inline_text ?? a.caption ?? '(empty)'}
@@ -273,7 +279,9 @@ export function RunDetailPage() {
 
       {consoleLogs.length > 0 && (
         <section className="detail-section">
-          <h3>Console log</h3>
+          <h3>
+            Console log <span className="count">{consoleLogs.length}</span>
+          </h3>
           {consoleLogs.map((a) => (
             <pre key={a.id} className="log-block">
               {a.inline_text ?? '(empty)'}
@@ -315,8 +323,8 @@ function ScreenshotCard({ artifact }: { artifact: RunArtifact }) {
         </div>
       )}
       <div className="caption">
-        <span className="mono">#{artifact.step_index}</span>{' '}
-        {artifact.caption ?? '(no caption)'}
+        <span className="step">#{artifact.step_index}</span>
+        <span>{artifact.caption ?? '(no caption)'}</span>
       </div>
     </div>
   );

--- a/tools/test-dashboard/src/pages/RunDetailPage.tsx
+++ b/tools/test-dashboard/src/pages/RunDetailPage.tsx
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import type { RunArtifact, RunDetail } from '../types';
+import { getRun, queueRun } from '../services/api';
+import { useTestRunsChannel } from '../hooks/useAbly';
+import {
+  formatDuration,
+  formatTimestamp,
+  githubFileUrl,
+  githubShaUrl,
+  shortSha,
+} from '../utils/format';
+
+export function RunDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [run, setRun] = useState<RunDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(() => {
+    if (!id) return;
+    getRun(id)
+      .then((r) => {
+        setRun(r);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to load run');
+      });
+  }, [id]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Live updates: refetch when this run changes.
+  useTestRunsChannel(
+    useCallback(
+      (event) => {
+        if (event.run_id === id) refresh();
+      },
+      [id, refresh]
+    )
+  );
+
+  const handleRequeue = useCallback(
+    async (withStartingSnapshot: boolean) => {
+      if (!run) return;
+      setBusy(true);
+      try {
+        const created = await queueRun({
+          scenario: run.scenario,
+          ...(withStartingSnapshot && run.starting_snapshot_id
+            ? { starting_snapshot_id: run.starting_snapshot_id }
+            : {}),
+        });
+        navigate(`/run/${created.id}`);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Failed to queue run');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [run, navigate]
+  );
+
+  if (!id) return <div className="empty">Missing run id.</div>;
+  if (error && !run) return <div className="error-banner">Error: {error}</div>;
+  if (!run) return <div className="loading">Loading run…</div>;
+
+  const screenshots = run.artifacts
+    .filter((a) => a.type === 'screenshot')
+    .sort((a, b) => a.step_index - b.step_index);
+  const consoleLogs = run.artifacts.filter((a) => a.type === 'console');
+  const pageErrors = run.artifacts.filter((a) => a.type === 'page_error');
+  const transcripts = run.artifacts.filter((a) => a.type === 'transcript');
+
+  const failedFileLink = githubFileUrl(
+    run.failed_test_file,
+    run.failed_test_line,
+    run.code_sha
+  );
+
+  const shaUrl = githubShaUrl(run.code_sha);
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h2>
+            <span className={`status-badge status-${run.status}`}>{run.status}</span>{' '}
+            {run.scenario}
+          </h2>
+          <div className="page-subtitle">
+            Started {formatTimestamp(run.started_at)} · Finished{' '}
+            {formatTimestamp(run.finished_at)} · {formatDuration(run.duration_ms)}
+          </div>
+        </div>
+        <Link to="/" className="btn">
+          ← All runs
+        </Link>
+      </div>
+
+      {error && <div className="error-banner">Error: {error}</div>}
+
+      <section className="detail-section">
+        <h3>Summary</h3>
+        <div className="kv">
+          <span className="k">Trigger</span>
+          <span className="v">
+            {run.trigger_source}
+            {run.triggered_by ? ` · ${run.triggered_by}` : ''}
+          </span>
+          <span className="k">Final stage</span>
+          <span className="v">{run.final_stage ?? '—'}</span>
+          <span className="k">Starting snapshot</span>
+          <span className="v">
+            {run.starting_snapshot_id ? (
+              <Link to={`/snapshot/${run.starting_snapshot_id}`}>
+                {run.starting_snapshot?.name ?? run.starting_snapshot_id}
+              </Link>
+            ) : (
+              '—'
+            )}
+          </span>
+          <span className="k">Ending snapshot</span>
+          <span className="v">
+            {run.ending_snapshot_id ? (
+              <Link to={`/snapshot/${run.ending_snapshot_id}`}>
+                {run.ending_snapshot?.name ?? run.ending_snapshot_id}
+              </Link>
+            ) : (
+              '—'
+            )}
+          </span>
+          <span className="k">Code SHA</span>
+          <span className="v">
+            {shaUrl ? (
+              <a href={shaUrl} target="_blank" rel="noreferrer" className="mono">
+                {shortSha(run.code_sha)}
+              </a>
+            ) : (
+              '—'
+            )}
+          </span>
+          {run.notes && (
+            <>
+              <span className="k">Notes</span>
+              <span className="v">{run.notes}</span>
+            </>
+          )}
+        </div>
+
+        <div className="btn-row">
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => handleRequeue(true)}
+            disabled={busy || !run.starting_snapshot_id}
+            title={
+              run.starting_snapshot_id
+                ? 'Re-run with this run’s starting snapshot'
+                : 'No starting snapshot recorded'
+            }
+          >
+            Re-run from this start state
+          </button>
+          <button
+            type="button"
+            className="btn"
+            onClick={() => handleRequeue(false)}
+            disabled={busy}
+          >
+            Re-run with latest code
+          </button>
+          {run.starting_snapshot_id && (
+            <Link
+              to={`/snapshot/${run.starting_snapshot_id}`}
+              className="btn"
+            >
+              Open snapshot
+            </Link>
+          )}
+        </div>
+      </section>
+
+      {(run.error_message ||
+        run.failed_assertion ||
+        run.failed_test_file) && (
+        <section className="detail-section">
+          <h3>Failure</h3>
+          {run.error_message && (
+            <pre className="log-block error">{run.error_message}</pre>
+          )}
+          {run.failed_assertion && (
+            <>
+              <div className="page-subtitle" style={{ marginTop: '0.75rem' }}>
+                Failed assertion
+              </div>
+              <pre className="log-block">{run.failed_assertion}</pre>
+            </>
+          )}
+          {run.failed_test_file && (
+            <div style={{ marginTop: '0.75rem', fontSize: '0.82rem' }}>
+              <span className="k" style={{ color: 'var(--text-muted)' }}>
+                Test file:{' '}
+              </span>
+              {failedFileLink ? (
+                <a
+                  href={failedFileLink}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mono"
+                >
+                  {run.failed_test_file}
+                  {run.failed_test_line ? `:${run.failed_test_line}` : ''}
+                </a>
+              ) : (
+                <span className="mono">
+                  {run.failed_test_file}
+                  {run.failed_test_line ? `:${run.failed_test_line}` : ''}
+                </span>
+              )}
+            </div>
+          )}
+        </section>
+      )}
+
+      <section className="detail-section">
+        <h3>Screenshots ({screenshots.length})</h3>
+        {screenshots.length === 0 ? (
+          <div className="empty" style={{ padding: '1rem' }}>
+            No screenshots.
+          </div>
+        ) : (
+          <div className="screenshot-grid">
+            {screenshots.map((a) => (
+              <ScreenshotCard key={a.id} artifact={a} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {pageErrors.length > 0 && (
+        <section className="detail-section">
+          <h3>Page errors ({pageErrors.length})</h3>
+          {pageErrors.map((a) => (
+            <pre key={a.id} className="log-block error">
+              {a.inline_text ?? a.caption ?? '(empty)'}
+            </pre>
+          ))}
+        </section>
+      )}
+
+      {consoleLogs.length > 0 && (
+        <section className="detail-section">
+          <h3>Console log</h3>
+          {consoleLogs.map((a) => (
+            <pre key={a.id} className="log-block">
+              {a.inline_text ?? '(empty)'}
+            </pre>
+          ))}
+        </section>
+      )}
+
+      {transcripts.length > 0 && (
+        <section className="detail-section">
+          <h3>Transcript</h3>
+          {transcripts.map((a) => (
+            <pre key={a.id} className="transcript">
+              {a.inline_text ?? '(transcript stored externally)'}
+            </pre>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function ScreenshotCard({ artifact }: { artifact: RunArtifact }) {
+  return (
+    <div className="screenshot-card">
+      {artifact.blob_url ? (
+        <a href={artifact.blob_url} target="_blank" rel="noreferrer">
+          <img src={artifact.blob_url} alt={artifact.caption ?? 'screenshot'} />
+        </a>
+      ) : (
+        <div
+          style={{
+            padding: '2rem',
+            textAlign: 'center',
+            color: 'var(--text-muted)',
+          }}
+        >
+          (no blob_url)
+        </div>
+      )}
+      <div className="caption">
+        <span className="mono">#{artifact.step_index}</span>{' '}
+        {artifact.caption ?? '(no caption)'}
+      </div>
+    </div>
+  );
+}

--- a/tools/test-dashboard/src/pages/RunDetailPage.tsx
+++ b/tools/test-dashboard/src/pages/RunDetailPage.tsx
@@ -4,6 +4,10 @@ import type { RunArtifact, RunDetail } from '../types';
 import { getRun, queueRun } from '../services/api';
 import { useTestRunsChannel } from '../hooks/useAbly';
 import {
+  QUEUEING_DISABLED_MESSAGE,
+  WEB_QUEUEING_ENABLED,
+} from '../services/featureFlags';
+import {
   formatDuration,
   formatTimestamp,
   githubFileUrl,
@@ -157,9 +161,15 @@ export function RunDetailPage() {
             type="button"
             className="btn btn-primary"
             onClick={() => handleRequeue(true)}
-            disabled={busy || !run.starting_snapshot_id}
+            disabled={
+              busy ||
+              !run.starting_snapshot_id ||
+              !WEB_QUEUEING_ENABLED
+            }
             title={
-              run.starting_snapshot_id
+              !WEB_QUEUEING_ENABLED
+                ? QUEUEING_DISABLED_MESSAGE
+                : run.starting_snapshot_id
                 ? 'Re-run with this run’s starting snapshot'
                 : 'No starting snapshot recorded'
             }
@@ -170,7 +180,10 @@ export function RunDetailPage() {
             type="button"
             className="btn"
             onClick={() => handleRequeue(false)}
-            disabled={busy}
+            disabled={busy || !WEB_QUEUEING_ENABLED}
+            title={
+              WEB_QUEUEING_ENABLED ? undefined : QUEUEING_DISABLED_MESSAGE
+            }
           >
             Re-run with latest code
           </button>
@@ -183,6 +196,11 @@ export function RunDetailPage() {
             </Link>
           )}
         </div>
+        {!WEB_QUEUEING_ENABLED && (
+          <div className="hint" style={{ marginTop: '0.5rem' }}>
+            {QUEUEING_DISABLED_MESSAGE}
+          </div>
+        )}
       </section>
 
       {(run.error_message ||

--- a/tools/test-dashboard/src/pages/RunsFeedPage.tsx
+++ b/tools/test-dashboard/src/pages/RunsFeedPage.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { TestRun } from '../types';
+import { listRuns } from '../services/api';
+import { useTestRunsChannel } from '../hooks/useAbly';
+import {
+  formatDuration,
+  formatRelative,
+  githubShaUrl,
+  shortSha,
+} from '../utils/format';
+
+export function RunsFeedPage() {
+  const [runs, setRuns] = useState<TestRun[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    listRuns()
+      .then((r) => {
+        // Sort newest first defensively.
+        const sorted = [...r].sort((a, b) =>
+          b.created_at.localeCompare(a.created_at)
+        );
+        setRuns(sorted);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to load runs');
+      });
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Live updates: refetch on any test-runs event.
+  useTestRunsChannel(useCallback(() => refresh(), [refresh]));
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h2>Test Runs</h2>
+          <div className="page-subtitle">Newest first. Click for details.</div>
+        </div>
+        <Link to="/new-run" className="btn btn-primary">
+          + New Run
+        </Link>
+      </div>
+
+      {error && <div className="error-banner">Error: {error}</div>}
+
+      {runs === null && <div className="loading">Loading runs…</div>}
+
+      {runs && runs.length === 0 && (
+        <div className="empty">
+          <p>No runs yet.</p>
+          <p>
+            <Link to="/new-run">Trigger one from /new-run</Link>.
+          </p>
+        </div>
+      )}
+
+      {runs && runs.length > 0 && (
+        <div className="card-list">
+          {runs.map((run) => (
+            <RunCard key={run.id} run={run} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RunCard({ run }: { run: TestRun }) {
+  const shaUrl = githubShaUrl(run.code_sha);
+  return (
+    <Link to={`/run/${run.id}`} className="run-card">
+      <div className="run-card-header">
+        <span className={`status-badge status-${run.status}`}>{run.status}</span>
+        <span className="scenario">{run.scenario}</span>
+        <span className="trigger-badge">{run.trigger_source}</span>
+      </div>
+      <div className="run-card-meta">
+        <span>
+          <span className="label">started</span>
+          {formatRelative(run.started_at)}
+        </span>
+        <span>
+          <span className="label">duration</span>
+          {formatDuration(run.duration_ms)}
+        </span>
+        <span>
+          <span className="label">stage</span>
+          {run.final_stage ?? '—'}
+        </span>
+        <span>
+          <span className="label">snapshots</span>
+          <span className="mono">
+            {run.starting_snapshot_id ?? '—'} → {run.ending_snapshot_id ?? '—'}
+          </span>
+        </span>
+        <span>
+          <span className="label">sha</span>
+          {shaUrl ? (
+            <a
+              href={shaUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="mono"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {shortSha(run.code_sha)}
+            </a>
+          ) : (
+            <span className="mono">—</span>
+          )}
+        </span>
+        {run.triggered_by && (
+          <span>
+            <span className="label">by</span>
+            {run.triggered_by}
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/tools/test-dashboard/src/pages/RunsFeedPage.tsx
+++ b/tools/test-dashboard/src/pages/RunsFeedPage.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import type { TestRun } from '../types';
+import type { RunStatus, TestRun } from '../types';
 import { listRuns } from '../services/api';
 import { useTestRunsChannel } from '../hooks/useAbly';
 import {
@@ -10,14 +10,27 @@ import {
   shortSha,
 } from '../utils/format';
 
+type StatusFilter = 'all' | RunStatus;
+
+const STATUS_FILTERS: StatusFilter[] = [
+  'all',
+  'running',
+  'queued',
+  'pass',
+  'fail',
+  'error',
+  'cancelled',
+];
+
 export function RunsFeedPage() {
   const [runs, setRuns] = useState<TestRun[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [search, setSearch] = useState('');
 
   const refresh = useCallback(() => {
     listRuns()
       .then((r) => {
-        // Sort newest first defensively.
         const sorted = [...r].sort((a, b) =>
           b.created_at.localeCompare(a.created_at)
         );
@@ -36,12 +49,41 @@ export function RunsFeedPage() {
   // Live updates: refetch on any test-runs event.
   useTestRunsChannel(useCallback(() => refresh(), [refresh]));
 
+  const counts = useMemo(() => {
+    const c: Record<StatusFilter, number> = {
+      all: 0,
+      running: 0,
+      queued: 0,
+      pass: 0,
+      fail: 0,
+      error: 0,
+      cancelled: 0,
+    };
+    if (!runs) return c;
+    c.all = runs.length;
+    for (const r of runs) c[r.status]++;
+    return c;
+  }, [runs]);
+
+  const visibleRuns = useMemo(() => {
+    if (!runs) return null;
+    const term = search.trim().toLowerCase();
+    return runs.filter((r) => {
+      if (statusFilter !== 'all' && r.status !== statusFilter) return false;
+      if (term && !r.scenario.toLowerCase().includes(term)) return false;
+      return true;
+    });
+  }, [runs, statusFilter, search]);
+
   return (
     <div>
       <div className="page-header">
         <div>
           <h2>Test Runs</h2>
-          <div className="page-subtitle">Newest first. Click for details.</div>
+          <div className="page-subtitle">
+            {runs ? `${runs.length} run${runs.length === 1 ? '' : 's'}` : 'Loading…'}
+            {' · newest first · live'}
+          </div>
         </div>
         <Link to="/new-run" className="btn btn-primary">
           + New Run
@@ -50,20 +92,68 @@ export function RunsFeedPage() {
 
       {error && <div className="error-banner">Error: {error}</div>}
 
-      {runs === null && <div className="loading">Loading runs…</div>}
+      <div className="filter-bar" role="toolbar" aria-label="Filter runs">
+        <span className="filter-label">Status</span>
+        <div className="filter-pills">
+          {STATUS_FILTERS.map((s) => {
+            const isActive = statusFilter === s;
+            return (
+              <button
+                key={s}
+                type="button"
+                className={`filter-pill${isActive ? ' active' : ''}`}
+                aria-pressed={isActive}
+                onClick={() => setStatusFilter(s)}
+              >
+                <span>{s}</span>
+                <span className="count">{counts[s]}</span>
+              </button>
+            );
+          })}
+        </div>
+        <div className="filter-search">
+          <label htmlFor="run-search" className="visually-hidden">
+            Search scenarios
+          </label>
+          <input
+            id="run-search"
+            type="search"
+            placeholder="Filter by scenario name…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </div>
+      </div>
 
-      {runs && runs.length === 0 && (
-        <div className="empty">
-          <p>No runs yet.</p>
-          <p>
-            <Link to="/new-run">Trigger one from /new-run</Link>.
-          </p>
+      {runs === null && (
+        <div className="card-list" aria-hidden="true">
+          <div className="skeleton skeleton-card" />
+          <div className="skeleton skeleton-card" />
+          <div className="skeleton skeleton-card" />
         </div>
       )}
 
-      {runs && runs.length > 0 && (
+      {runs && visibleRuns && visibleRuns.length === 0 && (
+        <div className="empty">
+          {runs.length === 0 ? (
+            <>
+              <p>No runs yet.</p>
+              <p>
+                <Link to="/new-run">Trigger one</Link> or run the EC2 writer
+                script.
+              </p>
+            </>
+          ) : (
+            <p>No runs match the current filter.</p>
+          )}
+        </div>
+      )}
+
+      {visibleRuns && visibleRuns.length > 0 && (
         <div className="card-list">
-          {runs.map((run) => (
+          {visibleRuns.map((run) => (
             <RunCard key={run.id} run={run} />
           ))}
         </div>
@@ -75,52 +165,58 @@ export function RunsFeedPage() {
 function RunCard({ run }: { run: TestRun }) {
   const shaUrl = githubShaUrl(run.code_sha);
   return (
-    <Link to={`/run/${run.id}`} className="run-card">
+    <Link
+      to={`/run/${run.id}`}
+      className="run-card"
+      data-status={run.status}
+      aria-label={`${run.scenario} — ${run.status}`}
+    >
       <div className="run-card-header">
         <span className={`status-badge status-${run.status}`}>{run.status}</span>
         <span className="scenario">{run.scenario}</span>
         <span className="trigger-badge">{run.trigger_source}</span>
       </div>
       <div className="run-card-meta">
-        <span>
-          <span className="label">started</span>
-          {formatRelative(run.started_at)}
-        </span>
-        <span>
-          <span className="label">duration</span>
-          {formatDuration(run.duration_ms)}
-        </span>
-        <span>
-          <span className="label">stage</span>
-          {run.final_stage ?? '—'}
-        </span>
-        <span>
-          <span className="label">snapshots</span>
-          <span className="mono">
+        <div className="field">
+          <span className="label">Started</span>
+          <span className="value">{formatRelative(run.started_at)}</span>
+        </div>
+        <div className="field">
+          <span className="label">Duration</span>
+          <span className="value">{formatDuration(run.duration_ms)}</span>
+        </div>
+        <div className="field">
+          <span className="label">Stage</span>
+          <span className="value">{run.final_stage ?? '—'}</span>
+        </div>
+        <div className="field">
+          <span className="label">Snapshots</span>
+          <span className="value">
             {run.starting_snapshot_id ?? '—'} → {run.ending_snapshot_id ?? '—'}
           </span>
-        </span>
-        <span>
-          <span className="label">sha</span>
-          {shaUrl ? (
-            <a
-              href={shaUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="mono"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {shortSha(run.code_sha)}
-            </a>
-          ) : (
-            <span className="mono">—</span>
-          )}
-        </span>
-        {run.triggered_by && (
-          <span>
-            <span className="label">by</span>
-            {run.triggered_by}
+        </div>
+        <div className="field">
+          <span className="label">SHA</span>
+          <span className="value">
+            {shaUrl ? (
+              <a
+                href={shaUrl}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {shortSha(run.code_sha)}
+              </a>
+            ) : (
+              '—'
+            )}
           </span>
+        </div>
+        {run.triggered_by && (
+          <div className="field">
+            <span className="label">By</span>
+            <span className="value">{run.triggered_by}</span>
+          </div>
         )}
       </div>
     </Link>

--- a/tools/test-dashboard/src/pages/SnapshotDetailPage.tsx
+++ b/tools/test-dashboard/src/pages/SnapshotDetailPage.tsx
@@ -3,6 +3,10 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import type { Snapshot, TestRun } from '../types';
 import { getSnapshot, queueRun } from '../services/api';
 import {
+  QUEUEING_DISABLED_MESSAGE,
+  WEB_QUEUEING_ENABLED,
+} from '../services/featureFlags';
+import {
   formatDuration,
   formatRelative,
   shortSha,
@@ -143,11 +147,19 @@ export function SnapshotDetailPage() {
             <button
               type="submit"
               className="btn btn-primary"
-              disabled={busy || !scenario}
+              disabled={busy || !scenario || !WEB_QUEUEING_ENABLED}
+              title={
+                WEB_QUEUEING_ENABLED ? undefined : QUEUEING_DISABLED_MESSAGE
+              }
             >
               {busy ? 'Queueing…' : 'Queue run'}
             </button>
           </div>
+          {!WEB_QUEUEING_ENABLED && (
+            <div className="hint" style={{ marginTop: '0.5rem' }}>
+              {QUEUEING_DISABLED_MESSAGE}
+            </div>
+          )}
         </form>
       </section>
 

--- a/tools/test-dashboard/src/pages/SnapshotDetailPage.tsx
+++ b/tools/test-dashboard/src/pages/SnapshotDetailPage.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import type { Snapshot, TestRun } from '../types';
+import { getSnapshot, queueRun } from '../services/api';
+import {
+  formatDuration,
+  formatRelative,
+  shortSha,
+} from '../utils/format';
+
+// Hardcoded list of e2e specs (kept short — full list lives in e2e/tests/).
+// In Phase 1B the API can return the canonical list.
+const SCENARIOS = [
+  'single-user-journey',
+  'partner-journey',
+  'two-browser-smoke',
+  'two-browser-stage-0',
+  'two-browser-stage-1',
+  'two-browser-stage-2',
+  'two-browser-stage-3',
+  'two-browser-stage-4',
+  'two-browser-full-flow',
+  'two-browser-circuit-breaker',
+  'two-browser-reconciler-offer-optional',
+  'two-browser-reconciler-offer-sharing-refinement',
+  'stage-3-4-complete',
+  'live-ai-full-flow',
+];
+
+export function SnapshotDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [data, setData] = useState<{
+    snapshot: Snapshot;
+    runs: TestRun[];
+    parent: Snapshot | null;
+    children: Snapshot[];
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [scenario, setScenario] = useState<string>(SCENARIOS[0] ?? '');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    getSnapshot(id)
+      .then((d) => {
+        setData(d);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to load snapshot');
+      });
+  }, [id]);
+
+  const handleRun = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!id || !scenario) return;
+      setBusy(true);
+      try {
+        const created = await queueRun({
+          scenario,
+          starting_snapshot_id: id,
+        });
+        navigate(`/run/${created.id}`);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Failed to queue run');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [id, scenario, navigate]
+  );
+
+  if (!id) return <div className="empty">Missing snapshot id.</div>;
+  if (error && !data) return <div className="error-banner">Error: {error}</div>;
+  if (!data) return <div className="loading">Loading snapshot…</div>;
+
+  const { snapshot, runs, parent, children } = data;
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h2>{snapshot.name}</h2>
+          {snapshot.description && (
+            <div className="page-subtitle">{snapshot.description}</div>
+          )}
+        </div>
+        <Link to="/snapshots" className="btn">
+          ← Tree
+        </Link>
+      </div>
+
+      {error && <div className="error-banner">Error: {error}</div>}
+
+      <section className="detail-section">
+        <h3>Metadata</h3>
+        <div className="kv">
+          <span className="k">ID</span>
+          <span className="v mono">{snapshot.id}</span>
+          <span className="k">File path</span>
+          <span className="v mono">{snapshot.file_path}</span>
+          <span className="k">Parent</span>
+          <span className="v">
+            {parent ? (
+              <Link to={`/snapshot/${parent.id}`}>{parent.name}</Link>
+            ) : (
+              '(root)'
+            )}
+          </span>
+          <span className="k">Created</span>
+          <span className="v">{formatRelative(snapshot.created_at)}</span>
+        </div>
+
+        {snapshot.db_state_summary !== null &&
+          snapshot.db_state_summary !== undefined && (
+            <details className="json-block" style={{ marginTop: '0.75rem' }}>
+              <summary>DB state summary</summary>
+              <pre>{JSON.stringify(snapshot.db_state_summary, null, 2)}</pre>
+            </details>
+          )}
+      </section>
+
+      <section className="detail-section">
+        <h3>Run scenario from here</h3>
+        <form onSubmit={handleRun} className="form">
+          <div className="form-field">
+            <label htmlFor="scenario-select">Scenario</label>
+            <select
+              id="scenario-select"
+              value={scenario}
+              onChange={(e) => setScenario(e.target.value)}
+            >
+              {SCENARIOS.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={busy || !scenario}
+            >
+              {busy ? 'Queueing…' : 'Queue run'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="detail-section">
+        <h3>Child snapshots ({children.length})</h3>
+        {children.length === 0 ? (
+          <div className="empty" style={{ padding: '1rem' }}>
+            No children yet.
+          </div>
+        ) : (
+          <ul className="snapshot-tree">
+            {children.map((c) => (
+              <li key={c.id}>
+                <Link to={`/snapshot/${c.id}`} className="snapshot-link">
+                  <span className="mono">{c.name}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="detail-section">
+        <h3>Runs that started here ({runs.length})</h3>
+        {runs.length === 0 ? (
+          <div className="empty" style={{ padding: '1rem' }}>
+            No runs yet.
+          </div>
+        ) : (
+          <div className="card-list">
+            {runs.map((run) => (
+              <Link key={run.id} to={`/run/${run.id}`} className="run-card">
+                <div className="run-card-header">
+                  <span className={`status-badge status-${run.status}`}>
+                    {run.status}
+                  </span>
+                  <span className="scenario">{run.scenario}</span>
+                </div>
+                <div className="run-card-meta">
+                  <span>{formatRelative(run.started_at)}</span>
+                  <span>{formatDuration(run.duration_ms)}</span>
+                  <span className="mono">{shortSha(run.code_sha)}</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/tools/test-dashboard/src/pages/SnapshotDetailPage.tsx
+++ b/tools/test-dashboard/src/pages/SnapshotDetailPage.tsx
@@ -86,7 +86,11 @@ export function SnapshotDetailPage() {
     <div>
       <div className="page-header">
         <div>
-          <h2>{snapshot.name}</h2>
+          <h2>
+            <span className="mono" style={{ fontWeight: 600 }}>
+              {snapshot.name}
+            </span>
+          </h2>
           {snapshot.description && (
             <div className="page-subtitle">{snapshot.description}</div>
           )}
@@ -164,7 +168,9 @@ export function SnapshotDetailPage() {
       </section>
 
       <section className="detail-section">
-        <h3>Child snapshots ({children.length})</h3>
+        <h3>
+          Child snapshots <span className="count">{children.length}</span>
+        </h3>
         {children.length === 0 ? (
           <div className="empty" style={{ padding: '1rem' }}>
             No children yet.
@@ -183,7 +189,9 @@ export function SnapshotDetailPage() {
       </section>
 
       <section className="detail-section">
-        <h3>Runs that started here ({runs.length})</h3>
+        <h3>
+          Runs that started here <span className="count">{runs.length}</span>
+        </h3>
         {runs.length === 0 ? (
           <div className="empty" style={{ padding: '1rem' }}>
             No runs yet.
@@ -191,7 +199,12 @@ export function SnapshotDetailPage() {
         ) : (
           <div className="card-list">
             {runs.map((run) => (
-              <Link key={run.id} to={`/run/${run.id}`} className="run-card">
+              <Link
+                key={run.id}
+                to={`/run/${run.id}`}
+                className="run-card"
+                data-status={run.status}
+              >
                 <div className="run-card-header">
                   <span className={`status-badge status-${run.status}`}>
                     {run.status}
@@ -199,9 +212,18 @@ export function SnapshotDetailPage() {
                   <span className="scenario">{run.scenario}</span>
                 </div>
                 <div className="run-card-meta">
-                  <span>{formatRelative(run.started_at)}</span>
-                  <span>{formatDuration(run.duration_ms)}</span>
-                  <span className="mono">{shortSha(run.code_sha)}</span>
+                  <div className="field">
+                    <span className="label">Started</span>
+                    <span className="value">{formatRelative(run.started_at)}</span>
+                  </div>
+                  <div className="field">
+                    <span className="label">Duration</span>
+                    <span className="value">{formatDuration(run.duration_ms)}</span>
+                  </div>
+                  <div className="field">
+                    <span className="label">SHA</span>
+                    <span className="value">{shortSha(run.code_sha)}</span>
+                  </div>
                 </div>
               </Link>
             ))}

--- a/tools/test-dashboard/src/pages/SnapshotsTreePage.tsx
+++ b/tools/test-dashboard/src/pages/SnapshotsTreePage.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { SnapshotNode } from '../types';
+import { listSnapshots } from '../services/api';
+
+export function SnapshotsTreePage() {
+  const [tree, setTree] = useState<SnapshotNode[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listSnapshots()
+      .then((t) => {
+        setTree(t);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to load snapshots');
+      });
+  }, []);
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <h2>Snapshots</h2>
+          <div className="page-subtitle">Branching tree of saved DB states.</div>
+        </div>
+      </div>
+
+      {error && <div className="error-banner">Error: {error}</div>}
+      {tree === null && <div className="loading">Loading snapshots…</div>}
+
+      {tree && tree.length === 0 && (
+        <div className="empty">No snapshots yet.</div>
+      )}
+
+      {tree && tree.length > 0 && (
+        <ul className="snapshot-tree">
+          {tree.map((node) => (
+            <TreeNode key={node.id} node={node} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function TreeNode({ node }: { node: SnapshotNode }) {
+  return (
+    <li>
+      <Link to={`/snapshot/${node.id}`} className="snapshot-link">
+        <span className="mono">{node.name}</span>
+        <span className="run-count">({node.run_count} runs)</span>
+      </Link>
+      {node.children.length > 0 && (
+        <ul>
+          {node.children.map((child) => (
+            <TreeNode key={child.id} node={child} />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/tools/test-dashboard/src/services/api.ts
+++ b/tools/test-dashboard/src/services/api.ts
@@ -1,0 +1,133 @@
+// Fetch helpers for the test dashboard API.
+// In dev (and when VITE_USE_REAL_API is not set), failures fall back to mock data
+// so the UI remains browsable without the API running.
+
+import type {
+  TestRun,
+  RunDetail,
+  Snapshot,
+  SnapshotNode,
+} from '../types';
+import {
+  MOCK_RUNS,
+  MOCK_SNAPSHOTS,
+  buildMockRunDetail,
+  buildMockSnapshotTree,
+  buildMockSnapshotDetail,
+} from './mock';
+
+const SHOULD_FALLBACK =
+  import.meta.env.DEV && !import.meta.env.VITE_USE_REAL_API;
+
+async function getJSON<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(`${url} → ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function postJSON<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`${url} → ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+function withFallback<T>(
+  fetcher: () => Promise<T>,
+  fallback: () => T | null,
+  label: string
+): Promise<T> {
+  return fetcher().catch((err: unknown) => {
+    if (!SHOULD_FALLBACK) throw err;
+    const mock = fallback();
+    if (mock === null) {
+      throw err;
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[api] ${label} failed, falling back to mock data:`,
+      err instanceof Error ? err.message : err
+    );
+    return mock;
+  });
+}
+
+export function listRuns(): Promise<TestRun[]> {
+  return withFallback<TestRun[]>(
+    () => getJSON<TestRun[]>('/api/runs'),
+    () => MOCK_RUNS,
+    'listRuns'
+  );
+}
+
+export function getRun(id: string): Promise<RunDetail> {
+  return withFallback<RunDetail>(
+    () => getJSON<RunDetail>(`/api/runs/${encodeURIComponent(id)}`),
+    () => buildMockRunDetail(id),
+    `getRun(${id})`
+  );
+}
+
+export function listSnapshots(): Promise<SnapshotNode[]> {
+  return withFallback<SnapshotNode[]>(
+    () => getJSON<SnapshotNode[]>('/api/snapshots'),
+    () => buildMockSnapshotTree(),
+    'listSnapshots'
+  );
+}
+
+export interface SnapshotDetailResponse {
+  snapshot: Snapshot;
+  runs: TestRun[];
+  parent: Snapshot | null;
+  children: Snapshot[];
+}
+
+export function getSnapshot(id: string): Promise<SnapshotDetailResponse> {
+  return withFallback<SnapshotDetailResponse>(
+    () => getJSON<SnapshotDetailResponse>(`/api/snapshots/${encodeURIComponent(id)}`),
+    () => buildMockSnapshotDetail(id),
+    `getSnapshot(${id})`
+  );
+}
+
+export interface QueueRunPayload {
+  scenario: string;
+  starting_snapshot_id?: string;
+  notes?: string;
+}
+
+export function queueRun(payload: QueueRunPayload): Promise<TestRun> {
+  // No mock fallback for POST — we want errors to surface so the user knows the
+  // backend isn't wired yet.
+  return postJSON<TestRun>('/api/runs', payload);
+}
+
+/**
+ * Returns the flat list of snapshots from the server (helper for forms that
+ * need a select list rather than the full tree).
+ */
+export async function listSnapshotsFlat(): Promise<Snapshot[]> {
+  const tree = await listSnapshots();
+  const out: Snapshot[] = [];
+  const visit = (node: SnapshotNode) => {
+    const { children: _children, run_count: _run_count, ...snapshot } = node;
+    out.push(snapshot);
+    node.children.forEach(visit);
+  };
+  tree.forEach(visit);
+  if (out.length === 0 && SHOULD_FALLBACK) return MOCK_SNAPSHOTS;
+  return out;
+}

--- a/tools/test-dashboard/src/services/api.ts
+++ b/tools/test-dashboard/src/services/api.ts
@@ -80,9 +80,31 @@ export function getRun(id: string): Promise<RunDetail> {
   );
 }
 
+type FlatSnapshotRow = Snapshot & { run_count: number };
+
+function assembleSnapshotTree(rows: FlatSnapshotRow[]): SnapshotNode[] {
+  const byId = new Map<string, SnapshotNode>();
+  for (const row of rows) {
+    byId.set(row.id, { ...row, children: [] });
+  }
+  const roots: SnapshotNode[] = [];
+  for (const node of byId.values()) {
+    const parent = node.parent_id ? byId.get(node.parent_id) : undefined;
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  return roots;
+}
+
 export function listSnapshots(): Promise<SnapshotNode[]> {
   return withFallback<SnapshotNode[]>(
-    () => getJSON<SnapshotNode[]>('/api/snapshots'),
+    async () => {
+      const rows = await getJSON<FlatSnapshotRow[]>('/api/snapshots');
+      return assembleSnapshotTree(rows);
+    },
     () => buildMockSnapshotTree(),
     'listSnapshots'
   );

--- a/tools/test-dashboard/src/services/featureFlags.ts
+++ b/tools/test-dashboard/src/services/featureFlags.ts
@@ -1,0 +1,11 @@
+// Phase 1A: web queueing is intentionally bot-only — POST /api/runs requires
+// the BOT_WRITER_TOKEN, which the SPA does not have. Enabling this flag without
+// also wiring user auth on the API would just produce 401s.
+//
+// Flip to true (via VITE_WEB_QUEUEING_ENABLED=true) once Phase 1B lands Clerk
+// auth on the queue endpoint.
+export const WEB_QUEUEING_ENABLED =
+  import.meta.env.VITE_WEB_QUEUEING_ENABLED === 'true';
+
+export const QUEUEING_DISABLED_MESSAGE =
+  'Phase 1A: web-trigger is staged. The API rejects unauthenticated POSTs until Phase 1B wires user auth — for now queue runs via the EC2 writer script (scripts/ec2-bot/scripts/write-test-result.ts).';

--- a/tools/test-dashboard/src/services/mock.ts
+++ b/tools/test-dashboard/src/services/mock.ts
@@ -1,0 +1,385 @@
+// Mock data fallback. Used in dev when the API is unreachable.
+// Snapshot names match the actual files in backend/snapshots/.
+
+import type {
+  TestRun,
+  Snapshot,
+  RunArtifact,
+  RunDetail,
+  SnapshotNode,
+} from '../types';
+
+const NOW = Date.parse('2026-04-26T12:00:00Z');
+const minutesAgo = (m: number) => new Date(NOW - m * 60_000).toISOString();
+
+export const MOCK_SNAPSHOTS: Snapshot[] = [
+  {
+    id: 'snap-01',
+    name: 'snapshot-01-after-seed',
+    description: 'Fresh DB after seed; no users invited.',
+    parent_id: null,
+    file_path: 'backend/snapshots/snapshot-01-after-seed--2026-03-01T18-34-41.sql',
+    db_state_summary: { sessions: 0, users: 2 },
+    created_by_run_id: null,
+    created_at: '2026-03-01T18:34:41Z',
+  },
+  {
+    id: 'snap-02',
+    name: 'snapshot-02-alice-invitation-sent',
+    description: 'Alice has invited Bob.',
+    parent_id: 'snap-01',
+    file_path: 'backend/snapshots/snapshot-02-alice-invitation-sent--2026-03-01T18-43-36.sql',
+    db_state_summary: { sessions: 1, users: 2, invitations: 1 },
+    created_by_run_id: null,
+    created_at: '2026-03-01T18:43:36Z',
+  },
+  {
+    id: 'snap-03',
+    name: 'snapshot-03-invitation-accepted',
+    description: 'Bob accepted invitation.',
+    parent_id: 'snap-02',
+    file_path: 'backend/snapshots/snapshot-03-invitation-accepted--2026-03-01T18-43-57.sql',
+    db_state_summary: { sessions: 1, stage: 0 },
+    created_by_run_id: null,
+    created_at: '2026-03-01T18:43:57Z',
+  },
+  {
+    id: 'snap-04',
+    name: 'snapshot-04-bob-stage1-complete',
+    description: 'Bob completed stage 1.',
+    parent_id: 'snap-03',
+    file_path: 'backend/snapshots/snapshot-04-bob-stage1-complete--2026-03-01T18-48-57.sql',
+    db_state_summary: { stage: 1 },
+    created_by_run_id: null,
+    created_at: '2026-03-01T18:48:57Z',
+  },
+  {
+    id: 'snap-05',
+    name: 'snapshot-05-empathy-shared',
+    description: 'Empathy shared.',
+    parent_id: 'snap-04',
+    file_path: 'backend/snapshots/snapshot-05-empathy-shared--2026-03-01T18-51-26.sql',
+    db_state_summary: { stage: 2 },
+    created_by_run_id: null,
+    created_at: '2026-03-01T18:51:26Z',
+  },
+  {
+    id: 'snap-06',
+    name: 'snapshot-06-context-exchanged',
+    description: 'Context exchanged between partners.',
+    parent_id: 'snap-05',
+    file_path: 'backend/snapshots/snapshot-06-context-exchanged--2026-03-01T18-53-12.sql',
+    db_state_summary: { stage: 2 },
+    created_by_run_id: null,
+    created_at: '2026-03-01T18:53:12Z',
+  },
+  {
+    id: 'snap-07',
+    name: 'snapshot-07-empathy-validated',
+    description: 'Empathy validated.',
+    parent_id: 'snap-06',
+    file_path: 'backend/snapshots/snapshot-07-empathy-validated--2026-03-01T18-58-55.sql',
+    db_state_summary: { stage: 2 },
+    created_by_run_id: null,
+    created_at: '2026-03-01T18:58:55Z',
+  },
+  {
+    id: 'snap-08',
+    name: 'snapshot-08-stage3-complete',
+    description: 'Stage 3 complete.',
+    parent_id: 'snap-07',
+    file_path: 'backend/snapshots/snapshot-08-stage3-complete--2026-03-01T19-05-48.sql',
+    db_state_summary: { stage: 3 },
+    created_by_run_id: null,
+    created_at: '2026-03-01T19:05:48Z',
+  },
+  {
+    id: 'snap-09',
+    name: 'snapshot-09-session-resolved',
+    description: 'Session resolved at stage 4.',
+    parent_id: 'snap-08',
+    file_path: 'backend/snapshots/snapshot-09-session-resolved--2026-03-01T19-21-46.sql',
+    db_state_summary: { stage: 4 },
+    created_by_run_id: null,
+    created_at: '2026-03-01T19:21:46Z',
+  },
+];
+
+export const MOCK_RUNS: TestRun[] = [
+  {
+    id: 'run-001',
+    scenario: 'two-browser-full-flow',
+    status: 'pass',
+    started_at: minutesAgo(10),
+    finished_at: minutesAgo(5),
+    duration_ms: 5 * 60_000,
+    final_stage: 4,
+    starting_snapshot_id: 'snap-01',
+    ending_snapshot_id: 'snap-09',
+    code_sha: 'c7ee67b1234567',
+    trigger_source: 'cron',
+    triggered_by: 'daily-smoke',
+    error_message: null,
+    failed_assertion: null,
+    failed_test_file: null,
+    failed_test_line: null,
+    notes: null,
+    created_at: minutesAgo(10),
+  },
+  {
+    id: 'run-002',
+    scenario: 'two-browser-stage-3',
+    status: 'fail',
+    started_at: minutesAgo(45),
+    finished_at: minutesAgo(40),
+    duration_ms: 5 * 60_000,
+    final_stage: 3,
+    starting_snapshot_id: 'snap-07',
+    ending_snapshot_id: null,
+    code_sha: '2c0382e1234567',
+    trigger_source: 'slack',
+    triggered_by: 'jason@galuten.com',
+    error_message: 'Expected stage transition message but found nothing',
+    failed_assertion: "expect(page.locator('.transition-message')).toBeVisible()",
+    failed_test_file: 'e2e/tests/two-browser-stage-3.spec.ts',
+    failed_test_line: 142,
+    notes: null,
+    created_at: minutesAgo(45),
+  },
+  {
+    id: 'run-003',
+    scenario: 'single-user-journey',
+    status: 'running',
+    started_at: minutesAgo(2),
+    finished_at: null,
+    duration_ms: null,
+    final_stage: 1,
+    starting_snapshot_id: 'snap-01',
+    ending_snapshot_id: null,
+    code_sha: 'c7ee67b1234567',
+    trigger_source: 'web',
+    triggered_by: 'jason@galuten.com',
+    error_message: null,
+    failed_assertion: null,
+    failed_test_file: null,
+    failed_test_line: null,
+    notes: 'Smoke after waiting-status copy fix',
+    created_at: minutesAgo(2),
+  },
+  {
+    id: 'run-004',
+    scenario: 'two-browser-reconciler-offer-optional',
+    status: 'queued',
+    started_at: minutesAgo(1),
+    finished_at: null,
+    duration_ms: null,
+    final_stage: null,
+    starting_snapshot_id: 'snap-06',
+    ending_snapshot_id: null,
+    code_sha: null,
+    trigger_source: 'web',
+    triggered_by: 'jason@galuten.com',
+    error_message: null,
+    failed_assertion: null,
+    failed_test_file: null,
+    failed_test_line: null,
+    notes: null,
+    created_at: minutesAgo(1),
+  },
+  {
+    id: 'run-005',
+    scenario: 'two-browser-circuit-breaker',
+    status: 'error',
+    started_at: minutesAgo(180),
+    finished_at: minutesAgo(178),
+    duration_ms: 2 * 60_000,
+    final_stage: null,
+    starting_snapshot_id: 'snap-04',
+    ending_snapshot_id: null,
+    code_sha: '8507b6c1234567',
+    trigger_source: 'manual',
+    triggered_by: 'shantam@example.com',
+    error_message: 'browser launch timed out after 30s',
+    failed_assertion: null,
+    failed_test_file: null,
+    failed_test_line: null,
+    notes: null,
+    created_at: minutesAgo(180),
+  },
+  {
+    id: 'run-006',
+    scenario: 'partner-journey',
+    status: 'cancelled',
+    started_at: minutesAgo(360),
+    finished_at: minutesAgo(359),
+    duration_ms: 60_000,
+    final_stage: 0,
+    starting_snapshot_id: 'snap-01',
+    ending_snapshot_id: null,
+    code_sha: '250d0d71234567',
+    trigger_source: 'cron',
+    triggered_by: null,
+    error_message: 'cancelled by superseding run',
+    failed_assertion: null,
+    failed_test_file: null,
+    failed_test_line: null,
+    notes: null,
+    created_at: minutesAgo(360),
+  },
+];
+
+export const MOCK_ARTIFACTS_BY_RUN: Record<string, RunArtifact[]> = {
+  'run-001': [
+    {
+      id: 'a-001-1',
+      run_id: 'run-001',
+      type: 'screenshot',
+      blob_url: 'https://placehold.co/640x400/0a0e1a/4ade80?text=Step+1+%E2%80%94+Invitation',
+      inline_text: null,
+      caption: 'Step 1 — Alice sends invitation',
+      step_index: 1,
+      created_at: minutesAgo(9),
+    },
+    {
+      id: 'a-001-2',
+      run_id: 'run-001',
+      type: 'screenshot',
+      blob_url: 'https://placehold.co/640x400/0a0e1a/4ade80?text=Step+2+%E2%80%94+Stage+1',
+      inline_text: null,
+      caption: 'Step 2 — Stage 1 complete',
+      step_index: 2,
+      created_at: minutesAgo(8),
+    },
+    {
+      id: 'a-001-3',
+      run_id: 'run-001',
+      type: 'screenshot',
+      blob_url: 'https://placehold.co/640x400/0a0e1a/4ade80?text=Step+3+%E2%80%94+Resolved',
+      inline_text: null,
+      caption: 'Step 3 — Session resolved',
+      step_index: 3,
+      created_at: minutesAgo(5),
+    },
+    {
+      id: 'a-001-t',
+      run_id: 'run-001',
+      type: 'transcript',
+      blob_url: null,
+      inline_text:
+        '[Alice] I feel hurt when meetings start late.\n[Bob] I hear that meetings starting late hurts you.\n[Alice] Yes — exactly.',
+      caption: 'Full transcript',
+      step_index: 99,
+      created_at: minutesAgo(5),
+    },
+  ],
+  'run-002': [
+    {
+      id: 'a-002-1',
+      run_id: 'run-002',
+      type: 'screenshot',
+      blob_url: 'https://placehold.co/640x400/0a0e1a/f87171?text=Failed+at+Stage+3',
+      inline_text: null,
+      caption: 'Failed at stage 3 — transition missing',
+      step_index: 1,
+      created_at: minutesAgo(41),
+    },
+    {
+      id: 'a-002-c',
+      run_id: 'run-002',
+      type: 'console',
+      blob_url: null,
+      inline_text:
+        '[log] navigating to /session/abc\n[warn] retry 1/3 polling Ably channel\n[error] expected transition message but found nothing',
+      caption: 'Console log',
+      step_index: 50,
+      created_at: minutesAgo(40),
+    },
+    {
+      id: 'a-002-e',
+      run_id: 'run-002',
+      type: 'page_error',
+      blob_url: null,
+      inline_text:
+        'TypeError: Cannot read property "stage" of undefined\n  at TransitionMessage (/src/components/TransitionMessage.tsx:42:18)',
+      caption: 'Page error',
+      step_index: 51,
+      created_at: minutesAgo(40),
+    },
+  ],
+  'run-003': [
+    {
+      id: 'a-003-1',
+      run_id: 'run-003',
+      type: 'screenshot',
+      blob_url: 'https://placehold.co/640x400/0a0e1a/60a5fa?text=Running+%E2%80%94+Stage+1',
+      inline_text: null,
+      caption: 'Currently at stage 1',
+      step_index: 1,
+      created_at: minutesAgo(1),
+    },
+  ],
+  'run-005': [
+    {
+      id: 'a-005-e',
+      run_id: 'run-005',
+      type: 'page_error',
+      blob_url: null,
+      inline_text: 'Error: browser launch timed out after 30s',
+      caption: 'Launch error',
+      step_index: 0,
+      created_at: minutesAgo(179),
+    },
+  ],
+};
+
+export function buildMockRunDetail(id: string): RunDetail | null {
+  const run = MOCK_RUNS.find((r) => r.id === id);
+  if (!run) return null;
+  const artifacts = MOCK_ARTIFACTS_BY_RUN[run.id] ?? [];
+  const starting =
+    MOCK_SNAPSHOTS.find((s) => s.id === run.starting_snapshot_id) ?? null;
+  const ending =
+    MOCK_SNAPSHOTS.find((s) => s.id === run.ending_snapshot_id) ?? null;
+  return {
+    ...run,
+    artifacts,
+    starting_snapshot: starting,
+    ending_snapshot: ending,
+  };
+}
+
+export function buildMockSnapshotTree(): SnapshotNode[] {
+  const byId = new Map<string, SnapshotNode>();
+  for (const s of MOCK_SNAPSHOTS) {
+    byId.set(s.id, {
+      ...s,
+      children: [],
+      run_count: MOCK_RUNS.filter((r) => r.starting_snapshot_id === s.id).length,
+    });
+  }
+  const roots: SnapshotNode[] = [];
+  for (const node of byId.values()) {
+    if (node.parent_id && byId.has(node.parent_id)) {
+      byId.get(node.parent_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  return roots;
+}
+
+export function buildMockSnapshotDetail(id: string): {
+  snapshot: Snapshot;
+  runs: TestRun[];
+  parent: Snapshot | null;
+  children: Snapshot[];
+} | null {
+  const snapshot = MOCK_SNAPSHOTS.find((s) => s.id === id);
+  if (!snapshot) return null;
+  const parent = snapshot.parent_id
+    ? MOCK_SNAPSHOTS.find((s) => s.id === snapshot.parent_id) ?? null
+    : null;
+  const children = MOCK_SNAPSHOTS.filter((s) => s.parent_id === id);
+  const runs = MOCK_RUNS.filter((r) => r.starting_snapshot_id === id);
+  return { snapshot, runs, parent, children };
+}

--- a/tools/test-dashboard/src/style.css
+++ b/tools/test-dashboard/src/style.css
@@ -783,7 +783,8 @@ pre.log-block.error {
   box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
-.form-field .hint {
+.form-field .hint,
+.hint {
   font-size: 0.72rem;
   color: var(--text-muted);
   margin-top: var(--space-1);

--- a/tools/test-dashboard/src/style.css
+++ b/tools/test-dashboard/src/style.css
@@ -1,0 +1,489 @@
+:root {
+  --bg-base: #0a0e1a;
+  --bg-surface: #111827;
+  --bg-elevated: #1e293b;
+  --bg-overlay: #334155;
+
+  --text-primary: #f1f5f9;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+
+  --border: #334155;
+  --accent: #3b82f6;
+  --accent-glow: rgba(59, 130, 246, 0.5);
+
+  --status-pass: #4ade80;
+  --status-fail: #f87171;
+  --status-running: #60a5fa;
+  --status-queued: #fbbf24;
+  --status-error: #f97316;
+  --status-cancelled: #94a3b8;
+}
+
+* { box-sizing: border-box; }
+
+html, body, #app {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover { text-decoration: underline; }
+
+code, pre, .mono {
+  font-family: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+}
+
+/* ---------- Layout ---------- */
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  background: rgba(15, 23, 42, 0.95);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(10px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.app-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.brand-dot {
+  width: 8px;
+  height: 8px;
+  background: var(--accent);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--accent-glow);
+}
+
+.app-brand h1 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.app-nav {
+  display: flex;
+  gap: 1rem;
+  margin-left: auto;
+}
+
+.app-nav a {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+  text-decoration: none;
+}
+
+.app-nav a:hover {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+
+.app-nav a.active {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+
+.app-main {
+  flex: 1;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+/* ---------- Page chrome ---------- */
+
+.page-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.page-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.page-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 3rem 1rem;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+}
+
+.error-banner {
+  background: rgba(248, 113, 113, 0.1);
+  border: 1px solid var(--status-fail);
+  color: var(--status-fail);
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+}
+
+.loading {
+  color: var(--text-secondary);
+  padding: 2rem;
+  text-align: center;
+}
+
+/* ---------- Status badges ---------- */
+
+.status-badge {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border: 1px solid currentColor;
+}
+
+.status-pass     { color: var(--status-pass);      background: rgba(74, 222, 128, 0.1); }
+.status-fail     { color: var(--status-fail);      background: rgba(248, 113, 113, 0.1); }
+.status-running  { color: var(--status-running);   background: rgba(96, 165, 250, 0.1); }
+.status-queued   { color: var(--status-queued);    background: rgba(251, 191, 36, 0.1); }
+.status-error    { color: var(--status-error);     background: rgba(249, 115, 22, 0.1); }
+.status-cancelled{ color: var(--status-cancelled); background: rgba(148, 163, 184, 0.1); }
+
+.trigger-badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--bg-overlay);
+  color: var(--text-secondary);
+}
+
+/* ---------- Cards ---------- */
+
+.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.run-card {
+  display: block;
+  padding: 1rem 1.25rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  transition: border-color 0.15s, transform 0.05s;
+  text-decoration: none;
+  color: inherit;
+}
+
+.run-card:hover {
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.run-card:active { transform: scale(0.998); }
+
+.run-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.run-card-header .scenario {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.run-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.run-card-meta .label {
+  color: var(--text-muted);
+  margin-right: 0.25rem;
+}
+
+/* ---------- Detail page ---------- */
+
+.detail-section {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.detail-section h3 {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.screenshot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.screenshot-card {
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.screenshot-card img {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: #000;
+}
+
+.screenshot-card .caption {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  border-top: 1px solid var(--border);
+}
+
+pre.log-block {
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-size: 0.78rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+pre.log-block.error {
+  color: var(--status-fail);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.transcript {
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+/* ---------- Buttons ---------- */
+
+.btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.82rem;
+  font-weight: 500;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s;
+  font-family: inherit;
+}
+
+.btn:hover {
+  background: var(--bg-overlay);
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ---------- Forms ---------- */
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 600px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-field label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  padding: 0.5rem 0.7rem;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.85rem;
+}
+
+.form-field input:focus,
+.form-field select:focus,
+.form-field textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.form-field .hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Snapshot tree ---------- */
+
+.snapshot-tree {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.snapshot-tree ul {
+  list-style: none;
+  padding-left: 1.25rem;
+  margin: 0.25rem 0;
+  border-left: 1px dashed var(--border);
+}
+
+.snapshot-tree li {
+  padding: 0.25rem 0;
+}
+
+.snapshot-tree .snapshot-link {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+.snapshot-tree .snapshot-link:hover {
+  background: var(--bg-elevated);
+  text-decoration: none;
+}
+
+.snapshot-tree .run-count {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Misc ---------- */
+
+.kv {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.4rem 1rem;
+  font-size: 0.82rem;
+}
+
+.kv .k {
+  color: var(--text-muted);
+}
+
+.kv .v {
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+details.json-block {
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+}
+
+details.json-block summary {
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+details.json-block pre {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/tools/test-dashboard/src/style.css
+++ b/tools/test-dashboard/src/style.css
@@ -1,23 +1,62 @@
+/* ==========================================================================
+   MWF Test Dashboard — dark dev-tool theme
+   Stack: plain CSS (no frameworks). Single source of truth.
+   Palette derived from the "financial dashboard dark" recommendation.
+   ========================================================================== */
+
 :root {
-  --bg-base: #0a0e1a;
-  --bg-surface: #111827;
-  --bg-elevated: #1e293b;
-  --bg-overlay: #334155;
+  /* Surfaces */
+  --bg-base:        #020617;  /* deepest — page background */
+  --bg-surface:     #0E1223;  /* cards, sections */
+  --bg-elevated:    #1A1E2F;  /* hover, inputs */
+  --bg-overlay:     #272F42;  /* badge chips, tags */
 
-  --text-primary: #f1f5f9;
-  --text-secondary: #94a3b8;
-  --text-muted: #64748b;
+  /* Text */
+  --text-primary:   #F1F5F9;
+  --text-secondary: #94A3B8;
+  --text-muted:     #64748B;
 
-  --border: #334155;
-  --accent: #3b82f6;
-  --accent-glow: rgba(59, 130, 246, 0.5);
+  /* Borders + dividers */
+  --border:         #1E293B;
+  --border-strong:  #334155;
+  --border-focus:   #3B82F6;
 
-  --status-pass: #4ade80;
-  --status-fail: #f87171;
-  --status-running: #60a5fa;
-  --status-queued: #fbbf24;
-  --status-error: #f97316;
-  --status-cancelled: #94a3b8;
+  /* Brand accent (interactive) */
+  --accent:         #3B82F6;
+  --accent-hover:   #2563EB;
+  --accent-glow:    rgba(59, 130, 246, 0.35);
+
+  /* Status — paired tint + ink */
+  --status-pass:        #22C55E;
+  --status-pass-tint:   rgba(34, 197, 94, 0.12);
+  --status-fail:        #EF4444;
+  --status-fail-tint:   rgba(239, 68, 68, 0.14);
+  --status-running:     #60A5FA;
+  --status-running-tint:rgba(96, 165, 250, 0.14);
+  --status-queued:      #FBBF24;
+  --status-queued-tint: rgba(251, 191, 36, 0.14);
+  --status-error:       #F97316;
+  --status-error-tint:  rgba(249, 115, 22, 0.14);
+  --status-cancelled:   #94A3B8;
+  --status-cancelled-tint: rgba(148, 163, 184, 0.12);
+
+  /* Spacing scale (4pt rhythm) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+
+  /* Radii */
+  --radius-sm: 4px;
+  --radius:    6px;
+  --radius-lg: 10px;
+
+  /* Type */
+  --font-sans: 'Fira Sans', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
 }
 
 * { box-sizing: border-box; }
@@ -28,9 +67,16 @@ html, body, #app {
   min-height: 100vh;
   background: var(--bg-base);
   color: var(--text-primary);
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-family: var(--font-sans);
   font-size: 14px;
   line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* Tabular numerals globally — durations, timestamps, IDs all line up. */
+body, input, select, textarea, button {
+  font-variant-numeric: tabular-nums;
 }
 
 a {
@@ -38,12 +84,34 @@ a {
   text-decoration: none;
 }
 a:hover { text-decoration: underline; }
-
-code, pre, .mono {
-  font-family: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+a:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
-/* ---------- Layout ---------- */
+code, pre, .mono {
+  font-family: var(--font-mono);
+}
+
+::selection {
+  background: var(--accent-glow);
+  color: var(--text-primary);
+}
+
+/* Scrollbars (webkit) — subtle, dev-tool feel. */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
+  background: var(--bg-overlay);
+  border-radius: 999px;
+  border: 2px solid var(--bg-base);
+}
+::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+
+/* ==========================================================================
+   Layout shell
+   ========================================================================== */
 
 .app-shell {
   display: flex;
@@ -54,11 +122,12 @@ code, pre, .mono {
 .app-header {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
-  padding: 0.75rem 1.5rem;
-  background: rgba(15, 23, 42, 0.95);
+  gap: var(--space-6);
+  padding: var(--space-3) var(--space-6);
+  background: rgba(2, 6, 23, 0.85);
   border-bottom: 1px solid var(--border);
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   position: sticky;
   top: 0;
   z-index: 100;
@@ -67,7 +136,7 @@ code, pre, .mono {
 .app-brand {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .brand-dot {
@@ -76,38 +145,62 @@ code, pre, .mono {
   background: var(--accent);
   border-radius: 50%;
   box-shadow: 0 0 8px var(--accent-glow);
+  flex-shrink: 0;
 }
 
 .app-brand h1 {
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
+}
+
+.app-brand .env-tag {
+  margin-left: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  padding: 0.05rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 
 .app-nav {
   display: flex;
-  gap: 1rem;
+  gap: var(--space-1);
   margin-left: auto;
 }
 
 .app-nav a {
+  position: relative;
   color: var(--text-secondary);
   font-size: 0.85rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  transition: color 0.15s, background 0.15s;
+  font-weight: 500;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  transition: color 150ms ease, background 150ms ease;
   text-decoration: none;
 }
 
 .app-nav a:hover {
   color: var(--text-primary);
   background: var(--bg-elevated);
+  text-decoration: none;
 }
 
 .app-nav a.active {
   color: var(--text-primary);
-  background: var(--bg-elevated);
+}
+
+.app-nav a.active::after {
+  content: '';
+  position: absolute;
+  left: var(--space-3);
+  right: var(--space-3);
+  bottom: -2px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 2px;
 }
 
 .app-main {
@@ -115,23 +208,44 @@ code, pre, .mono {
   max-width: 1200px;
   width: 100%;
   margin: 0 auto;
-  padding: 1.5rem;
+  padding: var(--space-6);
 }
 
-/* ---------- Page chrome ---------- */
+.app-footer {
+  border-top: 1px solid var(--border);
+  padding: var(--space-3) var(--space-6);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  display: flex;
+  gap: var(--space-4);
+  font-family: var(--font-mono);
+}
+
+.app-footer a {
+  color: var(--text-secondary);
+}
+
+/* ==========================================================================
+   Page chrome
+   ========================================================================== */
 
 .page-header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  flex-wrap: wrap;
 }
 
 .page-header h2 {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 1.35rem;
   font-weight: 600;
+  letter-spacing: -0.01em;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
 }
 
 .page-subtitle {
@@ -142,81 +256,251 @@ code, pre, .mono {
 .empty {
   text-align: center;
   color: var(--text-secondary);
-  padding: 3rem 1rem;
-  border: 1px dashed var(--border);
-  border-radius: 8px;
+  padding: var(--space-8) var(--space-4);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: rgba(14, 18, 35, 0.4);
 }
 
+.empty p { margin: var(--space-2) 0; }
+
 .error-banner {
-  background: rgba(248, 113, 113, 0.1);
-  border: 1px solid var(--status-fail);
+  background: var(--status-fail-tint);
+  border: 1px solid rgba(239, 68, 68, 0.5);
   color: var(--status-fail);
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin-bottom: 1rem;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius);
+  margin-bottom: var(--space-4);
   font-size: 0.85rem;
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-start;
+}
+
+.warning-banner {
+  background: var(--status-queued-tint);
+  border: 1px solid rgba(251, 191, 36, 0.5);
+  color: var(--status-queued);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius);
+  margin-bottom: var(--space-4);
+  font-size: 0.85rem;
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-start;
 }
 
 .loading {
   color: var(--text-secondary);
-  padding: 2rem;
+  padding: var(--space-8);
   text-align: center;
 }
 
-/* ---------- Status badges ---------- */
+/* ==========================================================================
+   Filters (Runs feed)
+   ========================================================================== */
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: var(--space-4);
+}
+
+.filter-bar .filter-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-right: var(--space-1);
+}
+
+.filter-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.filter-pill {
+  font-family: var(--font-sans);
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 150ms, background 150ms, border-color 150ms;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.filter-pill:hover {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
+.filter-pill.active {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+  border-color: var(--accent);
+}
+
+.filter-pill .count {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.filter-pill.active .count { color: var(--text-secondary); }
+
+.filter-search {
+  flex: 1;
+  min-width: 200px;
+  margin-left: auto;
+}
+
+.filter-search input {
+  width: 100%;
+  padding: 0.4rem 0.75rem;
+  background: var(--bg-base);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.filter-search input::placeholder { color: var(--text-muted); }
+
+.filter-search input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+/* ==========================================================================
+   Status badges (color + dot — never color alone)
+   ========================================================================== */
 
 .status-badge {
-  display: inline-block;
-  padding: 0.15rem 0.55rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.18rem 0.6rem;
   border-radius: 999px;
   font-size: 0.7rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
+  font-family: var(--font-sans);
   border: 1px solid currentColor;
+  white-space: nowrap;
 }
 
-.status-pass     { color: var(--status-pass);      background: rgba(74, 222, 128, 0.1); }
-.status-fail     { color: var(--status-fail);      background: rgba(248, 113, 113, 0.1); }
-.status-running  { color: var(--status-running);   background: rgba(96, 165, 250, 0.1); }
-.status-queued   { color: var(--status-queued);    background: rgba(251, 191, 36, 0.1); }
-.status-error    { color: var(--status-error);     background: rgba(249, 115, 22, 0.1); }
-.status-cancelled{ color: var(--status-cancelled); background: rgba(148, 163, 184, 0.1); }
+.status-badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.status-pass      { color: var(--status-pass);      background: var(--status-pass-tint); }
+.status-fail      { color: var(--status-fail);      background: var(--status-fail-tint); }
+.status-running   { color: var(--status-running);   background: var(--status-running-tint); }
+.status-queued    { color: var(--status-queued);    background: var(--status-queued-tint); }
+.status-error     { color: var(--status-error);     background: var(--status-error-tint); }
+.status-cancelled { color: var(--status-cancelled); background: var(--status-cancelled-tint); }
+
+/* Pulsing dot for in-flight states. */
+.status-running::before,
+.status-queued::before {
+  animation: pulse-dot 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1;   transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(0.85); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-running::before,
+  .status-queued::before { animation: none; }
+}
 
 .trigger-badge {
   display: inline-block;
-  padding: 0.1rem 0.45rem;
-  border-radius: 4px;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-sm);
   font-size: 0.65rem;
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   background: var(--bg-overlay);
   color: var(--text-secondary);
+  font-family: var(--font-mono);
 }
 
-/* ---------- Cards ---------- */
+/* ==========================================================================
+   Run cards
+   ========================================================================== */
 
 .card-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-2);
 }
 
 .run-card {
   display: block;
-  padding: 1rem 1.25rem;
+  padding: var(--space-4) var(--space-5);
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  transition: border-color 0.15s, transform 0.05s;
+  border-radius: var(--radius);
+  transition: border-color 150ms ease, background 150ms ease, transform 60ms ease;
   text-decoration: none;
   color: inherit;
+  position: relative;
 }
 
+/* A 3px accent stripe on the left, color = status, that lights up on hover. */
+.run-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--border-strong);
+  border-radius: var(--radius) 0 0 var(--radius);
+  transition: background 150ms ease;
+}
+
+.run-card[data-status='pass']::before      { background: var(--status-pass); }
+.run-card[data-status='fail']::before      { background: var(--status-fail); }
+.run-card[data-status='running']::before   { background: var(--status-running); }
+.run-card[data-status='queued']::before    { background: var(--status-queued); }
+.run-card[data-status='error']::before     { background: var(--status-error); }
+.run-card[data-status='cancelled']::before { background: var(--status-cancelled); }
+
 .run-card:hover {
-  border-color: var(--accent);
+  border-color: var(--border-strong);
+  background: var(--bg-elevated);
   text-decoration: none;
+}
+
+.run-card:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
 }
 
 .run-card:active { transform: scale(0.998); }
@@ -224,131 +508,203 @@ code, pre, .mono {
 .run-card-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+  flex-wrap: wrap;
 }
 
 .run-card-header .scenario {
   font-weight: 600;
   font-size: 0.95rem;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  letter-spacing: -0.01em;
 }
 
 .run-card-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-2) var(--space-4);
   font-size: 0.78rem;
   color: var(--text-secondary);
 }
 
-.run-card-meta .label {
-  color: var(--text-muted);
-  margin-right: 0.25rem;
+.run-card-meta .field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
 }
 
-/* ---------- Detail page ---------- */
+.run-card-meta .label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.run-card-meta .value {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ==========================================================================
+   Detail page
+   ========================================================================== */
 
 .detail-section {
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1rem 1.25rem;
-  margin-bottom: 1rem;
+  border-radius: var(--radius);
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-3);
 }
 
 .detail-section h3 {
-  margin: 0 0 0.75rem 0;
-  font-size: 0.95rem;
+  margin: 0 0 var(--space-3) 0;
+  font-size: 0.85rem;
   font-weight: 600;
   color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.detail-section h3 .count {
+  font-family: var(--font-mono);
+  font-weight: 400;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .screenshot-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1rem;
+  gap: var(--space-3);
 }
 
 .screenshot-card {
   background: var(--bg-base);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   overflow: hidden;
+  transition: border-color 150ms ease;
 }
+
+.screenshot-card:hover { border-color: var(--border-strong); }
 
 .screenshot-card img {
   width: 100%;
   height: auto;
   display: block;
   background: #000;
+  aspect-ratio: 16/10;
+  object-fit: cover;
 }
 
 .screenshot-card .caption {
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   font-size: 0.75rem;
   color: var(--text-secondary);
   border-top: 1px solid var(--border);
+  display: flex;
+  gap: var(--space-2);
+  align-items: baseline;
+}
+
+.screenshot-card .caption .step {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  flex-shrink: 0;
 }
 
 pre.log-block {
   background: var(--bg-base);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0.75rem;
+  border-radius: var(--radius);
+  padding: var(--space-3);
   font-size: 0.78rem;
+  line-height: 1.5;
   overflow-x: auto;
   white-space: pre-wrap;
   word-break: break-word;
   max-height: 400px;
   overflow-y: auto;
+  margin: 0;
 }
+
+pre.log-block + pre.log-block { margin-top: var(--space-2); }
 
 pre.log-block.error {
   color: var(--status-fail);
-  border-color: rgba(248, 113, 113, 0.4);
+  border-color: rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.04);
 }
 
 .transcript {
   background: var(--bg-base);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0.75rem;
-  font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  font-family: var(--font-mono);
   font-size: 0.8rem;
+  line-height: 1.6;
   white-space: pre-wrap;
   max-height: 500px;
   overflow-y: auto;
+  margin: 0;
 }
 
-/* ---------- Buttons ---------- */
+/* ==========================================================================
+   Buttons
+   ========================================================================== */
 
 .btn-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 1rem;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
 }
 
 .btn {
-  display: inline-block;
-  padding: 0.5rem 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0.5rem 0.95rem;
   font-size: 0.82rem;
   font-weight: 500;
   background: var(--bg-elevated);
   color: var(--text-primary);
-  border: 1px solid var(--border);
-  border-radius: 6px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
   cursor: pointer;
   text-decoration: none;
-  transition: background 0.15s, border-color 0.15s;
-  font-family: inherit;
+  transition: background 150ms ease, border-color 150ms ease, color 150ms ease;
+  font-family: var(--font-sans);
+  min-height: 36px;
 }
 
 .btn:hover {
   background: var(--bg-overlay);
-  border-color: var(--accent);
+  border-color: var(--text-secondary);
   text-decoration: none;
+  color: var(--text-primary);
 }
+
+.btn:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+.btn:active { transform: scale(0.98); }
 
 .btn-primary {
   background: var(--accent);
@@ -357,46 +713,66 @@ pre.log-block.error {
 }
 
 .btn-primary:hover {
-  background: #2563eb;
-  border-color: #2563eb;
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: #fff;
 }
 
-.btn:disabled {
-  opacity: 0.5;
+.btn:disabled,
+.btn[aria-disabled='true'] {
+  opacity: 0.45;
   cursor: not-allowed;
+  transform: none;
 }
 
-/* ---------- Forms ---------- */
+.btn:disabled:hover {
+  background: var(--bg-elevated);
+  border-color: var(--border-strong);
+}
+
+/* ==========================================================================
+   Forms
+   ========================================================================== */
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-4);
   max-width: 600px;
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: var(--space-1);
 }
 
 .form-field label {
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: 0.75rem;
+  font-weight: 600;
   color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .form-field input,
 .form-field select,
 .form-field textarea {
-  padding: 0.5rem 0.7rem;
+  padding: 0.55rem 0.75rem;
   background: var(--bg-base);
-  border: 1px solid var(--border);
-  border-radius: 6px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
   color: var(--text-primary);
-  font-family: inherit;
+  font-family: var(--font-mono);
   font-size: 0.85rem;
+  min-height: 38px;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.form-field textarea {
+  font-family: var(--font-sans);
+  resize: vertical;
+  min-height: 80px;
 }
 
 .form-field input:focus,
@@ -404,14 +780,18 @@ pre.log-block.error {
 .form-field textarea:focus {
   outline: none;
   border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
 .form-field .hint {
   font-size: 0.72rem;
   color: var(--text-muted);
+  margin-top: var(--space-1);
 }
 
-/* ---------- Snapshot tree ---------- */
+/* ==========================================================================
+   Snapshot tree
+   ========================================================================== */
 
 .snapshot-tree {
   list-style: none;
@@ -421,23 +801,44 @@ pre.log-block.error {
 
 .snapshot-tree ul {
   list-style: none;
-  padding-left: 1.25rem;
-  margin: 0.25rem 0;
-  border-left: 1px dashed var(--border);
+  padding-left: var(--space-5);
+  margin: 0;
+  border-left: 1px solid var(--border-strong);
+  margin-left: 0.6rem;
 }
 
 .snapshot-tree li {
-  padding: 0.25rem 0;
+  padding: var(--space-1) 0;
+  position: relative;
+}
+
+.snapshot-tree ul > li::before {
+  content: '';
+  position: absolute;
+  left: calc(var(--space-5) * -1);
+  top: 1rem;
+  width: var(--space-4);
+  height: 1px;
+  background: var(--border-strong);
 }
 
 .snapshot-tree .snapshot-link {
   display: inline-flex;
-  align-items: baseline;
-  gap: 0.5rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
   text-decoration: none;
   color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  transition: background 150ms ease;
+}
+
+.snapshot-tree .snapshot-link::before {
+  content: '◆';
+  color: var(--text-muted);
+  font-size: 0.65rem;
 }
 
 .snapshot-tree .snapshot-link:hover {
@@ -446,44 +847,127 @@ pre.log-block.error {
 }
 
 .snapshot-tree .run-count {
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   color: var(--text-muted);
+  background: var(--bg-overlay);
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-family: var(--font-mono);
 }
 
-/* ---------- Misc ---------- */
+/* ==========================================================================
+   Key-value list (detail page summaries)
+   ========================================================================== */
 
 .kv {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: 0.4rem 1rem;
-  font-size: 0.82rem;
+  gap: var(--space-2) var(--space-5);
+  font-size: 0.84rem;
 }
 
 .kv .k {
   color: var(--text-muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+  align-self: center;
 }
 
 .kv .v {
   color: var(--text-primary);
   word-break: break-word;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+.kv .v.prose {
+  font-family: var(--font-sans);
 }
 
 details.json-block {
   background: var(--bg-base);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3);
 }
 
 details.json-block summary {
   cursor: pointer;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   color: var(--text-secondary);
+  font-weight: 500;
 }
 
+details.json-block summary:hover { color: var(--text-primary); }
+
 details.json-block pre {
-  margin: 0.5rem 0 0 0;
+  margin: var(--space-2) 0 0 0;
   font-size: 0.75rem;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+/* ==========================================================================
+   Skeletons (loading shimmer)
+   ========================================================================== */
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.04) 50%,
+    transparent 100%
+  );
+  animation: shimmer 1.4s linear infinite;
+}
+
+.skeleton-card { height: 96px; }
+
+@keyframes shimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after { animation: none; }
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+
+/* Visually hidden helper for accessible labels. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .app-main { padding: var(--space-4); }
+  .app-header { padding: var(--space-2) var(--space-4); }
+  .app-brand h1 { font-size: 0.85rem; }
+  .page-header h2 { font-size: 1.15rem; }
+  .run-card { padding: var(--space-3) var(--space-4); }
+  .run-card-meta { grid-template-columns: 1fr 1fr; }
+  .filter-search { margin-left: 0; }
 }

--- a/tools/test-dashboard/src/types.ts
+++ b/tools/test-dashboard/src/types.ts
@@ -1,0 +1,72 @@
+// Shared types for the test dashboard.
+// Must match the contract agreed with the API/bot author exactly.
+
+export type RunStatus =
+  | 'queued'
+  | 'running'
+  | 'pass'
+  | 'fail'
+  | 'error'
+  | 'cancelled';
+
+export type TriggerSource = 'slack' | 'cron' | 'web' | 'manual';
+
+export type ArtifactType =
+  | 'screenshot'
+  | 'transcript'
+  | 'page_error'
+  | 'console';
+
+export interface TestRun {
+  id: string;
+  scenario: string;
+  status: RunStatus;
+  started_at: string;
+  finished_at: string | null;
+  duration_ms: number | null;
+  final_stage: number | null;
+  starting_snapshot_id: string | null;
+  ending_snapshot_id: string | null;
+  code_sha: string | null;
+  trigger_source: TriggerSource;
+  triggered_by: string | null;
+  error_message: string | null;
+  failed_assertion: string | null;
+  failed_test_file: string | null;
+  failed_test_line: number | null;
+  notes: string | null;
+  created_at: string;
+}
+
+export interface Snapshot {
+  id: string;
+  name: string;
+  description: string | null;
+  parent_id: string | null;
+  file_path: string;
+  db_state_summary: unknown | null;
+  created_by_run_id: string | null;
+  created_at: string;
+}
+
+export interface RunArtifact {
+  id: string;
+  run_id: string;
+  type: ArtifactType;
+  blob_url: string | null;
+  inline_text: string | null;
+  caption: string | null;
+  step_index: number;
+  created_at: string;
+}
+
+export interface RunDetail extends TestRun {
+  artifacts: RunArtifact[];
+  starting_snapshot: Snapshot | null;
+  ending_snapshot: Snapshot | null;
+}
+
+export interface SnapshotNode extends Snapshot {
+  children: SnapshotNode[];
+  run_count: number;
+}

--- a/tools/test-dashboard/src/utils/format.ts
+++ b/tools/test-dashboard/src/utils/format.ts
@@ -1,0 +1,65 @@
+// Small formatting helpers shared across pages.
+
+export function formatDuration(ms: number | null): string {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${ms}ms`;
+  const totalSec = Math.round(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min === 0) return `${sec}s`;
+  return `${min}m ${sec.toString().padStart(2, '0')}s`;
+}
+
+export function formatTimestamp(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function formatRelative(iso: string | null): string {
+  if (!iso) return '—';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diff = Date.now() - then;
+  const sec = Math.round(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.round(hr / 24);
+  return `${days}d ago`;
+}
+
+export function shortSha(sha: string | null): string {
+  if (!sha) return '—';
+  return sha.slice(0, 7);
+}
+
+const GITHUB_REPO = 'ShantamG/meet-without-fear'; // adjust if needed
+
+export function githubShaUrl(sha: string | null): string | null {
+  if (!sha) return null;
+  return `https://github.com/${GITHUB_REPO}/commit/${sha}`;
+}
+
+export function githubFileUrl(
+  file: string | null,
+  line: number | null,
+  sha: string | null
+): string | null {
+  if (!file) return null;
+  const ref = sha ?? 'main';
+  const lineFrag = line ? `#L${line}` : '';
+  return `https://github.com/${GITHUB_REPO}/blob/${ref}/${file}${lineFrag}`;
+}

--- a/tools/test-dashboard/tsconfig.json
+++ b/tools/test-dashboard/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "types": [
+      "vite/client",
+      "node"
+    ],
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "api/**/*.ts",
+    "db/**/*.ts"
+  ]
+}

--- a/tools/test-dashboard/vercel.json
+++ b/tools/test-dashboard/vercel.json
@@ -1,0 +1,8 @@
+{
+  "buildCommand": "npm run build",
+  "installCommand": "npm install",
+  "outputDirectory": "dist",
+  "rewrites": [
+    { "source": "/((?!api/|assets/).*)", "destination": "/index.html" }
+  ]
+}

--- a/tools/test-dashboard/vercel.json
+++ b/tools/test-dashboard/vercel.json
@@ -3,6 +3,9 @@
   "installCommand": "npm install",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/((?!api/|assets/).*)", "destination": "/index.html" }
+    {
+      "source": "/((?!api/|assets/|@|src/|node_modules/)[^.]+)",
+      "destination": "/index.html"
+    }
   ]
 }

--- a/tools/test-dashboard/vite.config.ts
+++ b/tools/test-dashboard/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  root: path.resolve(__dirname),
+  resolve: {
+    alias: {
+      react: path.resolve(__dirname, 'node_modules/react'),
+      'react-dom': path.resolve(__dirname, 'node_modules/react-dom'),
+    },
+  },
+  server: {
+    port: 3003,
+    open: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+  envDir: path.resolve(__dirname),
+});


### PR DESCRIPTION
## Summary

New `tools/test-dashboard/` — a Vite SPA + Vercel serverless API + EC2 bot writer for surfacing Playwright e2e runs. Replaces "screenshots in Slack threads" with a browsable surface for the "look through 20 runs and decide what to investigate" loop.

- **Frontend**: 5 pages (runs feed, run detail, snapshot tree, snapshot detail, new-run form), Fira Sans/Code typography, dark dev-tool theme, mock data fallback in dev
- **Backend**: Vercel functions backed by Neon Postgres (`@vercel/postgres`) + Vercel Blob; bot mutations gated by `x-bot-token`
- **Bot writer**: `scripts/ec2-bot/scripts/write-test-result.ts` — uploads screenshots to Blob, posts artifact rows, finalizes the run with real timing
- **Auto-deploy**: `.github/workflows/vercel-deploy-test-dashboard.yml` mirrors the website pattern; fires on push to main when `tools/test-dashboard/**` changes
- **Phase 1A is read-only**: web POSTs to `/api/runs` are gated behind `BOT_WRITER_TOKEN` and the queue/requeue UI buttons are disabled with explanation banners until Phase 1B wires user auth

See `tools/test-dashboard/SETUP.md` for the operator runbook.

## Test plan

- [x] `npm run check && npm run build` clean
- [x] 6 Codex review rounds — all findings resolved
- [x] Tier 1: UI smoke with mock data (every page, filter, search, status badges, focus rings, banners) via agent-browser
- [x] Tier 2: Neon Postgres provisioned + connected; `npm run migrate` lands schema cleanly
- [x] Tier 3: API smoke against real Neon — auth gate, list, create, patch
- [x] Tier 4: bot writer end-to-end — run creation, 3 screenshots uploaded to Blob, final state PATCHed with real timing
- [ ] Tier 5: production deploy (this PR's GitHub Actions)
- [ ] Confirm production dashboard renders runs created during Tier 3/4 smoke
- [ ] Phase 1A close-out: EC2 wiring + Slack `@slam_paws test <scenario>` trigger + daily cron (follow-up branch)

## Notes

- Operator (Shantam) needs to: connect the existing Vercel project to GitHub repo variables (`VERCEL_TEST_DASHBOARD_PROJECT_ID` already set autonomously) and confirm the deploy succeeds. See SETUP.md for the EC2 bot env vars to add when wiring B-stage of the rollout.
- `@vercel/postgres` is deprecated upstream but works against Neon; future cleanup is a swap to `@neondatabase/serverless`.
- The hardcoded scenario list in `NewRunPage`/`SnapshotDetailPage` is a stub — Phase 1B should expose this via the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)