### PR TITLE
test(e2e): add live-ai-two-browser-full-flow scenario

### DIFF
--- a/e2e/helpers/two-browser-harness.ts
+++ b/e2e/helpers/two-browser-harness.ts
@@ -11,8 +11,10 @@ import { cleanupE2EData } from './cleanup';
 import { createUserContext, navigateToSession, handleMoodCheck } from './test-utils';
 
 export interface TwoBrowserConfig {
-  userA: { email: string; name: string; fixtureId: string };
-  userB: { email: string; name: string; fixtureId: string };
+  // fixtureId is optional: omit for real-AI runs (MOCK_LLM=false), provide for
+  // mocked runs that match a backend test fixture.
+  userA: { email: string; name: string; fixtureId?: string };
+  userB: { email: string; name: string; fixtureId?: string };
   apiBaseUrl?: string;  // defaults to process.env.API_BASE_URL || 'http://localhost:3000'
   appBaseUrl?: string;  // defaults to process.env.APP_BASE_URL || 'http://localhost:8082'
 }

--- a/e2e/playwright.live-ai.config.ts
+++ b/e2e/playwright.live-ai.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   testMatch: /live-ai-.*\.spec\.ts/,
   timeout: 1800000, // 30 minutes per test (two-browser real-AI flow can take 15+ min)
   expect: {
-    timeout: 90000, // real-AI roundtrips can take 60s+; pad for empathy/strategy turns
+    timeout: 180000, // structured-output turns (invitation/empathy/strategy drafts) can spike to 120s+ on Bedrock
   },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,

--- a/e2e/playwright.live-ai.config.ts
+++ b/e2e/playwright.live-ai.config.ts
@@ -1,6 +1,10 @@
 /**
  * Playwright config for live-AI tests (MOCK_LLM=false).
  *
+ * Picks up any spec named `live-ai-*.spec.ts` (single-user or two-browser).
+ * No E2E_FIXTURE_ID in webServer env — per-user fixtures (when used) flow
+ * through the X-E2E-Fixture-ID header from each browser context.
+ *
  * Run with:
  *   npx playwright test --config=e2e/playwright.live-ai.config.ts
  */
@@ -13,10 +17,10 @@ dotenv.config({ path: path.resolve(__dirname, '.env.test') });
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: 'live-ai-full-flow.spec.ts',
-  timeout: 900000, // 15 minutes per test (real AI: ~50-60s per response including classifier timeout)
+  testMatch: /live-ai-.*\.spec\.ts/,
+  timeout: 1800000, // 30 minutes per test (two-browser real-AI flow can take 15+ min)
   expect: {
-    timeout: 15000,
+    timeout: 90000, // real-AI roundtrips can take 60s+; pad for empathy/strategy turns
   },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
