### PR TITLE
fix(e2e): drop stale compact-agree-checkbox in signCompact helper

### DIFF
--- a/e2e/helpers/test-utils.ts
+++ b/e2e/helpers/test-utils.ts
@@ -169,11 +169,13 @@ export async function navigateToShareFromSession(
  * @param page - Playwright Page instance
  * @param timeout - Maximum time to wait for compact UI (default: 10000)
  */
-export async function signCompact(page: Page, timeout = 10000): Promise<void> {
-  const agreeCheckbox = page.getByTestId('compact-agree-checkbox');
-  await expect(agreeCheckbox).toBeVisible({ timeout });
-  await agreeCheckbox.click();
-  await page.getByTestId('compact-sign-button').click();
+export async function signCompact(page: Page, timeout = 30000): Promise<void> {
+  // The compact agreement bar was simplified — the standalone agree-checkbox
+  // no longer exists; the bar is now just a single Sign/Ready CTA. Mirrors
+  // the fix in PR #192 (single-user-journey.spec.ts).
+  const signButton = page.getByTestId('compact-sign-button');
+  await expect(signButton).toBeVisible({ timeout });
+  await signButton.click();
 }
 
 /**


### PR DESCRIPTION
Spotted while smoke-testing the test-dashboard's real-LLM path. `live-ai-full-flow` consistently failed at the same line because the shared `signCompact()` helper still references the removed `compact-agree-checkbox` testid. PR #192 fixed the inlined version in `single-user-journey` but didn't update the helper.

Mirrors #192: just wait for + click `compact-sign-button`. Same fix unblocks transition-message-display, the stage-2-empathy reconciler suite, and partner-journey, all of which use the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)