### PR TITLE
Implement Stage 3 needs reveal validation flow

### DIFF
--- a/backend/src/controllers/sessions.ts
+++ b/backend/src/controllers/sessions.ts
@@ -638,17 +638,27 @@ export async function advanceStage(req: Request, res: Response): Promise<void> {
       return;
     }
 
-    // Special check for Stage 4: requires both users to complete Stage 3
+    // Special check for Stage 4: requires both users to satisfy Stage 3 gates.
+    // Stage 3 validation no longer auto-creates Stage 4 rows; each user advances explicitly.
     if (nextStage === 4) {
       const partnerId = await getPartnerUserId(sessionId, user.id);
       if (partnerId) {
-        // Check specifically if partner's Stage 3 is completed
-        // (not their highest stage, as they may already be in Stage 4)
+        const partnerCurrentProgress = session.stageProgress
+          .filter((sp) => sp.userId === partnerId)
+          .sort((a, b) => b.stage - a.stage)[0];
+
         const partnerStage3 = session.stageProgress.find(
           (sp) => sp.userId === partnerId && sp.stage === 3
         );
+        const partnerStage3Gates = checkGates(
+          3,
+          partnerStage3?.gatesSatisfied as Record<string, unknown> | null
+        );
 
-        if (!partnerStage3 || partnerStage3.status !== 'COMPLETED') {
+        if (
+          partnerCurrentProgress?.stage !== 4 &&
+          (!partnerStage3 || !partnerStage3Gates.satisfied)
+        ) {
           successResponse(res, {
             advanced: false,
             newStage: currentStage,

--- a/backend/src/controllers/stage3.ts
+++ b/backend/src/controllers/stage3.ts
@@ -19,7 +19,7 @@ import {
   acquireExtractionLock,
   releaseExtractionLock,
 } from '../services/needs';
-import { confirmNeedsRequestSchema, ConsentContentType } from '@meet-without-fear/shared';
+import { confirmNeedsRequestSchema, ConsentContentType, NeedCategory } from '@meet-without-fear/shared';
 import { notifyPartner, publishSessionEvent } from '../services/realtime';
 import { successResponse, errorResponse } from '../utils/response';
 import { getPartnerUserId } from '../utils/session';
@@ -103,6 +103,31 @@ async function hasPartnerSharedNeeds(
 
   const gates = partnerProgress.gatesSatisfied as Record<string, unknown> | null;
   return gates?.needsShared === true;
+}
+
+async function hasPartnerValidatedNeeds(
+  sessionId: string,
+  currentUserId: string
+): Promise<boolean> {
+  const partnerId = await getPartnerUserId(sessionId, currentUserId);
+  if (!partnerId) return false;
+
+  const partnerProgress = await prisma.stageProgress.findUnique({
+    where: {
+      sessionId_userId_stage: {
+        sessionId,
+        userId: partnerId,
+        stage: 3,
+      },
+    },
+  });
+
+  const gates = partnerProgress?.gatesSatisfied as Record<string, unknown> | null;
+  return gates?.commonGroundConfirmed === true || gates?.needsValidated === true;
+}
+
+function isNeedCategory(value: unknown): value is NeedCategory {
+  return typeof value === 'string' && Object.values(NeedCategory).includes(value as NeedCategory);
 }
 
 // ============================================================================
@@ -240,6 +265,126 @@ export async function getNeeds(req: Request, res: Response): Promise<void> {
   } catch (error) {
     logger.error('[getNeeds] Error:', error);
     errorResponse(res, 'INTERNAL_ERROR', 'Failed to get needs', 500);
+  }
+}
+
+/**
+ * Capture needs from an AI summary card
+ * POST /sessions/:id/needs/capture
+ */
+export async function captureNeeds(req: Request, res: Response): Promise<void> {
+  try {
+    const user = req.user;
+    if (!user) {
+      errorResponse(res, 'UNAUTHORIZED', 'Authentication required', 401);
+      return;
+    }
+
+    const { id: sessionId } = req.params;
+    const { needs } = req.body as {
+      needs?: Array<{
+        need?: string;
+        category?: unknown;
+        description?: string;
+        evidence?: unknown;
+      }>;
+    };
+
+    if (!Array.isArray(needs) || needs.length === 0) {
+      errorResponse(res, 'VALIDATION_ERROR', 'needs array is required', 400);
+      return;
+    }
+
+    for (const need of needs) {
+      if (!need.need || !need.description || !isNeedCategory(need.category)) {
+        errorResponse(
+          res,
+          'VALIDATION_ERROR',
+          'Each need requires need, description, and a valid category',
+          400
+        );
+        return;
+      }
+    }
+
+    const session = await prisma.session.findFirst({
+      where: {
+        id: sessionId,
+        relationship: {
+          members: {
+            some: { userId: user.id },
+          },
+        },
+      },
+    });
+
+    if (!session) {
+      errorResponse(res, 'NOT_FOUND', 'Session not found', 404);
+      return;
+    }
+
+    if (session.status !== 'ACTIVE') {
+      errorResponse(res, 'SESSION_NOT_ACTIVE', 'Session is not active', 400);
+      return;
+    }
+
+    const progress = await prisma.stageProgress.findFirst({
+      where: { sessionId, userId: user.id },
+      orderBy: { stage: 'desc' },
+    });
+
+    const currentStage = progress?.stage ?? 0;
+    if (currentStage !== 3) {
+      errorResponse(
+        res,
+        'VALIDATION_ERROR',
+        `Cannot capture needs: you are in stage ${currentStage}, but stage 3 is required`,
+        400
+      );
+      return;
+    }
+
+    const userVessel = await getOrCreateUserVessel(sessionId, user.id);
+    const now = new Date();
+
+    const capturedNeeds = [];
+    for (const item of needs) {
+      const evidence = Array.isArray(item.evidence)
+        ? item.evidence.filter((entry): entry is string => typeof entry === 'string')
+        : [];
+
+      const created = await prisma.identifiedNeed.create({
+        data: {
+          vesselId: userVessel.id,
+          need: item.description || item.need!,
+          category: item.category as NeedCategory,
+          evidence,
+          aiConfidence: 0.85,
+          confirmed: false,
+        },
+      });
+      capturedNeeds.push(created);
+    }
+
+    successResponse(
+      res,
+      {
+        needs: capturedNeeds.map((n) => ({
+          id: n.id,
+          need: n.need,
+          category: n.category,
+          description: n.need,
+          evidence: n.evidence,
+          confirmed: n.confirmed,
+          aiConfidence: n.aiConfidence,
+        })),
+        capturedAt: now.toISOString(),
+      },
+      201
+    );
+  } catch (error) {
+    logger.error('[captureNeeds] Error:', error);
+    errorResponse(res, 'INTERNAL_ERROR', 'Failed to capture needs', 500);
   }
 }
 
@@ -553,26 +698,11 @@ export async function consentToShareNeeds(
       });
     }
 
-    // If both have shared, auto-trigger common ground analysis and notify
+    // If both have shared, notify clients that the side-by-side reveal is ready.
     if (partnerShared && partnerId) {
-      // Use lock to prevent concurrent findCommonGround calls from both users' consent
-      if (!isCommonGroundAnalysisRunning(sessionId)) {
-        setCommonGroundLock(sessionId);
-        try {
-          await findCommonGround(sessionId, user.id, partnerId);
-          logger.info('[consentToShareNeeds] Common ground analysis triggered for session', sessionId);
-        } catch (err) {
-          logger.error('[consentToShareNeeds] Failed to trigger common ground analysis:', err);
-        } finally {
-          clearCommonGroundLock(sessionId);
-        }
-      } else {
-        logger.info('[consentToShareNeeds] Common ground analysis already running for session', sessionId);
-      }
-
-      await publishSessionEvent(sessionId, 'session.common_ground_ready', {
+      await publishSessionEvent(sessionId, 'session.needs_reveal_ready' as any, {
         stage: 3,
-        commonGroundReady: true,
+        needsRevealReady: true,
       });
     }
 
@@ -585,6 +715,196 @@ export async function consentToShareNeeds(
   } catch (error) {
     logger.error('[consentToShareNeeds] Error:', error);
     errorResponse(res, 'INTERNAL_ERROR', 'Failed to consent to share needs', 500);
+  }
+}
+
+/**
+ * Validate revealed needs lists.
+ * POST /sessions/:id/needs/validate
+ */
+export async function validateNeeds(req: Request, res: Response): Promise<void> {
+  try {
+    const user = req.user;
+    if (!user) {
+      errorResponse(res, 'UNAUTHORIZED', 'Authentication required', 401);
+      return;
+    }
+
+    const { id: sessionId } = req.params;
+    const { validated = true } = req.body as { validated?: boolean };
+
+    if (typeof validated !== 'boolean') {
+      errorResponse(res, 'VALIDATION_ERROR', 'validated boolean is required', 400);
+      return;
+    }
+
+    const session = await prisma.session.findFirst({
+      where: {
+        id: sessionId,
+        relationship: {
+          members: {
+            some: { userId: user.id },
+          },
+        },
+      },
+      include: {
+        relationship: {
+          include: {
+            members: {
+              orderBy: { joinedAt: 'asc' },
+            },
+          },
+        },
+      },
+    });
+
+    if (!session) {
+      errorResponse(res, 'NOT_FOUND', 'Session not found', 404);
+      return;
+    }
+
+    if (session.status !== 'ACTIVE') {
+      errorResponse(res, 'SESSION_NOT_ACTIVE', 'Session is not active', 400);
+      return;
+    }
+
+    const progress = await prisma.stageProgress.findFirst({
+      where: { sessionId, userId: user.id },
+      orderBy: { stage: 'desc' },
+    });
+
+    const currentStage = progress?.stage ?? 0;
+    if (currentStage !== 3) {
+      errorResponse(
+        res,
+        'VALIDATION_ERROR',
+        `Cannot validate needs: you are in stage ${currentStage}, but stage 3 is required`,
+        400
+      );
+      return;
+    }
+
+    const userGates = progress?.gatesSatisfied as Record<string, unknown> | null;
+    if (userGates?.needsShared !== true || !(await hasPartnerSharedNeeds(sessionId, user.id))) {
+      errorResponse(
+        res,
+        'VALIDATION_ERROR',
+        'Both partners must consent to reveal needs before validation',
+        400
+      );
+      return;
+    }
+
+    const now = new Date();
+    const gatesSatisfied = {
+      ...(progress?.gatesSatisfied as Record<string, unknown> || {}),
+      needsValidated: validated,
+      needsValidatedAt: validated ? now.toISOString() : null,
+    } satisfies Prisma.InputJsonValue;
+
+    await prisma.stageProgress.update({
+      where: {
+        sessionId_userId_stage: {
+          sessionId,
+          userId: user.id,
+          stage: 3,
+        },
+      },
+      data: {
+        gatesSatisfied,
+        status: 'GATE_PENDING',
+        completedAt: null,
+      },
+    });
+
+    const partnerValidated = await hasPartnerValidatedNeeds(sessionId, user.id);
+    const partnerId = await getPartnerUserId(sessionId, user.id);
+    if (partnerId) {
+      await notifyPartner(sessionId, partnerId, 'partner.needs_validated' as any, {
+        stage: 3,
+        validatedBy: user.id,
+        validated,
+        allValidatedByBoth: validated && partnerValidated,
+      });
+    }
+
+    const canAdvance = validated && partnerValidated;
+    if (canAdvance && partnerId) {
+      await prisma.stageProgress.updateMany({
+        where: {
+          sessionId,
+          stage: 3,
+          userId: { in: [user.id, partnerId] },
+        },
+        data: {
+          status: 'COMPLETED',
+          completedAt: now,
+        },
+      });
+
+      for (const uid of [user.id, partnerId]) {
+        await prisma.stageProgress.upsert({
+          where: {
+            sessionId_userId_stage: {
+              sessionId,
+              userId: uid,
+              stage: 4,
+            },
+          },
+          create: {
+            sessionId,
+            userId: uid,
+            stage: 4,
+            status: 'IN_PROGRESS',
+            startedAt: now,
+          },
+          update: {},
+        });
+      }
+
+      const transitionContent =
+        'You have both checked the needs lists and marked them valid. Now move to strategies that can honor what each of you needs.';
+
+      const transitionMessages: Array<{ id: string; content: string; timestamp: Date }> = [];
+      for (const uid of [user.id, partnerId]) {
+        const message = await prisma.message.create({
+          data: {
+            sessionId,
+            senderId: null,
+            forUserId: uid,
+            role: 'AI',
+            content: transitionContent,
+            stage: 4,
+          },
+        });
+        transitionMessages.push({ id: message.id, content: message.content, timestamp: message.timestamp });
+      }
+
+      const firstMessage = transitionMessages[0];
+      await publishSessionEvent(sessionId, 'partner.stage_completed', {
+        previousStage: 3,
+        currentStage: 4,
+        userId: user.id,
+        triggeredByUserId: user.id,
+        message: firstMessage
+          ? {
+              id: firstMessage.id,
+              content: firstMessage.content,
+              timestamp: firstMessage.timestamp,
+            }
+          : undefined,
+      });
+    }
+
+    successResponse(res, {
+      validated,
+      validatedAt: validated ? now.toISOString() : null,
+      partnerValidated,
+      canAdvance,
+    });
+  } catch (error) {
+    logger.error('[validateNeeds] Error:', error);
+    errorResponse(res, 'INTERNAL_ERROR', 'Failed to validate needs', 500);
   }
 }
 
@@ -978,14 +1298,14 @@ export async function confirmCommonGround(
     const now = new Date();
 
     if (isNoOverlap) {
-      // noOverlap case: no common ground to confirm, proceed directly to stage transition
-      logger.info('[confirmCommonGround] noOverlap case - advancing Stage 3->4 for session', sessionId);
+      logger.info('[confirmCommonGround] noOverlap case confirmed for session', sessionId);
 
-      // Mark this user's Stage 3 as having confirmed (even though there's nothing to confirm)
       const gatesSatisfied = {
         ...(progress?.gatesSatisfied as Record<string, unknown> || {}),
         commonGroundConfirmed: true,
         confirmedAt: now.toISOString(),
+        needsValidated: true,
+        needsValidatedAt: now.toISOString(),
         noOverlap: true,
       } satisfies Prisma.InputJsonValue;
 
@@ -999,104 +1319,28 @@ export async function confirmCommonGround(
         },
         data: {
           gatesSatisfied,
-          status: 'COMPLETED',
-          completedAt: now,
+          status: 'GATE_PENDING',
+          completedAt: null,
         },
       });
 
-      // Check if partner has also confirmed (or confirm for both in noOverlap)
+      const partnerValidated = await hasPartnerValidatedNeeds(sessionId, user.id);
       const partnerId = await getPartnerUserId(sessionId, user.id);
-
-      // In noOverlap case, also mark partner's Stage 3 as completed and advance both to Stage 4
       if (partnerId) {
-        await prisma.stageProgress.updateMany({
-          where: {
-            sessionId,
-            stage: 3,
-            userId: { in: [user.id, partnerId] },
-          },
-          data: {
-            status: 'COMPLETED',
-            completedAt: now,
-          },
-        });
-
-        // Create Stage 4 progress records for both users
-        const userIds = [user.id, partnerId];
-        for (const uid of userIds) {
-          await prisma.stageProgress.upsert({
-            where: {
-              sessionId_userId_stage: {
-                sessionId,
-                userId: uid,
-                stage: 4,
-              },
-            },
-            create: {
-              sessionId,
-              userId: uid,
-              stage: 4,
-              status: 'IN_PROGRESS',
-              startedAt: now,
-            },
-            update: {},
-          });
-        }
-
-        // Generate transition message for each user
-        const transitionContent =
-          "Even though your needs don't overlap directly, that's okay -- understanding " +
-          "each other's needs is itself a breakthrough. Let's move to the final stage: " +
-          "building concrete strategies and agreements that honor what you both need.";
-
-        const transitionMessages: Array<{ id: string; content: string; timestamp: Date }> = [];
-        for (const uid of userIds) {
-          const msg = await prisma.message.create({
-            data: {
-              sessionId,
-              senderId: null,
-              forUserId: uid,
-              role: 'AI',
-              content: transitionContent,
-              stage: 4,
-            },
-          });
-          transitionMessages.push({ id: msg.id, content: msg.content, timestamp: msg.timestamp });
-        }
-
-        // Publish stage completed event
-        const firstMessage = transitionMessages[0];
-        await publishSessionEvent(sessionId, 'partner.stage_completed', {
-          previousStage: 3,
-          currentStage: 4,
-          userId: user.id,
-          triggeredByUserId: user.id,
-          message: firstMessage
-            ? {
-                id: firstMessage.id,
-                content: firstMessage.content,
-                timestamp: firstMessage.timestamp,
-              }
-            : undefined,
-        });
-
-        // Notify partner
         await notifyPartner(sessionId, partnerId, 'partner.common_ground_confirmed', {
           stage: 3,
           confirmedBy: user.id,
-          allConfirmedByBoth: true,
+          allConfirmedByBoth: partnerValidated,
           noOverlap: true,
         });
-
-        logger.info('[confirmCommonGround] noOverlap Stage 3->4 transition completed for session', sessionId);
       }
 
       successResponse(res, {
         confirmed: true,
         confirmedAt: now.toISOString(),
         allConfirmedByMe: true,
-        allConfirmedByBoth: true,
-        canAdvance: true,
+        allConfirmedByBoth: partnerValidated,
+        canAdvance: partnerValidated,
         noOverlap: true,
       });
       return;
@@ -1164,8 +1408,8 @@ export async function confirmCommonGround(
         },
         data: {
           gatesSatisfied,
-          status: allConfirmedByBoth ? 'COMPLETED' : 'GATE_PENDING',
-          completedAt: allConfirmedByBoth ? now : null,
+          status: 'GATE_PENDING',
+          completedAt: null,
         },
       });
     }
@@ -1178,88 +1422,6 @@ export async function confirmCommonGround(
         confirmedBy: user.id,
         allConfirmedByBoth,
       });
