### PR TITLE
fix(drawer): replace pull-to-refresh with auto-refresh on open

### DIFF
--- a/mobile/src/components/SessionDrawer/index.tsx
+++ b/mobile/src/components/SessionDrawer/index.tsx
@@ -11,13 +11,12 @@
  * - Closes on session selection
  */
 
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   SectionList,
-  RefreshControl,
   ActivityIndicator,
   Animated,
   Alert,
@@ -59,7 +58,15 @@ interface SessionSection {
 function ConversationsList({ onClose }: { onClose: () => void }) {
   const styles = useStyles();
   const router = useRouter();
-  const { data, isLoading, refetch, isRefetching } = useSessions();
+  const { isOpen } = useSessionDrawer();
+  const { data, isLoading, refetch } = useSessions();
+
+  // Auto-refresh sessions when the drawer opens
+  useEffect(() => {
+    if (isOpen) {
+      refetch();
+    }
+  }, [isOpen, refetch]);
   const archiveSession = useArchiveSession();
   const swipeableRefs = useRef<Map<string, Swipeable>>(new Map());
 
@@ -271,7 +278,6 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
       renderSectionHeader={renderSectionHeader}
       keyExtractor={(item) => item.id}
       contentContainerStyle={styles.listContent}
-      refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
       ItemSeparatorComponent={() => <View style={styles.separator} />}
       stickySectionHeadersEnabled={false}
     />


### PR DESCRIPTION
## Changes
- Remove: `RefreshControl` from the conversations drawer `SectionList` — eliminates the stuck spinner bug
- Add: Auto-refresh sessions via `useEffect` when the drawer opens (`isOpen` transitions to `true`)
- Simplify: No manual pull-down gesture needed; list stays fresh automatically

Related to #289

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "I have also seen that list stuck on the pull down state where the spinner is just sitting there stuck. I think it can be a lot simpler. No need for a pull down if we keep it up to date when opening the drawer."

## Docs updated
No doc changes needed — UI-only bug fix removing a component prop and adding a standard React hook.