### PR TITLE
feat(test-dashboard): @slam_paws test <scenario> Slack trigger

### DIFF
--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -681,6 +681,122 @@ async function postMwfForwardFallback(event) {
 // Event handling
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Test-dashboard trigger — `@slam_paws test <scenario> [from-snapshot:<id>]`
+// ---------------------------------------------------------------------------
+
+const TEST_TRIGGER_RE = /^test\s+(\S+)/i;
+const FROM_SNAPSHOT_RE = /from-snapshot:(\S+)/i;
+const RUN_AND_PUBLISH = `${SCRIPTS_DIR}/run-and-publish.sh`;
+
+/**
+ * Parse a message text for the test-trigger command. Strips the bot mention
+ * and any leading whitespace; returns { scenario, startingSnapshotId } or
+ * null if it isn't a test command.
+ */
+function parseTestCommand(text) {
+  if (!text) return null;
+  const mentionPrefix = `<@${BOT_USER_ID}>`;
+  if (!text.includes(mentionPrefix)) return null;
+  const stripped = text.replace(mentionPrefix, '').trim();
+  const m = stripped.match(TEST_TRIGGER_RE);
+  if (!m) return null;
+  // Reject "tests" / "testing" — only "test" exactly.
+  const verb = stripped.match(/^(\w+)/)?.[1];
+  if (verb && verb.toLowerCase() !== 'test') return null;
+  const scenario = m[1];
+  // Only treat as a scenario if it looks like a spec name (lowercase, dashes).
+  if (!/^[a-z0-9][a-z0-9-]*$/i.test(scenario)) return null;
+  const snapMatch = stripped.match(FROM_SNAPSHOT_RE);
+  return {
+    scenario,
+    startingSnapshotId: snapMatch ? snapMatch[1] : null,
+  };
+}
+
+/**
+ * If the message is a test trigger, claim it and spawn run-and-publish.sh
+ * detached. Posts a starting reply to the thread, then a result reply when
+ * the wrapper exits. Returns true if handled (caller should short-circuit
+ * normal channel routing), false otherwise.
+ */
+async function tryHandleTestCommand(event) {
+  const cmd = parseTestCommand(event.text);
+  if (!cmd) return false;
+
+  const { channel, ts, user } = event;
+  const replyTs = event.thread_ts || ts;
+
+  if (!claimMessage(channel, ts)) {
+    logMain(`Test trigger: skipping already-claimed ${ts}`);
+    return true;
+  }
+
+  const triggeredBy = user || 'slack-unknown';
+  logMain(`Test trigger: scenario=${cmd.scenario} channel=${channel} user=${triggeredBy}`);
+
+  await addReaction(channel, ts, 'eyes');
+  try {
+    await slack.chat.postMessage({
+      channel,
+      thread_ts: replyTs,
+      text: `Running \`${cmd.scenario}\`${cmd.startingSnapshotId ? ` from snapshot \`${cmd.startingSnapshotId}\`` : ''}… result will appear here when the run completes.`,
+    });
+  } catch (err) {
+    logMain(`Test trigger: failed to post starting reply: ${err.message}`);
+  }
+
+  const args = [cmd.scenario, '--trigger-source', 'slack', '--triggered-by', triggeredBy];
+  if (cmd.startingSnapshotId) {
+    args.push('--starting-snapshot-id', cmd.startingSnapshotId);
+  }
+
+  let stdoutBuf = '';
+  const child = spawn(RUN_AND_PUBLISH, args, {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  });
+  child.unref();
+
+  child.stdout.on('data', (d) => { stdoutBuf += d.toString(); });
+  child.stderr.on('data', (d) => { stdoutBuf += d.toString(); });
+
+  child.on('error', async (err) => {
+    logMain(`Test trigger: spawn failed: ${err.message}`);
+    await removeReaction(channel, ts, 'eyes');
+    await addReaction(channel, ts, 'x');
+    try {
+      await slack.chat.postMessage({
+        channel,
+        thread_ts: replyTs,
+        text: `❌ Could not launch \`${cmd.scenario}\`: ${err.message}`,
+      });
+    } catch { /* ignore */ }
+  });
+
+  child.on('exit', async (code) => {
+    await removeReaction(channel, ts, 'eyes');
+    await addReaction(channel, ts, code === 0 ? 'white_check_mark' : 'x');
+
+    const viewMatch = stdoutBuf.match(/view:\s+(\S+)/);
+    const url = viewMatch ? viewMatch[1] : null;
+    const status = code === 0 ? '✅ pass' : '❌ fail';
+    const text = url
+      ? `${status}: \`${cmd.scenario}\`\n${url}`
+      : `${status}: \`${cmd.scenario}\` (could not parse run URL — check /var/log/slam-bot/test-runs.log)`;
+
+    try {
+      await slack.chat.postMessage({ channel, thread_ts: replyTs, text });
+    } catch (err) {
+      logMain(`Test trigger: failed to post result reply: ${err.message}`);
+    }
+    logMain(`Test trigger: ${cmd.scenario} exited ${code}`);
+  });
+
+  return true;
+}
+
 async function handleMessageEvent(event) {
   // Only process actual message events (skip app_mention, reaction_added, etc.)
   if (event.type && event.type !== 'message') return;
@@ -692,6 +808,15 @@ async function handleMessageEvent(event) {
 
   // Skip message subtypes we don't care about (edits, deletes, joins, etc.)
   if (subtype && subtype !== 'file_share') return;
+
+  // ── Test-dashboard trigger ────────────────────────────────────────────────
+  // `@slam_paws test <scenario>` short-circuits the normal channel routing
+  // and runs an e2e scenario via run-and-publish.sh. Works in any channel
+  // where the bot can read messages, including ones not in CHANNEL_CONFIG.
+  if (await tryHandleTestCommand(event)) {
+    writeFileSync(HEARTBEAT_FILE, new Date().toISOString());
+    return;
+  }
 
   // Check if this channel is configured
   const config = CHANNEL_CONFIG[channel];

--- a/scripts/ec2-bot/socket-mode/test-parse-test-command.mjs
+++ b/scripts/ec2-bot/socket-mode/test-parse-test-command.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Standalone test for parseTestCommand — exercises the regex on the sample
+ * inputs we expect to see in Slack. Run with:
+ *
+ *   BOT_USER_ID=U123ABC node scripts/ec2-bot/socket-mode/test-parse-test-command.mjs
+ *
+ * Exits non-zero on any unexpected match/non-match so it's CI-friendly.
+ */
+
+// Mirror the parser in socket-listener.mjs. Kept verbatim — when this test
+// flags a mismatch, fix BOTH copies.
+const BOT_USER_ID = process.env.BOT_USER_ID || 'U_BOT_TEST';
+const TEST_TRIGGER_RE = /^test\s+(\S+)/i;
+const FROM_SNAPSHOT_RE = /from-snapshot:(\S+)/i;
+
+function parseTestCommand(text) {
+  if (!text) return null;
+  const mentionPrefix = `<@${BOT_USER_ID}>`;
+  if (!text.includes(mentionPrefix)) return null;
+  const stripped = text.replace(mentionPrefix, '').trim();
+  const m = stripped.match(TEST_TRIGGER_RE);
+  if (!m) return null;
+  const verb = stripped.match(/^(\w+)/)?.[1];
+  if (verb && verb.toLowerCase() !== 'test') return null;
+  const scenario = m[1];
+  if (!/^[a-z0-9][a-z0-9-]*$/i.test(scenario)) return null;
+  const snapMatch = stripped.match(FROM_SNAPSHOT_RE);
+  return { scenario, startingSnapshotId: snapMatch ? snapMatch[1] : null };
+}
+
+const cases = [
+  // [input,                                                    expected (or null)]
+  [`<@${BOT_USER_ID}> test single-user-journey`,                { scenario: 'single-user-journey', startingSnapshotId: null }],
+  [`<@${BOT_USER_ID}> test two-browser-stage-2`,                { scenario: 'two-browser-stage-2', startingSnapshotId: null }],
+  [`<@${BOT_USER_ID}>   test    two-browser-smoke`,             { scenario: 'two-browser-smoke', startingSnapshotId: null }],
+  [`hey <@${BOT_USER_ID}> test partner-journey please`,         null],  // text before "test" rejected
+  [`<@${BOT_USER_ID}> test stage-3-4-complete from-snapshot:01HK1234`,
+                                                                { scenario: 'stage-3-4-complete', startingSnapshotId: '01HK1234' }],
+  [`<@${BOT_USER_ID}> tests`,                                    null],  // "tests" not "test"
+  [`<@${BOT_USER_ID}> testing`,                                  null],
+  [`<@${BOT_USER_ID}> hello world`,                              null],
+  [`test single-user-journey`,                                   null],  // no mention
+  [``,                                                           null],
+  [null,                                                         null],
+  // Scenario name validation: only [a-z0-9-]
+  [`<@${BOT_USER_ID}> test ../../../etc/passwd`,                 null],
+  [`<@${BOT_USER_ID}> test "two browser stage 2"`,               null],
+  [`<@${BOT_USER_ID}> test --evil`,                              null],
+];
+
+let failed = 0;
+for (const [input, expected] of cases) {
+  const got = parseTestCommand(input);
+  const ok = JSON.stringify(got) === JSON.stringify(expected);
+  if (!ok) {
+    failed++;
+    console.error(`FAIL  input=${JSON.stringify(input)}\n      got=${JSON.stringify(got)}\n      want=${JSON.stringify(expected)}`);
+  }
+}
+
+if (failed === 0) {
+  console.log(`✓ ${cases.length}/${cases.length} parse cases passed`);
+  process.exit(0);
+} else {
+  console.error(`\n✗ ${failed}/${cases.length} parse cases failed`);
+  process.exit(1);
+}

--- a/scripts/ec2-bot/socket-mode/test-trigger.README.md
+++ b/scripts/ec2-bot/socket-mode/test-trigger.README.md
@@ -1,0 +1,87 @@
+# Slack `@slam_paws test` trigger
+
+Lets you kick off a Playwright e2e run from any channel where the bot can read messages, instead of SSHing to EC2 to launch `run-and-publish.sh` by hand.
+
+## Usage
+
+In Slack, mention the bot followed by `test <scenario>`:
+
+```
+@slam_paws test single-user-journey
+@slam_paws test two-browser-stage-2
+@slam_paws test stage-3-4-complete from-snapshot:01HK1234
+```
+
+The scenario name is the spec's filename without `.spec.ts`. See `e2e/tests/` for the canonical list.
+
+## What happens
+
+1. **Immediate**: bot adds 👀 reaction and posts a thread reply: *"Running `<scenario>`… result will appear here when the run completes."*
+2. **`run-and-publish.sh` runs in the background**: spawns Playwright, captures screenshots, posts artifacts to Vercel Blob, finalizes the dashboard row.
+3. **On completion**: bot swaps 👀 for ✅ (pass) or ❌ (fail), posts a thread reply with the dashboard URL.
+
+The handler is non-blocking — multiple test triggers in flight at once is fine.
+
+## Where it works
+
+Any channel where the slam-bot can read messages. Doesn't require the channel to be in `CHANNEL_CONFIG` because the test handler short-circuits before the normal channel routing.
+
+DMs work too: in a DM with the bot, just type `<@SLAM_BOT> test single-user-journey`.
+
+## Acceptable scenario names
+
+The parser only accepts scenario names matching `[a-z0-9][a-z0-9-]*` to keep shell injection paths closed. So:
+
+- ✅ `single-user-journey`
+- ✅ `two-browser-stage-2`
+- ❌ `"two browser stage 2"` (quoted with spaces)
+- ❌ `../../../etc/passwd` (path traversal)
+- ❌ `--evil` (flag injection)
+
+## Optional flags
+
+- `from-snapshot:<id>` — branch the run from a saved snapshot. The id comes from the dashboard's snapshot detail page URL.
+
+## Thread replies
+
+If you trigger from inside a thread, the result reply lands in the same thread. Triggering from the channel root opens a new thread.
+
+## Permission model
+
+There's no allowlist today — anyone in a channel where the bot is present can trigger a test. This is consistent with how the test-dashboard's `BOT_WRITER_TOKEN` is the trust root. If we need finer-grained control later, gate via Slack user ID.
+
+## Environment requirements
+
+Already satisfied if the EC2 bot has the env from the test-dashboard rollout:
+
+- `TEST_DASHBOARD_API_URL`
+- `BOT_WRITER_TOKEN`
+- `BLOB_READ_WRITE_TOKEN`
+- `DATABASE_URL` (for the actual test DB the e2e suite runs against)
+
+After deploying this PR, restart the socket listener so the new handler is loaded:
+
+```bash
+ssh slam-bot
+sudo systemctl restart slam-bot-socket
+```
+
+(The `deploy.sh` script in `scripts/ec2-bot/` syncs the listener and reinstalls the systemd unit.)
+
+## Local sanity test
+
+The pure-string parser has standalone tests:
+
+```bash
+BOT_USER_ID=U_TEST node scripts/ec2-bot/socket-mode/test-parse-test-command.mjs
+# ✓ 14/14 parse cases passed
+```
+
+These are the only tests that don't require a live Slack workspace. End-to-end testing happens by talking to the bot in Slack after deploy.
+
+## Troubleshooting
+
+- **No reaction at all**: bot may not have message-read permission in that channel. Invite it.
+- **`Could not launch <scenario>`**: `run-and-publish.sh` not at `/opt/slam-bot/scripts/`. Check the deploy symlink.
+- **`could not parse run URL`**: wrapper failed before printing the dashboard URL — check `/var/log/slam-bot/test-runs.log` (or whatever `2>&1` redirects the spawn to).
+- **Reaction stays at 👀 forever**: spawned process never exited. Check `ps aux | grep run-and-publish`.


### PR DESCRIPTION
## Summary

Stage B continued — adds the Slack trigger so anyone in a channel where the bot is present can kick off an e2e run with `@slam_paws test <scenario>`. Closes the loop the original plan described as "from Slack: bot enqueues + executes locally → on completion writes a Postgres row".

`socket-listener.mjs` now short-circuits the normal channel routing when it sees the test mention. The handler:

1. Posts a starting reply in the thread (or opens a new thread if triggered from the channel root): *"Running `<scenario>`… result will appear here when the run completes."*
2. Spawns `/opt/slam-bot/scripts/run-and-publish.sh` detached. Captures stdout/stderr.
3. Adds 👀 reaction. On exit, swaps to ✅ (pass) or ❌ (fail) and posts a thread reply with the dashboard URL parsed from the wrapper's stdout.

Optional `from-snapshot:<id>` flag in the message branches the run from a saved snapshot.

## Examples

```
@slam_paws test single-user-journey
@slam_paws test two-browser-stage-2
@slam_paws test stage-3-4-complete from-snapshot:01HK1234
```

## Security

The parser only accepts scenario names matching `[a-z0-9][a-z0-9-]*`. Path traversal, quoted strings, and flag injection are all rejected at the parser level — the args go to `spawn` as an array (no shell), so even a malformed scenario name can't escape into a shell command.

There's no Slack-user allowlist. Anyone in a channel where the bot is present can trigger a test. Consistent with the existing trust model (channel-based auth).

## Test plan

- [x] Standalone parser test: `node scripts/ec2-bot/socket-mode/test-parse-test-command.mjs` → 14/14 passed
- [x] `node --check socket-listener.mjs` syntax-clean
- [x] Verified the spawn args are constructed correctly (no shell, array args)
- [ ] After merge + EC2 deploy: type `@slam_paws test single-user-journey` in #agentic-devs, confirm bot reaction + thread replies + dashboard row
- [ ] Try a deliberately bad input (`@slam_paws test ../../../etc/passwd`) — should be silently ignored, not crash the listener

## Operator deployment

Standard `scripts/ec2-bot/deploy.sh` flow:

```bash
# From your laptop
./scripts/ec2-bot/deploy.sh
# Then on EC2:
ssh slam-bot 'sudo systemctl restart slam-bot-socket'
```

The deploy script syncs `socket-mode/` and reinstalls the systemd unit. Restart picks up the new handler.

## Out of scope (follow-up PRs)

- Snapshot save trigger from Slack (`@slam_paws save-snapshot <name>`) — natural pair with the test trigger but separate functionality
- Web-trigger auth (Phase 1B) — Clerk on `POST /api/runs`
- Live progress: stream test progress as Slack thread updates instead of just start/end

🤖 Generated with [Claude Code](https://claude.com/claude-code)