### PR TITLE
fix(test-dashboard): drop daily smoke cron

### DIFF
--- a/scripts/ec2-bot/crontab.txt
+++ b/scripts/ec2-bot/crontab.txt
@@ -48,10 +48,12 @@
 0 4 * * * /opt/slam-bot/scripts/prune-journal.sh >> /var/log/slam-bot/cron.log 2>&1
 5 4 * * * /opt/slam-bot/scripts/prune-claude-projects.sh >> /var/log/slam-bot/cron.log 2>&1
 
-# ── Daily smoke test (publishes to test-dashboard.vercel.app) ────────────────
-# 04:00 UTC ≈ 21:00 PT, off-peak. Publishes pass/fail + screenshots to the
-# test-dashboard via write-test-result.ts. See run-and-publish.README.md.
-0 4 * * * /opt/slam-bot/scripts/run-and-publish.sh single-user-journey --trigger-source cron --triggered-by daily-smoke >> /var/log/slam-bot/test-runs.log 2>&1
+# ── Test-dashboard runs ──────────────────────────────────────────────────────
+# Triggered on-demand only — via @slam_paws test <scenario> in Slack, or by
+# SSH'ing in and running /opt/slam-bot/scripts/run-and-publish.sh directly.
+# No scheduled cron because we don't want noisy nightly failures filling the
+# dashboard when the value of a heartbeat is low. Re-add a weekly entry here
+# if the dashboard ever feels too sparse.
 
 # ── API budget monitoring ────────────────────────────────────────────────────
 * * * * * /opt/slam-bot/scripts/api-budget-monitor.sh >> /var/log/slam-bot/cron.log 2>&1


### PR DESCRIPTION
Removes the 04:00 UTC daily run we added in #217 — `@slam_paws test` and direct SSH cover the on-demand trigger surface, so the daily heartbeat was just adding dashboard noise. Comment in crontab.txt notes how to re-add a weekly entry if it ever feels sparse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)