### PR TITLE
fix(empathy): remove accept/reject buttons from revisit drawer

### DIFF
--- a/mobile/src/components/ViewEmpathyStatementDrawer.tsx
+++ b/mobile/src/components/ViewEmpathyStatementDrawer.tsx
@@ -19,7 +19,7 @@ import {
   Platform,
 } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
-import { X, Send, MessageCircle, Check, CircleX } from 'lucide-react-native';
+import { X, Send, MessageCircle } from 'lucide-react-native';
 import { colors } from '@/theme';
 
 export interface ViewEmpathyStatementDrawerProps {
@@ -37,10 +37,6 @@ export interface ViewEmpathyStatementDrawerProps {
   onClose: () => void;
   /** Callback when user sends a refinement request from the drawer */
   onSendRefinement?: (message: string) => void;
-  /** Callback when user accepts the feedback without revising (acceptance check) */
-  onAcceptWithoutRevising?: () => void;
-  /** Callback when user cannot accept the feedback without revising */
-  onDeclineAcceptance?: (reason: string) => void;
 }
 
 export function ViewEmpathyStatementDrawer({
@@ -51,13 +47,9 @@ export function ViewEmpathyStatementDrawer({
   onShare,
   onClose,
   onSendRefinement,
-  onAcceptWithoutRevising,
-  onDeclineAcceptance,
 }: ViewEmpathyStatementDrawerProps) {
   const [isRefining, setIsRefining] = useState(false);
-  const [isDeclining, setIsDeclining] = useState(false);
   const [refinementText, setRefinementText] = useState('');
-  const [declineReason, setDeclineReason] = useState('');
   const scrollViewRef = useRef<ScrollView>(null);
 
   // When the refinement composer opens (and keyboard comes up), ensure we scroll the input into view.
@@ -78,22 +70,6 @@ export function ViewEmpathyStatementDrawer({
     };
   }, [isRefining]);
 
-  useEffect(() => {
-    if (!isDeclining) return;
-
-    const raf = requestAnimationFrame(() => {
-      scrollViewRef.current?.scrollToEnd({ animated: true });
-    });
-    const t = setTimeout(() => {
-      scrollViewRef.current?.scrollToEnd({ animated: true });
-    }, 150);
-
-    return () => {
-      cancelAnimationFrame(raf);
-      clearTimeout(t);
-    };
-  }, [isDeclining]);
-
   const handleSendRefinement = () => {
     const trimmed = refinementText.trim();
     if (!trimmed) return;
@@ -101,16 +77,6 @@ export function ViewEmpathyStatementDrawer({
     onSendRefinement?.(trimmed);
     setRefinementText('');
     setIsRefining(false);
-    onClose();
-  };
-
-  const handleDeclineAcceptance = () => {
-    const trimmed = declineReason.trim();
-    if (!trimmed) return;
-
-    onDeclineAcceptance?.(trimmed);
-    setDeclineReason('');
-    setIsDeclining(false);
     onClose();
   };
 
@@ -212,81 +178,8 @@ export function ViewEmpathyStatementDrawer({
                   </Text>
                 </TouchableOpacity>
               </View>
-            ) : isDeclining ? (
-              <View style={styles.refineComposer}>
-                <View style={styles.refineComposerHeader}>
-                  <Text style={styles.refineComposerTitle}>What makes this hard to accept?</Text>
-                  <TouchableOpacity
-                    onPress={() => {
-                      setIsDeclining(false);
-                      setDeclineReason('');
-                    }}
-                    accessibilityLabel="Close decline reason"
-                    hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-                    testID="close-decline-acceptance-reason"
-                  >
-                    <X color={colors.textSecondary} size={20} />
-                  </TouchableOpacity>
-                </View>
-                <TextInput
-                  style={styles.refineInput}
-                  multiline
-                  placeholder="Share what still feels unresolved..."
-                  placeholderTextColor={colors.textMuted}
-                  value={declineReason}
-                  onChangeText={setDeclineReason}
-                  autoFocus
-                  onFocus={() => scrollViewRef.current?.scrollToEnd({ animated: true })}
-                  testID="decline-acceptance-reason-input"
-                />
-                <TouchableOpacity
-                  style={[
-                    styles.sendRefineButton,
-                    !declineReason.trim() && styles.sendRefineButtonDisabled,
-                  ]}
-                  onPress={handleDeclineAcceptance}
-                  disabled={!declineReason.trim()}
-                  activeOpacity={0.8}
-                  testID="submit-decline-acceptance-button"
-                >
-                  <Send color={declineReason.trim() ? 'white' : colors.textMuted} size={20} />
-                  <Text
-                    style={[
-                      styles.sendRefineButtonText,
-                      !declineReason.trim() && styles.sendRefineButtonTextDisabled,
-                    ]}
-                  >
-                    Submit
-                  </Text>
-                </TouchableOpacity>
-              </View>
             ) : (
               <View style={styles.footer}>
-                {isRevising && onAcceptWithoutRevising && (
-                  <TouchableOpacity
-                    style={styles.acceptButton}
-                    onPress={() => {
-                      onAcceptWithoutRevising();
-                      onClose();
-                    }}
-                    testID="accept-without-revising-button"
-                    activeOpacity={0.8}
-                  >
-                    <Check color={colors.textSecondary} size={18} />
-                    <Text style={styles.acceptButtonText}>I accept their experience</Text>
-                  </TouchableOpacity>
-                )}
-                {isRevising && onDeclineAcceptance && (
-                  <TouchableOpacity
-                    style={styles.declineButton}
-                    onPress={() => setIsDeclining(true)}
-                    testID="decline-acceptance-button"
-                    activeOpacity={0.8}
-                  >
-                    <CircleX color={colors.error} size={18} />
-                    <Text style={styles.declineButtonText}>I cannot accept this</Text>
-                  </TouchableOpacity>
-                )}
                 <View style={styles.actionButtons}>
                   <TouchableOpacity
                     style={styles.refineButton}
@@ -463,44 +356,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '600',
     color: 'white',
-  },
-  acceptButton: {
-    width: '100%',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.bgSecondary,
-    borderRadius: 12,
-    paddingVertical: 14,
-    paddingHorizontal: 20,
-    marginBottom: 12,
-    borderWidth: 1,
-    borderColor: colors.border,
-    gap: 8,
-  },
-  acceptButtonText: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: colors.textSecondary,
-  },
-  declineButton: {
-    width: '100%',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.bgPrimary,
-    borderRadius: 12,
-    paddingVertical: 14,
-    paddingHorizontal: 20,
-    marginBottom: 12,
-    borderWidth: 1,
-    borderColor: colors.error,
-    gap: 8,
-  },
-  declineButtonText: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: colors.error,
   },
 });
 

--- a/mobile/src/components/__tests__/ViewEmpathyStatementDrawer.test.tsx
+++ b/mobile/src/components/__tests__/ViewEmpathyStatementDrawer.test.tsx
@@ -10,48 +10,19 @@ describe('ViewEmpathyStatementDrawer', () => {
     onShare: jest.fn(),
     onClose: jest.fn(),
     onSendRefinement: jest.fn(),
-    onAcceptWithoutRevising: jest.fn(),
-    onDeclineAcceptance: jest.fn(),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('shows partner-side acceptance actions while revising', () => {
+  it('does not show accept/reject buttons while revising', () => {
     render(<ViewEmpathyStatementDrawer {...defaultProps} isRevising />);
 
     expect(screen.getByText('Refine further')).toBeTruthy();
     expect(screen.getByText('Resubmit')).toBeTruthy();
-    expect(screen.getByText('I accept their experience')).toBeTruthy();
-    expect(screen.getByText('I cannot accept this')).toBeTruthy();
-  });
-
-  it('calls accept callback and closes when accepting without revising', () => {
-    render(<ViewEmpathyStatementDrawer {...defaultProps} isRevising />);
-
-    fireEvent.press(screen.getByTestId('accept-without-revising-button'));
-
-    expect(defaultProps.onAcceptWithoutRevising).toHaveBeenCalledTimes(1);
-    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('asks for a reason before declining acceptance', () => {
-    render(<ViewEmpathyStatementDrawer {...defaultProps} isRevising />);
-
-    fireEvent.press(screen.getByTestId('decline-acceptance-button'));
-    expect(screen.getByTestId('decline-acceptance-reason-input')).toBeTruthy();
-
-    fireEvent.changeText(
-      screen.getByTestId('decline-acceptance-reason-input'),
-      'This still misses why I was hurt.'
-    );
-    fireEvent.press(screen.getByTestId('submit-decline-acceptance-button'));
-
-    expect(defaultProps.onDeclineAcceptance).toHaveBeenCalledWith(
-      'This still misses why I was hurt.'
-    );
-    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('I accept their experience')).toBeNull();
+    expect(screen.queryByText('I cannot accept this')).toBeNull();
   });
 
   it('preserves resubmit action while revising', () => {

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -268,7 +268,6 @@ export function UnifiedSessionScreen({
     handleShareEmpathy,
     handleResubmitEmpathy,
     handleValidatePartnerEmpathy,
-    handleSkipRefinement,
     handleConfirmAllNeeds,
     handleConsentToShareNeeds,
     handleConfirmCommonGround,
@@ -2687,12 +2686,6 @@ export function UnifiedSessionScreen({
             // Prefix to make intent clear to the AI/prompt that this is a draft update
             sendMessage(refined);
             setShowEmpathyDrawer(false);
-          }}
-          onAcceptWithoutRevising={() => {
-            handleSkipRefinement(true);
-          }}
-          onDeclineAcceptance={(reason) => {
-            handleSkipRefinement(false, reason);
           }}
           onClose={() => setShowEmpathyDrawer(false)}
         />


### PR DESCRIPTION
## Changes
- Remove: "I accept their experience" and "I cannot accept this" buttons from the `ViewEmpathyStatementDrawer`
- Remove: Decline reason input UI and related state (`isDeclining`, `declineReason`)
- Remove: `onAcceptWithoutRevising` and `onDeclineAcceptance` props from `ViewEmpathyStatementDrawer`
- Clean up: Remove unused `handleSkipRefinement` destructure from `UnifiedSessionScreen`
- Update: Tests now verify accept/reject buttons do NOT appear during refine step

Related to #295

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "I am refining what I will share based n context from Darryl. It should not have those buttons."

## Docs updated
No doc changes needed — UI-only bug fix removing incorrect buttons from the empathy refinement drawer.