@@ -33,7 +37,7 @@ export default defineConfig({
   projects: [
     {
       name: 'live-ai-flow',
-      testMatch: /live-ai-full-flow\.spec\.ts/,
+      testMatch: /live-ai-.*\.spec\.ts/,
       use: {
         baseURL: 'http://localhost:8082',
       },
@@ -50,6 +54,9 @@ export default defineConfig({
         ...process.env,
         E2E_AUTH_BYPASS: 'true',
         MOCK_LLM: 'false',
+        // No E2E_FIXTURE_ID — two-browser specs supply per-user fixtures via
+        // X-E2E-Fixture-ID header. The single-user live-ai-full-flow spec
+        // does not rely on a global fixture id either (it reaches real LLM).
       },
     },
     {

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -1,0 +1,497 @@
+/**
+ * Live AI Two-Browser Full Flow E2E Test
+ *
+ * Two users + real Bedrock + Stages 0→4. Companion to:
+ *   - live-ai-full-flow.spec.ts        (real AI, single user, stages 0-2)
+ *   - two-browser-full-flow.spec.ts    (mocked AI, two users, stages 0-4)
+ *
+ * This spec proves real AI quality across the entire arc with both partners.
+ * It is the highest-coverage but slowest scenario in the suite — ~25 min,
+ * ~$1-3 in Bedrock per run. Run on demand only via @slam_paws.
+ *
+ * Assertion strategy:
+ *   - testIDs only (real AI text is non-deterministic)
+ *   - generous timeouts (real AI: 50-90s per turn; reconciler: up to 90s)
+ *   - no toHaveScreenshot snapshots (chat content varies between runs)
+ *
+ * Run with:
+ *   npx playwright test --config=e2e/playwright.live-ai.config.ts \
+ *     --grep live-ai-two-browser-full-flow
+ */
+
+import { test, expect, devices, APIRequestContext } from '@playwright/test';
+import { TwoBrowserHarness, getE2EHeaders } from '../helpers';
+import {
+  signCompact,
+  handleMoodCheck,
+  sendAndWaitForPanel,
+  confirmFeelHeard,
+  waitForReconcilerComplete,
+  navigateToShareFromSession,
+  navigateBackToChat,
+} from '../helpers/test-utils';
+
+test.use(devices['iPhone 12']);
+
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
+
+// Real-AI roundtrip per turn can hit 60-90s during empathy/strategy stretches.
+const AI_RESPONSE_TIMEOUT = 90000;
+// Reconciler involves multiple AI calls; pad for real AI.
+const RECONCILER_TIMEOUT = 90000;
+
+// User A messages — same arcs proven by live-ai-full-flow.spec.ts, with one
+// extra Stage 0 turn for cushion since the partner narrative is slightly
+// different from the single-user version.
+const USER_A_STAGE_0_MESSAGES = [
+  "My partner Taylor and I have been struggling to communicate lately. Every conversation about household responsibilities turns into an argument and I feel like we're not hearing each other.",
+  'Last night we tried to talk about chores and it blew up again. I ended up sleeping on the couch.',
+  "I just want us to be able to talk without it turning into a fight.",
+  "We've been together 5 years and this is the worst it's been. I want to invite Taylor to try this process with me.",
+  "Yeah, I'm ready to send the invitation now.",
+];
+
+const USER_A_STAGE_1_MESSAGES = [
+  "The worst part is feeling like Taylor doesn't care about my perspective. When I try to explain how I feel, they just shut down.",
+  "I've started dreading coming home because I never know if it's going to be a good night or a fight.",
+  "Sometimes I wonder if Taylor even wants to be in this relationship anymore.",
+  "I think what I really need is to feel like my feelings matter. Like I'm not just being dismissed.",
+  "Yeah, I just want to be heard. That's really what it comes down to.",
+  "It hurts because I know we used to be so good at talking to each other. Something changed.",
+  "I feel unappreciated and invisible in my own home.",
+];
+
+const USER_A_STAGE_2_MESSAGES = [
+  "I guess Taylor might be dealing with a lot of stress at work. They mentioned their team is understaffed and they feel overwhelmed.",
+  "Taylor grew up in a family where nobody talked about feelings. Shutting down is probably the only way they know to cope when things get intense.",
+  "When I bring up problems, Taylor probably hears it as criticism, like they're failing at the relationship. That must feel awful for someone who's already trying so hard.",
+  "I think Taylor is scared of losing us. They shut down not because they don't care, but because they care so much that the conflict feels threatening.",
+  "I think I really understand now. Taylor loves me but feels overwhelmed, criticized, and afraid. Their shutting down is their way of trying to protect what we have, even though it pushes me away.",
+  "Yes, I feel ready to share this with Taylor. I want them to know that I see their struggle and I understand why they withdraw.",
+  "I understand Taylor's perspective well enough now. I'd like to share my understanding with them.",
+];
+
+// User B (Taylor) — mirror of User A's narrative from Taylor's POV.
+const USER_B_STAGE_1_MESSAGES = [
+  "My partner Shantam has been bringing up complaints about chores constantly, and I just shut down because nothing I do seems good enough.",
+  "I've been working really long hours and coming home is supposed to feel safe, but it feels like another performance review.",
+  "What hurts is that I'm trying so hard at home and at work, and Shantam only seems to notice the things I haven't done yet.",
+  "I just want to feel like Shantam sees the effort I'm putting in, even when I'm overwhelmed.",
+  "I think what I really need is to feel like my struggles matter too, not just the household stuff.",
+  "I want us to be a team again, not adversaries on opposite sides of the kitchen.",
+  "Yes, I feel like you really hear me now. That's exactly it.",
+];
+
+const USER_B_STAGE_2_MESSAGES = [
+  "I think Shantam might feel taken for granted. They probably do a lot of invisible work that I don't acknowledge.",
+  "Shantam grew up in a household where keeping things tidy was how love was shown. When I let things slide, that probably feels like I'm withdrawing love.",
+  "When Shantam asks about chores, they're probably not criticizing me — they're trying to feel partnered with me, like we're a team.",
+  "Shantam doesn't want me to be perfect. They just want to feel seen and like we're in this together.",
+  "I think Shantam wants connection and partnership. My shutting down probably reads as 'I don't care', when really I'm just overwhelmed and afraid of failing.",
+  "I really understand now. Shantam wants us to be a team — they're not attacking me, they're reaching for me.",
+  "Yes, I'm ready to share this with Shantam.",
+];
+
+function makeApiRequest(
+  request: APIRequestContext,
+  userEmail: string,
+  userId: string
+) {
+  const headers = getE2EHeaders(userEmail, userId);
+  return {
+    get: (url: string) => request.get(url, { headers }),
+    post: (url: string, data?: object) => request.post(url, { headers, data }),
+  };
+}
+
+test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
+  let harness: TwoBrowserHarness;
+
+  test.beforeEach(async ({ browser, request }) => {
+    // No fixtureId — real Bedrock, not mocked.
+    harness = new TwoBrowserHarness({
+      userA: { email: 'live-ai-2b-a@e2e.test', name: 'Shantam' },
+      userB: { email: 'live-ai-2b-b@e2e.test', name: 'Taylor' },
+    });
+
+    await harness.cleanup();
+    await harness.setupUserA(browser, request);
+    await harness.createSession();
+  });
+
+  test.afterEach(async () => {
+    await harness.teardown();
+  });
+
+  test('both users complete full session with real AI', async ({ browser, request }) => {
+    test.setTimeout(1800000); // 30 minutes — real AI is ~50-90s per turn
+    const testStart = Date.now();
+    const elapsed = () => `[${((Date.now() - testStart) / 1000).toFixed(1)}s]`;
+
+    // ==========================================
+    // === STAGE 0: COMPACT SIGNING ===
+    // ==========================================
+
+    await harness.setupUserB(browser, request);
+    await harness.acceptInvitation();
+
+    console.log(`${elapsed()} Both users navigating + signing compact...`);
+    await harness.navigateUserA();
+    await signCompact(harness.userAPage);
+    await handleMoodCheck(harness.userAPage);
+
+    await harness.navigateUserB();
+    await signCompact(harness.userBPage);
+    await handleMoodCheck(harness.userBPage);
+
+    await expect(harness.userAPage.getByTestId('chat-input')).toBeVisible();
+    await expect(harness.userBPage.getByTestId('chat-input')).toBeVisible();
+    console.log(`${elapsed()} Compact signed, chat ready for both`);
+
+    // ==========================================
+    // === STAGE 0: USER A INVITATION ===
+    // ==========================================
+    // Only User A goes through the invitation flow — User B accepted via API.
+
+    console.log(`${elapsed()} === USER A: Invitation Crafting ===`);
+    const invitationTurns = await sendAndWaitForPanel(
+      harness.userAPage,
+      USER_A_STAGE_0_MESSAGES,
+      'invitation-draft-panel',
+      USER_A_STAGE_0_MESSAGES.length,
+      AI_RESPONSE_TIMEOUT
+    );
+    console.log(`${elapsed()} Invitation panel appeared after ${invitationTurns} message(s)`);
+
+    const invitationContinueButton = harness.userAPage.getByTestId('invitation-continue-button');
+    await expect(invitationContinueButton).toBeVisible({ timeout: 10000 });
+    await invitationContinueButton.click();
+    await expect(harness.userAPage.getByTestId('invitation-draft-panel')).not.toBeVisible({ timeout: 10000 });
+    console.log(`${elapsed()} Invitation confirmed`);
+
+    // ==========================================
+    // === STAGE 1: WITNESSING (parallel) ===
+    // ==========================================
+    // Both users drive their own conversations toward feel-heard. No
+    // cross-user side effects until either shares empathy in Stage 2, so we
+    // can run the Stage 1 message loops in parallel.
+
+    console.log(`${elapsed()} === STAGE 1: Witnessing (parallel) ===`);
+    const [userATurns1, userBTurns1] = await Promise.all([
+      sendAndWaitForPanel(
+        harness.userAPage,
+        USER_A_STAGE_1_MESSAGES,
+        'feel-heard-yes',
+        USER_A_STAGE_1_MESSAGES.length,
+        AI_RESPONSE_TIMEOUT
+      ),
+      sendAndWaitForPanel(
+        harness.userBPage,
+        USER_B_STAGE_1_MESSAGES,
+        'feel-heard-yes',
+        USER_B_STAGE_1_MESSAGES.length,
+        AI_RESPONSE_TIMEOUT
+      ),
+    ]);
+    console.log(`${elapsed()} Feel-heard appeared (A: ${userATurns1} turns, B: ${userBTurns1} turns)`);
+
+    await Promise.all([
+      confirmFeelHeard(harness.userAPage),
+      confirmFeelHeard(harness.userBPage),
+    ]);
+    console.log(`${elapsed()} Both users confirmed feel-heard`);
+
+    // ==========================================
+    // === STAGE 2: EMPATHY DRAFT (parallel) ===
+    // ==========================================
+    // Both must reach empathy-review-button BEFORE either shares — sharing
+    // triggers an Ably-delivered transition message into the partner's chat,
+    // which would inject an unexpected AI message mid-loop.
+
+    console.log(`${elapsed()} === STAGE 2: Empathy Drafting (parallel) ===`);
+    const [userATurns2, userBTurns2] = await Promise.all([
+      sendAndWaitForPanel(
+        harness.userAPage,
+        USER_A_STAGE_2_MESSAGES,
+        'empathy-review-button',
+        USER_A_STAGE_2_MESSAGES.length,
+        AI_RESPONSE_TIMEOUT
+      ),
+      sendAndWaitForPanel(
+        harness.userBPage,
+        USER_B_STAGE_2_MESSAGES,
+        'empathy-review-button',
+        USER_B_STAGE_2_MESSAGES.length,
+        AI_RESPONSE_TIMEOUT
+      ),
+    ]);
+    console.log(`${elapsed()} Empathy review appeared (A: ${userATurns2} turns, B: ${userBTurns2} turns)`);
+
+    // ==========================================
+    // === STAGE 2: SHARE EMPATHY (sequential) ===
+    // ==========================================
+    // User A shares first (no reconciler trigger). User B shares second
+    // (triggers reconciler).
+
+    console.log(`${elapsed()} User A sharing empathy...`);
+    const reviewBtnA = harness.userAPage.getByTestId('empathy-review-button');
+    await expect(reviewBtnA).toBeVisible({ timeout: 10000 });
+    // JS click bypasses pointer-events: none from the typewriter wrapper.
+    await reviewBtnA.evaluate((el: HTMLElement) => el.click());
+
+    const shareBtnA = harness.userAPage.getByTestId('share-empathy-button');
+    await expect(shareBtnA).toBeVisible({ timeout: 10000 });
+    await shareBtnA.evaluate((el: HTMLElement) => el.click());
+    console.log(`${elapsed()} User A shared`);
+
+    // Allow Ably delivery to User B before B shares (which triggers reconciler).
+    await harness.userAPage.waitForTimeout(2000);
+
+    console.log(`${elapsed()} User B sharing empathy (triggers reconciler)...`);
+    const reviewBtnB = harness.userBPage.getByTestId('empathy-review-button');
+    await expect(reviewBtnB).toBeVisible({ timeout: 10000 });
+    await reviewBtnB.evaluate((el: HTMLElement) => el.click());
+
+    const shareBtnB = harness.userBPage.getByTestId('share-empathy-button');
+    await expect(shareBtnB).toBeVisible({ timeout: 10000 });
+    await shareBtnB.evaluate((el: HTMLElement) => el.click());
+    console.log(`${elapsed()} User B shared`);
+
+    // ==========================================
+    // === RECONCILER COMPLETION ===
+    // ==========================================
+
+    await harness.userAPage.waitForTimeout(2000);
+    console.log(`${elapsed()} Waiting for reconciler...`);
+
+    const userAReconcilerComplete = await waitForReconcilerComplete(harness.userAPage, RECONCILER_TIMEOUT);
+    if (!userAReconcilerComplete) {
+      await harness.userAPage.screenshot({ path: 'test-results/live-ai-2b-reconciler-timeout-A.png' });
+      await harness.userBPage.screenshot({ path: 'test-results/live-ai-2b-reconciler-timeout-B.png' });
+      throw new Error(`Reconciler did not complete within ${RECONCILER_TIMEOUT}ms for User A`);
+    }
+    const userBReconcilerComplete = await waitForReconcilerComplete(harness.userBPage, RECONCILER_TIMEOUT);
+    if (!userBReconcilerComplete) {
+      await harness.userBPage.screenshot({ path: 'test-results/live-ai-2b-reconciler-timeout-B.png' });
+      throw new Error(`Reconciler did not complete within ${RECONCILER_TIMEOUT}ms for User B`);
+    }
+    console.log(`${elapsed()} Reconciler complete for both users`);
+
+    // ==========================================
+    // === STAGE 2 → 3 TRANSITION ===
+    // ==========================================
+
+    const apiA = makeApiRequest(request, harness.config.userA.email, harness.userAId);
+    const apiB = makeApiRequest(request, harness.config.userB.email, harness.userBId);
+
+    // Verify share page renders partner empathy + validation buttons.
+    await navigateToShareFromSession(harness.userAPage);
+    await navigateToShareFromSession(harness.userBPage);
+
+    const userAPartnerEmpathy = harness.userAPage
+      .locator('[data-testid^="share-screen-partner-tab-item-partner-empathy-"]')
+      .first();
+    const userBPartnerEmpathy = harness.userBPage
+      .locator('[data-testid^="share-screen-partner-tab-item-partner-empathy-"]')
+      .first();
+    await expect(userAPartnerEmpathy).toBeVisible({ timeout: 15000 });
+    await expect(userBPartnerEmpathy).toBeVisible({ timeout: 15000 });
+
+    // Validate empathy via API to advance both into Stage 3.
+    await Promise.all([
+      apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/empathy/validate`, { validated: true }),
+      apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/empathy/validate`, { validated: true }),
+    ]);
+    await harness.userAPage.waitForTimeout(2000);
+    console.log(`${elapsed()} Empathy validated by both, advancing to Stage 3`);
+
+    // ==========================================
+    // === STAGE 3: NEEDS EXTRACTION ===
+    // ==========================================
+
+    await navigateBackToChat(harness.userAPage);
+    await navigateBackToChat(harness.userBPage);
+    await handleMoodCheck(harness.userAPage);
+    await handleMoodCheck(harness.userBPage);
+
+    await Promise.all([
+      apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`),
+      apiB.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`),
+    ]);
+    await harness.userAPage.waitForTimeout(3000);
+
+    // Reload to render the needs review UI.
+    await Promise.all([harness.userAPage.reload(), harness.userBPage.reload()]);
+    await Promise.all([
+      harness.userAPage.waitForLoadState('networkidle'),
+      harness.userBPage.waitForLoadState('networkidle'),
+    ]);
+    await handleMoodCheck(harness.userAPage);
+    await handleMoodCheck(harness.userBPage);
+
+    await expect(harness.userAPage.getByText('Confirm my needs')).toBeVisible({ timeout: 60000 });
+    await expect(harness.userBPage.getByText('Confirm my needs')).toBeVisible({ timeout: 60000 });
+    console.log(`${elapsed()} Needs review UI rendered`);
+
+    const needsResponseA = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`);
+    const needsDataA = await needsResponseA.json();
+    const needsA = needsDataA.data?.needs || [];
+
+    const needsResponseB = await apiB.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`);
+    const needsDataB = await needsResponseB.json();
+    const needsB = needsDataB.data?.needs || [];
+
+    expect(needsA.length, 'Needs extraction returned no needs for User A').toBeGreaterThan(0);
+    expect(needsB.length, 'Needs extraction returned no needs for User B').toBeGreaterThan(0);
+
+    if (needsA.length > 0) {
+      const needIdsA = needsA.map((n: { id: string }) => n.id);
+      await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/confirm`, { needIds: needIdsA });
+      await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/consent`, { needIds: needIdsA });
+    }
+    if (needsB.length > 0) {
+      const needIdsB = needsB.map((n: { id: string }) => n.id);
+      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/confirm`, { needIds: needIdsB });
+      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/consent`, { needIds: needIdsB });
+    }
+    console.log(`${elapsed()} Needs confirmed + consented (A: ${needsA.length}, B: ${needsB.length})`);
+
+    // ==========================================
+    // === STAGE 3: COMMON GROUND ===
+    // ==========================================
+
+    let commonGroundComplete = false;
+    const cgDeadline = Date.now() + 90000; // 90s — real AI generates this
+    while (Date.now() < cgDeadline && !commonGroundComplete) {
+      const cgResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground`);
+      const cgData = await cgResponse.json();
+      if (cgData.data?.commonGround && cgData.data.commonGround.length > 0) {
+        commonGroundComplete = true;
+      } else {
+        await harness.userAPage.waitForTimeout(3000);
+      }
+    }
+    if (!commonGroundComplete) {
+      throw new Error('Common ground analysis did not complete within 90s');
+    }
+    console.log(`${elapsed()} Common ground generated`);
+
+    await Promise.all([harness.userAPage.reload(), harness.userBPage.reload()]);
+    await Promise.all([
+      harness.userAPage.waitForLoadState('networkidle'),
+      harness.userBPage.waitForLoadState('networkidle'),
+    ]);
+    await handleMoodCheck(harness.userAPage);
+    await handleMoodCheck(harness.userBPage);
+
+    await expect(harness.userAPage.getByText(/Shared Needs Discovered/i)).toBeVisible({ timeout: 15000 });
+    await expect(harness.userBPage.getByText(/Shared Needs Discovered/i)).toBeVisible({ timeout: 15000 });
+
+    const finalCgResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground`);
+    const finalCgData = await finalCgResponse.json();
+    const commonGroundItems = finalCgData.data?.commonGround || [];
+    const commonGroundIds = commonGroundItems.map((cg: { id: string }) => cg.id);
+
+    if (commonGroundIds.length > 0) {
+      await Promise.all([
+        apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground/confirm`, { commonGroundIds }),
+        apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground/confirm`, { commonGroundIds }),
+      ]);
+    }
+    await harness.userAPage.waitForTimeout(1000);
+
+    const advanceResponseA = await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
+    const advanceDataA = await advanceResponseA.json();
+    if (!advanceDataA.data?.advanced && advanceDataA.data?.blockedReason === 'PARTNER_NOT_READY') {
+      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
+      await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
+    } else {
+      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
+    }
+    await harness.userAPage.waitForTimeout(1000);
+    console.log(`${elapsed()} Advanced to Stage 4`);
+
+    // ==========================================
+    // === STAGE 4: STRATEGIES + AGREEMENT ===
+    // ==========================================
+
+    await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/strategies`, {
+      description: 'Have a 10-minute phone-free conversation at dinner each day',
+      needsAddressed: ['Connection', 'Recognition'],
+    });
+    await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/strategies`, {
+      description: 'Use a pause signal when conversations get heated',
+      needsAddressed: ['Safety', 'Connection'],
+    });
+    await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/strategies`, {
+      description: 'Say one specific thing I appreciate each morning',
+      needsAddressed: ['Recognition'],
+    });
+
+    const strategiesResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/strategies`);
+    const strategiesData = await strategiesResponse.json();
+    const strategies = strategiesData.data?.strategies || [];
+    expect(strategies.length).toBe(3);
+
+    await Promise.all([harness.userAPage.reload(), harness.userBPage.reload()]);
+    await Promise.all([
+      harness.userAPage.waitForLoadState('networkidle'),
+      harness.userBPage.waitForLoadState('networkidle'),
+    ]);
+    await handleMoodCheck(harness.userAPage);
+    await handleMoodCheck(harness.userBPage);
+
+    await Promise.all([
+      apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/strategies/ready`),
+      apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/strategies/ready`),
+    ]);
+
+    const [s1, s2, s3] = strategies;
+    await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/strategies/rank`, {
+      rankedIds: [s1.id, s2.id, s3.id],
+    });
+    const rankBResponse = await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/strategies/rank`, {
+      rankedIds: [s1.id, s3.id, s2.id],
+    });
+    const rankBData = await rankBResponse.json();
+    expect(rankBData.data?.canReveal).toBe(true);
+
+    const overlapResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/strategies/overlap`);
+    const overlapData = await overlapResponse.json();
+    const overlapStrategies = overlapData.data?.overlap || [];
+    expect(overlapStrategies.length).toBeGreaterThanOrEqual(1);
+    console.log(`${elapsed()} Strategy overlap: ${overlapStrategies.length} strategies`);
+
+    const followUpDate = new Date();
+    followUpDate.setDate(followUpDate.getDate() + 7);
+
+    const agreementResponse = await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/agreements`, {
+      strategyId: overlapStrategies[0].id,
+      description: overlapStrategies[0].description,
+      type: 'MICRO_EXPERIMENT',
+      followUpDate: followUpDate.toISOString(),
+    });
+    const agreementData = await agreementResponse.json();
+    const agreementId = agreementData.data?.agreement?.id;
+    expect(agreementId, 'Agreement creation did not return an id').toBeTruthy();
+
+    const confirmResponse = await apiB.post(
+      `${API_BASE_URL}/api/sessions/${harness.sessionId}/agreements/${agreementId}/confirm`,
+      { confirmed: true }
+    );
+    const confirmData = await confirmResponse.json();
+    expect(confirmData.data?.sessionComplete).toBe(true);
+    console.log(`${elapsed()} === SESSION COMPLETE ===`);
+
+    // Final diagnostic screenshots (no toHaveScreenshot — chat varies between runs).
+    await Promise.all([harness.userAPage.reload(), harness.userBPage.reload()]);
+    await Promise.all([
+      harness.userAPage.waitForLoadState('networkidle'),
+      harness.userBPage.waitForLoadState('networkidle'),
+    ]);
+    await handleMoodCheck(harness.userAPage);
+    await handleMoodCheck(harness.userBPage);
+    await harness.userAPage.screenshot({ path: 'test-results/live-ai-2b-final-A.png' });
+    await harness.userBPage.screenshot({ path: 'test-results/live-ai-2b-final-B.png' });
+  });
+});

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -35,10 +35,13 @@ test.use(devices['iPhone 12']);
 
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
 
