### PR TITLE
feat(test-dashboard): snapshot save/restore tooling

### DIFF
--- a/scripts/ec2-bot/scripts/restore-snapshot.sh
+++ b/scripts/ec2-bot/scripts/restore-snapshot.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# restore-snapshot.sh — fetch a snapshot's metadata from the dashboard and
+# reset the local backend DB to that state.
+#
+# Wraps backend/snapshots/reset-to-snapshot.ts which does the actual
+# truncate + psql restore + prisma migrate deploy.
+#
+# Usage:
+#   restore-snapshot.sh <snapshot-id>
+#
+# Example:
+#   restore-snapshot.sh 01KQ8FZG...
+#
+# Env:
+#   TEST_DASHBOARD_API_URL    where to fetch snapshot metadata from
+#   DATABASE_URL              backend test database (read by reset-to-snapshot.ts)
+#
+# Note: snapshot-id can also be a partial filename (e.g. "03-invitation-accepted")
+# in which case we skip the API and let reset-to-snapshot.ts find it on disk.
+
+set -uo pipefail
+
+BOT_ENV_FILE="${BOT_ENV_FILE:-/opt/slam-bot/.env}"
+if [ -f "$BOT_ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$BOT_ENV_FILE"
+  set +a
+fi
+
+if [ "$#" -ne 1 ]; then
+  cat >&2 <<EOF
+Usage: $0 <snapshot-id-or-name>
+
+Examples:
+  $0 01KQ8FZGABCDEF...        # fetch metadata from dashboard, then restore
+  $0 03-invitation-accepted   # restore directly from backend/snapshots/ by name match
+EOF
+  exit 2
+fi
+
+ID_OR_NAME="$1"
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+: "${DATABASE_URL:?DATABASE_URL must be set}"
+
+# Heuristic: if the id looks like a ULID (26 alphanum chars), look it up via
+# the dashboard. Otherwise pass straight through to reset-to-snapshot.ts which
+# can match by name fragment.
+if [[ "$ID_OR_NAME" =~ ^[0-9A-Z]{26}$ ]]; then
+  : "${TEST_DASHBOARD_API_URL:?TEST_DASHBOARD_API_URL must be set to look up by id}"
+  echo "[restore-snapshot] fetching $ID_OR_NAME metadata from dashboard"
+  RESPONSE=$(curl -s -w "\n%{http_code}" "$TEST_DASHBOARD_API_URL/api/snapshots/$ID_OR_NAME")
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  BODY=$(echo "$RESPONSE" | sed '$d')
+  if [ "$HTTP_CODE" != "200" ]; then
+    echo "[restore-snapshot] lookup failed: HTTP $HTTP_CODE" >&2
+    echo "$BODY" >&2
+    exit 1
+  fi
+  FILE_PATH=$(echo "$BODY" | jq -r '.snapshot.file_path')
+  if [ -z "$FILE_PATH" ] || [ "$FILE_PATH" = "null" ]; then
+    echo "[restore-snapshot] snapshot has no file_path" >&2
+    exit 1
+  fi
+  ABSOLUTE_PATH="$REPO_ROOT/$FILE_PATH"
+  if [ ! -f "$ABSOLUTE_PATH" ]; then
+    echo "[restore-snapshot] file_path points at $ABSOLUTE_PATH but it doesn't exist on this machine" >&2
+    echo "[restore-snapshot] (snapshots are filesystem-bound to the box that created them; copy it over first)" >&2
+    exit 1
+  fi
+  TARGET="$ABSOLUTE_PATH"
+else
+  # Pass-through: reset-to-snapshot.ts handles name fragments + absolute paths.
+  TARGET="$ID_OR_NAME"
+fi
+
+echo "[restore-snapshot] resetting DB to: $TARGET"
+(cd "$REPO_ROOT/backend" && npx tsx snapshots/reset-to-snapshot.ts "$TARGET")

--- a/scripts/ec2-bot/scripts/save-snapshot.sh
+++ b/scripts/ec2-bot/scripts/save-snapshot.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# save-snapshot.sh — capture the current backend DB state as a snapshot row
+# in the test-dashboard, plus the underlying .sql file on disk.
+#
+# Wraps backend/snapshots/create-snapshot.ts (which does the pg_dump) and
+# adds the dashboard registration so the snapshot tree picks it up.
+#
+# Usage:
+#   save-snapshot.sh <name> [--description <text>] [--parent-id <id>]
+#                            [--from-run-id <id>]
+#
+# Examples:
+#   save-snapshot.sh post-stage-2-empathy-shared
+#   save-snapshot.sh fresh-after-merge --description "Clean state, post-#216"
+#   save-snapshot.sh stage-3-complete --parent-id 01HK... --from-run-id 01KQ...
+#
+# Env (sourced from /opt/slam-bot/.env on EC2):
+#   TEST_DASHBOARD_API_URL    e.g. https://mwf-test-dashboard.vercel.app
+#   BOT_WRITER_TOKEN          x-bot-token value
+#   DATABASE_URL              backend test database (read by create-snapshot.ts)
+
+set -uo pipefail
+
+# Load bot env. Operator-set env vars win.
+BOT_ENV_FILE="${BOT_ENV_FILE:-/opt/slam-bot/.env}"
+if [ -f "$BOT_ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$BOT_ENV_FILE"
+  set +a
+fi
+
+# ── Args ─────────────────────────────────────────────────────────────────────
+if [ "$#" -lt 1 ]; then
+  cat >&2 <<EOF
+Usage: $0 <name> [flags]
+
+Required:
+  <name>                     human-readable snapshot name; used as filename
+                             slug and the dashboard "name" field
+                             (e.g. post-stage-2-empathy-shared)
+
+Optional:
+  --description <text>       free-form note about what this snapshot captures
+  --parent-id <id>           dashboard snapshot id this branched from
+  --from-run-id <id>         dashboard run id whose end state this captures
+EOF
+  exit 2
+fi
+
+NAME="$1"
+shift
+
+DESCRIPTION=""
+PARENT_ID=""
+FROM_RUN_ID=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --description)  DESCRIPTION="$2"; shift 2 ;;
+    --parent-id)    PARENT_ID="$2";   shift 2 ;;
+    --from-run-id)  FROM_RUN_ID="$2"; shift 2 ;;
+    *)
+      echo "Unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ── Env ──────────────────────────────────────────────────────────────────────
+: "${TEST_DASHBOARD_API_URL:?TEST_DASHBOARD_API_URL must be set}"
+: "${BOT_WRITER_TOKEN:?BOT_WRITER_TOKEN must be set}"
+: "${DATABASE_URL:?DATABASE_URL must be set (read by backend/snapshots/create-snapshot.ts)}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SNAPSHOTS_DIR="$REPO_ROOT/backend/snapshots"
+
+if [ ! -d "$SNAPSHOTS_DIR" ]; then
+  echo "[save-snapshot] backend/snapshots not found at $SNAPSHOTS_DIR" >&2
+  exit 1
+fi
+
+# ── 1. Dump the DB to a .sql file ────────────────────────────────────────────
+echo "[save-snapshot] dumping DB to backend/snapshots/snapshot-${NAME}--<timestamp>.sql"
+(cd "$REPO_ROOT/backend" && npx tsx snapshots/create-snapshot.ts "$NAME") || {
+  echo "[save-snapshot] create-snapshot.ts failed" >&2
+  exit 1
+}
+
+# Find the file we just created — newest snapshot-<name>-*.sql.
+SQL_FILE=$(ls -t "$SNAPSHOTS_DIR"/snapshot-"$NAME"--*.sql 2>/dev/null | head -1)
+if [ -z "$SQL_FILE" ] || [ ! -f "$SQL_FILE" ]; then
+  echo "[save-snapshot] could not find the SQL file we just dumped" >&2
+  exit 1
+fi
+RELATIVE_PATH="backend/snapshots/$(basename "$SQL_FILE")"
+echo "[save-snapshot] dumped: $RELATIVE_PATH ($(du -h "$SQL_FILE" | cut -f1))"
+
+# ── 2. Compute a quick db_state_summary (row counts in key tables) ───────────
+DB_SUMMARY="null"
+if command -v psql >/dev/null 2>&1; then
+  COUNTS=$(
+    PGPASSWORD=$(echo "$DATABASE_URL" | sed -n 's|.*://[^:]*:\([^@]*\)@.*|\1|p') \
+    psql "$DATABASE_URL" -tA -F: -c '
+      SELECT '\''Session'\'',          COUNT(*) FROM "Session"          UNION ALL
+      SELECT '\''Message'\'',          COUNT(*) FROM "Message"          UNION ALL
+      SELECT '\''StageProgress'\'',    COUNT(*) FROM "StageProgress"    UNION ALL
+      SELECT '\''EmpathyAttempt'\'',   COUNT(*) FROM "EmpathyAttempt"   UNION ALL
+      SELECT '\''Invitation'\'',       COUNT(*) FROM "Invitation"       UNION ALL
+      SELECT '\''User'\'',             COUNT(*) FROM "User";' 2>/dev/null || echo ""
+  )
+  if [ -n "$COUNTS" ]; then
+    # Build {"Session": 4, "Message": 27, ...} from the colon-separated rows.
+    DB_SUMMARY=$(echo "$COUNTS" | jq -Rn '
+      [inputs | select(length > 0) | split(":") | {(.[0]): (.[1] | tonumber)}]
+      | add // {}
+    ')
+  fi
+fi
+
+# ── 3. Register with the dashboard ───────────────────────────────────────────
+PAYLOAD=$(jq -n \
+  --arg name        "$NAME" \
+  --arg description "$DESCRIPTION" \
+  --arg file_path   "$RELATIVE_PATH" \
+  --arg parent_id   "$PARENT_ID" \
+  --arg created_by_run_id "$FROM_RUN_ID" \
+  --argjson db_state_summary "$DB_SUMMARY" \
+  '{
+     name: $name,
+     description: (if $description == "" then null else $description end),
+     file_path: $file_path,
+     parent_id: (if $parent_id == "" then null else $parent_id end),
+     created_by_run_id: (if $created_by_run_id == "" then null else $created_by_run_id end),
+     db_state_summary: $db_state_summary
+   }')
+
+echo "[save-snapshot] registering with dashboard at $TEST_DASHBOARD_API_URL"
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST "$TEST_DASHBOARD_API_URL/api/snapshots" \
+  -H "content-type: application/json" \
+  -H "x-bot-token: $BOT_WRITER_TOKEN" \
+  -d "$PAYLOAD")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" != "201" ]; then
+  echo "[save-snapshot] registration failed: HTTP $HTTP_CODE" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+SNAPSHOT_ID=$(echo "$BODY" | jq -r '.id')
+echo ""
+echo "[save-snapshot] DONE"
+echo "[save-snapshot] snapshot id: $SNAPSHOT_ID"
+echo "[save-snapshot] file:        $RELATIVE_PATH"
+echo "[save-snapshot] view:        $TEST_DASHBOARD_API_URL/snapshot/$SNAPSHOT_ID"

