### PR TITLE
fix(bot): update stale service IDs in diagnostic reference docs

### DIFF
--- a/bot-workspaces/shared/diagnostics/check-sentry.md
+++ b/bot-workspaces/shared/diagnostics/check-sentry.md
@@ -19,16 +19,16 @@ curl -s -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
 
 ## Default Check (both projects in parallel)
 
-### Gateway issues
+### Backend issues
 ```bash
 curl -s -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/projects/meet-without-fear-mind/meet-without-fear-families-gateway/issues/?query=is:unresolved&sort=date&limit=15"
+  "https://sentry.io/api/0/projects/meet-without-fear/mwf-backend/issues/?query=is:unresolved&sort=date&limit=15"
 ```
 
 ### Mobile issues
 ```bash
 curl -s -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/projects/meet-without-fear-mind/meet-without-fear-families-mobile/issues/?query=is:unresolved&sort=date&limit=15"
+  "https://sentry.io/api/0/projects/meet-without-fear/mwf-mobile/issues/?query=is:unresolved&sort=date&limit=15"
 ```
 
 ## Priority Signals

--- a/bot-workspaces/shared/diagnostics/render-logs.md
+++ b/bot-workspaces/shared/diagnostics/render-logs.md
@@ -14,7 +14,7 @@ See `.claude/config/services.json` for Render service ID.
 
 ```bash
 curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
-  "https://api.render.com/v1/logs?ownerId=tea-d0a2sd8gjchc73bc8bs0&resource=srv-d6cl3lfpm1nc7399boig&limit=100&direction=backward"
+  "https://api.render.com/v1/logs?ownerId=tea-d0a2sd8gjchc73bc8bs0&resource=srv-d58bj73uibrs73akacd0&limit=100&direction=backward"
 ```
 
 Useful query parameters: `limit` (default 100), `direction` (`backward`/`forward`), `startTime` and `endTime` (ISO 8601).


### PR DESCRIPTION
## Changes
- Fix: update Sentry org from `meet-without-fear-mind` to `meet-without-fear` in check-sentry.md
- Fix: update Sentry project slugs from `meet-without-fear-families-gateway`/`meet-without-fear-families-mobile` to `mwf-backend`/`mwf-mobile`
- Fix: rename "Gateway issues" heading to "Backend issues" to match current naming
- Fix: update Render service ID from `srv-d6cl3lfpm1nc7399boig` to `srv-d58bj73uibrs73akacd0` in render-logs.md

Related to #230

## Provenance
- **Channel:** GitHub issue
- **Requested by:** health-check bot
- **Original message:** Stale service IDs causing 404s (Sentry) and forbidden (Render) in bot diagnostics

## Docs updated
- `bot-workspaces/shared/diagnostics/check-sentry.md` — corrected Sentry org and project slugs
- `bot-workspaces/shared/diagnostics/render-logs.md` — corrected Render service ID