### PR TITLE
fix(test-dashboard): show screenshots full instead of cropping

### DIFF
--- a/tools/test-dashboard/src/style.css
+++ b/tools/test-dashboard/src/style.css
@@ -606,8 +606,6 @@ code, pre, .mono {
   height: auto;
   display: block;
   background: #000;
-  aspect-ratio: 16/10;
-  object-fit: cover;
 }
 
 .screenshot-card .caption {


### PR DESCRIPTION
Trivial CSS — `aspect-ratio: 16/10` + `object-fit: cover` was cropping mobile-portrait Playwright screenshots into a thin strip. Removing both shows the full image inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)