### PR TITLE
fix(topic-frame): separate topic confirmation from invitation draft

### DIFF
--- a/backend/src/controllers/topic-frame.ts
+++ b/backend/src/controllers/topic-frame.ts
@@ -90,10 +90,10 @@ export async function generateTopicFrame(req: Request, res: Response): Promise<v
       messages: [
         {
           role: 'user',
-          content: `The user is drafting an invitation for their partner to join a conflict resolution session. Here is the invitation message they have written:\n\n"${invitationRecord.invitationMessage}"\n\nGenerate a neutral topic frame (3-5 words) that captures what this conflict is about.`,
+          content: `The user is drafting an invitation for their partner to join a conflict resolution session. Here is the invitation message they have written:\n\n"${invitationRecord.invitationMessage}"\n\nGenerate a neutral topic frame (3-5 words) that captures what this conflict is about. Think through several candidates, critique them, then output your final choice on the last line.`,
         },
       ],
-      maxTokens: 50,
+      maxTokens: 300,
       sessionId,
       turnId,
       operation: 'topic-frame-generate',
@@ -206,10 +206,10 @@ export async function confirmTopicFrame(req: Request, res: Response): Promise<vo
         messages: [
           {
             role: 'user',
-            content: `${contextParts.join('\n\n')}\n\nGenerate the final neutral topic frame (3-5 words). You have final say on the framing — guard against inappropriate or blaming language.`,
+            content: `${contextParts.join('\n\n')}\n\nGenerate the final neutral topic frame (3-5 words). Think through several candidates, critique them, then output your final choice on the last line. You have final say on the framing — guard against inappropriate or blaming language.`,
           },
         ],
-        maxTokens: 50,
+        maxTokens: 300,
         sessionId,
         turnId,
         operation: 'topic-frame-confirm',
@@ -257,20 +257,36 @@ const TOPIC_FRAME_SYSTEM_PROMPT = `You are generating a neutral topic frame for 
 
 Based on the user's invitation message (written during Stage 0 invite drafting), produce a SHORT, NEUTRAL phrase (3-5 words) that describes the conflict topic. This will be shown to the other person when they receive the invitation, so they know what conflict they've been invited to engage with.
 
+PROCESS:
+First, think through 3-5 candidate topic frames. For each one, briefly critique it:
+- Is it too clinical or jargon-heavy? (e.g. "Communication frequency expectations" — bad, sounds like a therapy textbook)
+- Is it too vague? (e.g. "Relationship issues" — bad, could mean anything)
+- Is it a thinly disguised restatement of one side? (e.g. "Excessive contact requests" — bad, takes a side)
+- Does it capture the real-world situation in plain language the other person would recognize?
+Then pick the best one, or synthesize a better option from your candidates.
+
 RULES:
-- 3-5 words only. No more.
+- 3-5 words only for the final topic.
 - Neutral tone — no blame, no judgment, no emotional loading.
 - Specific enough that the other person recognizes it, but not so detailed it feels like a summary.
 - Use plain, everyday language. No clinical or therapeutic jargon.
 - Do NOT include names.
-- Output ONLY the topic frame text. No quotes, no explanation, no preamble.
 
-GOOD EXAMPLES:
+OUTPUT FORMAT:
+Write your thinking and candidates first, then on the last line write ONLY the final topic frame text (no quotes, no label, no explanation).
+
+GOOD EXAMPLES of final topics:
 - Tuesday pickup disagreement
 - Moving plans conversation
 - Holiday visit tension
 - Morning routine frustration
 - Budget priorities discussion
+- How often we talk
+
+BAD EXAMPLES (too clinical):
+- Communication frequency expectations
+- Interpersonal boundary negotiation
+- Parental contact dynamics
 
 BAD EXAMPLES (too vague):
 - Relationship issues
@@ -285,16 +301,26 @@ BAD EXAMPLES (too blaming):
 function normalizeTopicFrame(raw: string | null | undefined): string | null {
   if (!raw) return null;
 
-  const singleLine = raw
-    .trim()
-    .replace(/^["']|["']$/g, '')
-    .replace(/\s+/g, ' ');
+  // The response may contain thinking/critique lines followed by the final topic
+  // on the last line. Try each line from the end until we find a valid 3-5 word frame.
+  const lines = raw.trim().split('\n').filter((l) => l.trim());
 
-  if (!singleLine) return null;
-  if (/[.!?;:]/.test(singleLine)) return null;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const candidate = lines[i]
+      .trim()
+      .replace(/^["']|["']$/g, '')
+      .replace(/^[-•*]\s*/, '') // strip leading bullet
+      .replace(/\s+/g, ' ')
+      .trim();
 
-  const words = singleLine.split(' ').filter(Boolean);
-  if (words.length < 3 || words.length > 5) return null;
+    if (!candidate) continue;
+    if (/[.!?;:]/.test(candidate)) continue;
 
-  return singleLine;
+    const words = candidate.split(' ').filter(Boolean);
+    if (words.length < 3 || words.length > 5) continue;
+
+    return candidate;
+  }
+
+  return null;
 }

--- a/backend/src/controllers/topic-frame.ts
+++ b/backend/src/controllers/topic-frame.ts
@@ -302,25 +302,25 @@ function normalizeTopicFrame(raw: string | null | undefined): string | null {
   if (!raw) return null;
 
   // The response may contain thinking/critique lines followed by the final topic
-  // on the last line. Try each line from the end until we find a valid 3-5 word frame.
+  // on the last line. Only accept that final line so we do not accidentally
+  // persist a candidate that the model considered and rejected earlier.
   const lines = raw.trim().split('\n').filter((l) => l.trim());
+  const finalLine = lines[lines.length - 1];
+  if (!finalLine) return null;
 
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const candidate = lines[i]
-      .trim()
-      .replace(/^["']|["']$/g, '')
-      .replace(/^[-•*]\s*/, '') // strip leading bullet
-      .replace(/\s+/g, ' ')
-      .trim();
+  const candidate = finalLine
+    .trim()
+    .replace(/^[-•*]\s*/, '') // strip leading bullet
+    .replace(/^(?:final\s+(?:topic|choice|frame)|topic\s+frame|topic)\s*:\s*/i, '')
+    .replace(/^["']|["']$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
 
-    if (!candidate) continue;
-    if (/[.!?;:]/.test(candidate)) continue;
+  if (!candidate) return null;
+  if (/[.!?;:]/.test(candidate)) return null;
 
-    const words = candidate.split(' ').filter(Boolean);
-    if (words.length < 3 || words.length > 5) continue;
+  const words = candidate.split(' ').filter(Boolean);
+  if (words.length < 3 || words.length > 5) return null;
 
-    return candidate;
-  }
-
-  return null;
+  return candidate;
 }

--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -2,7 +2,7 @@
 title: Chat Interface
 sidebar_position: 3
 description: The primary conversation interface where users interact with the AI.
-updated: 2026-04-26
+updated: 2026-05-02
 status: living
 ---
 # Chat Interface
@@ -99,7 +99,10 @@ flowchart TB
     end
 ```
 
