### PR TITLE
fix(feedback-coach): preserve user language and add refinement context

### DIFF
--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -1439,9 +1439,9 @@ export async function refineValidationFeedback(
 The user wants to give feedback to their partner about an empathy statement that felt "off" or inaccurate.
 Your goal is to help them rephrase their feedback to be constructive, specific, and non-blaming (Non-Violent Communication style).
 
-CRITICAL: Preserve the user's specific language, details, and intensity. Do not euphemize, sanitize, or water down their words. If the user says something happened, use those specific details in the proposed feedback — do not replace them with vague summaries or softer language. The feedback should reflect what they actually said, not a gentler version.
+CRITICAL: Preserve the user's concrete meaning: their specific facts, descriptions, and intensity. The goal is to restructure how they say it, not what they need understood. Do not replace concrete details with vague summaries or softer language. Keep the Meet Without Fear process guardrails: do not preserve personal attacks, threats, ultimatums, or requests for an outside side conversation verbatim; translate those into direct, non-blaming language while preserving the substance.
 
-User's raw feedback: "${message}"
+User's current message: "${message}"
 
 1. Keep the conversational coaching response concise: 1-2 short sentences, no more than 45 words.
 2. Acknowledge the validity of their feeling without over-explaining or giving a long lesson.
@@ -1454,7 +1454,7 @@ User's raw feedback: "${message}"
    - Do not include wording like "ask me directly", "can we talk about this", "can we try that", or other language that implies the next step is an outside conversation.
    - End with an in-app revision request, such as "Could you revise your understanding with that in mind?"
 ${isRefinement ? `
-IMPORTANT — This is a refinement round. The user has already seen your previous proposed feedback and is now telling you what to adjust. Their message is a correction directed at YOU (the coach), not new raw feedback about the partner. Apply their adjustment to the most recent proposed feedback.` : ''}
+IMPORTANT — This is a refinement round. The user has already seen your previous proposed feedback and is now telling you what to adjust. Their current message is a correction directed at YOU (the coach), not new raw feedback about the partner. Apply their adjustment to the most recent proposed feedback, using the history for the original context.` : ''}
 
 Respond in JSON format:
 \`\`\`json

--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -1426,16 +1426,20 @@ export async function refineValidationFeedback(
       return;
     }
 
-    const { message } = parseResult.data;
+    const { message, history } = parseResult.data;
 
     // Create turnId
     const turnId = `${sessionId}-${user.id}-feedback-refine-${Date.now()}`;
     updateContext({ turnId, sessionId, userId: user.id });
 
+    const isRefinement = history && history.length > 0;
+
     // Prompt for feedback coaching
     const systemPrompt = `You are a Feedback Coach for Meet Without Fear.
 The user wants to give feedback to their partner about an empathy statement that felt "off" or inaccurate.
 Your goal is to help them rephrase their feedback to be constructive, specific, and non-blaming (Non-Violent Communication style).
+
+CRITICAL: Preserve the user's specific language, details, and intensity. Do not euphemize, sanitize, or water down their words. If the user says something happened, use those specific details in the proposed feedback — do not replace them with vague summaries or softer language. The feedback should reflect what they actually said, not a gentler version.
 
 User's raw feedback: "${message}"
 
@@ -1443,12 +1447,14 @@ User's raw feedback: "${message}"
 2. Acknowledge the validity of their feeling without over-explaining or giving a long lesson.
 3. Explicitly tell them they can keep refining or send the proposed feedback as-is.
 4. Draft a "Proposed Feedback" statement that they can send inside Meet Without Fear. This should be:
-   - Direct but kind.
+   - Direct and honest — preserve the user's specific words and details.
    - Focus on what was missed or misunderstood.
-   - Avoid "You are wrong" language; use "I felt..." or "My experience was...".
+   - Use "I" framing ("I felt...", "My experience was...") but keep the user's actual details intact.
    - Ask the partner to revise their empathy attempt in the app, not to start a direct side conversation.
    - Do not include wording like "ask me directly", "can we talk about this", "can we try that", or other language that implies the next step is an outside conversation.
    - End with an in-app revision request, such as "Could you revise your understanding with that in mind?"
+${isRefinement ? `
+IMPORTANT — This is a refinement round. The user has already seen your previous proposed feedback and is now telling you what to adjust. Their message is a correction directed at YOU (the coach), not new raw feedback about the partner. Apply their adjustment to the most recent proposed feedback.` : ''}
 
 Respond in JSON format:
 \`\`\`json
@@ -1465,9 +1471,23 @@ Respond in JSON format:
       messageLength: message.length,
     });
 
+    // Build message history for context continuity
+    const messages: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+    if (isRefinement) {
+      for (const entry of history) {
+        messages.push({
+          role: entry.role === 'coach' ? 'assistant' : 'user',
+          content: entry.content,
+        });
+      }
+      messages.push({ role: 'user', content: message });
+    } else {
+      messages.push({ role: 'user', content: 'Help me refine this.' });
+    }
+
     const aiResponse = await getModelCompletion(routingDecision.model, {
       systemPrompt,
-      messages: [{ role: 'user', content: 'Help me refine this.' }],
+      messages,
       maxTokens: 512,
       sessionId,
       operation: `feedback-refinement-${routingDecision.model}`,

--- a/backend/src/routes/__tests__/stage2.test.ts
+++ b/backend/src/routes/__tests__/stage2.test.ts
@@ -675,6 +675,40 @@ describe('Validation Feedback Routes', () => {
         })
       );
     });
+
+    it('passes refinement history and process guardrails to the model', async () => {
+      const req = mockRequest({
+        body: {
+          message: "Don't water that down",
+          history: [
+            { role: 'user', content: 'He was drunk with poop in his pants' },
+            { role: 'coach', content: 'Proposed feedback: serious incidents at drop-off' },
+          ],
+        },
+      });
+      const res = mockResponse();
+
+      const { extractJsonFromResponse } = require('../../utils/json-extractor');
+      const { getModelCompletion } = require('../../lib/bedrock');
+      extractJsonFromResponse.mockReturnValueOnce({
+        response: 'AI response',
+        proposedFeedback: 'Refined feedback',
+      });
+
+      await refineValidationFeedback(req, res);
+
+      expect(getModelCompletion).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          systemPrompt: expect.stringContaining('do not preserve personal attacks, threats, ultimatums'),
+          messages: [
+            { role: 'user', content: 'He was drunk with poop in his pants' },
+            { role: 'assistant', content: 'Proposed feedback: serious incidents at drop-off' },
+            { role: 'user', content: "Don't water that down" },
+          ],
+        })
+      );
+    });
   });
 
   describe('POST /sessions/:id/empathy/skip-refinement', () => {

--- a/mobile/src/hooks/__tests__/useRefinementChat.test.ts
+++ b/mobile/src/hooks/__tests__/useRefinementChat.test.ts
@@ -1,0 +1,74 @@
+import { MessageRole } from '@meet-without-fear/shared';
+
+jest.mock('../../lib/api', () => ({
+  post: jest.fn(),
+}));
+
+jest.mock('../useStages', () => ({
+  useRefineValidationFeedback: jest.fn(),
+  useSaveValidationFeedbackDraft: jest.fn(),
+}));
+
+import {
+  buildValidationFeedbackRefinementPayload,
+  type RefinementMessage,
+} from '../useRefinementChat';
+
+describe('buildValidationFeedbackRefinementPayload', () => {
+  it('wraps the initial feedback with partner context', () => {
+    const payload = buildValidationFeedbackRefinementPayload(
+      'He was drunk with poop in his pants',
+      [],
+      'You felt worried at drop-off'
+    );
+
+    expect(payload).toEqual({
+      message: [
+        'Partner empathy statement:\n"You felt worried at drop-off"',
+        'What feels off:\n"He was drunk with poop in his pants"',
+        'Help me turn this into feedback I can send.',
+      ].join('\n\n'),
+    });
+  });
+
+  it('sends follow-up corrections as-is with prior coach context', () => {
+    const priorMessages: RefinementMessage[] = [
+      {
+        id: 'rough',
+        sessionId: 'session-123',
+        role: MessageRole.USER,
+        content: 'He was drunk with poop in his pants',
+        timestamp: '2026-05-02T00:00:00.000Z',
+        senderId: 'me',
+        stage: 2,
+      },
+      {
+        id: 'coach',
+        sessionId: 'session-123',
+        role: MessageRole.AI,
+        content: 'I hear you.',
+        proposedContent: 'I felt concerned about serious incidents at drop-off.',
+        timestamp: '2026-05-02T00:00:01.000Z',
+        senderId: null,
+        stage: 2,
+      },
+    ];
+
+    const payload = buildValidationFeedbackRefinementPayload(
+      "No, don't water that down",
+      priorMessages,
+      'You felt worried at drop-off'
+    );
+
+    expect(payload).toEqual({
+      message: "No, don't water that down",
+      history: [
+        { role: 'user', content: 'He was drunk with poop in his pants' },
+        {
+          role: 'coach',
+          content: 'I hear you.\n\nProposed feedback: I felt concerned about serious incidents at drop-off.',
+        },
+      ],
+    });
+  });
+});

--- a/mobile/src/hooks/useRefinementChat.ts
+++ b/mobile/src/hooks/useRefinementChat.ts
@@ -37,6 +37,38 @@ export interface RefinementMessage extends ChatMessage {
   proposedContent?: string | null;
 }
 
+export function buildValidationFeedbackRefinementPayload(
+  content: string,
+  priorMessages: RefinementMessage[],
+  partnerStatement: string
+): {
+  message: string;
+  history?: Array<{ role: 'coach' | 'user'; content: string }>;
+} {
+  const history: Array<{ role: 'coach' | 'user'; content: string }> = [];
+  for (const msg of priorMessages) {
+    if (msg.role === MessageRole.AI && msg.proposedContent) {
+      history.push({ role: 'coach', content: `${msg.content}\n\nProposed feedback: ${msg.proposedContent}` });
+    } else if (msg.role === MessageRole.USER) {
+      history.push({ role: 'user', content: msg.content });
+    }
+  }
+
+  if (history.length > 0) {
+    return { message: content, history };
+  }
+
+  return {
+    message: [
+      partnerStatement
+        ? `Partner empathy statement:\n"${partnerStatement}"`
+        : null,
+      `What feels off:\n"${content}"`,
+      'Help me turn this into feedback I can send.',
+    ].filter(Boolean).join('\n\n'),
+  };
+}
+
 // ============================================================================
 // Hook
 // ============================================================================
@@ -208,27 +240,11 @@ export function useValidationFeedbackCoachChat(
   }, [sessionId]);
 
   const requestRefinement = useCallback(
-    (content: string, currentMessages: RefinementMessage[], partnerStatement = partnerStatementRef.current) => {
-      const message = [
-        partnerStatement
-          ? `Partner empathy statement:\n"${partnerStatement}"`
-          : null,
-        `What feels off:\n"${content}"`,
-        'Help me turn this into feedback I can send.',
-      ].filter(Boolean).join('\n\n');
-
-      // Build conversation history from prior coach/user exchanges
-      const history: Array<{ role: 'coach' | 'user'; content: string }> = [];
-      for (const msg of currentMessages) {
-        if (msg.role === MessageRole.AI && msg.proposedContent) {
-          history.push({ role: 'coach', content: `${msg.content}\n\nProposed feedback: ${msg.proposedContent}` });
-        } else if (msg.role === MessageRole.USER) {
-          history.push({ role: 'user', content: msg.content });
-        }
-      }
+    (content: string, priorMessages: RefinementMessage[], partnerStatement = partnerStatementRef.current) => {
+      const payload = buildValidationFeedbackRefinementPayload(content, priorMessages, partnerStatement);
 
       refineFeedback(
-        { sessionId, message, history: history.length > 0 ? history : undefined },
+        { sessionId, ...payload },
         {
           onSuccess: (data) => {
             const aiMsg: RefinementMessage = {
@@ -275,7 +291,7 @@ export function useValidationFeedbackCoachChat(
       };
       setMessages((prev) => {
         const updated = [...prev, userMsg];
-        requestRefinement(content, updated);
+        requestRefinement(content, prev);
         return updated;
       });
     },

--- a/mobile/src/hooks/useRefinementChat.ts
+++ b/mobile/src/hooks/useRefinementChat.ts
@@ -208,7 +208,7 @@ export function useValidationFeedbackCoachChat(
   }, [sessionId]);
 
   const requestRefinement = useCallback(
-    (content: string, partnerStatement = partnerStatementRef.current) => {
+    (content: string, currentMessages: RefinementMessage[], partnerStatement = partnerStatementRef.current) => {
       const message = [
         partnerStatement
           ? `Partner empathy statement:\n"${partnerStatement}"`
@@ -217,8 +217,18 @@ export function useValidationFeedbackCoachChat(
         'Help me turn this into feedback I can send.',
       ].filter(Boolean).join('\n\n');
 
+      // Build conversation history from prior coach/user exchanges
+      const history: Array<{ role: 'coach' | 'user'; content: string }> = [];
+      for (const msg of currentMessages) {
+        if (msg.role === MessageRole.AI && msg.proposedContent) {
+          history.push({ role: 'coach', content: `${msg.content}\n\nProposed feedback: ${msg.proposedContent}` });
+        } else if (msg.role === MessageRole.USER) {
+          history.push({ role: 'user', content: msg.content });
+        }
+      }
+
       refineFeedback(
-        { sessionId, message },
+        { sessionId, message, history: history.length > 0 ? history : undefined },
         {
           onSuccess: (data) => {
             const aiMsg: RefinementMessage = {
@@ -263,8 +273,11 @@ export function useValidationFeedbackCoachChat(
         senderId: 'me',
         stage: 2,
       };
-      setMessages((prev) => [...prev, userMsg]);
-      requestRefinement(content);
+      setMessages((prev) => {
+        const updated = [...prev, userMsg];
+        requestRefinement(content, updated);
+        return updated;
+      });
     },
     [requestRefinement, sessionId]
   );
@@ -324,7 +337,7 @@ export function useValidationFeedbackCoachChat(
     setMessages(initialMessages);
 
     if (roughFeedback.trim()) {
-      requestRefinement(roughFeedback.trim(), partnerEmpathyStatement);
+      requestRefinement(roughFeedback.trim(), [], partnerEmpathyStatement);
     }
   }, [partnerEmpathyStatement, requestRefinement, roughFeedback, sessionId]);
 

--- a/shared/src/contracts/stages.ts
+++ b/shared/src/contracts/stages.ts
@@ -163,6 +163,10 @@ export type SaveValidationFeedbackDraftResponseInput = z.infer<typeof saveValida
 
 export const refineValidationFeedbackRequestSchema = z.object({
   message: z.string().min(1, 'Message is required'),
+  history: z.array(z.object({
+    role: z.enum(['coach', 'user']),
+    content: z.string(),
+  })).optional(),
 });
 
 export type RefineValidationFeedbackRequestInput = z.infer<typeof refineValidationFeedbackRequestSchema>;

--- a/shared/src/dto/empathy.ts
+++ b/shared/src/dto/empathy.ts
@@ -162,6 +162,7 @@ export interface SaveValidationFeedbackDraftResponse {
 
 export interface RefineValidationFeedbackRequest {
   message: string;
+  history?: Array<{ role: 'coach' | 'user'; content: string }>;
 }
 
 export interface RefineValidationFeedbackResponse {


### PR DESCRIPTION
## Changes
- Fix: Add explicit prompt instruction to preserve user's specific language, details, and intensity — no more euphemizing or sanitizing their words
- Fix: Pass conversation history (prior coach proposals + user corrections) to the refinement endpoint so the model has context for follow-up corrections
- Fix: Add refinement-round prompt section telling the model that follow-up messages are meta-corrections to its output, not new raw feedback about the partner
- Add: Optional `history` field to `RefineValidationFeedbackRequest` schema (backwards-compatible)
- Update: Mobile `useValidationFeedbackCoachChat` builds and sends conversation history with each refinement request

Related to #283

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** The feedback coach isn't understanding adjustments. And is meaningfully watering down what the user is saying
- **Prompt(s) used:** GitHub issue #283

## Docs updated
No doc changes needed — the API contract (endpoint path, response shape) is unchanged. The `history` field is optional and backwards-compatible. Changes are to prompt content and internal message passing only.