### PR TITLE
fix(test-dashboard): resolve symlinks before computing REPO_ROOT

### DIFF
--- a/scripts/ec2-bot/scripts/restore-snapshot.sh
+++ b/scripts/ec2-bot/scripts/restore-snapshot.sh
@@ -40,7 +40,9 @@ EOF
 fi
 
 ID_OR_NAME="$1"
-REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+# Resolve symlinks before walking up (EC2 invokes via /opt/slam-bot/scripts/...).
+SCRIPT_REAL="$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")"
+REPO_ROOT="$(cd "$(dirname "$SCRIPT_REAL")/../../.." && pwd)"
 
 : "${DATABASE_URL:?DATABASE_URL must be set}"
 

--- a/scripts/ec2-bot/scripts/run-and-publish.sh
+++ b/scripts/ec2-bot/scripts/run-and-publish.sh
@@ -87,7 +87,10 @@ done
 : "${BOT_WRITER_TOKEN:?BOT_WRITER_TOKEN must be set}"
 : "${BLOB_READ_WRITE_TOKEN:=}"   # screenshots only; non-fatal if missing
 
-REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+# Resolve symlinks before walking up — on EC2 this script is invoked via
+# /opt/slam-bot/scripts/run-and-publish.sh which symlinks to the repo.
+SCRIPT_REAL="$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")"
+REPO_ROOT="$(cd "$(dirname "$SCRIPT_REAL")/../../.." && pwd)"
 E2E_DIR="$REPO_ROOT/e2e"
 RESULTS_DIR="$E2E_DIR/test-results"
 SUMMARY_FILE="$RESULTS_DIR/dashboard-summary.json"

--- a/scripts/ec2-bot/scripts/save-snapshot.sh
+++ b/scripts/ec2-bot/scripts/save-snapshot.sh
@@ -72,7 +72,9 @@ done
 : "${BOT_WRITER_TOKEN:?BOT_WRITER_TOKEN must be set}"
 : "${DATABASE_URL:?DATABASE_URL must be set (read by backend/snapshots/create-snapshot.ts)}"
 
-REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+# Resolve symlinks before walking up (EC2 invokes via /opt/slam-bot/scripts/...).
+SCRIPT_REAL="$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")"
+REPO_ROOT="$(cd "$(dirname "$SCRIPT_REAL")/../../.." && pwd)"
 SNAPSHOTS_DIR="$REPO_ROOT/backend/snapshots"
 
 if [ ! -d "$SNAPSHOTS_DIR" ]; then


### PR DESCRIPTION
Tiny fix discovered while wiring the bot on EC2. `dirname $0` walks up from the symlink path `/opt/slam-bot/scripts/` instead of the underlying repo, so `REPO_ROOT` came out as `/` and run-and-publish.sh failed with `cannot find e2e dir at //e2e`. Adds `readlink -f` / `realpath` fallback. Verified locally with a fresh symlink that the invocation now resolves correctly. Same fix applied to save-snapshot.sh and restore-snapshot.sh which have the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)