--- a/scripts/ec2-bot/scripts/snapshot.README.md
+++ b/scripts/ec2-bot/scripts/snapshot.README.md
@@ -1,0 +1,79 @@
+# save-snapshot.sh / restore-snapshot.sh
+
+Capture and restore backend DB snapshots, with the corresponding metadata row registered in the test-dashboard so the snapshot tree is browsable + tests can branch from any point.
+
+These wrap the existing `backend/snapshots/{create,reset-to}-snapshot.ts` scripts (which do the actual `pg_dump` / `psql` work) and add the dashboard registration on top.
+
+## Required env
+
+Sourced from `/opt/slam-bot/.env` automatically:
+
+| Var | What it's for |
+|---|---|
+| `TEST_DASHBOARD_API_URL` | e.g. `https://mwf-test-dashboard.vercel.app` |
+| `BOT_WRITER_TOKEN` | x-bot-token for the dashboard write API (save only) |
+| `DATABASE_URL` | Backend test database (`postgresql://...`); read by the underlying TS scripts |
+
+## Save a snapshot
+
+```bash
+# Minimal: dump current DB state, register on dashboard
+./scripts/ec2-bot/scripts/save-snapshot.sh post-stage-2-empathy-shared
+
+# With description + lineage (recommended)
+./scripts/ec2-bot/scripts/save-snapshot.sh stage-3-complete \
+  --description "Right after Bob accepts Alice's empathy, ready for stage 3" \
+  --parent-id 01HKABC...                                    \
+  --from-run-id 01KQ86MS...                                 # the run that produced this state
+```
+
+Output:
+```
+[save-snapshot] dumping DB to backend/snapshots/snapshot-stage-3-complete--<timestamp>.sql
+[save-snapshot] dumped: backend/snapshots/snapshot-stage-3-complete--2026-04-27T20-15-00.sql (47K)
+[save-snapshot] registering with dashboard at https://mwf-test-dashboard.vercel.app
+[save-snapshot] DONE
+[save-snapshot] snapshot id: 01KQ8FZGABCDEFGH...
+[save-snapshot] file:        backend/snapshots/snapshot-stage-3-complete--2026-04-27T20-15-00.sql
+[save-snapshot] view:        https://mwf-test-dashboard.vercel.app/snapshot/01KQ8FZGABCDEFGH...
+```
+
+The dashboard's snapshot detail page now shows this node, its parent, and any runs that branched from it.
+
+### What gets captured
+
+- **The .sql file** — `pg_dump --data-only` of the data tables (User, Session, Message, StageProgress, EmpathyAttempt, etc.) — same set as `backend/snapshots/create-snapshot.ts`.
+- **The dashboard row** — name, description, parent_id, file_path, created_by_run_id, and a `db_state_summary` JSONB with row counts in the most-used tables (`Session`, `Message`, `StageProgress`, `EmpathyAttempt`, `Invitation`, `User`).
+
+The `.sql` file lives **on the box that created it**. Snapshots are filesystem-bound today; cross-machine restore needs you to copy the file. (Future: upload the .sql to Blob too.)
+
+## Restore a snapshot
+
+```bash
+# By dashboard ID (looks up file_path via /api/snapshots/:id, then restores)
+./scripts/ec2-bot/scripts/restore-snapshot.sh 01KQ8FZGABCDEFGH...
+
+# By name fragment (skips the dashboard, lets reset-to-snapshot.ts find the file)
+./scripts/ec2-bot/scripts/restore-snapshot.sh 03-invitation-accepted
+```
+
+The dashboard-ID path enforces that the file exists locally (since snapshots are FS-bound). If the file's missing, the script tells you which `.sql` to copy over.
+
+The underlying `reset-to-snapshot.ts` does:
+1. `TRUNCATE` the data tables (CASCADE)
+2. `psql -f <file>` to load the snapshot
+3. `npx prisma migrate deploy` to apply any new migrations on top
+
+## Common workflows
+
+**"Branch a new test run from snapshot X"** — pass `--starting-snapshot-id` to `run-and-publish.sh`. The bot writer records the lineage; the dashboard's snapshot detail page lists every run that started here.
+
+**"Save the state after my test passed"** — the test runner calls `save-snapshot.sh <name> --from-run-id <id>` after a green run. (Manual today; could be automated by `run-and-publish.sh` accepting a `--save-on-pass <name>` flag — follow-up.)
+
+**"Investigate what changed between two snapshots"** — restore A, dump key tables, restore B, dump again, diff. (Phase 1C: dashboard surfaces this diff inline.)
+
+## Troubleshooting
+
+- **`registration failed: HTTP 401`** — `BOT_WRITER_TOKEN` mismatch. Same value must be set in Vercel env + the bot's `.env`.
+- **`file_path points at ... but it doesn't exist on this machine`** — snapshot was created on a different box. Either copy the `.sql` over or recreate via `save-snapshot.sh` here.
+- **`create-snapshot.ts failed`** — usually `DATABASE_URL` not set, or the user lacks `pg_dump` permissions. Confirm `psql -d $DATABASE_URL -c '\dt'` works first.


