### PR TITLE
[codex] skip duplicate Stage 2 accuracy prompt

### DIFF
--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -1440,10 +1440,13 @@ Your goal is to help them rephrase their feedback to be constructive, specific, 
 User's raw feedback: "${message}"
 
 1. Acknowledge the validity of their feeling.
-2. Draft a "Proposed Feedback" statement that they could send to their partner. This should be:
+2. Draft a "Proposed Feedback" statement that they can send inside Meet Without Fear. This should be:
    - Direct but kind.
    - Focus on what was missed or misunderstood.
    - Avoid "You are wrong" language; use "I felt..." or "My experience was...".
+   - Ask the partner to revise their empathy attempt in the app, not to start a direct side conversation.
+   - Do not include wording like "ask me directly", "can we talk about this", "can we try that", or other language that implies the next step is an outside conversation.
+   - End with an in-app revision request, such as "Could you revise your understanding with that in mind?"
 
 Respond in JSON format:
 \`\`\`json

--- a/docs/backend/prompts/stage-2-feedback-coach.md
+++ b/docs/backend/prompts/stage-2-feedback-coach.md
@@ -35,6 +35,9 @@ YOUR RESPONSIBILITIES:
    - Bad: "You missed the point."
    - Good: "The part about my fear feels missing from this."
 3. **Draft**: Propose a clear, gentle message they can send back.
+   - The next step happens inside Meet Without Fear: the partner receives this feedback and revises their empathy attempt.
+   - Do not suggest a direct side conversation or wording like "ask me directly", "can we talk about this", or "can we try that?"
+   - Prefer an in-app revision request, such as "Could you revise your understanding with that in mind?"
 
 OUTPUT FORMAT:
 Respond in JSON.

--- a/mobile/src/components/AccuracyFeedbackDrawer.tsx
+++ b/mobile/src/components/AccuracyFeedbackDrawer.tsx
@@ -37,6 +37,8 @@ export interface AccuracyFeedbackDrawerProps {
   onInaccurate: (feedback: string) => void;
   /** Callback when drawer is closed */
   onClose: () => void;
+  /** Which step to show first when the drawer opens */
+  initialStep?: 'accuracy' | 'feedback';
 }
 
 export function AccuracyFeedbackDrawer({
@@ -47,18 +49,21 @@ export function AccuracyFeedbackDrawer({
   onPartiallyAccurate,
   onInaccurate,
   onClose,
+  initialStep = 'accuracy',
 }: AccuracyFeedbackDrawerProps) {
-  const [isFeedbackStep, setIsFeedbackStep] = useState(false);
+  const [isFeedbackStep, setIsFeedbackStep] = useState(initialStep === 'feedback');
   const [roughFeedback, setRoughFeedback] = useState('');
   const [showFeedbackError, setShowFeedbackError] = useState(false);
 
   useEffect(() => {
-    if (!visible) {
-      setIsFeedbackStep(false);
+    if (visible) {
+      setIsFeedbackStep(initialStep === 'feedback');
+    } else {
+      setIsFeedbackStep(initialStep === 'feedback');
       setRoughFeedback('');
       setShowFeedbackError(false);
     }
-  }, [visible]);
+  }, [visible, initialStep]);
 
   const handleAccurate = () => {
     onAccurate();
@@ -102,7 +107,7 @@ export function AccuracyFeedbackDrawer({
         <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
           {/* Header with close button */}
           <View style={styles.header}>
-            {isFeedbackStep && (
+            {isFeedbackStep && initialStep !== 'feedback' && (
               <TouchableOpacity
                 style={styles.backButton}
                 onPress={handleBackToOptions}
@@ -139,7 +144,9 @@ export function AccuracyFeedbackDrawer({
                 {partnerName}'s understanding
               </Text>
               <Text style={styles.subtitle}>
-                {partnerName} shared this to show they understand your perspective. How well does it capture your experience?
+                {isFeedbackStep
+                  ? 'Here is the understanding you are responding to.'
+                  : `${partnerName} shared this to show they understand your perspective. How well does it capture your experience?`}
               </Text>
 
               {/* Partner's empathy statement */}

--- a/mobile/src/components/__tests__/AccuracyFeedbackDrawer.test.tsx
+++ b/mobile/src/components/__tests__/AccuracyFeedbackDrawer.test.tsx
@@ -28,6 +28,15 @@ describe('AccuracyFeedbackDrawer', () => {
     expect(defaultProps.onClose).not.toHaveBeenCalled();
   });
 
+  it('can open directly to rough feedback', () => {
+    render(<AccuracyFeedbackDrawer {...defaultProps} initialStep="feedback" />);
+
+    expect(screen.getByText('What feels off?')).toBeTruthy();
+    expect(screen.getByTestId('accuracy-rough-feedback-input')).toBeTruthy();
+    expect(screen.queryByText('How accurate is this?')).toBeNull();
+    expect(screen.queryByTestId('accuracy-feedback-back')).toBeNull();
+  });
+
   it('requires non-empty rough feedback', () => {
     render(<AccuracyFeedbackDrawer {...defaultProps} />);
 

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -2595,6 +2595,7 @@ export function UnifiedSessionScreen({
           visible={showAccuracyFeedbackDrawer}
           statement={partnerEmpathyData.attempt.content}
           partnerName={partnerName}
+          initialStep="feedback"
           onAccurate={() => {
             markCompleted('validated-empathy');
             handleValidatePartnerEmpathy(true);


### PR DESCRIPTION
## Summary
- Opens the Stage 2 accuracy feedback drawer directly on the rough-feedback step when the user taps "Not quite yet" from the inline validation card.
- Keeps the existing accuracy-choice screen available for any future/direct drawer use, but hides the back button when the flow intentionally starts at feedback.
- Adds a component test covering direct-to-feedback behavior.

## Validation
- `npm test --workspace mobile -- AccuracyFeedbackDrawer.test.tsx --runInBand`
- `npm run check --workspace mobile`
- `git diff --check -- mobile/src/components/AccuracyFeedbackDrawer.tsx mobile/src/components/__tests__/AccuracyFeedbackDrawer.test.tsx mobile/src/screens/UnifiedSessionScreen.tsx`