-// Real-AI roundtrip per turn can hit 60-90s during empathy/strategy stretches.
-const AI_RESPONSE_TIMEOUT = 90000;
+// Real-AI roundtrip per turn can hit 60-90s for plain followups, but
+// structured-output turns (invitation draft, empathy draft, strategy proposal)
+// can spike to 120s+ on Bedrock. Padded to 180s — first EC2 run hung at 90s
+// on the invitation-draft turn after 4 successful followups.
+const AI_RESPONSE_TIMEOUT = 180000;
 // Reconciler involves multiple AI calls; pad for real AI.
-const RECONCILER_TIMEOUT = 90000;
+const RECONCILER_TIMEOUT = 180000;
 
 // User A messages — same arcs proven by live-ai-full-flow.spec.ts, with one
 // extra Stage 0 turn for cushion since the partner narrative is slightly

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -134,29 +134,23 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     const elapsed = () => `[${((Date.now() - testStart) / 1000).toFixed(1)}s]`;
 
     // ==========================================
-    // === STAGE 0: COMPACT SIGNING ===
+    // === STAGE 0: USER A ALONE (invitation crafting) ===
     // ==========================================
+    // CRITICAL: User B's invitation must remain PENDING during Stage 0. The
+    // Stage 0 system prompt's job is to get User A to draft an invitation
+    // for their partner. With real AI, if the invitation is already ACCEPTED
+    // (the mocked-test default in TwoBrowserHarness), the AI correctly
+    // recognizes "the partner is already onboard" and refuses to produce
+    // the <draft> tag. So we set up + sign in only User A here, mirroring
+    // the real-life flow: A drafts → "sends" → B accepts.
 
