### PR TITLE
docs(stage-1): fix SSE event table drift

### DIFF
--- a/docs/backend/api/stage-1.md
+++ b/docs/backend/api/stage-1.md
@@ -3,6 +3,9 @@ title: "Stage 1 API: The Witness"
 sidebar_position: 6
 description: Endpoints for the witness stage - being heard by the AI.
 slug: /backend/api/stage-1
+created: 2026-03-11
+updated: 2026-05-02
+status: living
 ---
 # Stage 1 API: The Witness
 
@@ -22,10 +25,25 @@ The stream emits these event kinds until the connection closes:
 
 | Event | Payload |
 |-------|---------|
-| `chunk` | `{ content: string }` — an incremental text fragment |
-| `text_complete` | `{ content: string }` — the full assembled assistant text |
-| `metadata` | `{ messageId, emotionalReading?, suggestPause?, pauseReason? }` — message-level metadata once persistence is complete |
-| `error` | `{ code, message }` — stream-terminating error |
+| `user_message` | `{ id: string; content: string; timestamp: string }` — server-confirmed user message (replaces optimistic copy) |
+| `chunk` | `{ text: string }` — an incremental text fragment |
+| `metadata` | `{ metadata: StreamMetadata }` — AI tool-call metadata, emitted before `text_complete` |
+| `text_complete` | `{ metadata: StreamMetadata }` — AI text fully streamed (sent before DB persistence completes) |
+| `complete` | `{ messageId: string; metadata: StreamMetadata }` — AI message persisted and stream closed |
+| `error` | `{ message: string; retryable: boolean }` — stream-terminating error |
+
+Where `StreamMetadata` carries optional fields from the AI's session-state tool call:
+
+```typescript
+interface StreamMetadata {
+  offerFeelHeardCheck?: boolean;
+  offerReadyToShare?: boolean;
+  invitationMessage?: string | null;
+  proposedEmpathyStatement?: string | null;
+  proposedStrategies?: string[];
+  analysis?: string;
+}
+```
 
 ### Legacy non-streaming endpoint (deprecated)
 

--- a/docs/backend/api/stage-1.md
+++ b/docs/backend/api/stage-1.md
@@ -38,10 +38,9 @@ Where `StreamMetadata` carries optional fields from the AI's session-state tool 
 interface StreamMetadata {
   offerFeelHeardCheck?: boolean;
   offerReadyToShare?: boolean;
-  invitationMessage?: string | null;
-  proposedEmpathyStatement?: string | null;
+  invitationMessage?: string;
+  proposedEmpathyStatement?: string;
   proposedStrategies?: string[];
-  analysis?: string;
 }
 ```
 


### PR DESCRIPTION
## Changes
- Fix: `chunk` payload documented as `{ content }` → actual is `{ text }`
- Fix: `text_complete` payload documented as `{ content }` → actual is `{ metadata: StreamMetadata }`
- Fix: `metadata` event had wrong field list → actual is `{ metadata: StreamMetadata }`
- Add: `complete` event was missing from table → `{ messageId: string; metadata: StreamMetadata }`
- Add: `user_message` event was missing from table → `{ id, content, timestamp }`
- Fix: `error` payload documented as `{ code, message }` → actual is `{ message, retryable }`
- Add: `StreamMetadata` interface definition inline for reference
- Fix: missing frontmatter (`created`, `updated`, `status: living`) on stage-1.md

Triggered by: 24h incremental docs audit. The drift predates this run but was exposed by `73f8fe8` touching `messages.ts`, which maps to this doc.

## Provenance
- **Channel:** cron / audit-docs
- **Requested by:** automated nightly audit (24h lookback)
- **Original message:** incremental docs audit triggered by git-history scan
- **Prompt(s) used:** audit-docs workspace / stages/incremental

## Docs updated
- `docs/backend/api/stage-1.md`