### PR TITLE
feat: add topic-alignment gate before reconciler share offers

### DIFF
--- a/backend/prisma/migrations/20260502000000_add_topic_mismatch_status/migration.sql
+++ b/backend/prisma/migrations/20260502000000_add_topic_mismatch_status/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "BrainActivityCallType" ADD VALUE 'TOPIC_ALIGNMENT';
+
+-- AlterEnum
+ALTER TYPE "EmpathyStatus" ADD VALUE 'TOPIC_MISMATCH';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -745,6 +745,7 @@ enum EmpathyStatus {
   READY // Reconciler complete, waiting for partner to also complete Stage 2 before revealing
   REVEALED // Recipient can now see statement
   VALIDATED // Recipient has validated accuracy
+  TOPIC_MISMATCH // Guesser's empathy attempt is about a different topic than subject's Stage 1
 }
 
 model EmpathyValidation {
@@ -1449,6 +1450,7 @@ enum BrainActivityCallType {
   GLOBAL_MEMORY_CONSOLIDATION
   DISTILLATION
   CROSS_SESSION_THEME
+  TOPIC_ALIGNMENT
 }
 
 enum ActivityType {

--- a/backend/src/services/__tests__/empathy-state-machine.test.ts
+++ b/backend/src/services/__tests__/empathy-state-machine.test.ts
@@ -21,6 +21,10 @@ describe('empathy-state-machine', () => {
       expect(transition(EmpathyStatus.HELD, 'MARK_READY')).toBe(EmpathyStatus.READY);
     });
 
+    it('HELD → TOPIC_MISMATCH on TOPIC_MISMATCH_DETECTED', () => {
+      expect(transition(EmpathyStatus.HELD, 'TOPIC_MISMATCH_DETECTED')).toBe(EmpathyStatus.TOPIC_MISMATCH);
+    });
+
     // ===== ANALYZING transitions =====
     it('ANALYZING → AWAITING_SHARING on GAPS_DETECTED', () => {
       expect(transition(EmpathyStatus.ANALYZING, 'GAPS_DETECTED')).toBe(EmpathyStatus.AWAITING_SHARING);
@@ -93,6 +97,7 @@ describe('empathy-state-machine', () => {
         'START_ANALYSIS', 'GAPS_DETECTED', 'NO_SIGNIFICANT_GAPS',
         'MARK_READY', 'CONTEXT_SHARED', 'DECLINE_SHARING',
         'RESUBMIT_WITH_GAPS', 'MUTUAL_REVEAL', 'VALIDATE',
+        'TOPIC_MISMATCH_DETECTED',
       ];
       for (const event of events) {
         expect(() => transition(EmpathyStatus.VALIDATED, event)).toThrow(
@@ -126,7 +131,8 @@ describe('empathy-state-machine', () => {
       expect(events).toContain('START_ANALYSIS');
       expect(events).toContain('GAPS_DETECTED');
       expect(events).toContain('MARK_READY');
-      expect(events).toHaveLength(3);
+      expect(events).toContain('TOPIC_MISMATCH_DETECTED');
+      expect(events).toHaveLength(4);
     });
 
     it('returns empty for VALIDATED (terminal)', () => {

--- a/backend/src/services/__tests__/reconciler.test.ts
+++ b/backend/src/services/__tests__/reconciler.test.ts
@@ -1378,5 +1378,153 @@ describe('Reconciler Service', () => {
         runReconcilerForDirection(sessionId, guesserId, subjectId)
       ).rejects.toThrow('Guesser has not submitted empathy statement');
     });
+
+    // ========================================================================
+    // Topic Alignment Gate
+    // ========================================================================
+
+    describe('topic alignment gate', () => {
+      it('blocks share path when high-confidence different_topic detected (production regression)', async () => {
+        // Production failure shape: one side discusses preschool/intoxication,
+        // the other discusses app/project scope
+        const { getHaikuJson } = require('../../lib/bedrock');
+        (getHaikuJson as jest.Mock).mockResolvedValue({
+          alignment: 'different_topic',
+          confidence: 92,
+          guesserTopic: 'App collaboration and project scope decisions',
+          subjectTopic: 'Preschool safety concern involving alleged intoxication of a caregiver',
+          rationale: 'Completely unrelated situations — different people, different contexts.',
+        });
+
+        // Mock empathy data: guesser guessed about app/project
+        (prisma.empathyAttempt.findFirst as jest.Mock).mockResolvedValue({
+          id: 'attempt-1',
+          sessionId,
+          sourceUserId: guesserId,
+          content: 'I think they feel overwhelmed by the project scope and want more say in feature decisions.',
+          sharedAt: new Date(),
+          status: 'HELD',
+        });
+
+        // Mock witnessing: subject discussed preschool/intoxication
+        (prisma.message.findMany as jest.Mock).mockResolvedValue([
+          {
+            content: 'I walked in and could tell something was wrong. The teacher seemed impaired, and the kids were unsupervised.',
+            extractedEmotions: ['fear', 'anger', 'protectiveness'],
+          },
+        ]);
+
+        const result = await runReconcilerForDirection(sessionId, guesserId, subjectId);
+
+        // Should NOT proceed to gap analysis or share offers
+        expect(result.empathyStatus).toBe('TOPIC_MISMATCH');
+        expect(result.result).toBeNull();
+        expect(result.shareOffer).toBeNull();
+
+        // Should set empathy status to TOPIC_MISMATCH in DB
+        expect(prisma.empathyAttempt.updateMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ status: 'TOPIC_MISMATCH' }),
+          })
+        );
+
+        // Should NOT call the reconciler analysis AI
+        const { getSonnetResponse } = require('../../lib/bedrock');
+        expect(getSonnetResponse).not.toHaveBeenCalled();
+      });
+
+      it('allows same-topic through to normal gap analysis', async () => {
+        const { getHaikuJson, getSonnetResponse } = require('../../lib/bedrock');
+        (getHaikuJson as jest.Mock).mockResolvedValue({
+          alignment: 'same_topic',
+          confidence: 95,
+          guesserTopic: 'Relationship communication difficulties',
+          subjectTopic: 'Feeling unheard in the relationship',
+          rationale: 'Both discuss the same relationship dynamic.',
+        });
+
+        (getSonnetResponse as jest.Mock).mockResolvedValue(
+          JSON.stringify({
+            alignment: { score: 85, summary: 'Good', correctlyIdentified: ['frustration'] },
+            gaps: { severity: 'minor', summary: 'Minor', missedFeelings: [], misattributions: [], mostImportantGap: null },
+            recommendation: { action: 'PROCEED', rationale: 'OK', sharingWouldHelp: false, suggestedShareFocus: null },
+          })
+        );
+
+        const result = await runReconcilerForDirection(sessionId, guesserId, subjectId);
+
+        expect(result.empathyStatus).toBe('READY');
+        expect(result.result).not.toBeNull();
+        // Sonnet was called for gap analysis
+        expect(getSonnetResponse).toHaveBeenCalled();
+      });
+
+      it('fails open when topic alignment returns insufficient_signal', async () => {
+        const { getHaikuJson, getSonnetResponse } = require('../../lib/bedrock');
+        (getHaikuJson as jest.Mock).mockResolvedValue({
+          alignment: 'insufficient_signal',
+          confidence: 20,
+          guesserTopic: 'unclear',
+          subjectTopic: 'unclear',
+          rationale: 'Content too short to determine.',
+        });
+
+        (getSonnetResponse as jest.Mock).mockResolvedValue(
+          JSON.stringify({
+            alignment: { score: 80, summary: 'Good', correctlyIdentified: [] },
+            gaps: { severity: 'minor', summary: 'Minor', missedFeelings: [], misattributions: [], mostImportantGap: null },
+            recommendation: { action: 'PROCEED', rationale: 'OK', sharingWouldHelp: false, suggestedShareFocus: null },
+          })
+        );
+
+        const result = await runReconcilerForDirection(sessionId, guesserId, subjectId);
+
+        // Should proceed to normal analysis (fail open)
+        expect(result.empathyStatus).toBe('READY');
+        expect(result.result).not.toBeNull();
+        expect(getSonnetResponse).toHaveBeenCalled();
+      });
+
+      it('fails open when different_topic has low confidence', async () => {
+        const { getHaikuJson, getSonnetResponse } = require('../../lib/bedrock');
+        (getHaikuJson as jest.Mock).mockResolvedValue({
+          alignment: 'different_topic',
+          confidence: 50,
+          guesserTopic: 'Possibly work-related stress',
+          subjectTopic: 'Possibly family conflict',
+          rationale: 'Ambiguous — could be related.',
+        });
+
+        (getSonnetResponse as jest.Mock).mockResolvedValue(
+          JSON.stringify({
+            alignment: { score: 70, summary: 'Moderate', correctlyIdentified: [] },
+            gaps: { severity: 'minor', summary: 'Minor', missedFeelings: [], misattributions: [], mostImportantGap: null },
+            recommendation: { action: 'PROCEED', rationale: 'OK', sharingWouldHelp: false, suggestedShareFocus: null },
+          })
+        );
+
+        const result = await runReconcilerForDirection(sessionId, guesserId, subjectId);
+
+        // Low confidence → fail open
+        expect(result.empathyStatus).toBe('READY');
+        expect(result.result).not.toBeNull();
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Topic Mismatch State Transition
+  // ==========================================================================
+
+  describe('TOPIC_MISMATCH state transition', () => {
+    it('transitions from HELD to TOPIC_MISMATCH on TOPIC_MISMATCH_DETECTED', () => {
+      expect(transition(EmpathyStatus.HELD, 'TOPIC_MISMATCH_DETECTED')).toBe(EmpathyStatus.TOPIC_MISMATCH);
+    });
+
+    it('throws on invalid TOPIC_MISMATCH_DETECTED from READY', () => {
+      expect(() => transition(EmpathyStatus.READY, 'TOPIC_MISMATCH_DETECTED')).toThrow(
+        'Invalid empathy state transition'
+      );
+    });
   });
 });

--- a/backend/src/services/empathy-state-machine.ts
+++ b/backend/src/services/empathy-state-machine.ts
@@ -17,6 +17,7 @@
  *   REFINING → AWAITING_SHARING (re-analysis after resubmit shows gaps)
  *   READY → REVEALED (both users ready, mutual reveal)
  *   REVEALED → VALIDATED (recipient validates accuracy)
+ *   HELD → TOPIC_MISMATCH (topic alignment gate detected different topics)
  */
 
 import { EmpathyStatus } from '@prisma/client';
@@ -31,7 +32,8 @@ export type EmpathyEvent =
   | 'DECLINE_SHARING'
   | 'RESUBMIT_WITH_GAPS'
   | 'MUTUAL_REVEAL'
-  | 'VALIDATE';
+  | 'VALIDATE'
+  | 'TOPIC_MISMATCH_DETECTED';
 
 /**
  * Transition table: maps (currentStatus, event) → newStatus
@@ -41,6 +43,7 @@ const TRANSITIONS: Record<string, EmpathyStatus | undefined> = {
   [`${EmpathyStatus.HELD}:START_ANALYSIS`]: EmpathyStatus.ANALYZING,
   [`${EmpathyStatus.HELD}:GAPS_DETECTED`]: EmpathyStatus.AWAITING_SHARING,
   [`${EmpathyStatus.HELD}:MARK_READY`]: EmpathyStatus.READY,
+  [`${EmpathyStatus.HELD}:TOPIC_MISMATCH_DETECTED`]: EmpathyStatus.TOPIC_MISMATCH,
 
   // From ANALYZING
   [`${EmpathyStatus.ANALYZING}:GAPS_DETECTED`]: EmpathyStatus.AWAITING_SHARING,

--- a/backend/src/services/reconciler/analysis.ts
+++ b/backend/src/services/reconciler/analysis.ts
@@ -194,6 +194,95 @@ async function extractThemes(content: string, sessionId: string, userId?: string
 }
 
 // ============================================================================
+// Topic Alignment Check
+// ============================================================================
+
+export type TopicAlignment = 'same_topic' | 'related_but_drifted' | 'different_topic' | 'insufficient_signal';
+
+export interface TopicAlignmentResult {
+  alignment: TopicAlignment;
+  confidence: number;
+  guesserTopic: string;
+  subjectTopic: string;
+  rationale: string;
+}
+
+/**
+ * Check whether the guesser's empathy attempt and the subject's Stage 1
+ * witnessing content are about the same topic. Uses a fast Haiku call.
+ *
+ * Policy:
+ * - high-confidence `different_topic` → hard stop (no share offer)
+ * - `related_but_drifted` → soft stop (logged, future UX warning)
+ * - `insufficient_signal` → fail open (continue normal flow)
+ */
+export async function checkTopicAlignment(
+  empathyStatement: string,
+  witnessingContent: string,
+  sessionId: string,
+  guesserId: string
+): Promise<TopicAlignmentResult> {
+  const turnId = `${sessionId}-${guesserId}-topic-alignment-${Date.now()}`;
+  const result = await getHaikuJson<TopicAlignmentResult>({
+    systemPrompt: `You are a topic-alignment classifier for an empathy exchange app.
+
+Compare the GUESSER's empathy statement (what they think their partner is feeling) against the SUBJECT's actual witnessing content (what the partner actually shared in Stage 1).
+
+Determine whether they are discussing the same underlying situation/topic.
+
+Return JSON:
+{
+  "alignment": "same_topic" | "related_but_drifted" | "different_topic" | "insufficient_signal",
+  "confidence": <0-100>,
+  "guesserTopic": "<1-sentence summary of what the guesser thinks the situation is>",
+  "subjectTopic": "<1-sentence summary of what the subject actually discussed>",
+  "rationale": "<brief explanation>"
+}
+
+Guidelines:
+- "same_topic": Both clearly discuss the same situation, relationship, or event, even if emotional accuracy varies.
+- "related_but_drifted": Overlapping context (same people, same relationship) but the specific situations or concerns are substantially different.
+- "different_topic": Completely unrelated situations — different people, different contexts, different events. The guesser appears to be guessing about something entirely different from what the subject shared.
+- "insufficient_signal": Not enough content to determine alignment (e.g., very short or vague statements).
+
+Focus ONLY on topic/situation alignment, NOT emotional accuracy. Two people can discuss the same topic but disagree on feelings — that is "same_topic".`,
+    messages: [
+      {
+        role: 'user',
+        content: `GUESSER'S EMPATHY STATEMENT:\n${empathyStatement}\n\nSUBJECT'S WITNESSING CONTENT:\n${witnessingContent}`,
+      },
+    ],
+    maxTokens: 512,
+    sessionId,
+    turnId,
+    operation: 'topic-alignment-check',
+    callType: BrainActivityCallType.TOPIC_ALIGNMENT,
+  });
+
+  if (!result) {
+    logger.warn('Topic alignment check returned null, failing open', { sessionId, guesserId });
+    return {
+      alignment: 'insufficient_signal',
+      confidence: 0,
+      guesserTopic: 'unknown',
+      subjectTopic: 'unknown',
+      rationale: 'AI classification failed — failing open',
+    };
+  }
+
+  logger.info('Topic alignment result', {
+    sessionId,
+    guesserId,
+    alignment: result.alignment,
+    confidence: result.confidence,
+    guesserTopic: result.guesserTopic,
+    subjectTopic: result.subjectTopic,
+  });
+
+  return result;
+}
+
+// ============================================================================
 // Abstract Guidance
 // ============================================================================
 

--- a/backend/src/services/reconciler/index.ts
+++ b/backend/src/services/reconciler/index.ts
@@ -34,6 +34,8 @@ export {
 // Analysis
 export {
   runReconciler,
+  checkTopicAlignment,
+  type TopicAlignmentResult,
 } from './analysis';
 
 // Sharing

--- a/backend/src/services/reconciler/state.ts
+++ b/backend/src/services/reconciler/state.ts
@@ -27,6 +27,7 @@ import {
   getEmpathyData,
   getWitnessingContent,
   analyzeEmpathyGap,
+  checkTopicAlignment,
 } from './analysis';
 import { checkAttempts, hasContextAlreadyBeenShared, markResultHandledAlreadyShared } from './circuit-breaker';
 import { generateShareSuggestion } from './sharing';
@@ -153,7 +154,7 @@ export async function runReconcilerForDirection(
   subjectId: string
 ): Promise<{
   result: ReconcilerResult | null;
-  empathyStatus: 'READY' | 'AWAITING_SHARING';
+  empathyStatus: 'READY' | 'AWAITING_SHARING' | 'TOPIC_MISMATCH';
   shareOffer: {
     suggestedContent: string;
     reason: string;
@@ -223,6 +224,54 @@ export async function runReconcilerForDirection(
     throw new Error('Subject has no Stage 1 content');
   }
   logger.debug('Found subject witnessing content', { themes: witnessingContent.themes.length, chars: witnessingContent.userMessages.length });
+
+  // ============================================================================
+  // TOPIC ALIGNMENT GATE
+  // Check that guesser and subject are discussing the same topic before
+  // running gap analysis. Prevents nonsensical share offers when topics diverge.
+  // ============================================================================
+  const topicAlignment = await checkTopicAlignment(
+    empathyData.statement,
+    witnessingContent.userMessages,
+    sessionId,
+    guesserId
+  );
+
+  if (
+    topicAlignment.alignment === 'different_topic' &&
+    topicAlignment.confidence >= 75
+  ) {
+    logger.warn('Topic mismatch detected — blocking reconciler share path', {
+      sessionId,
+      guesserId,
+      subjectId,
+      alignment: topicAlignment.alignment,
+      confidence: topicAlignment.confidence,
+      guesserTopic: topicAlignment.guesserTopic,
+      subjectTopic: topicAlignment.subjectTopic,
+      rationale: topicAlignment.rationale,
+    });
+
+    // Transition empathy status to TOPIC_MISMATCH
+    await prisma.$transaction(async (tx) => {
+      const attempt = await tx.empathyAttempt.findFirst({
+        where: { sessionId, sourceUserId: guesserId },
+      });
+      if (attempt) {
+        transition(attempt.status as EmpathyStatus, 'TOPIC_MISMATCH_DETECTED');
+      }
+      await tx.empathyAttempt.updateMany({
+        where: { sessionId, sourceUserId: guesserId },
+        data: { status: 'TOPIC_MISMATCH', statusVersion: { increment: 1 } },
+      });
+    });
+
+    return {
+      result: null,
+      empathyStatus: 'TOPIC_MISMATCH',
+      shareOffer: null,
+    };
+  }
 
   // Run the analysis
   const result = await analyzeEmpathyGap({

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -3,7 +3,7 @@ title: "Stage 2: Perspective Stretch - Empathy Exchange Flow"
 sidebar_position: 6
 description: This document describes the empathy exchange flow in Stage 2, including the reconciler system that analyzes empathy accuracy and manages the sharing of addit...
 created: 2026-03-11
-updated: 2026-04-28
+updated: 2026-05-02
 status: living
 ---
 # Stage 2: Perspective Stretch - Empathy Exchange Flow
@@ -28,6 +28,7 @@ stateDiagram-v2
 
     HELD --> READY: Reconciler finds minor/no gaps (direct)
     HELD --> AWAITING_SHARING: Reconciler finds significant gaps (direct)
+    HELD --> TOPIC_MISMATCH: Topic alignment gate detects different topics
 
     AWAITING_SHARING --> REFINING: Subject shares context
     REFINING --> READY: Guesser revises empathy (re-analyzed, circuit breaker forces READY)
@@ -40,11 +41,13 @@ stateDiagram-v2
     REVEALED --> VALIDATED: Subject validates empathy as accurate
     REVEALED --> REVEALED: Subject says empathy is inaccurate (validated=false; status stays REVEALED)
 
+    TOPIC_MISMATCH --> [*]: Users must re-anchor topics
+
     note right of HELD
         The ANALYZING state exists in empathy-state-machine.ts
         but is never triggered by the reconciler code.
         The reconciler transitions directly from HELD
-        to READY or AWAITING_SHARING.
+        to READY, AWAITING_SHARING, or TOPIC_MISMATCH.
     end note
 
     note right of REVEALED
@@ -90,7 +93,7 @@ The reconciler runs when one user confirms "feel heard" (completing Stage 1) and
 
 > **Implementation Note:** The reconciler has been refactored into a modular `backend/src/services/reconciler/` directory:
 > - `state.ts` — Empathy status transitions, reveal logic. Contains `runReconcilerForDirection()` (asymmetric) and `checkAndRevealBothIfReady()` (serializable transaction for mutual reveal).
-> - `analysis.ts` — Core AI gap analysis (`analyzeEmpathyGap()`), theme extraction, witnessing content retrieval.
+> - `analysis.ts` — Core AI gap analysis (`analyzeEmpathyGap()`), topic alignment check (`checkTopicAlignment()`), theme extraction, witnessing content retrieval.
 > - `sharing.ts` — Share suggestion generation, refinement, and response handling.
 > - `circuit-breaker.ts` — Attempt counting to prevent infinite refinement loops (max 3 per direction).
 > - `index.ts` — Barrel re-exports.
@@ -113,7 +116,11 @@ flowchart TB
 
     A --> B{Partner has HELD<br/>empathy attempt?}
     B -->|No| C[No action needed]
-    B -->|Yes| D[Run Reconciler Analysis]
+    B -->|Yes| TA[Topic Alignment Check<br/>Haiku classifier]
+
+    TA --> TAR{Topics aligned?}
+    TAR -->|different_topic<br/>high confidence| TM[Status → TOPIC_MISMATCH<br/>No share offer created]
+    TAR -->|same_topic /<br/>insufficient_signal| D[Run Reconciler Analysis]
 
     D --> E{Analyze gaps in<br/>partner's empathy attempt}
 
@@ -394,10 +401,11 @@ Only one panel shows at a time, in this priority order:
   consentRecordId: string | null; // FK to ConsentRecord (consent to share)
   content: string;            // The empathy statement
   status: 'HELD' | 'ANALYZING' | 'AWAITING_SHARING' | 'REFINING' |
-          'READY' | 'REVEALED' | 'VALIDATED' | 'NEEDS_WORK';
+          'READY' | 'REVEALED' | 'VALIDATED' | 'NEEDS_WORK' | 'TOPIC_MISMATCH';
   // READY = reconciler complete, waiting for partner to also complete Stage 2
   // ANALYZING exists in empathy-state-machine.ts but is never set by the reconciler code
   // NEEDS_WORK exists for legacy compatibility but is never set by current code
+  // TOPIC_MISMATCH = guesser's empathy is about a different topic than subject's Stage 1
   statusVersion: number;      // Incremented on every status change for event ordering
   sharedAt: Date;             // When initially shared
   revealedAt: Date | null;    // When revealed to subject (after mutual reveal)
@@ -551,6 +559,8 @@ This shows:
 ### Check Reconciler Logs
 Look for these key log messages (now using Winston structured logger — search JSON logs in production):
 - `Running asymmetric reconciliation` - Start of analysis (in `reconciler/state.ts`)
+- `Topic alignment result` (in `reconciler/analysis.ts`) — Topic check done; fields: `alignment`, `confidence`, `guesserTopic`, `subjectTopic`
+- `Topic mismatch detected — blocking reconciler share path` (in `reconciler/state.ts`) — High-confidence different_topic blocked the share path
 - `AI analysis complete` (in `reconciler/analysis.ts`) — AI analysis done; fields: `alignmentScore`, `gapSeverity`, `action`
 - `Reconciler outcome` (in `reconciler/state.ts`) — state transition committed; fields: `severity`, `action`, `empathyStatus`
 - `Share suggestion generated` - Suggestion created (in `reconciler/sharing.ts`)

--- a/shared/src/dto/empathy.ts
+++ b/shared/src/dto/empathy.ts
@@ -25,6 +25,8 @@ export const EmpathyStatus = {
   REVEALED: 'REVEALED',
   /** Recipient has validated accuracy */
   VALIDATED: 'VALIDATED',
+  /** Guesser's empathy attempt is about a different topic than subject's Stage 1 */
+  TOPIC_MISMATCH: 'TOPIC_MISMATCH',
 } as const;
 
 export type EmpathyStatus = (typeof EmpathyStatus)[keyof typeof EmpathyStatus];


### PR DESCRIPTION
## Changes
- Add: `checkTopicAlignment()` Haiku classifier in `reconciler/analysis.ts` that compares guesser empathy topic vs subject Stage 1 witnessing content
- Add: Topic alignment gate in `runReconcilerForDirection()` — blocks share-offer path for high-confidence `different_topic` (>=75%)
- Add: `TOPIC_MISMATCH` status to `EmpathyStatus` enum (Prisma schema, shared DTO, state machine)
- Add: `TOPIC_ALIGNMENT` to `BrainActivityCallType` for cost tracking
- Add: Fail-open policy — `insufficient_signal` or low-confidence results don't block production flow
- Add: Regression test based on production failure shape (preschool/intoxication vs app/project scope)
- Update: `reconciler-flow.md` — state diagram, decision tree, data model, debug logs

Related to #262

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (investigation of production session `cmog305d7008vq91wvl6m2b0l`)
- **Original message:** Production session showed two incompatible topics crossing via reconciler shared-context offers
- **Prompt(s) used:** `general-pr` workspace, issue #262

## Docs updated
- `docs/backend/reconciler-flow.md` — added TOPIC_MISMATCH state, topic alignment gate to decision tree, updated EmpathyAttempt data model, added debug log entries