-    await harness.setupUserB(browser, request);
-    await harness.acceptInvitation();
-
-    console.log(`${elapsed()} Both users navigating + signing compact...`);
+    console.log(`${elapsed()} User A navigating + signing compact...`);
     await harness.navigateUserA();
     await signCompact(harness.userAPage);
     await handleMoodCheck(harness.userAPage);
 
-    await harness.navigateUserB();
-    await signCompact(harness.userBPage);
-    await handleMoodCheck(harness.userBPage);
-
     await expect(harness.userAPage.getByTestId('chat-input')).toBeVisible();
-    await expect(harness.userBPage.getByTestId('chat-input')).toBeVisible();
-    console.log(`${elapsed()} Compact signed, chat ready for both`);
-
-    // ==========================================
-    // === STAGE 0: USER A INVITATION ===
-    // ==========================================
-    // Only User A goes through the invitation flow — User B accepted via API.
+    console.log(`${elapsed()} Compact signed, chat ready for User A`);
 
     console.log(`${elapsed()} === USER A: Invitation Crafting ===`);
     const invitationTurns = await sendAndWaitForPanel(
@@ -172,7 +166,19 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     await expect(invitationContinueButton).toBeVisible({ timeout: 10000 });
     await invitationContinueButton.click();
     await expect(harness.userAPage.getByTestId('invitation-draft-panel')).not.toBeVisible({ timeout: 10000 });
-    console.log(`${elapsed()} Invitation confirmed`);
+    console.log(`${elapsed()} Invitation confirmed — User B can now join`);
+
+    // ==========================================
+    // === USER B: ACCEPT + JOIN ===
+    // ==========================================
+
+    await harness.setupUserB(browser, request);
+    await harness.acceptInvitation();
+    await harness.navigateUserB();
+    await signCompact(harness.userBPage);
+    await handleMoodCheck(harness.userBPage);
+    await expect(harness.userBPage.getByTestId('chat-input')).toBeVisible();
+    console.log(`${elapsed()} User B accepted + signed compact`);
 
     // ==========================================
     // === STAGE 1: WITNESSING (parallel) ===

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -25,7 +25,6 @@ import {
   signCompact,
   handleMoodCheck,
   sendAndWaitForPanel,
-  confirmFeelHeard,
   waitForReconcilerComplete,
   navigateBackToChat,
 } from '../helpers/test-utils';
@@ -34,6 +33,35 @@ test.use(devices['iPhone 12']);
 
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
 const APP_BASE_URL = process.env.APP_BASE_URL || 'http://localhost:8082';
+
+// Robust feel-heard confirmation. The shared confirmFeelHeard helper uses
+// click({ force: true }), which still waits for the locator to be visible
+// — if the element re-renders or briefly detaches mid-stage-transition
+// (which happens with real-AI's longer streaming windows), Playwright waits
+// up to the full test timeout (30 min) for it to reattach. We saw User B
+// hang for ~26 min on this in run 01KQ8YJRDMP1D14EYF6BHF38H9.
+//
+// JS-evaluate-click bypasses every Playwright actionability check; we then
+// poll for disappearance with a hard cap.
+async function confirmFeelHeardRobust(
+  page: import('@playwright/test').Page
+): Promise<void> {
+  const btn = page.getByTestId('feel-heard-yes');
+  await expect(btn).toBeVisible({ timeout: 10000 });
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    await btn.evaluate((el: HTMLElement) => el.click()).catch(() => {});
+    // Poll for panel to disappear; if it does, we're done.
+    for (let poll = 0; poll < 5; poll++) {
+      await page.waitForTimeout(1000);
+      if (!(await btn.isVisible().catch(() => false))) {
+        await page.waitForTimeout(1000);
+        return;
+      }
+    }
+  }
+  throw new Error('feel-heard-yes panel did not disappear after 8 click attempts (40s)');
+}
 
 // Direct goto to the share screen — avoids the in-app navigation helper,
 // which has modal/indicator timing variance that's hard to satisfy with
