### PR TITLE
fix(stage2): register missing Feedback Coach routes

### DIFF
--- a/docs/backend/api/stage-2.md
+++ b/docs/backend/api/stage-2.md
@@ -211,8 +211,8 @@ Besides the Phase-1 / Phase-2 core above, the routes file exposes these controll
 | `POST` | `/api/v1/sessions/:id/empathy/skip-refinement` | Accept or decline the current gap as a "willing-to-accept" difference and advance without further refinement; updates `skippedRefinement`, `willingToAccept`, `skipReason` on the caller's StageProgress |
 | `GET`  | `/api/v1/sessions/:id/empathy/share-suggestion` | Asymmetric reconciler: fetch a suggestion to help the caller close an empathy gap for the partner |
 | `POST` | `/api/v1/sessions/:id/empathy/share-suggestion/respond` | Accept or decline a share suggestion |
-| `POST` | `/api/v1/sessions/:id/empathy/validation-feedback/draft` | Draft feedback via the "Feedback Coach" AI flow |
-| `POST` | `/api/v1/sessions/:id/empathy/validation-feedback/refine` | Iterate on feedback-coach output |
+| `POST` | `/api/v1/sessions/:id/empathy/feedback/draft` | Draft feedback via the "Feedback Coach" AI flow |
+| `POST` | `/api/v1/sessions/:id/empathy/feedback/refine` | Iterate on feedback-coach output |
 
 ---
 


### PR DESCRIPTION
## Changes
- Fix: Register three missing route handlers in `backend/src/routes/stage2.ts` that were causing 404s for Feedback Coach chat
  - `POST /sessions/:id/empathy/feedback/draft` → `saveValidationFeedbackDraft`
  - `POST /sessions/:id/empathy/feedback/refine` → `refineValidationFeedback`
  - `POST /sessions/:id/empathy/skip-refinement` → `skipRefinement`
- Fix: Correct route paths in `docs/backend/api/stage-2.md` (`feedback/` not `validation-feedback/`)

Related to #276

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** Another bug in the chat function

## Docs updated
- `docs/backend/api/stage-2.md` — corrected Feedback Coach endpoint paths to match actual routes