### PR TITLE
fix(mobile): wire web Mixpanel to real mixpanel-browser SDK

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -56,6 +56,7 @@
     "fbjs": "^3.0.5",
     "lucide-react-native": "^0.562.0",
     "metro-react-native-babel-transformer": "^0.77.0",
+    "mixpanel-browser": "^2.78.0",
     "mixpanel-react-native": "^3.1.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/mobile/src/components/MixpanelInitializer.tsx
+++ b/mobile/src/components/MixpanelInitializer.tsx
@@ -126,7 +126,7 @@ export function MixpanelInitializer() {
         // Set user properties
         setUserPropertiesOnce({
           first_seen_at: new Date().toISOString(),
-          signup_source: 'mobile',
+          signup_source: Platform.OS === 'web' ? 'web' : 'mobile',
         });
 
         setUserProperties({

--- a/mobile/src/services/mixpanel.web.ts
+++ b/mobile/src/services/mixpanel.web.ts
@@ -77,6 +77,7 @@ export const alias = (aliasId: string): void => {
   }
   try {
     mixpanel.alias(aliasId);
+    console.log('[Mixpanel Web] alias() completed for user:', aliasId);
   } catch (error) {
     console.error('[Mixpanel Web] alias() failed:', error);
   }

--- a/mobile/src/services/mixpanel.web.ts
+++ b/mobile/src/services/mixpanel.web.ts
@@ -1,13 +1,19 @@
 /**
- * Web stub for Mixpanel analytics.
- * Uses console logging in dev; no-op in production.
- * Can be replaced with mixpanel-browser SDK later for real web analytics.
+ * Web implementation of the Mixpanel analytics service.
+ *
+ * Mirrors the surface of `./mixpanel` (native) so call sites in `analytics.ts`
+ * and elsewhere remain platform-agnostic. Metro picks this file for web targets.
+ *
+ * No token → falls back to a console-logging no-op (matches native behavior).
  */
 
+import mixpanel from 'mixpanel-browser';
+
 let didInit = false;
+let hasToken = false;
 let identifiedUserId: string | null = null;
 
-const log = (message: string, ...args: unknown[]) => {
+const log = (message: string, ...args: unknown[]): void => {
   if (__DEV__) {
     console.log(`[Mixpanel Web] ${message}`, ...args);
   }
@@ -15,39 +21,109 @@ const log = (message: string, ...args: unknown[]) => {
 
 export const initializeMixpanel = async (): Promise<void> => {
   if (didInit) return;
-  log('Initialized (web no-op)');
+
+  const token = process.env.EXPO_PUBLIC_MIXPANEL_TOKEN;
+
+  if (token) {
+    mixpanel.init(token, {
+      debug: __DEV__,
+      track_pageview: false,
+      persistence: 'localStorage',
+    });
+    hasToken = true;
+    console.log('[Mixpanel Web] Initialized with real client');
+  } else {
+    log('Initialized (No-Op Mode — no EXPO_PUBLIC_MIXPANEL_TOKEN)');
+  }
+
   didInit = true;
 };
 
+const assertInit = (): void => {
+  if (__DEV__ && !didInit) {
+    console.warn('[Mixpanel Web] called before initializeMixpanel()');
+  }
+};
+
 export const track = (eventName: string, properties?: Record<string, unknown>): void => {
-  log('Track:', eventName, properties ?? {});
+  assertInit();
+  if (!hasToken) {
+    log('Track:', eventName, properties ?? {});
+    return;
+  }
+  mixpanel.track(eventName, properties);
 };
 
 export const identify = (userId: string): void => {
+  assertInit();
   if (identifiedUserId === userId) return;
-  log('Identify:', userId);
   identifiedUserId = userId;
+  if (!hasToken) {
+    log('Identify:', userId);
+    return;
+  }
+  try {
+    mixpanel.identify(userId);
+  } catch (error) {
+    console.error('[Mixpanel Web] identify() failed:', error);
+  }
 };
 
 export const alias = (aliasId: string): void => {
-  log('Alias:', aliasId);
+  assertInit();
+  if (!hasToken) {
+    log('Alias:', aliasId);
+    return;
+  }
+  try {
+    mixpanel.alias(aliasId);
+  } catch (error) {
+    console.error('[Mixpanel Web] alias() failed:', error);
+  }
 };
 
 export const setUserProperties = (properties: Record<string, unknown>): void => {
-  log('Set User Properties:', properties);
+  assertInit();
+  if (!hasToken) {
+    log('Set User Properties:', properties);
+    return;
+  }
+  try {
+    mixpanel.people.set(properties);
+  } catch (error) {
+    console.error('[Mixpanel Web] setUserProperties() failed:', error);
+  }
 };
 
 export const setUserPropertiesOnce = (properties: Record<string, unknown>): void => {
-  log('Set User Properties Once:', properties);
+  assertInit();
+  if (!hasToken) {
+    log('Set User Properties Once:', properties);
+    return;
+  }
+  try {
+    mixpanel.people.set_once(properties);
+  } catch (error) {
+    console.error('[Mixpanel Web] setUserPropertiesOnce() failed:', error);
+  }
 };
 
 export const registerSuperProperties = (properties: Record<string, unknown>): void => {
-  log('Register Super Properties:', properties);
+  assertInit();
+  if (!hasToken) {
+    log('Register Super Properties:', properties);
+    return;
+  }
+  mixpanel.register(properties);
 };
 
 export const reset = (): void => {
-  log('Reset');
   identifiedUserId = null;
+  if (!hasToken) {
+    log('Reset');
+    return;
+  }
+  mixpanel.reset();
 };
 
 export const isInitialized = (): boolean => didInit;

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,7 @@
         "fbjs": "^3.0.5",
         "lucide-react-native": "^0.562.0",
         "metro-react-native-babel-transformer": "^0.77.0",
+        "mixpanel-browser": "^2.78.0",
         "mixpanel-react-native": "^3.1.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- `mobile/src/services/mixpanel.web.ts` was a console-only no-op stub. Every `track`/`identify`/`alias` call from the Expo web build silently dropped on the floor, so users who used the browser version of the app (e.g. Stephanie) never appeared in Mixpanel.
- Replaced with a real implementation backed by `mixpanel-browser`, mirroring the surface of `./mixpanel` (native) so call sites in `analytics.ts` and elsewhere remain platform-agnostic.
- Falls back to the previous console-logging no-op when `EXPO_PUBLIC_MIXPANEL_TOKEN` is absent — matches native behavior.
- Preserves the existing `identify()` dedupe (no-op when the same `userId` re-identifies).
- Adds `mixpanel-browser ^2.78.0` to `mobile/package.json` (already present in the website workspace).

## Verification
- `npm run check` passes across all workspaces.

## Deploy note
`EXPO_PUBLIC_MIXPANEL_TOKEN` must be set at web build time wherever the web app is built/hosted. Expo inlines `EXPO_PUBLIC_*` vars at build time, so if native already has the token, the same `.env` carries through — but if web is built in a separate CI lane, double-check the env there. Without the token, the new code logs `[Mixpanel Web] Initialized (No-Op Mode — no EXPO_PUBLIC_MIXPANEL_TOKEN)` and silently no-ops.

## Test plan
- [ ] Confirm `EXPO_PUBLIC_MIXPANEL_TOKEN` is plumbed into the web build env
- [ ] Load the web build, sign in, take a session action
- [ ] Confirm events appear in Mixpanel under the signed-in `user_*` distinct_id
- [ ] Confirm anonymous-before-signin events get aliased to the user via the existing `alias()` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)