### PR DESCRIPTION
## Summary

Stage B continued — adds the bot scripts for capturing and restoring backend DB snapshots, with the corresponding metadata row registered in the test-dashboard so the snapshot tree is browsable and tests can branch from any prior point.

These wrap the existing `backend/snapshots/{create,reset-to}-snapshot.ts` scripts (which do the actual `pg_dump` / `psql` work) and add the dashboard registration on top.

- **`save-snapshot.sh <name>`** — dumps the data tables, captures row counts as `db_state_summary`, registers a row via `POST /api/snapshots`, prints the dashboard URL. Optional flags: `--description`, `--parent-id`, `--from-run-id` for lineage.
- **`restore-snapshot.sh <id-or-name>`** — ULID arg → looks up `file_path` via the dashboard, then restores from the local `.sql`. Name fragment arg → passes through to `reset-to-snapshot.ts` directly.

Both source `/opt/slam-bot/.env` so the bot's existing token plumbing works on EC2. Args + env validation tested locally.

## Why this matters

Right now the snapshot tree on the dashboard is empty — there are 9 `.sql` files in `backend/snapshots/` from local dev work but no rows in the `snapshots` Postgres table. Once these scripts are deployed:

- The bot can capture state mid-test (e.g. after each stage transition succeeds) and tag the run that produced it.
- Future runs can pass `--starting-snapshot-id <id>` to `run-and-publish.sh` (already wired) to branch off a known-good state instead of rebuilding from scratch.
- The "branch a new run from any prior snapshot via a button" loop — promised by the original plan — becomes possible once Phase 1B lights up the web trigger.

## Test plan

- [x] `save-snapshot.sh` with no args → prints usage, exits 2
- [x] `restore-snapshot.sh` with no args → prints usage, exits 2
- [x] `save-snapshot.sh <name>` without `TEST_DASHBOARD_API_URL` → fails with the right error message
- [ ] After merge + EC2 wiring: run `save-snapshot.sh smoke-snap` on EC2, confirm a row appears at `/snapshots`
- [ ] After step above: run `restore-snapshot.sh <id>`, confirm DB resets to the captured state

## Notes

- Snapshots are filesystem-bound today (the `.sql` lives on the box that created it). Cross-machine restore needs you to copy the file. Future enhancement: upload `.sql` to Vercel Blob too.
- The `db_state_summary` is currently row counts in the most-used tables. Phase 1C ships a richer diff view between two snapshots.
- This PR doesn't auto-call save-snapshot from anywhere — it's a manual tool for now. A natural follow-up: `run-and-publish.sh --save-on-pass <name>` to capture the end state of a green run automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)