### PR TITLE
docs(daily-strategy): once-daily briefing with dual-audience format

### DIFF
--- a/bot-workspaces/daily-strategy/CLAUDE.md
+++ b/bot-workspaces/daily-strategy/CLAUDE.md
@@ -1,8 +1,8 @@
 # Daily Strategy Workspace (L1)
 
-Generate a twice-daily strategy briefing posted to two channels: a short "Most Important Thing" message to #most-important-thing (one item, one rationale, response prompt) and a comprehensive daily summary to #daily-summary (full breakdown with proceeding/suggestion items, pipeline state, and retrospective). Re-presents unanswered items until the team responds.
+Generate a once-daily strategy briefing posted to two channels: a short "Most Important Thing" message to #most-important-thing (one item, one rationale, response prompt) and a comprehensive daily summary to #daily-summary (full breakdown with proceeding/suggestion items, pipeline state, and retrospective). Re-presents unanswered items until the team responds.
 
-Runs at 7 AM PT and 7 PM PT. Morning sets the day's plan; evening checks in on progress and tees up tomorrow.
+Runs at 7 AM PT. Sets the day's plan and reviews yesterday's progress.
 
 ## What to Load
 
@@ -49,5 +49,5 @@ The workspace implements a persistent response loop with a *consensus requiremen
 ## Orchestrator Rules
 
 - Single-pass: gather data, compose, post, exit
-- Cron-triggered (twice daily): no label swap needed at completion
+- Cron-triggered (once daily at 7 AM PT): no label swap needed at completion
 - If all data sources fail, post a short "Strategy briefing failed to gather data. Check bot logs." message and exit

--- a/bot-workspaces/daily-strategy/stages/2-strategize/CONTEXT.md
+++ b/bot-workspaces/daily-strategy/stages/2-strategize/CONTEXT.md
@@ -82,18 +82,22 @@ Items the bot recommends but will NOT start without explicit approval:
 
 ### 3. Compose #most-important-thing message
 
-This message is intentionally short. One item, one rationale, done.
+This message has two sections so both readers get what they need.
 
 ```
 *[One-sentence description of the single most important thing]*
 [One sentence: why it matters right now]
+[One sentence: what the bot wants to do about it]
 <issue/PR link>
+
+*Technical detail:*
+[2-4 sentences with code-level context for Shantam — file paths, architecture impact, implementation approach]
 ```
 
 Rules for the main message:
-- **Maximum 3 lines**: what, why, link. That's it.
-- No sections, no bullet lists, no pipeline summary, no "Proceeding" or "Suggestion" items
-- Plain language — no file paths, function names, or jargon (Darryl reads this)
+- **Top section is plain English** for Darryl — no file paths, function names, stack traces, or jargon
+- **Bottom section ("Technical detail")** is for Shantam — include technical specifics, code references, architecture context
+- Both sections appear in every briefing so each person gets what they need
 - Use `<https://github.com/shantamg/meet-without-fear/issues/N|#N>` for the link
 - If there are unanswered carry-forward items, the carry-forward IS the most important thing — re-present it
 - If there are genuinely no items, say: "Nothing urgent today — pipeline is healthy."
@@ -175,7 +179,7 @@ Post a thread reply on the daily summary with retrospective detail and scanner r
 
 Only include sections that have content. If a scanner returned "clean" status, mention it briefly (e.g., "No new Sentry patterns detected") rather than omitting it entirely — this confirms the scan ran.
 
-Use "Good morning!" for the 7 AM run, "Evening check-in!" for the 7 PM run.
+Use "Good morning!" as the greeting.
 
 Rules for the daily summary:
 - Keep each bullet to one line with issue link


### PR DESCRIPTION
## Summary

- Switch daily strategy briefing from twice daily (7am + 7pm PT) to once daily at 7am PT
- Add dual-audience format to #most-important-thing posts: plain English section for Darryl, technical detail section for Shantam

## Provenance

- Channel: #most-important-thing
- Requester: Darryl Finkton Jr (U0ASRE7NZL7)
- Original message: "I think we should switch this to a once a day thing..." / "And don't forget the plain English overview on those for me. Shantam wants the full technical version. So we need both"

## Note

The cron schedule change (removing the 7pm entry) was applied directly to the EC2 crontab and is already live. This PR updates the workspace docs to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)