### PR TITLE
fix(test-dashboard): real AI conversation as transcript

### DIFF
--- a/e2e/reporters/test-dashboard-reporter.ts
+++ b/e2e/reporters/test-dashboard-reporter.ts
@@ -18,7 +18,9 @@
  *     failed_test_line: number | null,
  *     console_logs: string,             // newline-joined
  *     page_errors: string,              // newline-joined
- *     transcript: string,               // newline-joined console.log() output from spec
+ *     spec_stdout: string,              // newline-joined console.log() output from spec
+ *                                       //   (NOT the AI conversation — wrapper queries the
+ *                                       //    Message table for that and posts as transcript)
  *     screenshot_dir: string,           // absolute path; same as Playwright's outputDir per-test
  *   }
  *
@@ -61,7 +63,12 @@ interface SummaryShape {
   failed_test_line: number | null;
   console_logs: string;
   page_errors: string;
-  transcript: string;
+  /**
+   * Test runner stdout — the spec's own console.log() calls (step labels,
+   * timing, etc). Useful for debugging spec failures. NOT the AI conversation;
+   * the wrapper queries the backend Message table separately for that.
+   */
+  spec_stdout: string;
   screenshot_dir: string;
   test_count: number;
   pass_count: number;
@@ -77,7 +84,7 @@ export default class TestDashboardReporter implements Reporter {
   private screenshotDir: string;
   private consoleLogs: string[] = [];
   private pageErrors: string[] = [];
-  private transcript: string[] = [];
+  private specStdout: string[] = [];
   private firstFailure: { test: TestCase; result: TestResult } | null = null;
   private testCount = 0;
   private passCount = 0;
@@ -112,7 +119,7 @@ export default class TestDashboardReporter implements Reporter {
     // stdout / stderr — captured per-test by Playwright. We accumulate.
     for (const out of result.stdout) {
       const text = typeof out === 'string' ? out : out.toString('utf8');
-      this.transcript.push(text.trimEnd());
+      this.specStdout.push(text.trimEnd());
     }
     for (const err of result.stderr) {
       const text = typeof err === 'string' ? err : err.toString('utf8');
@@ -193,7 +200,7 @@ export default class TestDashboardReporter implements Reporter {
       failed_test_line: failure?.test.location.line ?? null,
       console_logs: this.consoleLogs.join('\n'),
       page_errors: this.pageErrors.join('\n'),
-      transcript: this.transcript.join('\n'),
+      spec_stdout: this.specStdout.join('\n'),
       screenshot_dir: this.screenshotDir,
       test_count: this.testCount,
       pass_count: this.passCount,
@@ -203,7 +210,7 @@ export default class TestDashboardReporter implements Reporter {
     const summaryPath = join(this.outputDir, 'dashboard-summary.json');
     writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
     console.log(
-      `[dashboard-reporter] wrote ${summaryPath} (status=${summary.status}, ${summary.test_count} tests, ${this.transcript.length} stdout chunks)`
+      `[dashboard-reporter] wrote ${summaryPath} (status=${summary.status}, ${summary.test_count} tests, ${this.specStdout.length} stdout chunks)`
     );
   }
 
@@ -217,9 +224,9 @@ export default class TestDashboardReporter implements Reporter {
   }
 
   private parseFinalStage(): number | null {
-    // If the test name or transcript mentions "stage N", capture it.
+    // If the test name or spec stdout mentions "stage N", capture it.
     const re = /\bstage[\s-]*(\d)\b/i;
-    const sources = [...this.transcript, this.firstFailure?.test.title ?? ''].join('\n');
+    const sources = [...this.specStdout, this.firstFailure?.test.title ?? ''].join('\n');
     const m = sources.match(re);
     if (m) {
       const n = Number(m[1]);

--- a/scripts/ec2-bot/scripts/run-and-publish.sh
+++ b/scripts/ec2-bot/scripts/run-and-publish.sh
@@ -167,7 +167,7 @@ if [ ! -f "$SUMMARY_FILE" ]; then
   "failed_test_line": null,
   "console_logs": "",
   "page_errors": "",
-  "transcript": "",
+  "spec_stdout": "",
   "screenshot_dir": "$RESULTS_DIR/dashboard-screenshots",
   "test_count": 0,
   "pass_count": 0,
@@ -220,11 +220,52 @@ if [ -d "$SCREENSHOT_DIR" ] && [ -n "$(ls -A "$SCREENSHOT_DIR" 2>/dev/null)" ]; 
   CMD+=(--screenshots-dir "$SCREENSHOT_DIR")
 fi
 
-# Capture transcript as a side-file the writer can post.
+# ── Console artifact: spec stdout (test runner progress logs) ────────────────
+CONSOLE_FILE="$RESULTS_DIR/dashboard-console.txt"
+jq -r '.spec_stdout // ""' "$SUMMARY_FILE" > "$CONSOLE_FILE"
+if [ -s "$CONSOLE_FILE" ]; then
+  CMD+=(--console-file "$CONSOLE_FILE")
+fi
+
+# ── Transcript artifact: AI conversation messages from the backend DB ────────
+# Query Messages created during the test window. The test DB is fresh per run
+# (Playwright's globalSetup truncates), so any rows post-STARTED_AT are ours.
 TRANSCRIPT_FILE="$RESULTS_DIR/dashboard-transcript.txt"
-jq -r '.transcript' "$SUMMARY_FILE" > "$TRANSCRIPT_FILE"
+> "$TRANSCRIPT_FILE"
+
+# Source e2e/.env.test for the test DATABASE_URL.
+TEST_ENV_FILE="$E2E_DIR/.env.test"
+TEST_DATABASE_URL="${TEST_DATABASE_URL:-postgresql://mwf_user:mwf_password@localhost:5432/meet_without_fear_test}"
+if [ -f "$TEST_ENV_FILE" ]; then
+  TEST_DATABASE_URL=$(grep '^DATABASE_URL=' "$TEST_ENV_FILE" | head -1 | cut -d= -f2- | tr -d '"' || echo "$TEST_DATABASE_URL")
+fi
+
+if command -v psql >/dev/null 2>&1; then
+  # Format: [Speaker] content
+  # Speaker: user.name if senderId set, else role (USER/AI/SYSTEM/...).
+  # Use \n between rows in the SELECT itself to avoid shell-side line joining.
+  psql "$TEST_DATABASE_URL" -tA -F$'\x1f' -c "
+    SELECT
+      COALESCE(
+        '[' || u.name || ']',
+        '[' || m.role::text || ']'
+      ),
+      m.content
+    FROM \"Message\" m
+    LEFT JOIN \"User\" u ON u.id = m.\"senderId\"
+    WHERE m.\"timestamp\" >= '$REAL_STARTED_AT'::timestamptz
+    ORDER BY m.\"timestamp\" ASC;
+  " 2>/dev/null | awk -F$'\x1f' 'NF==2 { print $1 " " $2 }' > "$TRANSCRIPT_FILE" || {
+    echo "[run-and-publish] WARN: failed to query Messages from $TEST_DATABASE_URL — transcript will be empty"
+  }
+fi
+
 if [ -s "$TRANSCRIPT_FILE" ]; then
+  TRANSCRIPT_LINES=$(wc -l < "$TRANSCRIPT_FILE" | tr -d ' ')
+  echo "[run-and-publish] transcript: $TRANSCRIPT_LINES message(s) from Message table"
   CMD+=(--transcript-file "$TRANSCRIPT_FILE")
+else
+  echo "[run-and-publish] transcript: no messages found in test DB (test may have failed before any messages were created)"
 fi
 
 echo "[run-and-publish] publishing run (status=$STATUS, scenario=$SCENARIO)"

--- a/scripts/ec2-bot/scripts/write-test-result.ts
+++ b/scripts/ec2-bot/scripts/write-test-result.ts
@@ -42,6 +42,7 @@ interface Args {
   startedAt?: string;
   finishedAt?: string;
   durationMs?: number;
+  consoleFile?: string;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -73,6 +74,7 @@ function parseArgs(argv: string[]): Args {
       case '--started-at':          args.startedAt          = take(); break;
       case '--finished-at':         args.finishedAt         = take(); break;
       case '--duration-ms':         args.durationMs         = Number(take()); break;
+      case '--console-file':        args.consoleFile        = take(); break;
       case '--help':
       case '-h':
         printHelpAndExit();
@@ -291,6 +293,43 @@ interface FinalizeCtx {
   startedAtIso: string;
 }
 
+/**
+ * Post a text artifact (transcript or console) from a file. Missing file is
+ * a warning; read/post failures propagate.
+ */
+async function postTextArtifact(
+  ctx: FinalizeCtx,
+  filePath: string,
+  type: 'transcript' | 'console',
+  stepIndex: number
+): Promise<void> {
+  let exists = false;
+  try {
+    exists = statSync(filePath).isFile();
+  } catch {
+    // ENOENT etc. — warn below.
+  }
+  if (!exists) {
+    console.warn(
+      `[write-test-result] --${type}-file not found: ${filePath}`
+    );
+    return;
+  }
+  const text = readFileSync(filePath, 'utf8');
+  if (text.trim().length === 0) {
+    console.log(`[write-test-result] ${type} file empty, skipping post`);
+    return;
+  }
+  await apiFetch(ctx.apiBase, ctx.botToken, '/api/artifacts', 'POST', {
+    run_id: ctx.runId,
+    type,
+    inline_text: text,
+    caption: basename(filePath),
+    step_index: stepIndex,
+  });
+  console.log(`[write-test-result] ${type} posted (${text.length} chars)`);
+}
+
 async function uploadArtifactsAndFinalize(ctx: FinalizeCtx): Promise<void> {
   const { apiBase, botToken, blobToken, runId, args, startedAtIso } = ctx;
 
@@ -356,30 +395,15 @@ async function uploadArtifactsAndFinalize(ctx: FinalizeCtx): Promise<void> {
     }
   }
 
-  // 3. Transcript artifact. Same split: missing-file is a warning, read/post
-  // failures propagate.
+  // 3a. Transcript artifact (AI conversation messages). Same split:
+  // missing-file is a warning, read/post failures propagate.
   if (args.transcriptFile) {
-    let exists = false;
-    try {
-      exists = statSync(args.transcriptFile).isFile();
-    } catch {
-      // ENOENT etc. — warn below.
-    }
-    if (!exists) {
-      console.warn(
-        `[write-test-result] --transcript-file not found: ${args.transcriptFile}`
-      );
-    } else {
-      const text = readFileSync(args.transcriptFile, 'utf8');
-      await apiFetch(apiBase, botToken, '/api/artifacts', 'POST', {
-        run_id: runId,
-        type: 'transcript',
-        inline_text: text,
-        caption: basename(args.transcriptFile),
-        step_index: 9999, // sort transcript last
-      });
-      console.log(`[write-test-result] transcript posted (${text.length} chars)`);
-    }
+    await postTextArtifact(ctx, args.transcriptFile, 'transcript', 9999);
+  }
+
+  // 3b. Console artifact (test runner stdout — spec progress logs).
+  if (args.consoleFile) {
+    await postTextArtifact(ctx, args.consoleFile, 'console', 9998);
   }
 
   // 4. Final PATCH with status + timing + failure metadata.


### PR DESCRIPTION
Issue spotted by Jason: the transcript on a run detail page was showing the spec's own `console.log("Step 1: ...")` progress logging, not the actual AI conversation messages. The original plan's intent for `transcript` was the messages exchanged.

Three coordinated changes:
- **Reporter**: renames the JSON field `transcript` → `spec_stdout` to be honest about what's in there. The Playwright stdout still gets captured, just labeled correctly.
- **Wrapper**: queries the `Message` table in the e2e test DB after each run (DB is fresh per run, so rows post-`STARTED_AT` are this run's) and formats `[Speaker] content` lines. Posts as transcript artifact via existing `--transcript-file` flag.
- **Writer**: adds `--console-file` for the spec stdout, factored shared logic into `postTextArtifact()`.

Verified the SQL query directly on EC2 against the existing test DB rows — produces clean conversation. The next test run will exercise both artifact types end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)