### PR TITLE
feat(session-drawer): allow users to delete conversations

### DIFF
--- a/mobile/src/components/SessionDrawer/index.tsx
+++ b/mobile/src/components/SessionDrawer/index.tsx
@@ -6,7 +6,7 @@
  * Features:
  * - Native drawer with gesture support (swipe to close)
  * - Sessions organized into sections (Needs Attention / In Progress / Completed)
- * - Swipe-to-archive on session cards
+ * - Swipe-to-delete and long-press to delete on session cards
  * - New session button in header
  * - Closes on session selection
  */
@@ -27,11 +27,11 @@ import {
 import { Drawer } from 'react-native-drawer-layout';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { X, Plus, Archive } from 'lucide-react-native';
+import { X, Plus, Trash2 } from 'lucide-react-native';
 import { Swipeable } from 'react-native-gesture-handler';
 
 import { useSessionDrawer } from '../../hooks/useSessionDrawer';
-import { useSessions, useArchiveSession } from '../../hooks/useSessions';
+import { useSessions, useDeleteSession } from '../../hooks/useSessions';
 import { SessionCard } from '../SessionCard';
 import { createStyles } from '../../theme/styled';
 import { colors } from '../../theme';
@@ -60,13 +60,13 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
   const styles = useStyles();
   const router = useRouter();
   const { data, isLoading, refetch, isRefetching } = useSessions();
-  const archiveSession = useArchiveSession();
+  const deleteSession = useDeleteSession();
   const swipeableRefs = useRef<Map<string, Swipeable>>(new Map());
 
-  // Animation refs for optimistic archive
+  // Animation refs for optimistic delete
   const animationRefs = useRef<Record<string, { opacity: Animated.Value; height: Animated.Value }>>({});
   const layoutHeightsRef = useRef<Record<string, number>>({});
-  const [archivingSessions, setArchivingSessions] = useState<Set<string>>(new Set());
+  const [deletingSessions, setDeletingSessions] = useState<Set<string>>(new Set());
 
   const getAnimationValues = (sessionId: string) => {
     if (!animationRefs.current[sessionId]) {
@@ -118,18 +118,23 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
     router.push('/session/new');
   }, [onClose, router]);
 
-  const handleArchive = useCallback(
+  const handleDelete = useCallback(
     (session: SessionSummaryDTO) => {
       swipeableRefs.current.get(session.id)?.close();
 
       const partnerName = session.partner.name || 'this person';
-      Alert.alert('Archive Session', `Move this session with ${partnerName} to your archive?`, [
+      const isActive = ['ACTIVE', 'WAITING', 'PAUSED'].includes(session.status);
+      const message = isActive
+        ? `This will end your session with ${partnerName} and remove it from your list. They will be notified.`
+        : `Remove this conversation with ${partnerName} from your list?`;
+
+      Alert.alert('Delete Conversation', message, [
         { text: 'Cancel', style: 'cancel' },
         {
-          text: 'Archive',
-          style: 'default',
+          text: 'Delete',
+          style: 'destructive',
           onPress: () => {
-            setArchivingSessions((prev) => new Set(prev).add(session.id));
+            setDeletingSessions((prev) => new Set(prev).add(session.id));
             const animationValues = getAnimationValues(session.id);
             const measuredHeight = layoutHeightsRef.current[session.id] || 80;
             animationValues.height.setValue(measuredHeight);
@@ -147,15 +152,15 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
               }),
             ]).start(async () => {
               try {
-                await archiveSession.mutateAsync({ sessionId: session.id });
+                await deleteSession.mutateAsync({ sessionId: session.id });
                 delete animationRefs.current[session.id];
                 delete layoutHeightsRef.current[session.id];
               } catch {
                 animationValues.opacity.setValue(1);
                 animationValues.height.setValue(measuredHeight);
-                Alert.alert('Error', 'Failed to archive session.');
+                Alert.alert('Error', 'Failed to delete conversation.');
               } finally {
-                setArchivingSessions((prev) => {
+                setDeletingSessions((prev) => {
                   const newSet = new Set(prev);
                   newSet.delete(session.id);
                   return newSet;
@@ -166,7 +171,7 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
         },
       ]);
     },
-    [archiveSession]
+    [deleteSession]
   );
 
   const renderRightActions = useCallback(
@@ -183,21 +188,21 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
 
       return (
         <TouchableOpacity
-          style={styles.archiveAction}
-          onPress={() => handleArchive(session)}
+          style={styles.deleteAction}
+          onPress={() => handleDelete(session)}
         >
           <Animated.View style={{ transform: [{ scale }] }}>
-            <Archive color="#FFFFFF" size={20} />
+            <Trash2 color="#FFFFFF" size={20} />
           </Animated.View>
         </TouchableOpacity>
       );
     },
-    [handleArchive, styles]
+    [handleDelete, styles]
   );
 
   const renderItem = useCallback(
     ({ item }: { item: SessionSummaryDTO }) => {
-      const isArchiving = archivingSessions.has(item.id);
+      const isDeleting = deletingSessions.has(item.id);
       const animationValues = getAnimationValues(item.id);
 
       return (
@@ -209,7 +214,7 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
           style={[
             {
               opacity: animationValues.opacity,
-              ...(isArchiving ? { height: animationValues.height, overflow: 'hidden' } : {}),
+              ...(isDeleting ? { height: animationValues.height, overflow: 'hidden' } : {}),
             },
           ]}
         >
@@ -224,7 +229,9 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
           >
             <TouchableOpacity
               onPress={() => handleSessionPress(item.id)}
-              disabled={isArchiving}
+              onLongPress={() => handleDelete(item)}
+              delayLongPress={500}
+              disabled={isDeleting}
             >
               <SessionCard session={item} noMargin />
             </TouchableOpacity>
@@ -232,7 +239,7 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
         </Animated.View>
       );
     },
-    [archivingSessions, handleSessionPress, renderRightActions]
+    [deletingSessions, handleSessionPress, handleDelete, renderRightActions]
   );
 
   const renderSectionHeader = useCallback(
@@ -433,8 +440,8 @@ const useStyles = () =>
       fontWeight: '600',
       color: '#FFFFFF',
     },
-    archiveAction: {
-      backgroundColor: t.colors.textMuted,
+    deleteAction: {
+      backgroundColor: '#E53935',
       justifyContent: 'center',
       alignItems: 'center',
       width: 70,


### PR DESCRIPTION
## Changes
- Replace deprecated `useArchiveSession` with `useDeleteSession` for proper data cleanup
- Add long-press gesture on conversation cards as a more discoverable delete trigger
- Update swipe-to-delete with red trash icon and destructive confirmation style
- Show contextual warning for active sessions (partner will be notified)
- Show simpler confirmation for inactive/completed conversations

Related to #288

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr (U0ASRE7NZL7)
- **Original message:** Also, there's no way to delete the old conversation that I see on the conversations page
- **Prompt(s) used:** general-pr workspace

## Docs updated
No doc changes needed — UI-only change with no doc mapping for SessionDrawer component.