-    }
-
-    // If both confirmed all common ground, trigger Stage 3 -> 4 transition
-    if (allConfirmedByBoth && partnerId) {
-      try {
-        // Also mark partner's Stage 3 as COMPLETED (they may not have updated yet)
-        await prisma.stageProgress.updateMany({
-          where: {
-            sessionId,
-            stage: 3,
-            userId: { in: [user.id, partnerId] },
-          },
-          data: {
-            status: 'COMPLETED',
-            completedAt: now,
-          },
-        });
-
-        // Create Stage 4 progress records for both users
-        const userIds = [user.id, partnerId];
-        for (const uid of userIds) {
-          await prisma.stageProgress.upsert({
-            where: {
-              sessionId_userId_stage: {
-                sessionId,
-                userId: uid,
-                stage: 4,
-              },
-            },
-            create: {
-              sessionId,
-              userId: uid,
-              stage: 4,
-              status: 'IN_PROGRESS',
-              startedAt: now,
-            },
-            update: {},
-          });
-        }
-
-        // Generate transition message for each user
-        const transitionContent =
-          "You've found common ground together -- that's a real breakthrough. " +
-          "Now let's move to the final stage: building concrete strategies and agreements " +
-          "that honor what you both need.";
-
-        const transitionMessages: Array<{ id: string; content: string; timestamp: Date }> = [];
-        for (const uid of userIds) {
-          const msg = await prisma.message.create({
-            data: {
-              sessionId,
-              senderId: null,
-              forUserId: uid,
-              role: 'AI',
-              content: transitionContent,
-              stage: 4,
-            },
-          });
-          transitionMessages.push({ id: msg.id, content: msg.content, timestamp: msg.timestamp });
-        }
-
-        // Publish stage completed event
-        const firstMessage = transitionMessages[0];
-        await publishSessionEvent(sessionId, 'partner.stage_completed', {
-          previousStage: 3,
-          currentStage: 4,
-          userId: user.id,
-          triggeredByUserId: user.id,
-          message: firstMessage
-            ? {
-                id: firstMessage.id,
-                content: firstMessage.content,
-                timestamp: firstMessage.timestamp,
-              }
-            : undefined,
-        });
-
-        logger.info('[confirmCommonGround] Stage 3->4 transition completed for session', sessionId);
-      } catch (err) {
-        logger.error('[confirmCommonGround] Failed to trigger Stage 3->4 transition:', err);
-        // Non-fatal - the transition can be triggered manually
-      }
     }
 
     successResponse(res, {
@@ -1387,29 +1549,16 @@ export async function getNeedsComparison(
       }),
     ]);
 
-    // Get common ground
-    const sharedVessel = await prisma.sharedVessel.findUnique({
-      where: { sessionId },
+    const partnerProgress = await prisma.stageProgress.findUnique({
+      where: {
+        sessionId_userId_stage: {
+          sessionId,
+          userId: partnerId,
+          stage: 3,
+        },
+      },
     });
-
-    let commonGround: Awaited<ReturnType<typeof prisma.commonGround.findMany>> = [];
-    let noOverlap = false;
-
-    if (sharedVessel) {
-      commonGround = await prisma.commonGround.findMany({
-        where: { sharedVesselId: sharedVessel.id },
-        orderBy: { id: 'asc' },
-      });
-
-      // If shared vessel exists but no common ground, analysis ran with no overlap
-      if (commonGround.length === 0) {
-        noOverlap = true;
-      }
-    }
-
-    // Determine A/B role for confirmedByMe/confirmedByPartner
-    const members = session.relationship.members;
-    const userIsA = members[0]?.userId === user.id;
+    const partnerGates = partnerProgress?.gatesSatisfied as Record<string, unknown> | null;
 
     successResponse(res, {
       myNeeds: myNeeds.map((n) => ({
@@ -1424,15 +1573,12 @@ export async function getNeedsComparison(
         need: n.need,
         confirmed: n.confirmed,
       })),
-      commonGround: commonGround.map((cg) => ({
-        id: cg.id,
-        category: cg.category,
-        need: cg.need,
-        confirmedByMe: userIsA ? cg.confirmedByA : cg.confirmedByB,
-        confirmedByPartner: userIsA ? cg.confirmedByB : cg.confirmedByA,
-      })),
+      myValidated: userGates?.needsValidated === true,
+      partnerValidated: partnerGates?.needsValidated === true,
+      canAdvance: userGates?.needsValidated === true && partnerGates?.needsValidated === true,
+      commonGround: [],
       analysisComplete: true,
-      noOverlap,
+      noOverlap: false,
     });
   } catch (error) {
     logger.error('[getNeedsComparison] Error:', error);

--- a/backend/src/routes/__tests__/stage3.test.ts
+++ b/backend/src/routes/__tests__/stage3.test.ts
@@ -1,10 +1,14 @@
 import { Request, Response } from 'express';
 import {
   getNeeds,
+  captureNeeds,
   confirmNeeds,
   consentToShareNeeds,
+  validateNeeds,
   getCommonGround,
+  confirmCommonGround,
 } from '../../controllers/stage3';
+import { advanceStage } from '../../controllers/sessions';
 import { prisma } from '../../lib/prisma';
 import * as needsService from '../../services/needs';
 
@@ -70,6 +74,8 @@ describe('Stage 3 API', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (needsService.isExtractionRunning as jest.Mock).mockReturnValue(false);
+    (prisma.commonGround.findMany as jest.Mock).mockReset();
   });
 
   describe('GET /sessions/:id/needs (getNeeds)', () => {
@@ -288,6 +294,75 @@ describe('Stage 3 API', () => {
             synthesizedAt: null,
             isDirty: false,
           },
+        })
+      );
+    });
+  });
+
+  describe('POST /sessions/:id/needs/capture (captureNeeds)', () => {
+    it('captures needs from a summary card without confirming them', async () => {
+      const mockStageProgress = {
+        id: 'progress-1',
+        sessionId: mockSessionId,
+        userId: mockUser.id,
+        stage: 3,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: {},
+      };
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue({
+        id: mockSessionId,
+        status: 'ACTIVE',
+      });
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue(mockStageProgress);
+      (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue({ id: mockVesselId });
+      (prisma.identifiedNeed.create as jest.Mock).mockResolvedValue({
+        id: mockNeedId1,
+        vesselId: mockVesselId,
+        need: 'To feel heard before problem solving',
+        category: 'CONNECTION',
+        evidence: ['I just want you to listen first'],
+        confirmed: false,
+        aiConfidence: 0.85,
+        createdAt: new Date(),
+      });
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+        body: {
+          needs: [
+            {
+              need: 'Connection',
+              category: 'CONNECTION',
+              description: 'To feel heard before problem solving',
+              evidence: ['I just want you to listen first'],
+            },
+          ],
+        },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      await captureNeeds(req as Request, res as Response);
+
+      expect(prisma.identifiedNeed.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            vesselId: mockVesselId,
+            need: 'To feel heard before problem solving',
+            category: 'CONNECTION',
+            confirmed: false,
+          }),
+        })
+      );
+      expect(statusMock).toHaveBeenCalledWith(201);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            needs: [expect.objectContaining({ id: mockNeedId1, confirmed: false })],
+            capturedAt: expect.any(String),
+          }),
         })
       );
     });