@@ -230,8 +258,8 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     console.log(`${elapsed()} Feel-heard appeared (A: ${userATurns1} turns, B: ${userBTurns1} turns)`);
 
     await Promise.all([
-      confirmFeelHeard(harness.userAPage),
-      confirmFeelHeard(harness.userBPage),
+      confirmFeelHeardRobust(harness.userAPage),
+      confirmFeelHeardRobust(harness.userBPage),
     ]);
     console.log(`${elapsed()} Both users confirmed feel-heard`);
 

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -543,7 +543,9 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
       { confirmed: true }
     );
     const confirmData = await confirmResponse.json();
-    expect(confirmData.data?.sessionComplete).toBe(true);
+    // The API returns `sessionCanResolve`, not `sessionComplete` — that field
+    // name is stale in two-browser-full-flow.spec.ts too (asserts undefined).
+    expect(confirmData.data?.sessionCanResolve).toBe(true);
     console.log(`${elapsed()} === SESSION COMPLETE ===`);
 
     // Final diagnostic screenshots (no toHaveScreenshot — chat varies between runs).

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -27,13 +27,32 @@ import {
   sendAndWaitForPanel,
   confirmFeelHeard,
   waitForReconcilerComplete,
-  navigateToShareFromSession,
   navigateBackToChat,
 } from '../helpers/test-utils';
 
 test.use(devices['iPhone 12']);
 
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
+const APP_BASE_URL = process.env.APP_BASE_URL || 'http://localhost:8082';
+
+// Direct goto to /share — avoids the in-app navigation helper, which has
+// modal/indicator timing variance that's hard to satisfy with real AI's
+// state-update cadence. We're testing AI quality across stages, not the
+// chat→share routing (mocked two-browser-* specs cover that).
+async function gotoShare(
+  page: import('@playwright/test').Page,
+  sessionId: string,
+  userId: string,
+  userEmail: string
+): Promise<void> {
+  const params = new URLSearchParams({
+    'e2e-user-id': userId,
+    'e2e-user-email': userEmail,
+  });
+  await page.goto(`${APP_BASE_URL}/session/${sessionId}/share?${params.toString()}`);
+  await page.waitForLoadState('domcontentloaded');
+  await handleMoodCheck(page, 2000);
+}
 
 // Real-AI roundtrip per turn can hit 60-90s for plain followups, but
 // structured-output turns (invitation draft, empathy draft, strategy proposal)
