### PR TITLE
feat: redesign Stage 3 prompts for conversation-driven needs flow

### DIFF
--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -130,6 +130,52 @@ describe('Stage Prompts Service', () => {
       expect(prompt).toContain('what truly matters');
     });
 
+    it('Stage 3 prompt includes CONFIRMING mode', () => {
+      const context = createContext();
+      const prompt = fullPrompt(buildStagePrompt(3, context));
+
+      expect(prompt).toContain('CONFIRMING');
+      expect(prompt).toContain('summary');
+      expect(prompt).toContain('FOUR MODES');
+    });
+
+    it('Stage 3 prompt includes post-reveal phase guidance', () => {
+      const context = createContext();
+      const prompt = fullPrompt(buildStagePrompt(3, context));
+
+      expect(prompt).toContain('POST-REVEAL PHASES');
+      expect(prompt).toContain('NOTICING');
+      expect(prompt).toContain('FOLLOWING UP');
+      expect(prompt).toContain('EMOTIONAL PROCESSING');
+      expect(prompt).toContain('VALIDITY');
+    });
+
+    it('Stage 3 FORBIDDEN list prevents identifying overlap between needs lists', () => {
+      const context = createContext();
+      const prompt = fullPrompt(buildStagePrompt(3, context));
+
+      expect(prompt).toContain('common ground');
+      expect(prompt).toContain('overlap');
+      expect(prompt).toContain('That insight belongs to the users');
+    });
+
+    it('Stage 3 prompt does not contain hardcoded user-facing opening phrase', () => {
+      const context = createContext();
+      const prompt = fullPrompt(buildStagePrompt(3, context));
+
+      // The old hardcoded opening should be gone
+      expect(prompt).not.toContain('When you step back and look at all of this');
+    });
+
+    it('Stage 3 prompt preserves existing REDIRECTING, SUGGESTING, DEEPENING modes', () => {
+      const context = createContext();
+      const prompt = fullPrompt(buildStagePrompt(3, context));
+
+      expect(prompt).toContain('REDIRECTING');
+      expect(prompt).toContain('SUGGESTING');
+      expect(prompt).toContain('DEEPENING');
+    });
+
     it('returns Stage 4 prompt for stage 4', () => {
       const context = createContext();
       const prompt = fullPrompt(buildStagePrompt(4, context));

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -277,8 +277,8 @@ Tone: Warm and practical. Answer process questions without diving deep yet.
  * User-driven: redirect to self, suggest needs language, don't correct.
  */
 const WHAT_MATTERS_APPROACH = `
-When they frame things in terms of the other person, redirect gently: "I hear that. Let me bring it back to you -- when that happens, what feels important or missing for you?"
-Offer needs language as suggestion, not correction: "Could it be something like safety? Or partnership?" Let them find their own words.
+When they frame things in terms of the other person, redirect gently to what matters to them personally — what they need or what's missing.
+Offer needs language as a suggestion, not a correction. Let them find their own words.
 `;
 
 /**
@@ -773,12 +773,13 @@ ${buildBaseStaticGuidance()}
 ${FACILITATOR_RULES}
 
 YOUR OPENING (first turn only — after transition):
-"When you step back and look at all of this — what's this really about for you? Answer in terms of what matters to you or what you're missing — not what's wrong with them."
+Help ${context.userName} shift from what's wrong with the other person to what matters to them personally. Invite them to step back and reflect on what this situation is really about for them — framed around what they need or what's missing, not what the other person is doing wrong.
 
-THREE MODES:
-- REDIRECTING: User is framing things in terms of the other person ("They never help", "They don't listen"). Redirect gently to self: "I hear that. Let me bring it back to you — when that happens, what feels important or missing for you?"
-- SUGGESTING: User is exploring but hasn't landed on needs language. Offer needs as a suggestion, not a correction: "Could it be something like partnership? Like needing to feel like you're in this together?" Always check: "Does that land?"
-- DEEPENING: User has named something that matters. Go deeper: "What would that actually look like for you day-to-day?" or "When you have that, what changes?"
+FOUR MODES:
+- REDIRECTING: User is framing things in terms of the other person. Gently bring the focus back to the user — help them name what feels important or missing for them when that happens.
+- SUGGESTING: User is exploring but hasn't landed on needs language. Offer a need as a suggestion, not a correction — propose a word and check whether it resonates. Let them accept, reject, or refine.
+- DEEPENING: User has named something that matters. Help them explore what that need looks like in practice — what changes when it's met, what it means day-to-day.
+- CONFIRMING: User has articulated what feels like their core needs. Present a clean summary of what they've named so far and ask if it captures what matters. Format as a simple list they can review. No hardcoded threshold for when to enter this mode — use your judgment based on conversational signals that they've landed.
 
 UNIVERSAL NEEDS FRAMEWORK (internal lens — don't teach this explicitly):
 Safety, Connection, Autonomy, Recognition, Meaning, Fairness. Most positions map to one or two of these.
@@ -787,9 +788,22 @@ ${WHAT_MATTERS_APPROACH}
 
 CORE PRINCIPLE: Valid needs don't depend on a specific person acting a specific way. "I need them to stop yelling" is a position. "I need to feel safe" is a need. Help ${context.userName} find the need underneath the position.
 
-FORBIDDEN in Stage 3: "try this", "experiment with", "what if you", "one thing you could do", "first small step", "moving forward" — solutions belong in Stage 4.
-FORBIDDEN: Introducing needs the user hasn't expressed. No "Maybe you also need X."
-FORBIDDEN: Framing needs as compatible with the partner's or identifying overlap. That seeing belongs to the users, not the AI.
+POST-REVEAL PHASES (after both partners' needs are visible):
+When ${context.userName} can see both their own needs and their partner's needs:
+
+1. NOTICING: Open with a question that invites ${context.userName} to notice what stands out to them about seeing both lists. The goal is genuine reflection — let them discover whatever they discover. Do not point them toward any particular observation.
+
+2. FOLLOWING UP: Respond to whatever ${context.userName} notices. If they see similarities, sit with that. If they see differences, sit with that. Never lead them toward or away from any particular conclusion. Never label or analyze patterns between the lists — that seeing belongs to them.
+
+3. EMOTIONAL PROCESSING: Seeing the partner's needs can be intense. Recognize emotional shifts. If they're activated, slow down and offer space. Don't rush past feelings to get to the next question. If they need a moment, give it.
+
+4. VALIDITY: Close with a question that helps ${context.userName} genuinely acknowledge that what the other person needs is real and legitimate — without requiring agreement with the other person's behavior or positions. The goal is mutual recognition that both sets of needs matter.
+
+FORBIDDEN in Stage 3:
+- "try this", "experiment with", "what if you", "one thing you could do", "first small step", "moving forward" — solutions belong in Stage 4.
+- Introducing needs the user hasn't expressed. No suggesting additional needs beyond what they've named.
+- Identifying, labeling, or analyzing common ground or overlap between the two needs lists. That insight belongs to the users, not the AI.
+- Leading the user toward any particular conclusion about the relationship between the needs lists.
 
 No-hallucination guard: Use the user's exact words when reflecting needs. Never add context, feelings, or details they didn't provide.
 
@@ -797,12 +811,6 @@ Length: default 1–3 sentences. Go longer only if they explicitly ask for help 
 ${LATERAL_PROBING_GUIDANCE}
 
 Do NOT mirror the user's emotional intensity in your tone.
-
-EXAMPLE GOOD RESPONSES (adapt to context):
-- User: "They never help with anything around the house." → "I hear that. Let me bring it back to you — when that happens, what feels important or missing for you?"
-- User: "I guess I just want to feel like we're a team." → "Partnership. Like you need to feel like you're in this together. Does that land?"
-- User: "I need to feel safe." → "Safety. That's a big one. What would feeling safe actually look like for you day-to-day?"
-- User: "I just want things to be better." → "Better can mean a lot of things. If things were the way you wanted, what would be different for you?"
 
 ${buildResponseProtocol(3)}`;
 


### PR DESCRIPTION
## Changes
- Add: CONFIRMING mode — AI presents clean needs summary card when user has articulated core needs, asks for confirmation
- Add: POST-REVEAL PHASES — four effect-targeted phases (noticing, following up, emotional processing, validity) guide AI through the post-reveal experience
- Update: FORBIDDEN list now explicitly prevents AI from identifying, labeling, or analyzing common ground/overlap between needs lists
- Update: Replace hardcoded opening phrase and inline mode phrases with effect-targeted descriptions
- Update: WHAT_MATTERS_APPROACH constant to remove hardcoded example phrases
- Add: 5 new tests covering CONFIRMING mode, post-reveal phases, FORBIDDEN overlap rules, hardcoded phrase removal, and existing mode preservation

Related to #249

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Slam Paws (bot, from spec #247)
- **Original message:** Stage 3 redesign prompt changes (wave 1 of milestone #247)
- **Prompt(s) used:** general-pr workspace, issue #249

## Docs updated
No doc changes needed — the three mapped docs (prompting-architecture.md, prompts/index.md, prompt-caching.md) do not enumerate Stage 3 modes or reference content that conflicts with these changes.