### PR TITLE
docs: fix drift from 24h code changes (2026-04-28)

### DIFF
--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -3,7 +3,7 @@ title: Testing Patterns
 sidebar_position: 9
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-04-28
 status: living
 ---
 # Testing Patterns
@@ -31,6 +31,7 @@ status: living
   - `e2e/playwright.live-ai.config.ts` - real Bedrock AI run (slow, separate workflow)
   - `e2e/playwright.two-browser.config.ts` - multi-user scenarios. `testMatch: /two-browser-.*\.spec\.ts/`. `MOCK_LLM=true`, no global fixture ID — each browser sets its own via the `X-E2E-Fixture-ID` header.
 - Assertion: Playwright built-in matchers
+- **Publishing**: `scripts/ec2-bot/scripts/run-and-publish.sh` wraps any Playwright run and publishes results (screenshots, transcript, metadata) to the [Test Dashboard](../e2e-testing/architecture.md#test-run-publishing--dashboard) (Vercel). Trigger via `@slam_paws test <scenario>` in Slack or run the script directly on EC2.
 
 **Run Commands:**
 ```bash

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -3,7 +3,7 @@ title: "Stage 2: Perspective Stretch - Empathy Exchange Flow"
 sidebar_position: 6
 description: This document describes the empathy exchange flow in Stage 2, including the reconciler system that analyzes empathy accuracy and manages the sharing of addit...
 created: 2026-03-11
-updated: 2026-04-27
+updated: 2026-04-28
 status: living
 ---
 # Stage 2: Perspective Stretch - Empathy Exchange Flow
@@ -209,7 +209,8 @@ sequenceDiagram
     Note over A,B: Stage 1 Complete - Both felt heard
 
     A->>AI: Chat about B's perspective
-    AI->>A: Guides empathy development
+    Note over AI: Loads current empathy draft (if any) as editing context
+    AI->>A: Guides empathy development / refines existing draft
     AI->>A: Proposes empathy statement
 
     A->>System: Share empathy statement

--- a/docs/code-to-docs-mapping.json
+++ b/docs/code-to-docs-mapping.json
@@ -57,6 +57,7 @@
     { "code": "render.yaml",                             "label": "render.yaml",                   "docs": ["docs/deployment/render-config.md", "docs/deployment/index.md"] },
     { "code": "scripts/ec2-bot/**",                      "label": "scripts/ec2-bot",               "docs": ["docs/infrastructure/index.md"] },
     { "code": "bot-workspaces/**",                       "label": "bot-workspaces",                "docs": ["docs/infrastructure/index.md"] },
-    { "code": ".github/workflows/**",                    "label": ".github/workflows",             "docs": ["docs/infrastructure/index.md"] }
+    { "code": ".github/workflows/**",                    "label": ".github/workflows",             "docs": ["docs/infrastructure/index.md"] },
+    { "code": "tools/test-dashboard/**",                 "label": "tools/test-dashboard",           "docs": ["docs/e2e-testing/architecture.md", "docs/infrastructure/index.md"] }
   ]
 }

--- a/docs/e2e-testing/architecture.md
+++ b/docs/e2e-testing/architecture.md
@@ -3,7 +3,7 @@ title: E2E Testing Architecture
 sidebar_position: 2
 description: This document describes the end-to-end testing approach used in Meet Without Fear.
 created: 2026-03-11
-updated: 2026-04-27
+updated: 2026-04-28
 status: living
 ---
 # E2E Testing Architecture
@@ -397,6 +397,7 @@ Enabled only when `E2E_AUTH_BYPASS=true`:
 | `e2e/playwright.live-ai.config.ts` | Playwright config for live AI tests (real LLM, no mocking) |
 | `e2e/global-setup.ts` | Pre-test database cleanup |
 | `e2e/helpers/` | Test utilities (SessionBuilder, headers) |
+| `e2e/reporters/test-dashboard-reporter.ts` | Custom Playwright reporter; writes `dashboard-summary.json` for publishing |
 | `backend/src/fixtures/` | TypeScript fixture definitions |
 | `backend/src/fixtures/index.ts` | Fixture registry |
 | `backend/src/fixtures/types.ts` | Fixture type definitions |
@@ -405,6 +406,58 @@ Enabled only when `E2E_AUTH_BYPASS=true`:
 | `backend/src/routes/e2e.ts` | E2E helper endpoints |
 | `backend/src/testing/state-factory.ts` | Session stage creation |
 | `mobile/src/providers/E2EAuthProvider.tsx` | Mobile auth bypass |
+
+## Test Run Publishing & Dashboard
+
+The **MWF Test Dashboard** (`tools/test-dashboard/`) is a Vercel-deployed React UI for browsing Playwright test runs, screenshots, and snapshots. It replaces Slack screenshot threads as the primary browse surface.
+
+### Publishing pipeline (`run-and-publish.sh`)
+
+`scripts/ec2-bot/scripts/run-and-publish.sh` wraps a Playwright run and publishes results:
+
+1. Selects the right config based on scenario prefix (`two-browser-*`, `live-ai-*`, or default)
+2. Appends `e2e/reporters/test-dashboard-reporter.ts` to capture a `dashboard-summary.json`
+3. Calls `scripts/ec2-bot/scripts/write-test-result.ts` to upload screenshots to Vercel Blob and PATCH the run row in Vercel Postgres
+
+Artifacts written per run:
+- `e2e/test-results/dashboard-summary.json` — source of truth for the writer
+- `e2e/test-results/dashboard-screenshots/*.png` — screenshots renamed in step order
+- `e2e/test-results/dashboard-transcript.txt` — AI conversation transcript
+
+### Slack trigger (`@slam_paws test`)
+
+Any Slack channel where the bot is present accepts:
+
+```
+@slam_paws test single-user-journey
+@slam_paws test two-browser-stage-2
+@slam_paws test stage-3-4-complete from-snapshot:01HK1234
+```
+
+- Bot reacts 👀 and posts a thread reply immediately
+- `run-and-publish.sh` runs in the background (non-blocking; multiple in-flight OK)
+- On completion: reaction swaps to ✅ (pass) or ❌ (fail) and a dashboard URL is posted
+
+Scenario names must match `[a-z0-9][a-z0-9-]*` (shell-safety guard).
+
+### On-demand only
+
+Test-dashboard runs are triggered on-demand (Slack or SSH) — there is no scheduled cron. See `scripts/ec2-bot/crontab.txt` for the comment explaining the tradeoff.
+
+### Required env vars (EC2 bot)
+
+| Var | Purpose |
+|-----|---------|
+| `TEST_DASHBOARD_API_URL` | e.g. `https://mwf-test-dashboard.vercel.app` |
+| `BOT_WRITER_TOKEN` | Bot write token for the dashboard API |
+| `BLOB_READ_WRITE_TOKEN` | Vercel Blob token for screenshot uploads |
+
+### Dashboard architecture
+
+- **Frontend**: React 19 + Vite + react-router-dom v7, deployed to Vercel
+- **API**: `tools/test-dashboard/api/*.ts` — Vercel serverless functions
+- **Storage**: Vercel Postgres (run/snapshot metadata) + Vercel Blob (screenshots)
+- **Realtime**: Ably channel `test-runs:updates` for live progress
 
 ## Two-Browser Testing
 

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -3,7 +3,7 @@ title: Infrastructure
 sidebar_position: 1
 description: Slam bot (EC2), Render hosting, Vercel deploys, GitHub automation.
 created: 2026-03-11
-updated: 2026-04-27
+updated: 2026-04-28
 status: living
 ---
 
@@ -24,7 +24,7 @@ Operational infrastructure for Meet Without Fear.
 
 | Service | Purpose |
 |---|---|
-| `slam-bot-socket.service` | Socket Mode listener for real-time Slack events. Routes incoming messages by channel: DMs and `#slam-paws`/`#agentic-devs`/`#bugs-and-requests`/`#most-important-thing` go to the `slack-triage` workspace; `#mwf-sessions` messages go to the `mwf-session` workspace (or, when `MWF_BACKEND_URL` is set, forward directly to the backend Bedrock pipeline). |
+| `slam-bot-socket.service` | Socket Mode listener for real-time Slack events. Routes incoming messages by channel: DMs and `#slam-paws`/`#agentic-devs`/`#bugs-and-requests`/`#most-important-thing` go to the `slack-triage` workspace; `#mwf-sessions` messages go to the `mwf-session` workspace (or, when `MWF_BACKEND_URL` is set, forward directly to the backend Bedrock pipeline). Also handles `@slam_paws test <scenario>` commands from any channel — spawns `run-and-publish.sh` in the background, replies in-thread with 👀 / ✅ / ❌ and a dashboard URL. |
 | `slam-bot-state-scanner.service` | GitHub state scanner daemon (`github-state-scanner.sh` loop). Hardened with `MemoryMax=256M` and `TasksMax=64` to prevent runaway resource use. |
 
 ### Cron jobs
@@ -45,6 +45,7 @@ The crontab (installed by `deploy.sh`) covers roughly the following categories. 
 | daily | `sync-labels.sh`, `bot-health-check.sh`, `api-budget-summary.sh --post`, `api-budget-summary.sh --alert`, `prune-journal.sh`, `prune-claude-projects.sh`, `sweep-mwf-sessions.sh` | Housekeeping + daily health + budget digest (post to `#bot-ops` + over-budget alert) + session retention |
 | twice daily (08:00 / 20:00) | `sync-staging.sh` | Merge `main` → `bot/staging`; PR accumulated bot work back to `main` |
 | scheduled | `workspace-dispatcher.sh` variants | `bug-fix`, `health-check`, `docs-audit`, `security-audit`, `stale-sweeper`, `pr-reviewer`, `daily-strategy` runs |
+| on-demand only | `run-and-publish.sh` | E2E test runs published to dashboard — triggered via `@slam_paws test <scenario>` in Slack or manually via SSH. No scheduled cron (see `scripts/ec2-bot/crontab.txt`). |
 
 Local operator scripts live at `scripts/ec2-bot/`:
 
@@ -56,6 +57,10 @@ Local operator scripts live at `scripts/ec2-bot/`:
 | `configure-slack.sh` | Write Slack tokens + channel IDs (`SLAM_BOT_CHANNEL_ID` for `#slam-paws`, `AGENTIC_DEVS_CHANNEL_ID` for `#agentic-devs`, `BUGS_AND_REQUESTS_CHANNEL_ID` for `#bugs-and-requests`, `MOST_IMPORTANT_THING_CHANNEL_ID` for `#most-important-thing`, `DAILY_SUMMARY_CHANNEL_ID` for `#daily-summary`, `MWF_SESSIONS_CHANNEL_ID` for `#mwf-sessions`) to `/opt/slam-bot/.env` and start the socket service |
 | `configure-mixpanel.sh` | Write Mixpanel service-account credentials |
 | `configure-db.sh` | Create/rotate `slam_bot_readonly` role on the Render Postgres |
+| `run-and-publish.sh` | Wrap a Playwright e2e run and publish results (screenshots, transcript, metadata) to the test dashboard. Called by the `@slam_paws test` Slack handler or manually via SSH. |
+| `save-snapshot.sh` | Save a named DB + app-state snapshot so test runs can branch from a known point. |
+| `restore-snapshot.sh` | Restore a previously saved snapshot by ID (used with `--starting-snapshot-id` in `run-and-publish.sh`). |
+| `write-test-result.ts` | Upload test artifacts (screenshots → Vercel Blob) and PATCH the run row in Vercel Postgres. Called by `run-and-publish.sh` after Playwright exits. |
 
 ### Session data directories
 
@@ -123,6 +128,7 @@ Set `CHANNEL=<channel>` in the env so the emoji reaction handlers work.
 - **Docs site (this one)**: Vercel
 - **Marketing site**: Vercel (`website/`)
 - **Web app** (`app.meetwithoutfear.com`): Vercel — Expo Web build of `mobile/`, Vercel project `mwf-app`. Deployed via `.github/workflows/vercel-deploy-app.yml` on pushes to `main` that touch `mobile/**` or `shared/**`.
+- **Test Dashboard**: Vercel (`mwf-test-dashboard`) — Browsable UI for e2e test runs, screenshots, and snapshots. Vercel Postgres (Neon) for run/snapshot metadata; Vercel Blob for screenshots. Deployed via `.github/workflows/vercel-deploy-test-dashboard.yml` on pushes to `main` that touch `tools/test-dashboard/**`. See [E2E Testing Architecture: Test Run Publishing & Dashboard](../e2e-testing/architecture.md#test-run-publishing--dashboard).
 
 See [deployment](../deployment/index.md) for release procedures and env var reference.
 
@@ -133,4 +139,5 @@ See [deployment](../deployment/index.md) for release procedures and env var refe
 - `.github/workflows/render-deploy.yml` — Push-to-`main` backend deploy: filters to pushes that touch `backend/`, `shared/`, the lockfile, `render.yaml`, or the workflow itself, then POSTs the Render deploy hook (stored in repo secret `RENDER_DEPLOY_HOOK`). Render's built-in auto-deploy must be **off** — this workflow is the sole deploy trigger.
 - `.github/workflows/vercel-deploy-app.yml` — Push-to-`main` Expo Web deploy: filters to pushes touching `mobile/**` or `shared/**`, builds the Expo Web bundle, and deploys to `app.meetwithoutfear.com` via Vercel (`mwf-app` project). Also supports `workflow_dispatch`.
 - `.github/workflows/vercel-deploy-website.yml` — Push-to-`main` marketing site deploy: filters to pushes touching `website/**`, deploys to Vercel.
+- `.github/workflows/vercel-deploy-test-dashboard.yml` — Push-to-`main` test dashboard deploy: filters to pushes touching `tools/test-dashboard/**`, deploys Vite SPA + Vercel serverless functions to `mwf-test-dashboard` project. Also supports `workflow_dispatch`.
 - `.github/workflows/ota-update.yml` — Push-to-`main` OTA update: publishes an Expo OTA update to the `production` EAS branch for iOS whenever `mobile/**` or `shared/**` changes on `main`. Also supports `workflow_dispatch` with a custom message. Uses `EXPO_TOKEN` secret. Roll back a bad update with `eas update:delete <group-id> --non-interactive`.


### PR DESCRIPTION
## Changes

- Add: "Test Run Publishing & Dashboard" section to `docs/e2e-testing/architecture.md` covering `run-and-publish.sh`, `@slam_paws test` Slack trigger, snapshot save/restore, and dashboard architecture
- Add: Test dashboard Vercel deployment to `docs/infrastructure/index.md` (production hosting, GitHub workflows, EC2 scripts table, systemd description, cron table)
- Add: E2E publishing reference to `docs/architecture/testing.md`
- Fix: `docs/backend/reconciler-flow.md` sequenceDiagram to clarify AI loads existing empathy draft as editing context in regular Stage 2 (not just during reconciler refinement path)
- Add: `tools/test-dashboard/**` to `docs/code-to-docs-mapping.json`

## Provenance

- **Channel:** cron (nightly docs-audit)
- **Requested by:** automated
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs

## Docs updated

- `docs/e2e-testing/architecture.md` — added Test Run Publishing & Dashboard section
- `docs/infrastructure/index.md` — added test-dashboard deployment, scripts, cron, systemd
- `docs/architecture/testing.md` — added E2E publishing reference
- `docs/backend/reconciler-flow.md` — clarified empathy draft loading in Stage 2 sequenceDiagram
- `docs/code-to-docs-mapping.json` — added tools/test-dashboard mapping