### PR TITLE
fix: register missing Feedback Coach routes for Stage 2 validation flow

### DIFF
--- a/backend/src/routes/stage2.ts
+++ b/backend/src/routes/stage2.ts
@@ -10,6 +10,9 @@
  * - GET /sessions/:id/empathy/status - Get empathy exchange status
  * - POST /sessions/:id/empathy/refine - Refinement conversation (when NEEDS_WORK or REFINING)
  * - POST /sessions/:id/empathy/resubmit - Resubmit revised empathy statement
+ * - POST /sessions/:id/empathy/skip-refinement - Skip refinement / acceptance check
+ * - POST /sessions/:id/empathy/feedback/draft - Save validation feedback draft
+ * - POST /sessions/:id/empathy/feedback/refine - Refine validation feedback (Feedback Coach)
  *
  * NEW: Share suggestion flow (asymmetric reconciler)
  * - GET /sessions/:id/empathy/share-suggestion - Get share suggestion for current user
@@ -30,6 +33,9 @@ import {
   resubmitEmpathy,
   getShareSuggestion,
   respondToShareSuggestion,
+  skipRefinement,
+  saveValidationFeedbackDraft,
+  refineValidationFeedback,
 } from '../controllers/stage2';
 
 const router = Router();
@@ -96,6 +102,34 @@ router.post(
   requireAuth,
   requireSessionAccess,
   asyncHandler(resubmitEmpathy)
+);
+
+// ============================================================================
+// Validation Feedback / Feedback Coach Flow
+// ============================================================================
+
+// Skip refinement (accept the difference or decline)
+router.post(
+  '/sessions/:id/empathy/skip-refinement',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(skipRefinement)
+);
+
+// Save validation feedback draft
+router.post(
+  '/sessions/:id/empathy/feedback/draft',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(saveValidationFeedbackDraft)
+);
+
+// Refine validation feedback via Feedback Coach AI
+router.post(
+  '/sessions/:id/empathy/feedback/refine',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(refineValidationFeedback)
 );
 
 // ============================================================================

--- a/docs/backend/api/stage-2.md
+++ b/docs/backend/api/stage-2.md
@@ -211,8 +211,8 @@ Besides the Phase-1 / Phase-2 core above, the routes file exposes these controll
 | `POST` | `/api/v1/sessions/:id/empathy/skip-refinement` | Accept the current gap as a "willing-to-accept" difference and advance without further refinement; updates `skippedRefinement`, `willingToAccept`, `skipReason` on the caller's StageProgress |
 | `GET`  | `/api/v1/sessions/:id/empathy/share-suggestion` | Asymmetric reconciler: fetch a suggestion to help the caller close an empathy gap for the partner |
 | `POST` | `/api/v1/sessions/:id/empathy/share-suggestion/respond` | Accept or decline a share suggestion |
-| `POST` | `/api/v1/sessions/:id/empathy/validation-feedback/draft` | Draft feedback via the "Feedback Coach" AI flow |
-| `POST` | `/api/v1/sessions/:id/empathy/validation-feedback/refine` | Iterate on feedback-coach output |
+| `POST` | `/api/v1/sessions/:id/empathy/feedback/draft` | Draft feedback via the "Feedback Coach" AI flow |
+| `POST` | `/api/v1/sessions/:id/empathy/feedback/refine` | Iterate on feedback-coach output |
 
 ---
 


### PR DESCRIPTION
## Changes
- Fix: Register three missing routes in `backend/src/routes/stage2.ts` that were blocking the Feedback Coach flow:
  - `POST /sessions/:id/empathy/skip-refinement` — skip refinement / acceptance check
  - `POST /sessions/:id/empathy/feedback/draft` — save validation feedback draft
  - `POST /sessions/:id/empathy/feedback/refine` — refine validation feedback via Feedback Coach AI
- Fix: Correct endpoint paths in `docs/backend/api/stage-2.md` to match actual routes (`/feedback/` not `/validation-feedback/`)

All three controller functions (`skipRefinement`, `saveValidationFeedbackDraft`, `refineValidationFeedback`) were fully implemented in `backend/src/controllers/stage2.ts` but never imported or registered in the routes file. This caused the mobile app's "Not quite yet" flow to hit unreachable endpoints, resulting in an empty Feedback Coach chat.

Related to #265

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** Look at the most recent session I'm having with Darryl. I tried clicking not quite yet and the screen that came up was an empty chat.

## Docs updated
- `docs/backend/api/stage-2.md` — corrected endpoint paths for feedback coach routes