### PR TITLE
docs: fix Mixpanel SDK attribution for Expo web build

### DIFF
--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -3,7 +3,7 @@ title: External Integrations
 sidebar_position: 6
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-03-12
+updated: 2026-05-01
 status: living
 ---
 # External Integrations
@@ -87,11 +87,12 @@ status: living
 
 **Analytics & Monitoring:**
 - Mixpanel - Event analytics
-  - SDK: `mixpanel-react-native` (mobile), `mixpanel-browser` (website)
+  - SDK: `mixpanel-react-native` (mobile/native), `mixpanel-browser` (mobile/Expo web build)
   - Auth: `EXPO_PUBLIC_MIXPANEL_TOKEN` (environment variable, public token)
   - Tracking: Session events, user actions, completion milestones
   - Files:
-    - Mobile: `mobile/src/services/mixpanel.ts`, `mobile/src/services/analytics.ts`
+    - Mobile (native): `mobile/src/services/mixpanel.ts`, `mobile/src/services/analytics.ts`
+    - Mobile (Expo web build): `mobile/src/services/mixpanel.web.ts` (platform override using `mixpanel-browser`)
     - Website: Google Analytics via Next.js
 
 ## Data Storage

--- a/docs/architecture/stack.md
+++ b/docs/architecture/stack.md
@@ -3,7 +3,7 @@ title: Technology Stack
 sidebar_position: 7
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-04-15
+updated: 2026-05-01
 status: living
 ---
 # Technology Stack
@@ -96,7 +96,7 @@ status: living
 - Clerk 1.7.73 (backend) / 2.19.26 (mobile) / 6.38.1 (website) - Authentication provider
 
 **Analytics & Logging:**
-- Mixpanel 3.1.3 (mobile) / 2.73.0 (web) - Event analytics
+- Mixpanel `mixpanel-react-native` 3.1.3 (mobile/native), `mixpanel-browser` 2.78.0 (mobile/Expo web build), 2.73.0 (website) - Event analytics
 - Winston 3.19.0 - Structured logging framework (backend)
 - @sentry/node 10.43.0 - Error tracking and monitoring (used in logger.ts)
 


### PR DESCRIPTION
## Changes
- Fix: `integrations.md` incorrectly attributed `mixpanel-browser` to "(website)"; it's the Expo web build platform override
- Fix: `integrations.md` files list for mobile was missing `mobile/src/services/mixpanel.web.ts`
- Fix: `stack.md` Mixpanel version entry now distinguishes all three variants (react-native/native, browser/Expo web, browser/website)
- Update: bumped `updated` frontmatter dates to 2026-05-01 on both docs

## Provenance
- **Channel:** cron / audit-docs
- **Requested by:** Automated nightly incremental docs audit
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs incremental stage

## Docs updated
- `docs/architecture/integrations.md`
- `docs/architecture/stack.md`