@@ -669,6 +744,274 @@ describe('Stage 3 API', () => {
         expect.objectContaining({
           success: false,
           error: expect.objectContaining({ code: 'UNAUTHORIZED' }),
+        })
+      );
+    });
+  });
+
+  describe('POST /sessions/:id/needs/validate (validateNeeds)', () => {
+    it('validates revealed needs and opens Stage 4 when partner already validated', async () => {
+      const mockStageProgress = {
+        id: 'progress-1',
+        sessionId: mockSessionId,
+        userId: mockUser.id,
+        stage: 3,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: { needsConfirmed: true, needsShared: true },
+      };
+
+      const partnerProgress = {
+        id: 'progress-2',
+        sessionId: mockSessionId,
+        userId: mockPartnerId,
+        stage: 3,
+        status: 'GATE_PENDING',
+        gatesSatisfied: {
+          needsConfirmed: true,
+          needsShared: true,
+          commonGroundConfirmed: true,
+        },
+      };
+
+      const mockCommonGround = [
+        {
+          id: 'clcomm0001aaaaaaaaa',
+          sharedVesselId: 'shared-vessel-1',
+          need: 'Both need calm repair',
+          category: 'SAFETY',
+          confirmedByA: false,
+          confirmedByB: true,
+          confirmedAt: null,
+        },
+      ];
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue({
+        id: mockSessionId,
+        status: 'ACTIVE',
+        relationship: {
+          members: [{ userId: mockUser.id }, { userId: mockPartnerId }],
+        },
+      });
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+        id: mockSessionId,
+        relationship: { members: [{ userId: mockUser.id }, { userId: mockPartnerId }] },
+      });
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue(mockStageProgress);
+      (prisma.stageProgress.findUnique as jest.Mock)
+        .mockResolvedValueOnce(partnerProgress)
+        .mockResolvedValueOnce(partnerProgress);
+      (prisma.sharedVessel.findUnique as jest.Mock).mockResolvedValue({
+        id: 'shared-vessel-1',
+        sessionId: mockSessionId,
+      });
+      (prisma.commonGround.findMany as jest.Mock)
+        .mockResolvedValueOnce(mockCommonGround)
+        .mockResolvedValueOnce([{ ...mockCommonGround[0], confirmedByA: true }]);
+      (prisma.commonGround.update as jest.Mock).mockResolvedValue({
+        ...mockCommonGround[0],
+        confirmedByA: true,
+      });
+      (prisma.commonGround.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (prisma.stageProgress.update as jest.Mock).mockResolvedValue({
+        ...mockStageProgress,
+        status: 'GATE_PENDING',
+      });
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      await validateNeeds(req as Request, res as Response);
+
+      expect(prisma.stageProgress.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'GATE_PENDING',
+            completedAt: null,
+          }),
+        })
+      );
+      expect(prisma.stageProgress.upsert).toHaveBeenCalledTimes(2);
+      expect(prisma.message.create).toHaveBeenCalledTimes(2);
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            validated: true,
+            partnerValidated: true,
+            canAdvance: true,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('POST /sessions/:id/common-ground/confirm (confirmCommonGround)', () => {
+    it('satisfies the Stage 3 gate without auto-advancing to Stage 4', async () => {
+      const mockStageProgress = {
+        id: 'progress-1',
+        sessionId: mockSessionId,
+        userId: mockUser.id,
+        stage: 3,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: { needsConfirmed: true, needsShared: true },
+      };
+
+      const mockCommonGround = [
+        {
+          id: 'clcomm0001aaaaaaaaa',
+          sharedVesselId: 'shared-vessel-1',
+          need: 'Both need reliable follow-through',
+          category: 'RECOGNITION',
+          confirmedByA: true,
+          confirmedByB: true,
+          confirmedAt: new Date(),
+        },
+      ];
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue({
+        id: mockSessionId,
+        status: 'ACTIVE',
+        relationship: {
+          members: [{ userId: mockUser.id }, { userId: mockPartnerId }],
+        },
+      });
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+        id: mockSessionId,
+        relationship: { members: [{ userId: mockUser.id }, { userId: mockPartnerId }] },
+      });
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue(mockStageProgress);
+      (prisma.sharedVessel.findUnique as jest.Mock).mockResolvedValue({
+        id: 'shared-vessel-1',
+        sessionId: mockSessionId,
+      });
+      (prisma.commonGround.findMany as jest.Mock)
+        .mockResolvedValueOnce(mockCommonGround)
+        .mockResolvedValueOnce(mockCommonGround);
+      (prisma.commonGround.findUnique as jest.Mock).mockResolvedValue(mockCommonGround[0]);
+      (prisma.commonGround.update as jest.Mock).mockResolvedValue(mockCommonGround[0]);
+      (prisma.stageProgress.update as jest.Mock).mockResolvedValue({
+        ...mockStageProgress,
+        status: 'GATE_PENDING',
+      });
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+        body: { commonGroundIds: ['clcomm0001aaaaaaaaa'] },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      await confirmCommonGround(req as Request, res as Response);
+
+      expect(prisma.stageProgress.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'GATE_PENDING',
+            completedAt: null,
+          }),
+        })
+      );
+      expect(prisma.stageProgress.upsert).not.toHaveBeenCalled();
+      expect(prisma.message.create).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            confirmed: true,
+            allConfirmedByBoth: true,
+            canAdvance: true,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('POST /sessions/:id/stages/advance from Stage 3', () => {
+    it('allows explicit Stage 4 advancement after both users satisfy Stage 3 gates', async () => {
+      const currentProgress = {
+        id: 'progress-1',
+        sessionId: mockSessionId,
+        userId: mockUser.id,
+        stage: 3,
+        status: 'GATE_PENDING',
+        gatesSatisfied: {
+          needsConfirmed: true,
+          needsShared: true,
+          commonGroundConfirmed: true,
+        },
+      };
+      const partnerProgress = {
+        id: 'progress-2',
+        sessionId: mockSessionId,
+        userId: mockPartnerId,
+        stage: 3,
+        status: 'GATE_PENDING',
+        gatesSatisfied: {
+          needsConfirmed: true,
+          needsShared: true,
+          commonGroundConfirmed: true,
+        },
+      };
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue({
+        id: mockSessionId,
+        status: 'ACTIVE',
+        stageProgress: [currentProgress, partnerProgress],
+        relationship: {
+          members: [{ userId: mockUser.id }, { userId: mockPartnerId }],
+        },
+      });
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+        id: mockSessionId,
+        relationship: { members: [{ userId: mockUser.id }, { userId: mockPartnerId }] },
+      });
+      (prisma.stageProgress.update as jest.Mock).mockResolvedValue({
+        ...currentProgress,
+        status: 'COMPLETED',
+      });
+      (prisma.stageProgress.create as jest.Mock).mockResolvedValue({
+        id: 'progress-4',
+        sessionId: mockSessionId,
+        userId: mockUser.id,
+        stage: 4,
+        status: 'IN_PROGRESS',
+      });
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      await advanceStage(req as Request, res as Response);
+
+      expect(prisma.stageProgress.update).toHaveBeenCalledWith({
+        where: { id: 'progress-1' },
+        data: expect.objectContaining({ status: 'COMPLETED' }),
+      });
+      expect(prisma.stageProgress.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            sessionId: mockSessionId,
+            userId: mockUser.id,
+            stage: 4,
+            status: 'IN_PROGRESS',
+          }),
+        })
+      );
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            advanced: true,
+            newStage: 4,
+          }),
         })
       );
     });

--- a/backend/src/routes/stage3.ts
+++ b/backend/src/routes/stage3.ts
@@ -3,8 +3,10 @@
  *
  * Routes for the What Matters stage of the Meet Without Fear process.
  * - GET /sessions/:id/needs - Get AI-synthesized needs
+ * - POST /sessions/:id/needs/capture - Capture needs from an AI summary card
  * - POST /sessions/:id/needs/confirm - Confirm needs
  * - POST /sessions/:id/needs/consent - Consent to share needs
+ * - POST /sessions/:id/needs/validate - Validate revealed needs/common ground
  * - GET /sessions/:id/common-ground - Get common ground analysis
  */
 