@@ -296,8 +315,8 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     const apiB = makeApiRequest(request, harness.config.userB.email, harness.userBId);
 
     // Verify share page renders partner empathy + validation buttons.
-    await navigateToShareFromSession(harness.userAPage);
-    await navigateToShareFromSession(harness.userBPage);
+    await gotoShare(harness.userAPage, harness.sessionId, harness.userAId, harness.config.userA.email);
+    await gotoShare(harness.userBPage, harness.sessionId, harness.userBId, harness.config.userB.email);
 
     const userAPartnerEmpathy = harness.userAPage
       .locator('[data-testid^="share-screen-partner-tab-item-partner-empathy-"]')

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -342,12 +342,41 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     // ==========================================
     // === STAGE 3: NEEDS EXTRACTION ===
     // ==========================================
+    // Backend gate (stage3.ts:191): needs extraction won't run unless the
+    // user has sent at least one message in Stage 3 — prevents needs from
+    // appearing before any conversation. Each user sends one message
+    // answering the AI's "what do you need?" opener so extraction triggers
+    // on the GET /needs call.
+
+    console.log(`${elapsed()} === STAGE 3: Need Mapping (parallel) ===`);
+    const sendStage3Message = async (
+      page: import('@playwright/test').Page,
+      message: string
+    ): Promise<void> => {
+      await page.getByTestId('chat-input').fill(message);
+      await page.getByTestId('send-button').click();
+      const typingIndicator = page.getByTestId('typing-indicator');
+      // Visible→hidden = AI streaming finished.
+      await typingIndicator.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+      await typingIndicator.waitFor({ state: 'hidden', timeout: AI_RESPONSE_TIMEOUT });
+    };
+
+    await Promise.all([
+      sendStage3Message(
+        harness.userAPage,
+        "What I really need is to feel like Taylor sees the effort I'm putting in and to feel partnered with, not interrogated. I need to be able to bring up something at home without it feeling like an attack."
+      ),
+      sendStage3Message(
+        harness.userBPage,
+        "What I need is to feel like I can come home and recover without it feeling like another performance review. I need space to be human, not perfect, and to feel appreciated for what I do manage."
+      ),
+    ]);
+    console.log(`${elapsed()} Stage 3 messages exchanged — triggering needs extraction`);
 
     // Trigger needs extraction via API. Real AI takes ~30-60s — the GET
     // endpoint blocks until extraction completes, so the Promise.all is the
     // wait. (Mocked specs need a tiny waitForTimeout because their fixture
     // returns instantly; with real AI the API itself is the wait.)