-During the invite drafting phase, the bottom panel shows the drafted invite, an AI-proposed neutral 3-5 word topic frame, and an optional steering input. The share action and "sent it" continuation stay disabled until the topic frame is confirmed, so the invited partner sees the same topic anchor before accepting.
+The invite drafting phase uses a two-step bottom panel:
+
+1. **Topic confirmation** — The panel first shows only the AI-proposed neutral 3-5 word topic frame with an optional steering input and a confirm button. The invitation message and share controls are hidden.
+2. **Invitation sharing** — Once the topic is confirmed, the panel transitions to show the drafted invite message, the confirmed topic, the share button, a refine option, and the "sent it" continuation.
 
 ### Stage 1: The Witness Chat
 

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -2058,7 +2058,7 @@ export function UnifiedSessionScreen({
               maxHeight: Animated.multiply(
                 invitationPanelAnim.interpolate({
                   inputRange: [0, 1],
-	                  outputRange: [0, 560],
+	                  outputRange: [0, 600],
                 }),
                 invitationKeyboardCollapseAnim,
               ),
@@ -2076,116 +2076,114 @@ export function UnifiedSessionScreen({
             }}
             pointerEvents="auto"
           >
-            {/* 5. INNER CONTAINER
-           Move the styles that contain padding/bg/borders HERE.
-           This ensures they don't take up space when the parent height is 0.
-        */}
+            {/* 5. INNER CONTAINER — Two-phase invitation flow:
+                 Phase 1: Topic confirmation only (until confirmed)
+                 Phase 2: Invitation sharing (after topic confirmed)
+            */}
             <View style={styles.invitationDraftContainer} testID="invitation-draft-panel">
-              <Text style={styles.invitationDraftMessage}>
-                "{invitationMessage}"
-              </Text>
+              {!topicFrameConfirmed ? (
+                /* Phase 1: Topic confirmation — show only the topic step */
+                <View style={styles.topicFrameContainer}>
+                  <Text style={styles.topicFrameLabel}>Topic</Text>
+                  {isGeneratingTopicFrame ? (
+                    <View style={styles.topicFrameLoading}>
+                      <ActivityIndicator size="small" color={styles.accentColor.color} />
+                      <Text style={styles.topicFrameStatus}>Preparing topic...</Text>
+                    </View>
+                  ) : topicFrame ? (
+                    <>
+                      <Text style={styles.topicFrameText}>{topicFrame}</Text>
+                      <TextInput
+                        style={styles.topicFrameInput}
+                        value={topicFrameSteer}
+                        onChangeText={setTopicFrameSteer}
+                        placeholder="Suggest a different direction"
+                        placeholderTextColor={styles.topicFramePlaceholder.color}
+                        maxLength={100}
+                        testID="topic-frame-steer-input"
+                      />
+                      <TouchableOpacity
+                        style={[
+                          styles.topicFrameButton,
+                          isConfirmingTopicFrame && styles.topicFrameButtonDisabled,
+                        ]}
+                        onPress={handleConfirmTopicFrame}
+                        disabled={isConfirmingTopicFrame}
+                        testID="topic-frame-confirm-button"
+                      >
+                        {isConfirmingTopicFrame ? (
+                          <ActivityIndicator size="small" color={styles.topicFrameButtonText.color} />
+                        ) : (
+                          <Text style={styles.topicFrameButtonText}>
+                            {topicFrameSteer.trim() ? 'Update and confirm' : 'Confirm topic'}
+                          </Text>
+                        )}
+                      </TouchableOpacity>
+                    </>
+                  ) : (
+                    <TouchableOpacity
+                      style={styles.topicFrameButton}
+                      onPress={() => {
+                        topicFrameRequestedRef.current = true;
+                        generateTopicFrame({ sessionId });
+                      }}
+                      testID="topic-frame-generate-button"
+                    >
+                      <Text style={styles.topicFrameButtonText}>Prepare topic</Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              ) : (
+                /* Phase 2: Invitation sharing — topic confirmed, show invitation */
+                <>
+                  <Text style={styles.invitationDraftMessage}>
+                    "{invitationMessage}"
+                  </Text>
 
-              <View style={styles.topicFrameContainer}>
-                <Text style={styles.topicFrameLabel}>Topic</Text>
-                {isGeneratingTopicFrame ? (
-                  <View style={styles.topicFrameLoading}>
-                    <ActivityIndicator size="small" color={styles.accentColor.color} />
-                    <Text style={styles.topicFrameStatus}>Preparing topic...</Text>
-                  </View>
-                ) : topicFrame ? (
-                  <>
+                  <View style={styles.topicFrameContainer}>
+                    <Text style={styles.topicFrameLabel}>Topic</Text>
                     <Text style={styles.topicFrameText}>{topicFrame}</Text>
-                    {!topicFrameConfirmed && (
-                      <>
-                        <TextInput
-                          style={styles.topicFrameInput}
-                          value={topicFrameSteer}
-                          onChangeText={setTopicFrameSteer}
-                          placeholder="Steer the topic direction"
-                          placeholderTextColor={styles.topicFramePlaceholder.color}
-                          maxLength={100}
-                          testID="topic-frame-steer-input"
-                        />
-                        <TouchableOpacity
-                          style={[
-                            styles.topicFrameButton,
-                            isConfirmingTopicFrame && styles.topicFrameButtonDisabled,
-                          ]}
-                          onPress={handleConfirmTopicFrame}
-                          disabled={isConfirmingTopicFrame}
-                          testID="topic-frame-confirm-button"
-                        >
-                          {isConfirmingTopicFrame ? (
-                            <ActivityIndicator size="small" color={styles.topicFrameButtonText.color} />
-                          ) : (
-                            <Text style={styles.topicFrameButtonText}>
-                              {topicFrameSteer.trim() ? 'Update and confirm' : 'Confirm topic'}
-                            </Text>
-                          )}
-                        </TouchableOpacity>
-                      </>
-                    )}
-                  </>
-                ) : (
+                  </View>
+
+                  <InvitationShareButton
+                    invitationMessage={invitationMessage!}
+                    invitationUrl={invitationUrl}
+                    topicFrame={topicFrame}
+                    partnerName={partnerName}
+                    senderName={user?.name || user?.firstName || undefined}
+                    testID="invitation-share-button"
+                  />
+
                   <TouchableOpacity
-                    style={styles.topicFrameButton}
-                    onPress={() => {
-                      topicFrameRequestedRef.current = true;
-                      generateTopicFrame({ sessionId });
-                    }}
-                    testID="topic-frame-generate-button"
+                    style={styles.refineInvitationButton}
+                    onPress={() => setShowInvitationRefine(true)}
+                    testID="invitation-refine-button"
                   >
-                    <Text style={styles.topicFrameButtonText}>Prepare topic</Text>
+                    <Text style={styles.refineInvitationButtonText}>
+                      Refine invitation
+                    </Text>
                   </TouchableOpacity>
-                )}
-              </View>
 
-              <InvitationShareButton
-                invitationMessage={invitationMessage!}
-                invitationUrl={invitationUrl}
-                topicFrame={topicFrame}
-                partnerName={partnerName}
-                senderName={user?.name || user?.firstName || undefined}
-                disabled={!topicFrameConfirmed}
-                testID="invitation-share-button"
-              />
-
-              <TouchableOpacity
-                style={styles.refineInvitationButton}
-                onPress={() => setShowInvitationRefine(true)}
-                testID="invitation-refine-button"
-              >
-                <Text style={styles.refineInvitationButtonText}>
-                  Refine invitation
-                </Text>
-              </TouchableOpacity>
-
-              <TouchableOpacity
-                style={[
-                  styles.continueButton,
-                  !topicFrameConfirmed && styles.continueButtonDisabled,
-                ]}
-                onPress={() => {
-                  if (!topicFrameConfirmed) {
-                    showError('Confirm the topic first', 'The invitation needs a finalized topic before it can be shared.');
-                    return;
-                  }
-                  // Track invitation sent
-                  trackInvitationSent(sessionId, 'share_sheet');
-                  setIsRefiningInvitation(false); // Exit refinement mode
-                  // Local latch: Immediately hide panel, survives cache race conditions
-                  markCompleted('confirmed-invitation');
-                  // Cache-First: useConfirmInvitationMessage.onMutate sets invitation.messageConfirmed optimistically
-                  // The indicator will appear immediately because the cache is updated
-                  handleConfirmInvitationMessage(invitationMessage!);
-                }}
-                disabled={!topicFrameConfirmed}
-                testID="invitation-continue-button"
-              >
-                <Text style={styles.continueButtonText}>
-                  {isRefiningInvitation ? "I've sent it - Back to conversation" : "I've sent it - Continue"}
-                </Text>
-              </TouchableOpacity>
+                  <TouchableOpacity
+                    style={styles.continueButton}
+                    onPress={() => {
+                      // Track invitation sent
+                      trackInvitationSent(sessionId, 'share_sheet');
+                      setIsRefiningInvitation(false); // Exit refinement mode
+                      // Local latch: Immediately hide panel, survives cache race conditions
+                      markCompleted('confirmed-invitation');
+                      // Cache-First: useConfirmInvitationMessage.onMutate sets invitation.messageConfirmed optimistically
+                      // The indicator will appear immediately because the cache is updated
+                      handleConfirmInvitationMessage(invitationMessage!);
+                    }}
+                    testID="invitation-continue-button"
+                  >
+                    <Text style={styles.continueButtonText}>
+                      {isRefiningInvitation ? "I've sent it - Back to conversation" : "I've sent it - Continue"}
+                    </Text>
+                  </TouchableOpacity>
+                </>
+              )}
             </View>
           </Animated.View>
         );


### PR DESCRIPTION
## Changes
- Fix: Split invitation panel into two clean phases — topic confirmation shown alone first, then invitation sharing after topic is confirmed
- Fix: Hide invitation message, share button, refine button, and continue button until topic frame is confirmed
- Fix: Improve topic generation quality by adding a thinking/critique step where the AI generates multiple candidates, evaluates each for clinical jargon or one-sidedness, then selects the best one
- Fix: Update `normalizeTopicFrame()` to extract the final topic from multi-line AI responses (thinking + final answer)
- Docs: Update chat-interface wireframe doc to describe the new two-phase flow

Related to #285

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "it's a mess now... If we need to confirm the topic, can we just show that until confirmed? We can leave the invitation popup alone and do it after... also, look how ridiculously obvious that title is... Create a thinking step in the prompt where it thinks of 5 options and then afterward picks the best one"

## Docs updated
- `docs/mobile/wireframes/chat-interface.md` — Updated Stage 0 panel description from single-panel to two-phase flow