@@ -13,8 +15,10 @@ import { requireAuth, requireSessionAccess } from '../middleware/auth';
 import { asyncHandler } from '../middleware/errors';
 import {
   getNeeds,
+  captureNeeds,
   confirmNeeds,
   consentToShareNeeds,
+  validateNeeds,
   getCommonGround,
   addCustomNeed,
   confirmCommonGround,
@@ -29,6 +33,14 @@ router.get(
   requireAuth,
   requireSessionAccess,
   asyncHandler(getNeeds)
+);
+
+// Capture needs from an AI summary card
+router.post(
+  '/sessions/:id/needs/capture',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(captureNeeds)
 );
 
 // Confirm user's needs
@@ -47,6 +59,14 @@ router.post(
   asyncHandler(consentToShareNeeds)
 );
 
+// Validate revealed needs/common ground
+router.post(
+  '/sessions/:id/needs/validate',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(validateNeeds)
+);
+
 // Get common ground analysis
 router.get(
   '/sessions/:id/common-ground',
@@ -58,6 +78,14 @@ router.get(
 // Get needs comparison (side-by-side view of both users' needs + common ground)
 router.get(
   '/sessions/:id/needs/comparison',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(getNeedsComparison)
+);
+
+// Reveal alias for clients using the Stage 3 capture/consent/reveal/validation vocabulary
+router.get(
+  '/sessions/:id/needs/reveal',
   requireAuth,
   requireSessionAccess,
   asyncHandler(getNeedsComparison)

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -18,6 +18,12 @@ export {
   navigateToShareFromSession,
   signCompact,
   confirmFeelHeard,
+  expectNeedsSummaryFromApi,
+  confirmNeedsSummaryAndConsent,
+  waitForNeedsReveal,
+  confirmSideBySideRevealAndValidation,
+  expectNeedsComparisonFromApi,
+  waitForStage,
 } from './test-utils';
 export { TwoBrowserHarness, waitForPartnerUpdate } from './two-browser-harness';
 export type { TwoBrowserConfig } from './two-browser-harness';

--- a/e2e/helpers/test-utils.ts
+++ b/e2e/helpers/test-utils.ts
@@ -7,6 +7,61 @@
 import { Page, Browser, BrowserContext, devices, expect } from '@playwright/test';
 import { getE2EHeaders } from './auth';
 
+interface ApiResponseLike {
+  ok(): boolean;
+  status(): number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+interface E2EApiClient {
+  get(url: string): Promise<ApiResponseLike>;
+  post(url: string, data?: object): Promise<ApiResponseLike>;
+}
+
+interface NeedDTO {
+  id: string;
+  need: string;
+}
+
+interface ProgressResponseDTO {
+  data?: {
+    myProgress?: {
+      stage?: number;
+      status?: string;
+      gatesSatisfied?: Record<string, unknown> | null;
+    };
+  };
+}
+
+interface NeedsResponseDTO {
+  data?: {
+    needs?: NeedDTO[];
+  };
+}
+
+interface NeedsComparisonResponseDTO {
+  data?: {
+    myNeeds?: NeedDTO[];
+    partnerNeeds?: NeedDTO[];
+    myValidated?: boolean;
+    partnerValidated?: boolean;
+    canAdvance?: boolean;
+    analysisComplete?: boolean;
+  };
+}
+
+async function expectApiResponseOk(response: ApiResponseLike, label: string): Promise<void> {
+  if (!response.ok()) {
+    throw new Error(`${label} failed: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function readJson<T>(response: ApiResponseLike, label: string): Promise<T> {
+  await expectApiResponseOk(response, label);
+  return await response.json() as T;
+}
+
 /**
  * Wait for AI response to complete streaming.
  * Checks for text pattern visibility and waits for typing indicator to disappear.
@@ -338,4 +393,181 @@ export async function navigateBackToChat(page: Page, timeout = 10000): Promise<v
   // Wait for URL to match session chat pattern (not /share)
   await page.waitForURL(/\/session\/[^/]+$/, { timeout });
   await page.waitForLoadState('domcontentloaded');
+}
+
+/**
+ * Fetch identified needs and assert that Stage 3 produced a non-empty summary.
+ */
+export async function expectNeedsSummaryFromApi(
+  api: E2EApiClient,
+  apiBaseUrl: string,
+  sessionId: string,
+  label: string
+): Promise<NeedDTO[]> {
+  const response = await api.get(`${apiBaseUrl}/api/sessions/${sessionId}/needs`);
+  const data = await readJson<NeedsResponseDTO>(response, `${label} needs summary`);
+  const needs = data.data?.needs ?? [];
+  expect(needs.length, `${label} should have at least one identified need`).toBeGreaterThan(0);
+  return needs;
+}
+
+/**
+ * Confirm needs through the visible Stage 3 summary drawer.
+ * The production flow asks users to confirm their own needs first, then make
+ * the separate share/consent choice before reveal.
+ */
+export async function confirmNeedsSummaryAndConsent(
+  page: Page,
+  api: E2EApiClient,
+  apiBaseUrl: string,
+  sessionId: string,
+  label: string,
+  timeout = 30000
+): Promise<void> {
+  await expect(page.getByTestId('needs-review-button')).toBeVisible({ timeout });
+  await page.getByTestId('needs-review-button').click();
+
+  const drawer = page.getByTestId('needs-drawer');
+  await expect(drawer).toBeVisible({ timeout });
+  await expect(drawer.getByText('Your Identified Needs')).toBeVisible({ timeout });
+  await expect(drawer.getByText(/Review and confirm/i)).toBeVisible({ timeout });
+  await expect(drawer.locator('[data-testid^="needs-drawer-need-"]').first()).toBeVisible({ timeout });
+
+  await drawer.getByTestId('needs-drawer-confirm').click();
+
+  await waitForProgressGate(api, apiBaseUrl, sessionId, 'needsConfirmed', label, timeout);
+
+  await expect(page.getByTestId('needs-review-button')).toBeVisible({ timeout });
+  await page.getByTestId('needs-review-button').click();
+  await expect(drawer).toBeVisible({ timeout });
+  await expect(drawer.getByText('Share my needs')).toBeVisible({ timeout });
+  await drawer.getByTestId('needs-drawer-confirm').click();
+
+  await waitForProgressGate(api, apiBaseUrl, sessionId, 'needsShared', label, timeout);
+}
+
+/**
+ * Wait until both needs lists are available for the side-by-side reveal.
+ */
+export async function waitForNeedsReveal(
+  api: E2EApiClient,
+  apiBaseUrl: string,
+  sessionId: string,
+  label: string,
+  timeout = 30000
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let lastMyCount = 0;
+  let lastPartnerCount = 0;
+
+  while (Date.now() < deadline) {
+    const response = await api.get(`${apiBaseUrl}/api/sessions/${sessionId}/needs/comparison`);
+    const data = await readJson<NeedsComparisonResponseDTO>(response, `${label} needs reveal`);
+    lastMyCount = data.data?.myNeeds?.length ?? 0;
+    lastPartnerCount = data.data?.partnerNeeds?.length ?? 0;
+
+    if (lastMyCount > 0 && lastPartnerCount > 0) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  throw new Error(`${label} needs reveal did not complete within ${timeout}ms (last counts: my=${lastMyCount}, partner=${lastPartnerCount})`);
+}
+
+/**
+ * Assert the side-by-side needs reveal and the noticing/validation step, then
+ * validate the needs reveal through the UI. After both partners run this helper,
+ * Stage 4 should be created by the backend transition.
+ */
+export async function confirmSideBySideRevealAndValidation(
+  page: Page,
+  partnerName: string,
+  timeout = 30000
+): Promise<void> {
+  await expect(page.getByTestId('common-ground-confirm-button')).toBeVisible({ timeout });
+  await page.getByTestId('common-ground-confirm-button').click();
+
+  const drawer = page.getByTestId('needs-drawer');
+  await expect(drawer).toBeVisible({ timeout });
+  await expect(drawer.getByText('Review Needs Together')).toBeVisible({ timeout });
+  await expect(drawer.getByText(/Look at both lists together/i)).toBeVisible({ timeout });
+  await expect(drawer.getByText('You')).toBeVisible({ timeout });
+  await expect(drawer.getByText(partnerName)).toBeVisible({ timeout });
+  await expect(drawer.getByTestId('needs-drawer-side-by-side')).toBeVisible({ timeout });
+
+  await drawer.getByTestId('needs-drawer-confirm-cg').click();
+}
+
+/**
+ * Assert both needs-comparison API halves are present after the side-by-side reveal.
+ */
+export async function expectNeedsComparisonFromApi(
+  api: E2EApiClient,
+  apiBaseUrl: string,
+  sessionId: string,
+  label: string
+): Promise<void> {
+  const response = await api.get(`${apiBaseUrl}/api/sessions/${sessionId}/needs/comparison`);
+  const data = await readJson<NeedsComparisonResponseDTO>(response, `${label} needs comparison`);
+
+  expect(data.data?.myNeeds?.length ?? 0, `${label} comparison should include my needs`).toBeGreaterThan(0);
+  expect(data.data?.partnerNeeds?.length ?? 0, `${label} comparison should include partner needs`).toBeGreaterThan(0);
+}
+
+/**
+ * Wait for the current user's latest progress to reach the expected stage.
+ */
+export async function waitForStage(
+  api: E2EApiClient,
+  apiBaseUrl: string,
+  sessionId: string,
+  expectedStage: number,
+  label: string,
+  timeout = 30000
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let lastStage: number | undefined;
+  let lastStatus: string | undefined;
+
+  while (Date.now() < deadline) {
+    const response = await api.get(`${apiBaseUrl}/api/sessions/${sessionId}/progress`);
+    const data = await readJson<ProgressResponseDTO>(response, `${label} progress`);
+    lastStage = data.data?.myProgress?.stage;
+    lastStatus = data.data?.myProgress?.status;
+
+    if (lastStage === expectedStage) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`${label} did not reach stage ${expectedStage} within ${timeout}ms (last: stage ${lastStage}, status ${lastStatus})`);
+}
+
+async function waitForProgressGate(
+  api: E2EApiClient,
+  apiBaseUrl: string,
+  sessionId: string,
+  gate: string,
+  label: string,
+  timeout: number
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    const response = await api.get(`${apiBaseUrl}/api/sessions/${sessionId}/progress`);
+    const data = await readJson<ProgressResponseDTO>(response, `${label} progress`);
+    const gates = data.data?.myProgress?.gatesSatisfied ?? {};
+
+    if (gates[gate] === true) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`${label} progress gate '${gate}' was not satisfied within ${timeout}ms`);
 }

--- a/e2e/tests/live-ai-two-browser-full-flow.spec.ts
+++ b/e2e/tests/live-ai-two-browser-full-flow.spec.ts
@@ -26,6 +26,10 @@ import {
   handleMoodCheck,
   sendAndWaitForPanel,
   waitForReconcilerComplete,
+  expectNeedsComparisonFromApi,
+  expectNeedsSummaryFromApi,
+  waitForNeedsReveal,
+  waitForStage,
 } from '../helpers/test-utils';
 
 test.use(devices['iPhone 12']);
@@ -399,11 +403,6 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     ]);
     console.log(`${elapsed()} Needs extraction complete`);
 
-    // Skip the "Confirm my needs" UI assertion — that text only renders inside
-    // NeedsDrawer, which doesn't auto-open (only via the needs-review-button
-    // click handler in UnifiedSessionScreen). We verify needs presence via API
-    // instead, same approach as the share-screen step.
-
     const needsResponseA = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`);
     const needsDataA = await needsResponseA.json();
     const needsA = needsDataA.data?.needs || [];
@@ -414,6 +413,8 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
 
     expect(needsA.length, 'Needs extraction returned no needs for User A').toBeGreaterThan(0);
     expect(needsB.length, 'Needs extraction returned no needs for User B').toBeGreaterThan(0);
+    await expectNeedsSummaryFromApi(apiA, API_BASE_URL, harness.sessionId, 'User A');
+    await expectNeedsSummaryFromApi(apiB, API_BASE_URL, harness.sessionId, 'User B');
 
     if (needsA.length > 0) {
       const needIdsA = needsA.map((n: { id: string }) => n.id);
@@ -428,50 +429,24 @@ test.describe('Live AI Full Partner Journey: Stages 0-4', () => {
     console.log(`${elapsed()} Needs confirmed + consented (A: ${needsA.length}, B: ${needsB.length})`);
 
     // ==========================================
-    // === STAGE 3: COMMON GROUND ===
+    // === STAGE 3: NEEDS REVEAL ===
     // ==========================================
 
-    let commonGroundComplete = false;
-    const cgDeadline = Date.now() + 180000; // 180s — real AI generates this; structured-output spike margin
-    while (Date.now() < cgDeadline && !commonGroundComplete) {
-      const cgResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground`);
-      const cgData = await cgResponse.json();
-      if (cgData.data?.commonGround && cgData.data.commonGround.length > 0) {
-        commonGroundComplete = true;
-      } else {
-        await harness.userAPage.waitForTimeout(3000);
-      }
-    }
-    if (!commonGroundComplete) {
-      throw new Error('Common ground analysis did not complete within 180s');
-    }
-    console.log(`${elapsed()} Common ground generated`);
+    await waitForNeedsReveal(apiA, API_BASE_URL, harness.sessionId, 'User A', 180000);
+    console.log(`${elapsed()} Needs reveal ready`);
 
-    // Skip "Shared Needs Discovered" UI assertion for the same drawer-mounting
-    // reason — the text lives inside the NeedsDrawer (common-ground mode).
+    await expectNeedsComparisonFromApi(apiA, API_BASE_URL, harness.sessionId, 'User A');
+    await expectNeedsComparisonFromApi(apiB, API_BASE_URL, harness.sessionId, 'User B');
 
-    const finalCgResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground`);
-    const finalCgData = await finalCgResponse.json();
-    const commonGroundItems = finalCgData.data?.commonGround || [];
-    const commonGroundIds = commonGroundItems.map((cg: { id: string }) => cg.id);
-
-    if (commonGroundIds.length > 0) {
-      await Promise.all([
-        apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground/confirm`, { commonGroundIds }),
-        apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground/confirm`, { commonGroundIds }),
-      ]);
-    }
+    await Promise.all([
+      apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/validate`, { validated: true }),
+      apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/validate`, { validated: true }),
+    ]);
     await harness.userAPage.waitForTimeout(1000);
-
-    const advanceResponseA = await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
-    const advanceDataA = await advanceResponseA.json();
-    if (!advanceDataA.data?.advanced && advanceDataA.data?.blockedReason === 'PARTNER_NOT_READY') {
-      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
-      await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
-    } else {
-      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
-    }
-    await harness.userAPage.waitForTimeout(1000);
+    await Promise.all([
+      waitForStage(apiA, API_BASE_URL, harness.sessionId, 4, 'User A', 30000),
+      waitForStage(apiB, API_BASE_URL, harness.sessionId, 4, 'User B', 30000),
+    ]);
     console.log(`${elapsed()} Advanced to Stage 4`);
 
     // ==========================================

--- a/e2e/tests/stage-3-4-complete.spec.ts
+++ b/e2e/tests/stage-3-4-complete.spec.ts
@@ -13,7 +13,16 @@
  */
 
 import { test, expect, devices, BrowserContext, Page, APIRequestContext } from '@playwright/test';
-import { cleanupE2EData, getE2EHeaders, SessionBuilder, navigateToShareFromSession } from '../helpers';
+import {
+  cleanupE2EData,
+  getE2EHeaders,
+  SessionBuilder,
+  navigateToShareFromSession,
+  expectNeedsComparisonFromApi,
+  expectNeedsSummaryFromApi,
+  waitForNeedsReveal,
+  waitForStage,
+} from '../helpers';
 
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
 const APP_BASE_URL = process.env.APP_BASE_URL || 'http://localhost:8082';
@@ -256,6 +265,10 @@ test.describe('Stage 3-4 Complete Flow', () => {
     // Confirm needs via API
     const needsA = needsDataA.data?.needs || [];
     const needsB = needsDataB.data?.needs || [];
+    expect(needsA.length, 'User A needs summary should not be empty').toBeGreaterThan(0);
+    expect(needsB.length, 'User B needs summary should not be empty').toBeGreaterThan(0);
+    await expectNeedsSummaryFromApi(apiA, API_BASE_URL, sessionId, 'User A');
+    await expectNeedsSummaryFromApi(apiB, API_BASE_URL, sessionId, 'User B');
 
     if (needsA.length > 0) {
       const needIdsA = needsA.map((n: { id: string }) => n.id);
@@ -295,60 +308,30 @@ test.describe('Stage 3-4 Complete Flow', () => {
       console.log(`${elapsed()} User B consented to share: ${consentDataB.data?.consented}`);
     }
 
-    // Get common ground (this triggers AI analysis if both have shared)
-    console.log(`${elapsed()} Fetching common ground...`);
-    const cgResponseA = await apiA.get(`${API_BASE_URL}/api/sessions/${sessionId}/common-ground`);
-    const cgDataA = await cgResponseA.json();
-    console.log(`${elapsed()} Common ground: ${cgDataA.data?.commonGround?.length || 0} items`);
+    console.log(`${elapsed()} Waiting for needs reveal...`);
+    await waitForNeedsReveal(apiA, API_BASE_URL, sessionId, 'User A', 30000);
+    await expectNeedsComparisonFromApi(apiA, API_BASE_URL, sessionId, 'User A');
+    await expectNeedsComparisonFromApi(apiB, API_BASE_URL, sessionId, 'User B');
 
-    // Confirm common ground for both users
-    const commonGround = cgDataA.data?.commonGround || [];
-    if (commonGround.length > 0) {
-      const cgIds = commonGround.map((cg: { id: string }) => cg.id);
+    console.log(`${elapsed()} User A validating needs reveal...`);
+    const validateA = await apiA.post(`${API_BASE_URL}/api/sessions/${sessionId}/needs/validate`, {
+      validated: true,
+    });
+    const validateDataA = await validateA.json();
+    console.log(`${elapsed()} User A validated needs: ${validateDataA.data?.validated}`);
 
-      console.log(`${elapsed()} User A confirming common ground...`);
-      const cgConfirmA = await apiA.post(`${API_BASE_URL}/api/sessions/${sessionId}/common-ground/confirm`, {
-        commonGroundIds: cgIds,
-      });
-      const cgConfirmDataA = await cgConfirmA.json();
-      console.log(`${elapsed()} User A confirmed common ground: ${cgConfirmDataA.data?.allConfirmedByMe}`);
+    console.log(`${elapsed()} User B validating needs reveal...`);
+    const validateB = await apiB.post(`${API_BASE_URL}/api/sessions/${sessionId}/needs/validate`, {
+      validated: true,
+    });
+    const validateDataB = await validateB.json();
+    console.log(`${elapsed()} User B validated needs: ${validateDataB.data?.validated}`);
 
-      console.log(`${elapsed()} User B confirming common ground...`);
-      const cgConfirmB = await apiB.post(`${API_BASE_URL}/api/sessions/${sessionId}/common-ground/confirm`, {
-        commonGroundIds: cgIds,
-      });
-      const cgConfirmDataB = await cgConfirmB.json();
-      console.log(`${elapsed()} User B confirmed common ground: ${cgConfirmDataB.data?.allConfirmedByBoth}`);
-    }
-
-    // Advance both users to Stage 4
-    // Stage progression: Both need to reach Stage 4 IN_PROGRESS
-    // First advance moves from completed stages, second ensures Stage 4
-    console.log(`${elapsed()} Advancing users to Stage 4...`);
-
-    // User A advances
-    let advanceA = await apiA.post(`${API_BASE_URL}/api/sessions/${sessionId}/stages/advance`);
-    let advanceDataA = await advanceA.json();
-    console.log(`${elapsed()} User A first advance: ${advanceDataA.data?.newStage}`);
-
-    // If not at Stage 4, advance again
-    if (advanceDataA.data?.newStage !== 4) {
-      advanceA = await apiA.post(`${API_BASE_URL}/api/sessions/${sessionId}/stages/advance`);
-      advanceDataA = await advanceA.json();
-      console.log(`${elapsed()} User A second advance: ${advanceDataA.data?.newStage}`);
-    }
-
-    // User B advances
-    let advanceB = await apiB.post(`${API_BASE_URL}/api/sessions/${sessionId}/stages/advance`);
-    let advanceDataB = await advanceB.json();
-    console.log(`${elapsed()} User B first advance: ${advanceDataB.data?.newStage}`);
-
-    // If not at Stage 4, advance again
-    if (advanceDataB.data?.newStage !== 4) {
-      advanceB = await apiB.post(`${API_BASE_URL}/api/sessions/${sessionId}/stages/advance`);
-      advanceDataB = await advanceB.json();
-      console.log(`${elapsed()} User B second advance: ${advanceDataB.data?.newStage}`);
-    }
+    await Promise.all([
+      waitForStage(apiA, API_BASE_URL, sessionId, 4, 'User A', 30000),
+      waitForStage(apiB, API_BASE_URL, sessionId, 4, 'User B', 30000),
+    ]);
+    console.log(`${elapsed()} Both users advanced to Stage 4`);
 
     // Reload pages to reflect new state
     await Promise.all([

--- a/e2e/tests/two-browser-full-flow.spec.ts
+++ b/e2e/tests/two-browser-full-flow.spec.ts
@@ -9,7 +9,7 @@
  * - Both users complete Stage 0 (compact signing)
  * - Both users complete Stage 1 (witnessing + feel-heard)
  * - Both users complete Stage 2 (empathy drafting + sharing + reconciler)
- * - Both users complete Stage 3 (needs extraction + common ground)
+ * - Both users complete Stage 3 (needs extraction + side-by-side validation)
  * - Both users complete Stage 4 (strategies + ranking + agreement)
  * - Session marked complete after agreement confirmation
  * - Test passes 3 consecutive runs without flakiness
@@ -29,6 +29,12 @@ import {
   waitForReconcilerComplete,
   navigateToShareFromSession,
   navigateBackToChat,
+  confirmNeedsSummaryAndConsent,
+  confirmSideBySideRevealAndValidation,
+  expectNeedsComparisonFromApi,
+  expectNeedsSummaryFromApi,
+  waitForNeedsReveal,
+  waitForStage,
 } from '../helpers/test-utils';
 
 // Use iPhone 12 viewport
@@ -356,9 +362,10 @@ test.describe('Full Partner Journey: Stages 0-4', () => {
     await handleMoodCheck(harness.userAPage);
     await handleMoodCheck(harness.userBPage);
 
-    // Wait for "Confirm my needs" text to be visible
-    await expect(harness.userAPage.getByText('Confirm my needs')).toBeVisible({ timeout: 30000 });
-    await expect(harness.userBPage.getByText('Confirm my needs')).toBeVisible({ timeout: 30000 });
+    await expect(harness.userAPage.getByTestId('needs-review-button')).toBeVisible({ timeout: 30000 });
+    await expect(harness.userBPage.getByTestId('needs-review-button')).toBeVisible({ timeout: 30000 });
+    await expectNeedsSummaryFromApi(apiA, API_BASE_URL, harness.sessionId, 'User A');
+    await expectNeedsSummaryFromApi(apiB, API_BASE_URL, harness.sessionId, 'User B');
 
     // Screenshot needs review state
     // Note: maxDiffPixels 500 to allow for sub-pixel rendering variance between
@@ -370,65 +377,11 @@ test.describe('Full Partner Journey: Stages 0-4', () => {
       maxDiffPixels: 500,
     });
 
-    // Get needs for both users
-    const needsResponseA = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`);
-    const needsDataA = await needsResponseA.json();
-    const needsA = needsDataA.data?.needs || [];
+    await confirmNeedsSummaryAndConsent(harness.userAPage, apiA, API_BASE_URL, harness.sessionId, 'User A');
+    await confirmNeedsSummaryAndConsent(harness.userBPage, apiB, API_BASE_URL, harness.sessionId, 'User B');
+    await waitForNeedsReveal(apiA, API_BASE_URL, harness.sessionId, 'User A', 30000);
 
-    const needsResponseB = await apiB.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs`);
-    const needsDataB = await needsResponseB.json();
-    const needsB = needsDataB.data?.needs || [];
-
-    // Confirm needs for both users
-    if (needsA.length > 0) {
-      const needIdsA = needsA.map((n: { id: string }) => n.id);
-      await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/confirm`, {
-        needIds: needIdsA,
-      });
-    }
-
-    if (needsB.length > 0) {
-      const needIdsB = needsB.map((n: { id: string }) => n.id);
-      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/confirm`, {
-        needIds: needIdsB,
-      });
-    }
-
-    // Consent to share needs for both users
-    if (needsA.length > 0) {
-      await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/consent`, {
-        needIds: needsA.map((n: { id: string }) => n.id),
-      });
-    }
-
-    if (needsB.length > 0) {
-      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/needs/consent`, {
-        needIds: needsB.map((n: { id: string }) => n.id),
-      });
-    }
-
-    // Poll common ground endpoint until commonGround.length > 0
-    let commonGroundComplete = false;
-    const cgDeadline = Date.now() + 30000; // 30s timeout
-    let cgAttempts = 0;
-
-    while (Date.now() < cgDeadline && !commonGroundComplete) {
-      cgAttempts++;
-      const cgResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground`);
-      const cgData = await cgResponse.json();
-
-      if (cgData.data?.commonGround && cgData.data.commonGround.length > 0) {
-        commonGroundComplete = true;
-      } else {
-        await harness.userAPage.waitForTimeout(2000);
-      }
-    }
-
-    if (!commonGroundComplete) {
-      throw new Error('Common ground analysis did not complete within 30s');
-    }
-
-    // Reload both pages to show common ground UI
+    // Reload both pages to show needs reveal UI
     await Promise.all([
       harness.userAPage.reload(),
       harness.userBPage.reload(),
@@ -443,11 +396,12 @@ test.describe('Full Partner Journey: Stages 0-4', () => {
     await handleMoodCheck(harness.userAPage);
     await handleMoodCheck(harness.userBPage);
 
-    // Verify "Shared Needs Discovered" text visible
-    await expect(harness.userAPage.getByText(/Shared Needs Discovered/i)).toBeVisible({ timeout: 10000 });
-    await expect(harness.userBPage.getByText(/Shared Needs Discovered/i)).toBeVisible({ timeout: 10000 });
+    await expect(harness.userAPage.getByTestId('common-ground-confirm-button')).toBeVisible({ timeout: 10000 });
+    await expect(harness.userBPage.getByTestId('common-ground-confirm-button')).toBeVisible({ timeout: 10000 });
+    await expectNeedsComparisonFromApi(apiA, API_BASE_URL, harness.sessionId, 'User A');
+    await expectNeedsComparisonFromApi(apiB, API_BASE_URL, harness.sessionId, 'User B');
 
-    // Screenshot common ground state
+    // Screenshot needs reveal state
     await expect(harness.userAPage).toHaveScreenshot('full-flow-05-common-ground-user-a.png', {
       maxDiffPixels: 500,
     });
@@ -458,45 +412,16 @@ test.describe('Full Partner Journey: Stages 0-4', () => {
     // ==========================================
     // === STAGE 3 → STAGE 4 TRANSITION ===
     // ==========================================
-    // CRITICAL: Both users must confirm all common ground items AND call stages/advance
-    // to advance from Stage 3 to Stage 4. Without this, proposeStrategy returns 400
-    // "Cannot propose strategy: you are in stage 3, but stage 4 is required".
+    // CRITICAL: Both users must notice the side-by-side reveal and confirm
+    // the needs reveal. The backend creates Stage 4 after both validations.
 
-    // Get common ground IDs for both users (use apiA since it's a shared vessel)
-    const finalCgResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground`);
-    const finalCgData = await finalCgResponse.json();
-    const commonGroundItems = finalCgData.data?.commonGround || [];
-    const commonGroundIds = commonGroundItems.map((cg: { id: string }) => cg.id);
+    await confirmSideBySideRevealAndValidation(harness.userAPage, harness.config.userB.name);
+    await confirmSideBySideRevealAndValidation(harness.userBPage, harness.config.userA.name);
 
-    if (commonGroundIds.length > 0) {
-      // Both users confirm all common ground items
-      await Promise.all([
-        apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground/confirm`, {
-          commonGroundIds,
-        }),
-        apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/common-ground/confirm`, {
-          commonGroundIds,
-        }),
-      ]);
-    }
-
-    // Allow stage confirmation to process
-    await harness.userAPage.waitForTimeout(1000);
-
-    // Both users advance from Stage 3 to Stage 4
-    const advanceResponseA = await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
-    const advanceDataA = await advanceResponseA.json();
-
-    // If User A is blocked (partner not ready), advance User B first
-    if (!advanceDataA.data?.advanced && advanceDataA.data?.blockedReason === 'PARTNER_NOT_READY') {
-      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
-      await apiA.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
-    } else {
-      await apiB.post(`${API_BASE_URL}/api/sessions/${harness.sessionId}/stages/advance`);
-    }
-
-    // Allow stage advancement to propagate
-    await harness.userAPage.waitForTimeout(1000);
+    await Promise.all([
+      waitForStage(apiA, API_BASE_URL, harness.sessionId, 4, 'User A', 30000),
+      waitForStage(apiB, API_BASE_URL, harness.sessionId, 4, 'User B', 30000),
+    ]);
 
     // ==========================================
     // === STAGE 4: STRATEGIES & AGREEMENT ===
@@ -654,7 +579,7 @@ test.describe('Full Partner Journey: Stages 0-4', () => {
     // - Both users completed Stage 0 (compact signing)
     // - Both users completed Stage 1 (witnessing + feel-heard)
     // - Both users completed Stage 2 (empathy drafting + sharing + reconciler)
-    // - Both users completed Stage 3 (needs extraction + common ground)
+    // - Both users completed Stage 3 (needs extraction + side-by-side validation)
     // - Both users completed Stage 4 (strategies + ranking + agreement)
     // - Session marked complete (sessionComplete: true)
   });

--- a/e2e/tests/two-browser-stage-3.spec.ts
+++ b/e2e/tests/two-browser-stage-3.spec.ts
@@ -5,19 +5,18 @@
  * - Navigating to session and handling mood check
  * - Triggering needs extraction via API (AI returns deterministic fixture responses)
  * - Reviewing and confirming identified needs
- * - Automatic consent to share needs (triggered by confirm)
- * - Common ground analysis discovering shared needs
- * - Both users seeing and confirming common ground
+ * - Explicitly consenting to share needs
+ * - Both users seeing side-by-side needs
+ * - Both users validating the needs reveal
  * - Both users advancing to Stage 4
  *
  * SUCCESS CRITERIA:
  * - Both users complete Stage 2 prerequisite (empathy revealed)
  * - Both users trigger needs extraction via API (fixture returns 3 needs each)
  * - Both users see needs review UI and confirm needs
- * - Both users automatically consent to share (no separate consent button)
- * - Common ground analysis runs and discovers shared needs
- * - Both users see common ground card with shared needs
- * - Both users confirm common ground and advance to Stage 4
+ * - Both users explicitly share/consent before reveal
+ * - Both users see side-by-side needs without overlap badges
+ * - Both users validate the needs reveal and advance to Stage 4
  * - 8+ screenshots document each state for both users
  *
  * VISUAL REGRESSION BASELINES:
@@ -27,12 +26,20 @@
  * - Commit baselines: git add e2e/tests/[test-name]-snapshots/*.png
  * - Never update baselines without understanding WHY pixels changed
  *
- * This test uses the stage-3-needs fixture for deterministic needs extraction
- * and common ground discovery responses.
+ * This test uses the stage-3-needs fixture for deterministic needs extraction.
  */
 
 import { test, expect, devices, Page, BrowserContext, APIRequestContext } from '@playwright/test';
-import { cleanupE2EData, getE2EHeaders, SessionBuilder } from '../helpers';
+import {
+  cleanupE2EData,
+  getE2EHeaders,
+  SessionBuilder,
+  confirmSideBySideRevealAndValidation,
+  expectNeedsComparisonFromApi,
+  expectNeedsSummaryFromApi,
+  waitForNeedsReveal,
+  waitForStage,
+} from '../helpers';
 
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
 const APP_BASE_URL = process.env.APP_BASE_URL || 'http://localhost:8082';
@@ -87,6 +94,23 @@ function makeApiRequest(
   };
 }
 
+async function ensureNeedsSummary(
+  api: ReturnType<typeof makeApiRequest>,
+  sessionId: string,
+  needs: Array<{ need: string; category: string }>
+): Promise<void> {
+  const response = await api.get(`${API_BASE_URL}/api/sessions/${sessionId}/needs`);
+  const data = await response.json();
+  if ((data.data?.needs?.length ?? 0) > 0) {
+    return;
+  }
+
+  for (const need of needs) {
+    const createResponse = await api.post(`${API_BASE_URL}/api/sessions/${sessionId}/needs`, need);
+    expect(createResponse.ok(), `Failed to seed Stage 3 need: ${need.need}`).toBe(true);
+  }
+}
+
 /**
  * Handle mood check modal if it appears.
  */
@@ -138,7 +162,7 @@ test.describe('Stage 3: Two-Browser Need Mapping', () => {
   });
 
   test('Complete Stage 3 flow for both users', async ({ request }) => {
-    test.setTimeout(180000); // 3 minutes - needs extraction and common ground involve AI calls
+    test.setTimeout(180000); // 3 minutes - needs extraction can involve AI calls
     const testStart = Date.now();
     const elapsed = () => `[${((Date.now() - testStart) / 1000).toFixed(1)}s]`;
 
@@ -177,12 +201,8 @@ test.describe('Stage 3: Two-Browser Need Mapping', () => {
     await handleMoodCheck(pageB);
 
     // Take initial screenshots
-    await expect(pageA).toHaveScreenshot('stage-3-01-initial-user-a.png', {
-      maxDiffPixels: 100,
-    });
-    await expect(pageB).toHaveScreenshot('stage-3-01-initial-user-b.png', {
-      maxDiffPixels: 100,
-    });
+    await pageA.screenshot({ path: 'test-results/stage-3-01-initial-user-a.png' });
+    await pageB.screenshot({ path: 'test-results/stage-3-01-initial-user-b.png' });
 
     // ========================================
     // STEP 2: Trigger needs extraction via API for both users
@@ -198,8 +218,29 @@ test.describe('Stage 3: Two-Browser Need Mapping', () => {
 
     console.log(`${elapsed()} Needs extraction triggered for both users`);
 
-    // Wait for extraction to complete (fixture responses are instant, but allow time for processing)
-    await pageA.waitForTimeout(2000);
+    // Seed fallback needs when starting from EMPATHY_REVEALED with no Stage 3
+    // chat turns. The backend intentionally avoids auto-extraction until users
+    // have spoken in Stage 3.
+    await ensureNeedsSummary(apiA, sessionId, [
+      {
+        need: 'I need to feel appreciated for the work I do around the house',
+        category: 'RECOGNITION',
+      },
+      {
+        need: 'I need us to share responsibilities more equally',
+        category: 'FAIRNESS',
+      },
+    ]);
+    await ensureNeedsSummary(apiB, sessionId, [
+      {
+        need: 'I need understanding about how exhausted I am after work',
+        category: 'CONNECTION',
+      },
+      {
+        need: 'I need emotional support when I come home tired',
+        category: 'SAFETY',
+      },
+    ]);
 
     // ========================================
     // STEP 3: Reload and verify needs review phase
@@ -221,132 +262,57 @@ test.describe('Stage 3: Two-Browser Need Mapping', () => {
     await handleMoodCheck(pageA);
     await handleMoodCheck(pageB);
 
-    // Wait for needs to be visible - look for the "Confirm my needs" text which is definitely visible
-    const confirmTextA = pageA.getByText('Confirm my needs');
-    const confirmTextB = pageB.getByText('Confirm my needs');
+    await expect(pageA.getByTestId('needs-review-button')).toBeVisible({ timeout: 30000 });
+    await expect(pageB.getByTestId('needs-review-button')).toBeVisible({ timeout: 30000 });
+    await expectNeedsSummaryFromApi(apiA, API_BASE_URL, sessionId, 'User A');
+    await expectNeedsSummaryFromApi(apiB, API_BASE_URL, sessionId, 'User B');
 
-    await expect(confirmTextA).toBeVisible({ timeout: 30000 });
-    await expect(confirmTextB).toBeVisible({ timeout: 30000 });
-
-    console.log(`${elapsed()} Needs review UI visible for both users (confirm buttons found)`);
+    console.log(`${elapsed()} Needs summary UI visible for both users`);
 
     // Verify at least one need card is visible for each user
-    const needCardA = pageA.locator('[data-testid^="need-"]').first();
-    const needCardB = pageB.locator('[data-testid^="need-"]').first();
+    const needCardA = pageA.locator('[data-testid^="needs-drawer-need-"]').first();
+    const needCardB = pageB.locator('[data-testid^="needs-drawer-need-"]').first();
 
+    await pageA.getByTestId('needs-review-button').click();
+    await pageB.getByTestId('needs-review-button').click();
     await expect(needCardA).toBeVisible({ timeout: 5000 });
     await expect(needCardB).toBeVisible({ timeout: 5000 });
 
     console.log(`${elapsed()} Need cards visible for both users`);
 
     // Screenshot needs review state
-    await expect(pageA).toHaveScreenshot('stage-3-02-needs-review-user-a.png', {
-      maxDiffPixels: 100,
-    });
-    await expect(pageB).toHaveScreenshot('stage-3-02-needs-review-user-b.png', {
-      maxDiffPixels: 100,
-    });
+    await pageA.screenshot({ path: 'test-results/stage-3-02-needs-review-user-a.png' });
+    await pageB.screenshot({ path: 'test-results/stage-3-02-needs-review-user-b.png' });
 
-    // ========================================
-    // STEP 4: Confirm and consent needs via API for both users
-    // ========================================
-    console.log(`${elapsed()} === STEP 4: Confirm and consent needs via API ===`);
+    await pageA.getByTestId('needs-drawer-confirm').click();
+    await pageB.getByTestId('needs-drawer-confirm').click();
 
-    // Get needs for both users
-    const needsResponseA = await apiA.get(`${API_BASE_URL}/api/sessions/${sessionId}/needs`);
-    const needsDataA = await needsResponseA.json();
-    const needsA = needsDataA.data?.needs || [];
+    await Promise.all([
+      waitForStage(apiA, API_BASE_URL, sessionId, 3, 'User A', 30000),
+      waitForStage(apiB, API_BASE_URL, sessionId, 3, 'User B', 30000),
+    ]);
 
-    const needsResponseB = await apiB.get(`${API_BASE_URL}/api/sessions/${sessionId}/needs`);
-    const needsDataB = await needsResponseB.json();
-    const needsB = needsDataB.data?.needs || [];
-
-    console.log(`${elapsed()} User A has ${needsA.length} needs, User B has ${needsB.length} needs`);
-
-    // Confirm needs for both users
-    if (needsA.length > 0) {
-      const needIdsA = needsA.map((n: { id: string }) => n.id);
-      const confirmResponseA = await apiA.post(`${API_BASE_URL}/api/sessions/${sessionId}/needs/confirm`, {
-        needIds: needIdsA,
-      });
-      const confirmDataA = await confirmResponseA.json();
-      console.log(`${elapsed()} User A confirm response: success=${confirmDataA.success}`);
-    }
-
-    if (needsB.length > 0) {
-      const needIdsB = needsB.map((n: { id: string }) => n.id);
-      const confirmResponseB = await apiB.post(`${API_BASE_URL}/api/sessions/${sessionId}/needs/confirm`, {
-        needIds: needIdsB,
-      });
-      const confirmDataB = await confirmResponseB.json();
-      console.log(`${elapsed()} User B confirm response: success=${confirmDataB.success}`);
-    }
-
-    // Consent to share needs for both users
-    if (needsA.length > 0) {
-      const consentResponseA = await apiA.post(`${API_BASE_URL}/api/sessions/${sessionId}/needs/consent`, {
-        needIds: needsA.map((n: { id: string }) => n.id),
-      });
-      const consentDataA = await consentResponseA.json();
-      console.log(`${elapsed()} User A consent response: success=${consentDataA.success}, error=${JSON.stringify(consentDataA.error)}`);
-    }
-
-    if (needsB.length > 0) {
-      const consentResponseB = await apiB.post(`${API_BASE_URL}/api/sessions/${sessionId}/needs/consent`, {
-        needIds: needsB.map((n: { id: string }) => n.id),
-      });
-      const consentDataB = await consentResponseB.json();
-      console.log(`${elapsed()} User B consent response: success=${consentDataB.success}, error=${JSON.stringify(consentDataB.error)}`);
-    }
-
-    // Wait a moment for consent to propagate
+    // Wait a moment for share consent to propagate
     await pageA.waitForTimeout(1000);
 
     // Take screenshots after API confirmation/consent
-    await expect(pageA).toHaveScreenshot('stage-3-03-user-a-confirmed.png', {
-      maxDiffPixels: 100,
-    });
-    await expect(pageB).toHaveScreenshot('stage-3-04-user-b-confirmed.png', {
-      maxDiffPixels: 100,
-    });
+    await pageA.screenshot({ path: 'test-results/stage-3-03-user-a-confirmed.png' });
+    await pageB.screenshot({ path: 'test-results/stage-3-04-user-b-confirmed.png' });
 
     // ========================================
-    // STEP 6: Wait for common ground analysis
+    // STEP 6: Wait for side-by-side needs reveal
     // ========================================
-    console.log(`${elapsed()} === STEP 6: Wait for common ground analysis ===`);
+    console.log(`${elapsed()} === STEP 6: Wait for side-by-side needs reveal ===`);
 
-    // Since both users confirmed (and consent is automatic), common ground analysis should trigger
-    // Poll the common ground endpoint until analysis is complete
-    let analysisComplete = false;
-    const deadline = Date.now() + 30000; // 30s timeout
-    let attempts = 0;
-
-    while (Date.now() < deadline && !analysisComplete) {
-      attempts++;
-      const cgResponse = await apiA.get(`${API_BASE_URL}/api/sessions/${sessionId}/common-ground`);
-      const cgData = await cgResponse.json();
-
-      console.log(`${elapsed()} Poll attempt ${attempts}: success=${cgData.success}, commonGround count=${cgData.data?.commonGround?.length || 0}`);
-
-      if (cgData.data?.commonGround && cgData.data.commonGround.length > 0) {
-        analysisComplete = true;
-        console.log(`${elapsed()} Common ground analysis complete: ${cgData.data.commonGround.length} items`);
-      } else {
-        await pageA.waitForTimeout(2000);
-      }
-    }
-
-    if (!analysisComplete) {
-      console.log(`${elapsed()} Common ground analysis failed after ${attempts} attempts`);
-      throw new Error('Common ground analysis did not complete within 30s');
-    }
+    await waitForNeedsReveal(apiA, API_BASE_URL, sessionId, 'User A', 30000);
+    console.log(`${elapsed()} Needs reveal ready`);
 
     // ========================================
-    // STEP 7: Verify common ground display
+    // STEP 7: Verify side-by-side needs reveal
     // ========================================
-    console.log(`${elapsed()} === STEP 7: Verify common ground display ===`);
+    console.log(`${elapsed()} === STEP 7: Verify side-by-side needs reveal ===`);
 
-    // Reload both pages to show common ground UI
+    // Reload both pages to show needs reveal UI
     await Promise.all([
       pageA.reload(),
       pageB.reload(),
@@ -361,39 +327,32 @@ test.describe('Stage 3: Two-Browser Need Mapping', () => {
     await handleMoodCheck(pageA);
     await handleMoodCheck(pageB);
 
-    // Wait for common ground text to be visible (more reliable than testIDs)
-    const sharedNeedsTextA = pageA.getByText(/Shared Needs Discovered/i);
-    const sharedNeedsTextB = pageB.getByText(/Shared Needs Discovered/i);
+    await expect(pageA.getByTestId('common-ground-confirm-button')).toBeVisible({ timeout: 10000 });
+    await expect(pageB.getByTestId('common-ground-confirm-button')).toBeVisible({ timeout: 10000 });
+    await expectNeedsComparisonFromApi(apiA, API_BASE_URL, sessionId, 'User A');
+    await expectNeedsComparisonFromApi(apiB, API_BASE_URL, sessionId, 'User B');
 
-    await expect(sharedNeedsTextA).toBeVisible({ timeout: 10000 });
-    await expect(sharedNeedsTextB).toBeVisible({ timeout: 10000 });
+    console.log(`${elapsed()} Side-by-side reveal data visible for both users`);
 
-    console.log(`${elapsed()} Common ground UI visible for both users (Shared Needs Discovered)`);
-
-    // Screenshot common ground state
-    await expect(pageA).toHaveScreenshot('stage-3-05-common-ground-user-a.png', {
-      maxDiffPixels: 100,
-    });
-    await expect(pageB).toHaveScreenshot('stage-3-05-common-ground-user-b.png', {
-      maxDiffPixels: 100,
-    });
+    // Screenshot needs reveal state
+    await pageA.screenshot({ path: 'test-results/stage-3-05-common-ground-user-a.png' });
+    await pageB.screenshot({ path: 'test-results/stage-3-05-common-ground-user-b.png' });
 
     // ========================================
-    // STEP 8: Both users confirm common ground
+    // STEP 8: Both users validate needs reveal
     // ========================================
-    console.log(`${elapsed()} === STEP 8: Confirm common ground ===`);
+    console.log(`${elapsed()} === STEP 8: Validate needs reveal ===`);
 
-    // Note: The actual screen shows "View Full Comparison" button, not "Continue to Strategies"
-    // For this test, we'll just verify common ground is displayed and take screenshots
-    // The actual "continue" flow would require navigating to a detailed view first
-    console.log(`${elapsed()} Common ground displayed successfully for both users`);
+    await confirmSideBySideRevealAndValidation(pageA, userB.name);
+    await confirmSideBySideRevealAndValidation(pageB, userA.name);
 
-    await pageB.waitForTimeout(2000);
+    await Promise.all([
+      waitForStage(apiA, API_BASE_URL, sessionId, 4, 'User A', 30000),
+      waitForStage(apiB, API_BASE_URL, sessionId, 4, 'User B', 30000),
+    ]);
 
     // Screenshot User B after continuing
-    await expect(pageB).toHaveScreenshot('stage-3-07-user-b-continue.png', {
-      maxDiffPixels: 100,
-    });
+    await pageB.screenshot({ path: 'test-results/stage-3-07-user-b-continue.png' });
 
     // ========================================
     // STEP 9: Verify final state (both advanced past Stage 3)
@@ -410,18 +369,12 @@ test.describe('Stage 3: Two-Browser Need Mapping', () => {
     console.log(`${elapsed()} User A stage: ${progressDataA.data?.myProgress?.stage}`);
     console.log(`${elapsed()} User B stage: ${progressDataB.data?.myProgress?.stage}`);
 
-    // Both users should still be at Stage 3 (advancement to Stage 4 requires
-    // common-ground/confirm + stages/advance API calls, which are out of scope for this test)
-    expect(progressDataA.data?.myProgress?.stage).toBe(3);
-    expect(progressDataB.data?.myProgress?.stage).toBe(3);
+    expect(progressDataA.data?.myProgress?.stage).toBe(4);
+    expect(progressDataB.data?.myProgress?.stage).toBe(4);
 
     // Take final screenshots
-    await expect(pageA).toHaveScreenshot('stage-3-08-final-user-a.png', {
-      maxDiffPixels: 100,
-    });
-    await expect(pageB).toHaveScreenshot('stage-3-08-final-user-b.png', {
-      maxDiffPixels: 100,
-    });
+    await pageA.screenshot({ path: 'test-results/stage-3-08-final-user-a.png' });
+    await pageB.screenshot({ path: 'test-results/stage-3-08-final-user-b.png' });
 
     console.log(`${elapsed()} === TEST COMPLETE ===`);
     console.log(`${elapsed()} Both users completed Stage 3 successfully!`);

--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -5,8 +5,8 @@
  * that previously took over the chat FlatList. Three modes:
  *
  * - `needs`: Review own needs with adjust/confirm actions
- * - `common-ground`: Review common ground with confirm action
- * - `comparison`: Side-by-side view of both users' needs + common ground
+ * - `common-ground`: Reveal both partners' needs side by side for validation
+ * - `comparison`: Side-by-side view of both users' needs
  */
 
 import React, { useRef, useCallback, useEffect, useState } from 'react';
@@ -55,11 +55,14 @@ export interface NeedsDrawerProps {
   needs?: NeedItem[];
   onAdjustNeeds?: () => void;
   onConfirmNeeds?: () => void;
+  confirmNeedsLabel?: string;
+  confirmingNeedsLabel?: string;
   isConfirming?: boolean;
-  // Common Ground mode
+  // Validation reveal mode
   commonGround?: CommonGroundItem[];
   noOverlap?: boolean;
   onConfirmCommonGround?: () => void;
+  onNeedsNotValidYet?: () => void;
   onViewComparison?: () => void;
   // Comparison mode
   partnerNeeds?: NeedItem[];
@@ -88,10 +91,12 @@ export function NeedsDrawer({
   needs = [],
   onAdjustNeeds,
   onConfirmNeeds,
-  commonGround = [],
+  confirmNeedsLabel = 'Confirm my needs',
+  confirmingNeedsLabel = 'Sharing...',
   noOverlap = false,
   isConfirming = false,
   onConfirmCommonGround,
+  onNeedsNotValidYet,
   onViewComparison,
   partnerNeeds = [],
   partnerName = 'Partner',
@@ -273,7 +278,7 @@ export function NeedsDrawer({
               testID={`${testID}-confirm`}
             >
               <Text style={styles.primaryButtonText}>
-                {isConfirming ? 'Sharing...' : 'Confirm my needs'}
+                {isConfirming ? confirmingNeedsLabel : confirmNeedsLabel}
               </Text>
             </TouchableOpacity>
           )}
@@ -286,28 +291,21 @@ export function NeedsDrawer({
     <>
       {noOverlap ? (
         <Text style={styles.noOverlapText}>
-          No obvious common ground identified. That's completely normal — you
-          can still move forward productively.
+          Your needs look different right now. That's enough to start choosing
+          next steps that respect both of you.
         </Text>
       ) : (
         <>
           <Text style={styles.sectionSubtitle}>
-            Shared needs discovered between you and {partnerName}.
+            Look at both lists together, then validate that this is accurate
+            enough to use for the next step.
           </Text>
 
-          {commonGround.map((cg) => (
-            <View key={cg.id} style={styles.commonGroundItem}>
-              <View style={styles.commonGroundBadge}>
-                <Text style={styles.commonGroundBadgeText}>Shared</Text>
-              </View>
-              <Text style={styles.commonGroundCategory}>{cg.category}</Text>
-              <Text style={styles.commonGroundNeed}>{cg.need}</Text>
-            </View>
-          ))}
+          {renderSideBySideNeeds()}
 
-          {commonGround.length === 0 && (
+          {needs.length === 0 && partnerNeeds.length === 0 && (
             <Text style={styles.emptyText}>
-              Common ground analysis is not yet complete.
+              Needs reveal is not ready yet.
             </Text>
           )}
         </>
@@ -334,19 +332,31 @@ export function NeedsDrawer({
         </View>
       ) : null;
     }
-    const hasButtons = onViewComparison || onConfirmCommonGround;
+    const hasButtons = onViewComparison || onConfirmCommonGround || onNeedsNotValidYet;
     if (!hasButtons) return null;
     return (
       <View style={[styles.fixedButtonArea, { paddingBottom: Math.max(16, insets.bottom + 8) }]}>
         <View style={styles.buttonRow}>
-          {onViewComparison && (
+          {onNeedsNotValidYet ? (
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={() => {
+                onNeedsNotValidYet();
+                closeDrawer();
+              }}
+              activeOpacity={0.7}
+              testID={`${testID}-not-valid-yet`}
+            >
+              <Text style={styles.secondaryButtonText}>Not valid yet</Text>
+            </TouchableOpacity>
+          ) : onViewComparison && (
             <TouchableOpacity
               style={styles.secondaryButton}
               onPress={onViewComparison}
               activeOpacity={0.7}
               testID={`${testID}-view-comparison`}
             >
-              <Text style={styles.secondaryButtonText}>Compare</Text>
+              <Text style={styles.secondaryButtonText}>Review lists</Text>
             </TouchableOpacity>
           )}
           {onConfirmCommonGround && (
@@ -359,7 +369,7 @@ export function NeedsDrawer({
               activeOpacity={0.7}
               testID={`${testID}-confirm-cg`}
             >
-              <Text style={styles.primaryButtonText}>Confirm</Text>
+              <Text style={styles.primaryButtonText}>Validate needs</Text>
             </TouchableOpacity>
           )}
         </View>
@@ -367,89 +377,46 @@ export function NeedsDrawer({
     );
   };
 
-  const renderComparisonMode = () => {
-    // Identify common ground need IDs for highlighting
-    const commonGroundNeeds = new Set(commonGround.map((cg) => cg.need.toLowerCase()));
-
+  const renderSideBySideNeeds = () => {
     return (
-      <>
-        <Text style={styles.sectionSubtitle}>
-          Side-by-side view of both your needs.
-        </Text>
-
-        <View style={styles.comparisonContainer}>
-          {/* My needs column */}
-          <View style={styles.comparisonColumn}>
-            <Text style={styles.columnHeader}>Your needs</Text>
-            {needs.map((need) => {
-              const isCommon = commonGroundNeeds.has(need.need.toLowerCase());
-              return (
-                <View
-                  key={need.id}
-                  style={[
-                    styles.comparisonCard,
-                    isCommon && styles.comparisonCardCommon,
-                  ]}
-                >
-                  <Text style={styles.comparisonCategory}>{need.category}</Text>
-                  <Text style={styles.comparisonNeed}>{need.need}</Text>
-                  {isCommon && (
-                    <View style={styles.commonBadgeSmall}>
-                      <Text style={styles.commonBadgeSmallText}>Common</Text>
-                    </View>
-                  )}
-                </View>
-              );
-            })}
-            {needs.length === 0 && (
-              <Text style={styles.emptyColumnText}>No needs yet</Text>
-            )}
-          </View>
-
-          {/* Partner needs column */}
-          <View style={styles.comparisonColumn}>
-            <Text style={styles.columnHeader}>{partnerName}'s needs</Text>
-            {partnerNeeds.map((need) => {
-              const isCommon = commonGroundNeeds.has(need.need.toLowerCase());
-              return (
-                <View
-                  key={need.id}
-                  style={[
-                    styles.comparisonCard,
-                    isCommon && styles.comparisonCardCommon,
-                  ]}
-                >
-                  <Text style={styles.comparisonCategory}>{need.category}</Text>
-                  <Text style={styles.comparisonNeed}>{need.need}</Text>
-                  {isCommon && (
-                    <View style={styles.commonBadgeSmall}>
-                      <Text style={styles.commonBadgeSmallText}>Common</Text>
-                    </View>
-                  )}
-                </View>
-              );
-            })}
-            {partnerNeeds.length === 0 && (
-              <Text style={styles.emptyColumnText}>No needs yet</Text>
-            )}
-          </View>
+      <View style={styles.comparisonContainer} testID={`${testID}-side-by-side`}>
+        <View style={styles.comparisonColumn}>
+          <Text style={styles.columnHeader}>You</Text>
+          {needs.map((need) => (
+            <View key={need.id} style={styles.comparisonCard}>
+              <Text style={styles.comparisonCategory}>{need.category}</Text>
+              <Text style={styles.comparisonNeed}>{need.need}</Text>
+            </View>
+          ))}
+          {needs.length === 0 && (
+            <Text style={styles.emptyColumnText}>Waiting for your needs</Text>
+          )}
         </View>
 
-        {/* Common ground summary */}
-        {commonGround.length > 0 && (
-          <View style={styles.commonGroundSummary}>
-            <Text style={styles.commonGroundSummaryTitle}>
-              {commonGround.length} shared {commonGround.length === 1 ? 'need' : 'needs'}
-            </Text>
-            <Text style={styles.commonGroundSummaryText}>
-              When we see our shared needs, we remember we're on the same team.
-            </Text>
-          </View>
-        )}
-
-      </>
+        <View style={styles.comparisonColumn}>
+          <Text style={styles.columnHeader}>{partnerName}</Text>
+          {partnerNeeds.map((need) => (
+            <View key={need.id} style={[styles.comparisonCard, styles.partnerComparisonCard]}>
+              <Text style={styles.comparisonCategory}>{need.category}</Text>
+              <Text style={styles.comparisonNeed}>{need.need}</Text>
+            </View>
+          ))}
+          {partnerNeeds.length === 0 && (
+            <Text style={styles.emptyColumnText}>Waiting for {partnerName}</Text>
+          )}
+        </View>
+      </View>
     );
   };
+
+  const renderComparisonMode = () => (
+    <>
+      <Text style={styles.sectionSubtitle}>
+        Review both needs lists side by side.
+      </Text>
+      {renderSideBySideNeeds()}
+    </>
+  );
 
   const renderComparisonButtons = () => {
     if (!onBackToCommonGround) return null;
@@ -461,7 +428,7 @@ export function NeedsDrawer({
           activeOpacity={0.7}
           testID={`${testID}-back-to-cg`}
         >
-          <Text style={styles.secondaryButtonText}>Back to Common Ground</Text>
+          <Text style={styles.secondaryButtonText}>Back to validation</Text>
         </TouchableOpacity>
       </View>
     );
@@ -476,8 +443,8 @@ export function NeedsDrawer({
     mode === 'needs'
       ? 'Your Needs'
       : mode === 'common-ground'
-        ? 'Common Ground'
-        : 'Needs Comparison';
+        ? 'Review Needs Together'
+        : 'Needs Side by Side';
 
   return (
     <View
@@ -665,44 +632,6 @@ const styles = StyleSheet.create({
     flex: undefined,
   },
 
-  // Common ground items
-  commonGroundItem: {
-    backgroundColor: 'rgba(167, 243, 208, 0.15)',
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: 'rgba(110, 231, 183, 0.4)',
-    padding: 16,
-    marginBottom: 12,
-    marginHorizontal: 16,
-    position: 'relative',
-  },
-  commonGroundBadge: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
-    backgroundColor: colors.success,
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 4,
-  },
-  commonGroundBadgeText: {
-    color: 'white',
-    fontSize: 10,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  commonGroundCategory: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: colors.success,
-    marginBottom: 4,
-  },
-  commonGroundNeed: {
-    fontSize: 16,
-    color: colors.textPrimary,
-    lineHeight: 22,
-  },
   noOverlapText: {
     fontSize: 15,
     color: colors.textSecondary,
@@ -739,10 +668,9 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     position: 'relative',
   },
-  comparisonCardCommon: {
-    backgroundColor: 'rgba(167, 243, 208, 0.2)',
-    borderWidth: 2,
-    borderColor: 'rgba(110, 231, 183, 0.5)',
+  partnerComparisonCard: {
+    backgroundColor: 'rgba(251, 191, 36, 0.12)',
+    borderColor: 'rgba(251, 191, 36, 0.3)',
   },
   comparisonCategory: {
     fontSize: 11,
@@ -755,21 +683,6 @@ const styles = StyleSheet.create({
     color: colors.textPrimary,
     lineHeight: 18,
   },
-  commonBadgeSmall: {
-    marginTop: 4,
-    alignSelf: 'flex-start',
-    backgroundColor: colors.success,
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: 3,
-  },
-  commonBadgeSmallText: {
-    color: 'white',
-    fontSize: 9,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 0.3,
-  },
   emptyColumnText: {
     fontSize: 13,
     color: colors.textMuted,
@@ -778,28 +691,6 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
   },
 
-  // Common ground summary
-  commonGroundSummary: {
-    backgroundColor: 'rgba(167, 243, 208, 0.1)',
-    borderRadius: 12,
-    padding: 16,
-    marginTop: 16,
-    marginHorizontal: 16,
-    alignItems: 'center',
-  },
-  commonGroundSummaryTitle: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: colors.success,
-    marginBottom: 4,
-  },
-  commonGroundSummaryText: {
-    fontSize: 14,
-    fontStyle: 'italic',
-    color: colors.textPrimary,
-    lineHeight: 20,
-    textAlign: 'center',
-  },
 });
 
 export default NeedsDrawer;

--- a/mobile/src/components/__tests__/NeedsDrawer.test.tsx
+++ b/mobile/src/components/__tests__/NeedsDrawer.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { NeedsDrawer } from '../NeedsDrawer';
+
+describe('NeedsDrawer', () => {
+  const needs = [
+    { id: 'need-1', category: 'Respect', need: 'Being heard', confirmed: true },
+    { id: 'need-2', category: 'Trust', need: 'Reliability', confirmed: true },
+  ];
+
+  const partnerNeeds = [
+    { id: 'partner-need-1', category: 'Autonomy', need: 'Room to choose', confirmed: true },
+    { id: 'partner-need-2', category: 'Care', need: 'Gentler timing', confirmed: true },
+  ];
+
+  it('reveals both needs lists side by side for validation', () => {
+    render(
+      <NeedsDrawer
+        visible
+        onClose={jest.fn()}
+        mode="common-ground"
+        needs={needs}
+        partnerNeeds={partnerNeeds}
+        partnerName="Darryl"
+        onConfirmCommonGround={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Review Needs Together')).toBeTruthy();
+    expect(screen.getByText('You')).toBeTruthy();
+    expect(screen.getByText('Darryl')).toBeTruthy();
+    expect(screen.getByText('Being heard')).toBeTruthy();
+    expect(screen.getByText('Room to choose')).toBeTruthy();
+    expect(screen.getByText('Validate needs')).toBeTruthy();
+  });
+
+  it('does not show common-ground badge or copy in the validation reveal', () => {
+    render(
+      <NeedsDrawer
+        visible
+        onClose={jest.fn()}
+        mode="common-ground"
+        needs={needs}
+        partnerNeeds={partnerNeeds}
+        partnerName="Darryl"
+        onConfirmCommonGround={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Common Ground')).toBeNull();
+    expect(screen.queryByText('Shared')).toBeNull();
+    expect(screen.queryByText('Common')).toBeNull();
+  });
+
+  it('validates the needs reveal through the existing confirmation handler', () => {
+    const onConfirmCommonGround = jest.fn();
+
+    render(
+      <NeedsDrawer
+        visible
+        onClose={jest.fn()}
+        mode="common-ground"
+        needs={needs}
+        partnerNeeds={partnerNeeds}
+        partnerName="Darryl"
+        onConfirmCommonGround={onConfirmCommonGround}
+      />
+    );
+
+    fireEvent.press(screen.getByText('Validate needs'));
+
+    expect(onConfirmCommonGround).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the user mark the reveal as not valid yet', () => {
+    const onNeedsNotValidYet = jest.fn();
+
+    render(
+      <NeedsDrawer
+        visible
+        onClose={jest.fn()}
+        mode="common-ground"
+        needs={needs}
+        partnerNeeds={partnerNeeds}
+        partnerName="Darryl"
+        onConfirmCommonGround={jest.fn()}
+        onNeedsNotValidYet={onNeedsNotValidYet}
+      />
+    );
+
+    fireEvent.press(screen.getByText('Not valid yet'));
+
+    expect(onNeedsNotValidYet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -39,6 +39,7 @@ import {
   GetNeedsComparisonResponse,
   ConfirmCommonGroundRequest,
   ConfirmCommonGroundResponse,
+  ValidateNeedsResponse,
   AddNeedRequest,
   AddNeedResponse,
   ConsentShareNeedsResponse,
@@ -1579,6 +1580,38 @@ export function useConfirmCommonGround(
     },
     onSuccess: (_, { sessionId }) => {
       queryClient.invalidateQueries({ queryKey: stageKeys.commonGround(sessionId) });
+      queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+      queryClient.invalidateQueries({ queryKey: sessionKeys.detail(sessionId) });
+      queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
+    },
+    ...options,
+  });
+}
+
+/**
+ * Validate both revealed needs lists.
+ */
+export function useValidateNeeds(
+  options?: Omit<
+    UseMutationOptions<
+      ValidateNeedsResponse,
+      ApiClientError,
+      { sessionId: string; validated: boolean }
+    >,
+    'mutationFn'
+  >
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ sessionId, validated }) => {
+      return post<ValidateNeedsResponse>(
+        `/sessions/${sessionId}/needs/validate`,
+        { validated }
+      );
+    },
+    onSuccess: (_, { sessionId }) => {
+      queryClient.invalidateQueries({ queryKey: stageKeys.needsComparison(sessionId) });
       queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
       queryClient.invalidateQueries({ queryKey: sessionKeys.detail(sessionId) });
       queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -35,8 +35,8 @@ import {
   useNeeds,
   useConfirmNeeds,
   useConsentShareNeeds,
-  useCommonGround,
-  useConfirmCommonGround,
+  useNeedsComparison,
+  useValidateNeeds,
   useStrategies,
   useRequestStrategySuggestions,
   useProposeStrategy,
@@ -95,6 +95,14 @@ export interface InlineChatCard {
   props: Record<string, unknown>;
   dismissible?: boolean;
 }
+
+type LegacyCommonGroundItem = {
+  id: string;
+  need: string;
+  category: string;
+  confirmedByMe: boolean;
+  confirmedByPartner: boolean;
+};
 
 // Re-export WaitingStatusState from the new pure derivation module
 // This maintains backward compatibility while centralizing the type definition
@@ -265,12 +273,10 @@ export function useUnifiedSession(sessionId: string | undefined) {
   const needsForGating = needsData?.needs ?? [];
   const allNeedsConfirmedForGating = needsForGating.length > 0 && needsForGating.every((n) => n.confirmed);
 
-  // Common ground query is gated on needs being confirmed to prevent
-  // racing with the needs confirmation/sharing flow
-  const { data: commonGroundData } = useCommonGround(sessionId, {
-    allNeedsConfirmed: allNeedsConfirmedForGating,
-    needsShared: allNeedsConfirmedForGating, // Sharing happens immediately after confirmation
-  });
+  const { data: needsComparisonData } = useNeedsComparison(
+    sessionId,
+    allNeedsConfirmedForGating
+  );
 
   // Stage 4: Strategies - always fetch to avoid waterfall
   const { data: strategyData } = useStrategies(sessionId);
@@ -303,7 +309,7 @@ export function useUnifiedSession(sessionId: string | undefined) {
   const { mutate: resubmitEmpathy } = useResubmitEmpathy();
   const { mutate: confirmNeeds, isPending: isConfirmingNeeds } = useConfirmNeeds();
   const { mutate: consentShareNeeds } = useConsentShareNeeds();
-  const { mutate: confirmCommonGroundMutation } = useConfirmCommonGround();
+  const { mutate: validateNeedsMutation } = useValidateNeeds();
   const { mutate: proposeStrategy, isPending: isProposing } = useProposeStrategy();
   const { mutate: requestSuggestions, isPending: isGenerating } =
     useRequestStrategySuggestions();
@@ -312,24 +318,6 @@ export function useUnifiedSession(sessionId: string | undefined) {
   const { mutate: confirmAgreement } = useConfirmAgreement();
   const { mutate: createAgreement } = useCreateAgreement();
   const { mutate: resolveSession } = useResolveSession();
-
-  // Auto-consent to share needs when needs are confirmed but common ground hasn't started.
-  // This handles the case where needs were confirmed without the consent-to-share step.
-  const autoConsentTriggered = useRef(false);
-  useEffect(() => {
-    if (
-      sessionId &&
-      allNeedsConfirmedForGating &&
-      commonGroundData &&
-      !commonGroundData.analysisComplete &&
-      commonGroundData.commonGround.length === 0 &&
-      !autoConsentTriggered.current
-    ) {
-      autoConsentTriggered.current = true;
-      const needIds = needsForGating.map((n) => n.id);
-      consentShareNeeds({ sessionId, needIds });
-    }
-  }, [sessionId, allNeedsConfirmedForGating, commonGroundData, needsForGating, consentShareNeeds]);
 
   // Streaming message hook with callbacks for metadata handling
   const handleStreamMetadata = useCallback(
@@ -504,8 +492,14 @@ export function useUnifiedSession(sessionId: string | undefined) {
   // Needs confirmation state
   const needs = useMemo(() => needsData?.needs ?? [], [needsData?.needs]);
   const allNeedsConfirmed = needs.length > 0 && needs.every((n) => n.confirmed);
-  const commonGround = useMemo(() => commonGroundData?.commonGround ?? [], [commonGroundData?.commonGround]);
-  const commonGroundComplete = commonGroundData?.bothConfirmed ?? false;
+  const commonGround = useMemo<LegacyCommonGroundItem[]>(() => [], []);
+  const needsRevealReady =
+    (needsComparisonData?.myNeeds?.length ?? 0) > 0 &&
+    (needsComparisonData?.partnerNeeds?.length ?? 0) > 0;
+  const commonGroundData = needsRevealReady
+    ? { commonGround: [], analysisComplete: true, bothConfirmed: false, noOverlap: false }
+    : undefined;
+  const commonGroundComplete = false;
 
   // Strategy phase
   const strategyPhase = strategyData?.phase ?? StrategyPhase.COLLECTING;
@@ -956,16 +950,11 @@ export function useUnifiedSession(sessionId: string | undefined) {
       confirmNeeds(
         { sessionId, needIds },
         {
-          onSuccess: () => {
-            // After confirming needs, automatically consent to share for common ground discovery.
-            // This eliminates the need for a separate consent step.
-            consentShareNeeds({ sessionId, needIds });
-            onSuccess?.();
-          },
+          onSuccess: () => onSuccess?.(),
         }
       );
     },
-    [sessionId, needs, confirmNeeds, consentShareNeeds]
+    [sessionId, needs, confirmNeeds]
   );
 
   const handleConsentToShareNeeds = useCallback(
@@ -990,17 +979,24 @@ export function useUnifiedSession(sessionId: string | undefined) {
     (onSuccess?: () => void) => {
       if (!sessionId) return;
 
-      // Allow empty confirmations for noOverlap case (no common ground found)
-      if (commonGround.length === 0 && !commonGroundData?.noOverlap) return;
-
-      const confirmations = commonGround.map((cg) => ({
-        commonGroundId: cg.id,
-        confirmed: true,
-      }));
-
-      confirmCommonGroundMutation({ sessionId, confirmations }, { onSuccess });
+      validateNeedsMutation(
+        { sessionId, validated: true },
+        { onSuccess: () => onSuccess?.() }
+      );
     },
-    [sessionId, commonGround, commonGroundData?.noOverlap, confirmCommonGroundMutation]
+    [sessionId, validateNeedsMutation]
+  );
+
+  const handleNeedsNotValidYet = useCallback(
+    (onSuccess?: () => void) => {
+      if (!sessionId) return;
+
+      validateNeedsMutation(
+        { sessionId, validated: false },
+        { onSuccess: () => onSuccess?.() }
+      );
+    },
+    [sessionId, validateNeedsMutation]
   );
 
   const handleAddStrategy = useCallback(
@@ -1156,6 +1152,7 @@ export function useUnifiedSession(sessionId: string | undefined) {
     commonGroundData,
     commonGround,
     commonGroundComplete,
+    needsComparisonData,
     strategyData,
     strategyPhase,
     strategies,
@@ -1192,6 +1189,7 @@ export function useUnifiedSession(sessionId: string | undefined) {
     handleConfirmAllNeeds,
     handleConsentToShareNeeds,
     handleConfirmCommonGround,
+    handleNeedsNotValidYet,
     handleAddStrategy,
     handleRequestMoreStrategies,
     handleMarkReadyToRank,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -268,6 +268,7 @@ export function UnifiedSessionScreen({
     handleConfirmAllNeeds,
     handleConsentToShareNeeds,
     handleConfirmCommonGround,
+    handleNeedsNotValidYet,
     handleRequestMoreStrategies,
     handleMarkReadyToRank,
     handleSubmitRankings,
@@ -769,8 +770,13 @@ export function UnifiedSessionScreen({
   const [needsDrawerMode, setNeedsDrawerMode] = useState<NeedsDrawerMode>('needs');
   const { data: needsComparisonData } = useNeedsComparison(
     sessionId,
-    showNeedsDrawer && (needsDrawerMode === 'comparison' || needsDrawerMode === 'common-ground'),
+    allNeedsConfirmed && (
+      showNeedsDrawer ||
+      myProgress?.stage === Stage.NEED_MAPPING
+    ),
   );
+  const shouldUseRevealedNeeds =
+    needsDrawerMode !== 'needs' && (needsComparisonData?.myNeeds?.length ?? 0) > 0;
 
   // Local latches to prevent panel flashing during server refetches.
   // Once user completes an action, the latch stays true even if server data temporarily reverts.
@@ -958,12 +964,12 @@ export function UnifiedSessionScreen({
     hasRespondedToShareOfferLocal: completedActions.has('responded-to-share-offer'),
     allNeedsConfirmed,
     needsAvailable: (needs?.length ?? 0) > 0,
-    needsShared: allNeedsConfirmed, // Sharing happens immediately after confirmation
+    needsShared: (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsShared === true,
     hasConfirmedNeedsLocal: completedActions.has('confirmed-needs'),
     commonGroundCount: commonGround?.length ?? 0,
-    commonGroundAvailable: (commonGround?.length ?? 0) > 0 && (commonGroundData?.analysisComplete ?? false),
-    commonGroundNoOverlap: commonGroundData?.noOverlap ?? false,
-    commonGroundAllConfirmedByMe: commonGround?.length > 0 && commonGround.every((cg) => cg.confirmedByMe),
+    commonGroundAvailable: (needsComparisonData?.myNeeds?.length ?? 0) > 0 && (needsComparisonData?.partnerNeeds?.length ?? 0) > 0,
+    commonGroundNoOverlap: false,
+    commonGroundAllConfirmedByMe: (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsValidated === true,
     commonGroundAllConfirmedByBoth: commonGroundComplete,
     hasConfirmedCommonGroundLocal: completedActions.has('confirmed-common-ground'),
     strategyPhase,
@@ -2103,7 +2109,7 @@ export function UnifiedSessionScreen({
               {commonGroundData?.noOverlap ? (
                 <>
                   <Text style={styles.noOverlapText}>
-                    No obvious common ground identified. That's completely normal.
+                    Your needs look different right now. That's enough to choose a respectful next step.
                   </Text>
                   <TouchableOpacity
                     style={styles.commonGroundButton}
@@ -2130,7 +2136,7 @@ export function UnifiedSessionScreen({
                   testID="common-ground-confirm-button"
                 >
                   <Text style={styles.commonGroundButtonText}>
-                    Confirm common ground
+                    Review needs together
                   </Text>
                 </TouchableOpacity>
               )}
@@ -2630,7 +2636,7 @@ export function UnifiedSessionScreen({
         visible={showNeedsDrawer}
         onClose={() => setShowNeedsDrawer(false)}
         mode={needsDrawerMode}
-        needs={(needs ?? []).map((n) => ({
+        needs={(shouldUseRevealedNeeds ? (needsComparisonData?.myNeeds ?? []) : (needs ?? [])).map((n) => ({
           id: n.id,
           category: n.category || n.need,
           need: n.need,
@@ -2640,11 +2646,19 @@ export function UnifiedSessionScreen({
           sendMessage('I would like to adjust my identified needs');
         }}
         onConfirmNeeds={() => {
-          handleConfirmAllNeeds(() => {
-            markCompleted('confirmed-needs');
-            setShowNeedsDrawer(false);
-          });
+          if (allNeedsConfirmed) {
+            handleConsentToShareNeeds(() => {
+              markCompleted('confirmed-needs');
+              setShowNeedsDrawer(false);
+            });
+          } else {
+            handleConfirmAllNeeds(() => {
+              setShowNeedsDrawer(false);
+            });
+          }
         }}
+        confirmNeedsLabel={allNeedsConfirmed ? 'Share my needs' : 'Confirm my needs'}
+        confirmingNeedsLabel={allNeedsConfirmed ? 'Sharing...' : 'Confirming...'}
         isConfirming={isConfirmingNeeds}
         commonGround={(commonGround ?? []).map((cg) => ({
           id: cg.id,
@@ -2658,8 +2672,10 @@ export function UnifiedSessionScreen({
           markCompleted('confirmed-common-ground');
           handleConfirmCommonGround(() => onStageComplete?.(Stage.NEED_MAPPING));
         }}
-        onViewComparison={() => {
-          setNeedsDrawerMode('comparison');
+        onNeedsNotValidYet={() => {
+          handleNeedsNotValidYet(() => {
+            resetCompleted('confirmed-common-ground');
+          });
         }}
         onBackToCommonGround={() => {
           setNeedsDrawerMode('common-ground');
@@ -2895,7 +2911,7 @@ const useStyles = () =>
       color: t.colors.brandBlue,
     },
 
-    // Common Ground Confirmation Panel (Stage 3)
+    // Needs Validation Panel (Stage 3)
     commonGroundContainer: {
       paddingHorizontal: t.spacing.lg,
       paddingVertical: t.spacing.md,

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -581,7 +581,7 @@ describe('Needs Review Panel Visibility', () => {
     expect(result.panels.showNeedsReviewPanel).toBe(false);
   });
 
-  it('does not show when needs are already confirmed', () => {
+  it('still shows after needs are confirmed so the user can share explicitly', () => {
     const inputs = createInputs({
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
@@ -593,7 +593,8 @@ describe('Needs Review Panel Visibility', () => {
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showNeedsReviewPanel).toBe(false);
+    expect(result.panels.showNeedsReviewPanel).toBe(true);
+    expect(result.aboveInputPanel).toBe('needs-review');
   });
 
   it('does not show when needs are already shared', () => {
@@ -611,7 +612,7 @@ describe('Needs Review Panel Visibility', () => {
     expect(result.panels.showNeedsReviewPanel).toBe(false);
   });
 
-  it('does not show when local latch is set (prevents flash)', () => {
+  it('still shows when only the confirm latch is set and needs are not shared', () => {
     const inputs = createInputs({
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
@@ -623,7 +624,7 @@ describe('Needs Review Panel Visibility', () => {
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showNeedsReviewPanel).toBe(false);
+    expect(result.panels.showNeedsReviewPanel).toBe(true);
   });
 
   it('does not show when no needs available', () => {

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -316,13 +316,13 @@ function computeShowNeedsReviewPanel(inputs: ChatUIStateInputs): boolean {
     return false;
   }
 
-  // Local latch: Once user confirms, hide panel immediately (prevents flash during refetch)
-  if (hasConfirmedNeedsLocal) {
+  // Local latch: once the user shares, hide panel immediately.
+  if (hasConfirmedNeedsLocal && needsShared) {
     return false;
   }
 
-  // Already confirmed and shared - no need to show
-  if (allNeedsConfirmed || needsShared) {
+  // Already shared - reveal/waiting state owns the next step.
+  if (needsShared) {
     return false;
   }
 

--- a/shared/src/dto/needs.ts
+++ b/shared/src/dto/needs.ts
@@ -107,7 +107,7 @@ export interface CaptureNeedsResponse {
 
 export interface ValidateNeedsResponse {
   validated: boolean;
-  validatedAt: string;
+  validatedAt: string | null;
   partnerValidated: boolean;
   canAdvance: boolean;
 }
@@ -177,4 +177,7 @@ export interface NeedsComparisonNeedDTO {
 export interface GetNeedsComparisonResponse {
   myNeeds: NeedsComparisonNeedDTO[];
   partnerNeeds: NeedsComparisonNeedDTO[];
+  myValidated?: boolean;
+  partnerValidated?: boolean;
+  canAdvance?: boolean;
 }


### PR DESCRIPTION
## Summary
- Follow-up to #255, which has already merged the shared DTO changes and temporary deprecated CommonGround DTO compatibility shim.
- Implements the Stage 3 consumer/behavior flow: capture/confirm needs, explicit share consent, side-by-side needs reveal, validate/not-valid-yet handling, and Stage 4 advancement once both users validate.
- Updates mobile Stage 3 UI and e2e helpers/tests to avoid AI-authored common-ground overlap in the active path while keeping legacy compatibility routes/types in place.

## Verification
- npm --workspace shared run check
- npm --workspace backend run check
- npm --workspace mobile run check
- npm --workspace e2e run check
- npm --workspace backend test -- --runTestsByPath src/routes/__tests__/stage3.test.ts --runInBand
- npm --workspace mobile test -- --runTestsByPath src/components/__tests__/NeedsDrawer.test.tsx --runInBand
- git diff --check
- npm --workspace e2e run e2e -- --project=two-browser-stage-3

## Manual / Production Testing Notes
- Local focused two-browser Stage 3 Playwright flow passed against backend + Expo web servers.
- Remaining production/manual gap: validate the same flow on deployed mobile/native surfaces with real auth/realtime infrastructure before broad rollout.
