### PR TITLE
[codex] Improve feedback coach refinement context

### DIFF
--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -1439,8 +1439,10 @@ Your goal is to help them rephrase their feedback to be constructive, specific, 
 
 User's raw feedback: "${message}"
 
-1. Acknowledge the validity of their feeling.
-2. Draft a "Proposed Feedback" statement that they can send inside Meet Without Fear. This should be:
+1. Keep the conversational coaching response concise: 1-2 short sentences, no more than 45 words.
+2. Acknowledge the validity of their feeling without over-explaining or giving a long lesson.
+3. Explicitly tell them they can keep refining or send the proposed feedback as-is.
+4. Draft a "Proposed Feedback" statement that they can send inside Meet Without Fear. This should be:
    - Direct but kind.
    - Focus on what was missed or misunderstood.
    - Avoid "You are wrong" language; use "I felt..." or "My experience was...".

--- a/mobile/src/hooks/useRefinementChat.ts
+++ b/mobile/src/hooks/useRefinementChat.ts
@@ -283,19 +283,35 @@ export function useValidationFeedbackCoachChat(
     partnerStatementRef.current = partnerEmpathyStatement;
     setIsFinalized(false);
 
-    const initialMessages: RefinementMessage[] = [{
-      id: `feedback-initial-${Date.now()}`,
+    const initialMessages: RefinementMessage[] = [];
+    const trimmedPartnerStatement = partnerEmpathyStatement.trim();
+    const openedAt = Date.now();
+
+    if (trimmedPartnerStatement) {
+      initialMessages.push({
+        id: `feedback-source-${openedAt}`,
+        sessionId,
+        role: MessageRole.AI,
+        content: `This is the statement you're responding to:\n\n"${trimmedPartnerStatement}"`,
+        timestamp: new Date().toISOString(),
+        senderId: null,
+        stage: 2,
+      });
+    }
+
+    initialMessages.push({
+      id: `feedback-initial-${openedAt}`,
       sessionId,
       role: MessageRole.AI,
-      content: `Thanks for naming what felt off. I'll help you turn that into feedback ${partnerEmpathyStatement ? 'that responds to the statement you received' : 'your partner can understand'} without making it harsher than it needs to be.`,
+      content: `I'll help turn your note into feedback you can send. You can send the draft as-is, or tell me what to adjust.`,
       timestamp: new Date().toISOString(),
       senderId: null,
       stage: 2,
-    }];
+    });
 
     if (roughFeedback.trim()) {
       initialMessages.push({
-        id: `feedback-rough-${Date.now()}`,
+        id: `feedback-rough-${openedAt}`,
         sessionId,
         role: MessageRole.USER,
         content: roughFeedback.trim(),


### PR DESCRIPTION
## Summary
- Seed the feedback coach chat with the partner empathy statement before the user's rough note.
- Tighten the feedback-coach prompt so AI guidance is concise and explicitly offers send-as-is or keep-refining next steps.

## Why
When users refine feedback, they need the original message visible for reference, and the coach response should behave more like the existing share-refinement flow.

## Validation
- npm --workspace mobile run check
- npm --workspace backend run check
- npm --workspace backend test -- --runTestsByPath src/routes/__tests__/stage2.test.ts