### PR TITLE
fix(backend): harden auth middleware against Prisma deadlock on concurrent login

### DIFF
--- a/backend/src/middleware/__tests__/auth.test.ts
+++ b/backend/src/middleware/__tests__/auth.test.ts
@@ -143,14 +143,15 @@ describe('Auth Middleware', () => {
       expect(next).not.toHaveBeenCalled();
     });
 
-    it('authenticates user with valid Clerk token', async () => {
+    it('authenticates existing user with valid Clerk token (find + update)', async () => {
       mockVerifyToken.mockResolvedValue({ sub: 'clerk-user-123' });
       mockGetUser.mockResolvedValue({
         firstName: 'Test',
         lastName: 'User',
         emailAddresses: [{ emailAddress: 'test@example.com' }],
       });
-      (prisma.user.upsert as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockUser);
 
       const req = createMockRequest({
         headers: { authorization: 'Bearer valid-clerk-token' },
@@ -160,24 +161,76 @@ describe('Auth Middleware', () => {
 
       await requireAuth(req as Request, res as Response, next);
 
-      expect(mockVerifyToken).toHaveBeenCalledWith('valid-clerk-token', {
-        secretKey: 'sk_test_xxx',
-      });
-      expect(mockGetUser).toHaveBeenCalledWith('clerk-user-123');
-      expect(prisma.user.upsert).toHaveBeenCalledWith({
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
         where: { clerkId: 'clerk-user-123' },
-        update: { email: 'test@example.com', name: 'Test User', firstName: 'Test', lastName: 'User' },
-        create: {
-          clerkId: 'clerk-user-123',
-          email: 'test@example.com',
-          name: 'Test User',
-          firstName: 'Test',
-          lastName: 'User',
-        },
       });
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { clerkId: 'clerk-user-123' },
+        data: { email: 'test@example.com', name: 'Test User', firstName: 'Test', lastName: 'User' },
+      });
+      expect(prisma.user.create).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalled();
       expect(req.user).toEqual(mockUser);
       expect(req.clerkUserId).toBe('clerk-user-123');
+    });
+
+    it('creates new user when not found (find + create)', async () => {
+      mockVerifyToken.mockResolvedValue({ sub: 'clerk-new-user' });
+      mockGetUser.mockResolvedValue({
+        firstName: 'New',
+        lastName: 'User',
+        emailAddresses: [{ emailAddress: 'new@example.com' }],
+      });
+      const newUser = { ...mockUser, id: 'user-new', clerkId: 'clerk-new-user', email: 'new@example.com', name: 'New User' };
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.user.create as jest.Mock).mockResolvedValue(newUser);
+
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer valid-clerk-token' },
+      });
+      const { res } = createMockResponse();
+      const next = jest.fn();
+
+      await requireAuth(req as Request, res as Response, next);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { clerkId: 'clerk-new-user' },
+      });
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: { clerkId: 'clerk-new-user', email: 'new@example.com', name: 'New User', firstName: 'New', lastName: 'User' },
+      });
+      expect(prisma.user.update).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+      expect(req.user).toEqual(newUser);
+    });
+
+    it('handles concurrent create race (P2002 fallback)', async () => {
+      const { Prisma } = jest.requireActual('@prisma/client');
+      mockVerifyToken.mockResolvedValue({ sub: 'clerk-race-user' });
+      mockGetUser.mockResolvedValue({
+        firstName: 'Race',
+        lastName: 'User',
+        emailAddresses: [{ emailAddress: 'race@example.com' }],
+      });
+      const raceUser = { ...mockUser, id: 'user-race', clerkId: 'clerk-race-user', email: 'race@example.com' };
+      // First findUnique: not found. Create fails with P2002. Second findUnique: found.
+      (prisma.user.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(raceUser);
+      const p2002Error = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', { code: 'P2002', clientVersion: '5.0.0' });
+      (prisma.user.create as jest.Mock).mockRejectedValue(p2002Error);
+
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer valid-clerk-token' },
+      });
+      const { res } = createMockResponse();
+      const next = jest.fn();
+
+      await requireAuth(req as Request, res as Response, next);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledTimes(2);
+      expect(next).toHaveBeenCalled();
+      expect(req.user).toEqual(raceUser);
     });
   });
 
@@ -201,7 +254,8 @@ describe('Auth Middleware', () => {
         lastName: 'User',
         emailAddresses: [{ emailAddress: 'test@example.com' }],
       });
-      (prisma.user.upsert as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockUser);
 
       const req = createMockRequest({
         headers: { authorization: 'Bearer valid-clerk-token' },

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -177,23 +177,31 @@ async function handleClerkAuth(
     const lastName = clerkUser.lastName || null;
     const name = [firstName, lastName].filter(Boolean).join(' ') || null;
 
-    // Upsert user based on Clerk ID
-    const user = await prisma.user.upsert({
-      where: { clerkId: clerkUserId },
-      update: {
-        email,
-        name,
-        firstName,
-        lastName,
-      },
-      create: {
-        clerkId: clerkUserId,
-        email,
-        name,
-        firstName,
-        lastName,
-      },
-    });
+    // Find-or-create user by Clerk ID.
+    // Avoids prisma.user.upsert() which uses SELECT FOR UPDATE internally
+    // and deadlocks (40P01) when concurrent requests race on the same user.
+    let user = await prisma.user.findUnique({ where: { clerkId: clerkUserId } });
+
+    if (user) {
+      user = await prisma.user.update({
+        where: { clerkId: clerkUserId },
+        data: { email, name, firstName, lastName },
+      });
+    } else {
+      try {
+        user = await prisma.user.create({
+          data: { clerkId: clerkUserId, email, name, firstName, lastName },
+        });
+      } catch (error) {
+        // Concurrent create race: another request inserted first
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          user = await prisma.user.findUnique({ where: { clerkId: clerkUserId } });
+          if (!user) throw error;
+        } else {
+          throw error;
+        }
+      }
+    }
 
     req.user = user;
     req.clerkUserId = clerkUserId;


### PR DESCRIPTION
## Changes
- Replace `prisma.user.upsert()` in `handleClerkAuth` with `findUnique` + conditional `update`/`create`
- Add P2002 (unique constraint) fallback for concurrent create races — same pattern already used in the E2E auth bypass path
- Add tests for existing-user update path, new-user create path, and concurrent create race (P2002 fallback)

Related to #234

## Provenance
- **Channel:** GitHub Issue
- **Requested by:** Slam Paws (daily strategy Sentry scan)
- **Original message:** Sentry MWF-BACKEND-F — PostgreSQL deadlock (40P01) on `prisma.user.upsert()` in auth middleware
- **Prompt(s) used:** `general-pr`

## Docs updated
No doc changes needed — internal implementation fix; mapped doc (`backend-overview.md`) does not reference the upsert pattern.