-    console.log(`${elapsed()} Triggering needs extraction (real AI, ~30-60s/user)...`);
     await Promise.all([
       apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`),
       apiB.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`),

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -32,7 +32,6 @@ import {
 test.use(devices['iPhone 12']);
 
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
-const APP_BASE_URL = process.env.APP_BASE_URL || 'http://localhost:8082';
 
 // Robust feel-heard confirmation. The shared confirmFeelHeard helper uses
 // click({ force: true }), which still waits for the locator to be visible
@@ -63,28 +62,13 @@ async function confirmFeelHeardRobust(
   throw new Error('feel-heard-yes panel did not disappear after 8 click attempts (40s)');
 }
 
-// Direct goto to the share screen — avoids the in-app navigation helper,
-// which has modal/indicator timing variance that's hard to satisfy with
-// real AI's state-update cadence. We're testing AI quality across stages,
-// not the chat→share routing (mocked two-browser-* specs cover that).
-//
-// The screen file is `sharing-status.tsx`; the existing helper's regex
-// `/\/session\/.*\/share/` matches "sharing-status" as a substring, which
-// is why other specs appear to navigate to "/share".
-async function gotoShare(
-  page: import('@playwright/test').Page,
-  sessionId: string,
-  userId: string,
-  userEmail: string
-): Promise<void> {
-  const params = new URLSearchParams({
-    'e2e-user-id': userId,
-    'e2e-user-email': userEmail,
-  });
-  await page.goto(`${APP_BASE_URL}/session/${sessionId}/sharing-status?${params.toString()}`);
-  await page.waitForLoadState('domcontentloaded');
-  await handleMoodCheck(page, 2000);
-}
+// Note: There is no longer a separate /share or /sharing-status screen —
+// `sharing-status.tsx` is a redirect stub back to /session/{id} ("@deprecated
+// Sharing functionality has been moved to the Partner tab"). The
+// share-screen-partner-tab-item-partner-empathy-* testID two-browser-full-flow
+// asserts against has also been removed from the codebase. We skip share-screen
+// UI verification entirely and rely on the empathy/validate API call to
+// advance the state machine into Stage 3.
 
 // Real-AI roundtrip per turn can hit 60-90s for plain followups, but
 // structured-output turns (invitation draft, empathy draft, strategy proposal)
@@ -346,20 +330,9 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     const apiA = makeApiRequest(request, harness.config.userA.email, harness.userAId);
     const apiB = makeApiRequest(request, harness.config.userB.email, harness.userBId);
 
-    // Verify share page renders partner empathy + validation buttons.
-    await gotoShare(harness.userAPage, harness.sessionId, harness.userAId, harness.config.userA.email);
-    await gotoShare(harness.userBPage, harness.sessionId, harness.userBId, harness.config.userB.email);
-
-    const userAPartnerEmpathy = harness.userAPage
-      .locator('[data-testid^="share-screen-partner-tab-item-partner-empathy-"]')
-      .first();
-    const userBPartnerEmpathy = harness.userBPage
-      .locator('[data-testid^="share-screen-partner-tab-item-partner-empathy-"]')
-      .first();
-    await expect(userAPartnerEmpathy).toBeVisible({ timeout: 15000 });
-    await expect(userBPartnerEmpathy).toBeVisible({ timeout: 15000 });
-
-    // Validate empathy via API to advance both into Stage 3.
+    // Validate empathy via API to advance both into Stage 3. Skips
+    // share-screen UI verification — that path is covered by mocked
+    // two-browser-* specs and the route + testIDs have shifted under us.
     await Promise.all([
       apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/empathy/validate`, { validated: true }),
       apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/empathy/validate`, { validated: true }),
@@ -423,7 +396,7 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     // ==========================================
 
     let commonGroundComplete = false;
-    const cgDeadline = Date.now() + 90000; // 90s — real AI generates this
+    const cgDeadline = Date.now() + 180000; // 180s — real AI generates this; structured-output spike margin
     while (Date.now() < cgDeadline && !commonGroundComplete) {
       const cgResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground`);
       const cgData = await cgResponse.json();
@@ -434,7 +407,7 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
       }
     }
     if (!commonGroundComplete) {
-      throw new Error('Common ground analysis did not complete within 90s');
+      throw new Error('Common ground analysis did not complete within 180s');
     }
     console.log(`${elapsed()} Common ground generated`);
 

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -26,7 +26,6 @@ import {
   handleMoodCheck,
   sendAndWaitForPanel,
   waitForReconcilerComplete,
-  navigateBackToChat,
 } from '../helpers/test-utils';
 
 test.use(devices['iPhone 12']);
@@ -344,29 +343,21 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     // === STAGE 3: NEEDS EXTRACTION ===
     // ==========================================
 
-    await navigateBackToChat(harness.userAPage);
-    await navigateBackToChat(harness.userBPage);
-    await handleMoodCheck(harness.userAPage);
-    await handleMoodCheck(harness.userBPage);
-
+    // Trigger needs extraction via API. Real AI takes ~30-60s — the GET
+    // endpoint blocks until extraction completes, so the Promise.all is the
+    // wait. (Mocked specs need a tiny waitForTimeout because their fixture
+    // returns instantly; with real AI the API itself is the wait.)
+    console.log(`${elapsed()} Triggering needs extraction (real AI, ~30-60s/user)...`);
     await Promise.all([
       apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`),
       apiB.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`),
     ]);
-    await harness.userAPage.waitForTimeout(3000);
+    console.log(`${elapsed()} Needs extraction complete`);
 
-    // Reload to render the needs review UI.
-    await Promise.all([harness.userAPage.reload(), harness.userBPage.reload()]);
-    await Promise.all([
-      harness.userAPage.waitForLoadState('networkidle'),
-      harness.userBPage.waitForLoadState('networkidle'),
-    ]);
-    await handleMoodCheck(harness.userAPage);
-    await handleMoodCheck(harness.userBPage);
-
-    await expect(harness.userAPage.getByText('Confirm my needs')).toBeVisible({ timeout: 60000 });
-    await expect(harness.userBPage.getByText('Confirm my needs')).toBeVisible({ timeout: 60000 });
-    console.log(`${elapsed()} Needs review UI rendered`);
+    // Skip the "Confirm my needs" UI assertion — that text only renders inside
+    // NeedsDrawer, which doesn't auto-open (only via the needs-review-button
+    // click handler in UnifiedSessionScreen). We verify needs presence via API
+    // instead, same approach as the share-screen step.
 
     const needsResponseA = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`);
     const needsDataA = await needsResponseA.json();
@@ -411,16 +402,8 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     }
     console.log(`${elapsed()} Common ground generated`);
 
-    await Promise.all([harness.userAPage.reload(), harness.userBPage.reload()]);
-    await Promise.all([
-      harness.userAPage.waitForLoadState('networkidle'),
-      harness.userBPage.waitForLoadState('networkidle'),
-    ]);
-    await handleMoodCheck(harness.userAPage);
-    await handleMoodCheck(harness.userBPage);
-
-    await expect(harness.userAPage.getByText(/Shared Needs Discovered/i)).toBeVisible({ timeout: 15000 });
-    await expect(harness.userBPage.getByText(/Shared Needs Discovered/i)).toBeVisible({ timeout: 15000 });
+    // Skip "Shared Needs Discovered" UI assertion for the same drawer-mounting
+    // reason — the text lives inside the NeedsDrawer (common-ground mode).
 
     const finalCgResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground`);
     const finalCgData = await finalCgResponse.json();

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -348,7 +348,21 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     // answering the AI's "what do you need?" opener so extraction triggers
     // on the GET /needs call.
 
+    // After empathy share, chat-input was hidden ("waiting for partner").
+    // Reload to pick up Stage 3 state after empathy/validate, then wait for
+    // chat-input to become visible before attempting to send messages —
+    // otherwise fill() silently no-ops on a hidden input.
     console.log(`${elapsed()} === STAGE 3: Need Mapping (parallel) ===`);
+    await Promise.all([harness.userAPage.reload(), harness.userBPage.reload()]);
+    await Promise.all([
+      harness.userAPage.waitForLoadState('networkidle'),
+      harness.userBPage.waitForLoadState('networkidle'),
+    ]);
+    await handleMoodCheck(harness.userAPage);
+    await handleMoodCheck(harness.userBPage);
+    await expect(harness.userAPage.getByTestId('chat-input')).toBeVisible({ timeout: 30000 });
+    await expect(harness.userBPage.getByTestId('chat-input')).toBeVisible({ timeout: 30000 });
+
     const sendStage3Message = async (
       page: import('@playwright/test').Page,
       message: string
@@ -356,8 +370,10 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
       await page.getByTestId('chat-input').fill(message);
       await page.getByTestId('send-button').click();
       const typingIndicator = page.getByTestId('typing-indicator');
-      // Visible→hidden = AI streaming finished.
-      await typingIndicator.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+      // Wait for typing-indicator to appear (AI started). If it doesn't appear
+      // within 30s, the message didn't dispatch — fail loudly rather than
+      // silently no-op the hidden-wait.
+      await typingIndicator.waitFor({ state: 'visible', timeout: 30000 });
       await typingIndicator.waitFor({ state: 'hidden', timeout: AI_RESPONSE_TIMEOUT });
     };
 

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -35,10 +35,14 @@ test.use(devices['iPhone 12']);
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
 const APP_BASE_URL = process.env.APP_BASE_URL || 'http://localhost:8082';
 
-// Direct goto to /share — avoids the in-app navigation helper, which has
-// modal/indicator timing variance that's hard to satisfy with real AI's
-// state-update cadence. We're testing AI quality across stages, not the
-// chat→share routing (mocked two-browser-* specs cover that).
+// Direct goto to the share screen — avoids the in-app navigation helper,
+// which has modal/indicator timing variance that's hard to satisfy with
+// real AI's state-update cadence. We're testing AI quality across stages,
+// not the chat→share routing (mocked two-browser-* specs cover that).
+//
+// The screen file is `sharing-status.tsx`; the existing helper's regex
+// `/\/session\/.*\/share/` matches "sharing-status" as a substring, which
+// is why other specs appear to navigate to "/share".
 async function gotoShare(
   page: import('@playwright/test').Page,
   sessionId: string,
@@ -49,7 +53,7 @@ async function gotoShare(
     'e2e-user-id': userId,
     'e2e-user-email': userEmail,
   });
-  await page.goto(`${APP_BASE_URL}/session/${sessionId}/share?${params.toString()}`);
+  await page.goto(`${APP_BASE_URL}/session/${sessionId}/sharing-status?${params.toString()}`);
   await page.waitForLoadState('domcontentloaded');
   await handleMoodCheck(page, 2000);
 }

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -43,15 +43,17 @@ const AI_RESPONSE_TIMEOUT = 180000;
 // Reconciler involves multiple AI calls; pad for real AI.
 const RECONCILER_TIMEOUT = 180000;
 
-// User A messages — same arcs proven by live-ai-full-flow.spec.ts, with one
-// extra Stage 0 turn for cushion since the partner narrative is slightly
-// different from the single-user version.
+// User A messages — Stage 0 needs concrete dialogue, not just "we argued",
+// because the AI gates the invitation draft on having enough substance to
+// summarize. First EC2 retry hit prompt compliance: AI kept asking "what was
+// actually said?" and never produced <draft> until 5 messages were exhausted.
 const USER_A_STAGE_0_MESSAGES = [
   "My partner Taylor and I have been struggling to communicate lately. Every conversation about household responsibilities turns into an argument and I feel like we're not hearing each other.",
-  'Last night we tried to talk about chores and it blew up again. I ended up sleeping on the couch.',
-  "I just want us to be able to talk without it turning into a fight.",
-  "We've been together 5 years and this is the worst it's been. I want to invite Taylor to try this process with me.",
-  "Yeah, I'm ready to send the invitation now.",
+  "Last night I came home and the kitchen was a mess. I asked Taylor 'didn't we agree you'd handle the dishes today?' and they snapped 'I had a bad day, can you not start with this right now?' I said 'I'm not starting anything, I just walked in.' They said 'this is exactly what I mean, you always have something to complain about.' I went to the couch and slept there.",
+  "I keep replaying it. I feel unheard and dismissed — like nothing I bring up gets received as me reaching for them, only as criticism.",
+  "We've been together 5 years and this is the worst it's been. I want to invite Taylor to try this Meet Without Fear process with me — to have a conversation that doesn't blow up.",
+  "Yes, I'm ready to send the invitation now.",
+  "I've told you what happened — Taylor said I always have something to complain about, and I slept on the couch. I want to invite them to do this with me.",
 ];
 
 const USER_A_STAGE_1_MESSAGES = [


### PR DESCRIPTION
## Summary

Adds the missing e2e coverage gap: **two users + real Bedrock + Stages 0→4**. Companion to:
- `live-ai-full-flow.spec.ts` — real AI, single user, stages 0–2
- `two-browser-full-flow.spec.ts` — mocked AI, two users, stages 0–4

Run on demand only via `@slam_paws test live-ai-two-browser-full-flow` (~$1–2 / run, ~5–6 min). Not on a schedule.

## Verification

EC2 run on commit 219d679: **PASS in 328s (5m 28s)**
- Dashboard: https://mwf-test-dashboard.vercel.app/run/01KQ91X7596YSA7PHKHKKNB9AP
- Stage 0: invitation panel after 3 turns
- Stage 1: feel-heard after 4 (A) / 6 (B) turns
- Stage 2: empathy review after 4 (A) / 5 (B) turns + reconciler complete
- Stage 3: Need Mapping conversation + 4 needs each user + common ground generated
- Stage 4: 3 strategies, ranked, overlap, agreement created + confirmed

## Changes

- **`e2e/playwright.live-ai.config.ts`** — promote `testMatch` to `/live-ai-.*\.spec\.ts/` so any new `live-ai-*` spec is auto-routed by `scripts/ec2-bot/scripts/run-and-publish.sh`. Bumps `expect.timeout` to 180s (real-AI structured-output turns can spike past 90s) and per-test `timeout` to 30 min.
- **`e2e/helpers/two-browser-harness.ts`** — make `fixtureId` optional on `TwoBrowserConfig` (purely additive — every existing two-browser spec sets it).
- **`e2e/tests/live-ai-two-browser-full-flow.spec.ts`** — new spec.

## Notable design choices in the spec

A bunch of things had to differ from the mocked `two-browser-full-flow.spec.ts` to work with real AI:

1. **Defer User B's invitation accept until after User A drafts.** Real AI gates the Stage 0 `<draft>` block on the partner not yet being onboard. Mocked specs ignore this gate via fixture replay. We restructured to mirror the real-life timing: A signs compact → drafts → "sends" → B accepts.
2. **Concrete Stage 0 dialogue**, with named-exchange specifics ("they snapped 'I had a bad day'"), so the AI has substance to summarize. Generic situational descriptions ("we argued") aren't enough — the AI keeps asking for what was actually said.
3. **180 s `AI_RESPONSE_TIMEOUT` + `RECONCILER_TIMEOUT`.** Plain followups are ~30 s, but structured-output turns (invitation draft, empathy draft, strategy proposal) can spike to 120 s+ on Bedrock.
4. **`evaluate(el => el.click())` for `feel-heard-yes`.** Playwright's `click({ force: true })` still waits for the locator to be visible — if the element re-renders mid-stage-transition (real-AI's longer streaming windows make this common), `click` waits up to the test timeout. We saw User B hang for ~26 min on this. JS-evaluate-click bypasses every Playwright actionability wait.
5. **Skip share-screen UI verification.** `sharing-status.tsx` is a `@deprecated` redirect stub now ("Sharing functionality has been moved to the Partner tab"), and the `share-screen-partner-tab-item-partner-empathy-*` testID has been removed from the codebase. The mocked spec's assertions on these are stale. We verify via API state instead.
6. **Skip drawer-mounted text assertions** (`Confirm my needs`, `Shared Needs Discovered`). `NeedsDrawer` returns `null` when `visible=false`, and there's no auto-open in `UnifiedSessionScreen` — those assertions in the mocked spec only seem to pass against fixtured DB state. We verify needs presence via API.
7. **Send Stage 3 messages before triggering needs extraction.** Backend gate (`stage3.ts:191`): extraction won't run unless the user has at least one `stage=3, role=USER` message — prevents needs from appearing before any conversation.
8. **Reload pages between Stage 2 share and Stage 3 messaging.** After empathy share, `chat-input` is hidden ("waiting for partner"). Even after `empathy/validate` advances state, the existing client UI doesn't re-render until reload or Ably propagation.
9. **Assert on `sessionCanResolve`, not `sessionComplete`.** The agreement-confirm endpoint returns `sessionCanResolve` (per `controllers/stage4.ts:854-868`); `sessionComplete` is a stale field name copy-pasted from `two-browser-full-flow.spec.ts` (latent bug there too — `expect(undefined).toBe(true)`).

## Test plan

- [x] `npm run check` (e2e) — clean.
- [x] EC2 run on commit 219d679 — pass, dashboard URL above.
- [ ] After merge: `@slam_paws test live-ai-two-browser-full-flow` from Slack — wrapper auto-routes the prefix; should work end-to-end.

## Cost + cadence

~$1–2 in Bedrock per run, ~5–6 min runtime. On-demand only — no cron entry; Slack `@slam_paws test live-ai-two-browser-full-flow` is the canonical trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
