### PR TITLE
fix(mobile): prevent Mixpanel identity failure and duplicate events

### DIFF
--- a/mobile/src/components/MixpanelInitializer.tsx
+++ b/mobile/src/components/MixpanelInitializer.tsx
@@ -77,8 +77,11 @@ export function MixpanelInitializer() {
     if (!isLoaded) return;
 
     async function handleAuthChange() {
-      // Sign in transition
-      if (isSignedIn && user && prevSignedIn.current === false) {
+      const wasPrevSignedIn = prevSignedIn.current;
+      prevSignedIn.current = isSignedIn ?? false;
+
+      // Sign in transition (includes first load with existing session: null → true)
+      if (isSignedIn && user && wasPrevSignedIn !== true) {
         const userId = user.id;
 
         // Check if we need to alias (first time this user on this device)
@@ -107,17 +110,18 @@ export function MixpanelInitializer() {
         // Register user_id as super property
         registerSuperProperties({ user_id: userId });
 
-        // Determine provider and if new user
-        const provider = user.externalAccounts?.[0]?.provider || 'unknown';
-        const createdAt = user.createdAt ? new Date(user.createdAt).getTime() : 0;
-        const isNewUser = Date.now() - createdAt < 60000; // Created within last minute
+        // Track sign in/up only for real sign-in transitions (not app launch with existing session)
+        if (wasPrevSignedIn === false) {
+          const provider = user.externalAccounts?.[0]?.provider || 'unknown';
+          const createdAt = user.createdAt ? new Date(user.createdAt).getTime() : 0;
+          const isNewUser = Date.now() - createdAt < 60000; // Created within last minute
 
-        // Track sign in/up
-        track(isNewUser ? 'Sign Up Completed' : 'Sign In Completed', {
-          method: 'oauth',
-          provider,
-          user_id: userId,
-        });
+          track(isNewUser ? 'Sign Up Completed' : 'Sign In Completed', {
+            method: 'oauth',
+            provider,
+            user_id: userId,
+          });
+        }
 
         // Set user properties
         setUserPropertiesOnce({
@@ -133,28 +137,24 @@ export function MixpanelInitializer() {
       }
 
       // Sign out transition
-      if (!isSignedIn && prevSignedIn.current === true) {
+      if (!isSignedIn && wasPrevSignedIn === true) {
         track('Logout');
         reset();
         // Mark that we reset Mixpanel - this prevents alias() errors on next login
         // since the SDK's anonymous distinctId may be invalid after reset()
         await AsyncStorage.setItem(RESET_FLAG, 'true');
       }
-
-      prevSignedIn.current = isSignedIn ?? false;
     }
 
     handleAuthChange();
   }, [isLoaded, isSignedIn, user]);
 
-  // Re-identify on app foreground (defensive)
+  // Update session properties on app foreground
   useEffect(() => {
     if (!isLoaded || !isSignedIn || !user) return;
 
     const subscription = AppState.addEventListener('change', (nextAppState) => {
       if (nextAppState === 'active' && user?.id) {
-        // Re-identify and update session
-        identify(user.id);
         registerSuperProperties({
           app_session_id: getCurrentSessionId(),
           user_id: user.id,

--- a/mobile/src/services/mixpanel.ts
+++ b/mobile/src/services/mixpanel.ts
@@ -48,6 +48,7 @@ const createNoOpClient = (): IMixpanel => {
 // This will hold our client, either the real one or the no-op one.
 let mixpanelClient: IMixpanel;
 let didInit = false;
+let identifiedUserId: string | null = null;
 
 /**
  * Initialize the Mixpanel client.
@@ -94,22 +95,19 @@ export const track = (eventName: string, properties?: Record<string, unknown>): 
 };
 
 /**
- * Simple identify function with dev guard.
- * This should be called when a user logs in or when the app loads with a stored user.
+ * Identify the current user. Skips if already identified with the same userId
+ * to prevent errAnonDistinctIdAssignedAlready errors from the Mixpanel SDK.
  */
 export const identify = (userId: string): void => {
-  console.log('[Mixpanel] identify() called', {
-    userId,
-    didInit,
-    clientExists: !!mixpanelClient,
-    timestamp: new Date().toISOString(),
-  });
-
   assertInit();
+
+  if (identifiedUserId === userId) {
+    return;
+  }
 
   try {
     mixpanelClient?.identify(userId);
-    console.log('[Mixpanel] identify() completed successfully for user:', userId);
+    identifiedUserId = userId;
   } catch (error) {
     console.error('[Mixpanel] identify() failed:', error);
   }
@@ -189,6 +187,7 @@ export const registerSuperProperties = (properties: Record<string, unknown>): vo
  */
 export const reset = (): void => {
   mixpanelClient?.reset();
+  identifiedUserId = null;
 };
 
 /**

--- a/mobile/src/services/mixpanel.web.ts
+++ b/mobile/src/services/mixpanel.web.ts
@@ -5,6 +5,7 @@
  */
 
 let didInit = false;
+let identifiedUserId: string | null = null;
 
 const log = (message: string, ...args: unknown[]) => {
   if (__DEV__) {
@@ -23,7 +24,9 @@ export const track = (eventName: string, properties?: Record<string, unknown>): 
 };
 
 export const identify = (userId: string): void => {
+  if (identifiedUserId === userId) return;
   log('Identify:', userId);
+  identifiedUserId = userId;
 };
 
 export const alias = (aliasId: string): void => {
@@ -44,6 +47,7 @@ export const registerSuperProperties = (properties: Record<string, unknown>): vo
 
 export const reset = (): void => {
   log('Reset');
+  identifiedUserId = null;
 };
 
 export const isInitialized = (): boolean => didInit;


### PR DESCRIPTION
## Changes
- Fix: add deduplication guard to `identify()` in `mixpanel.ts` and `mixpanel.web.ts` — skip if already identified with the same userId, preventing `errAnonDistinctIdAssignedAlready`
- Fix: capture `prevSignedIn.current` before async work in auth change handler to prevent race condition causing duplicate Logout events
- Fix: handle already-signed-in users on app launch (`null → true` transition) so they get properly identified without firing spurious Sign In events
- Fix: remove redundant `identify()` from foreground AppState listener — SDK maintains identity after first call, re-calling triggers identity errors
- Fix: guard Sign In/Up event tracking to only fire on real sign-in transitions (`false → true`), not app launch with existing session (`null → true`)

Related to #232

## Provenance
- **Channel:** GitHub Issues
- **Requested by:** bot (daily strategy scan)
- **Original message:** Mixpanel identity failure causing users to be force-logged out on launch
- **Prompt(s) used:** `general-pr`

## Docs updated
No doc changes needed — bug fix in mobile analytics integration code only.