### PR TITLE
slam-bot: owner DMs bypass the resource gate

### DIFF
--- a/scripts/ec2-bot/scripts/run-claude.sh
+++ b/scripts/ec2-bot/scripts/run-claude.sh
@@ -39,8 +39,13 @@ source "$LIB_DIR/gh-budget.sh"
 gh_budget_setup
 
 # ── Resource check gate (#557) ──
+# Owner DMs (dm-reply) bypass the gate: when the user DMs the bot it's usually
+# *because* something looks funny, so we always answer even if the box is
+# saturated. Reserves implicit headroom for live debugging.
 QUEUE_DIR="$BOT_QUEUE_DIR"
-if ! "$SCRIPT_DIR/check-resources.sh" > /dev/null 2>&1; then
+if [ "$COMMAND_SLUG" = "dm-reply" ]; then
+  echo "[$(date)] BYPASS resource gate for $COMMAND_SLUG (owner DM)" >> "$LOGFILE"
+elif ! "$SCRIPT_DIR/check-resources.sh" > /dev/null 2>&1; then
   RESOURCE_MSG=$("$SCRIPT_DIR/check-resources.sh" 2>&1 || true)
   echo "[$(date)] QUEUED $COMMAND_SLUG — $RESOURCE_MSG" >> "$LOGFILE"
   create_queue_entry "$QUEUE_DIR" > /dev/null


### PR DESCRIPTION
## Summary

- When the EC2 box is saturated (memory/CPU/disk over threshold in `check-resources.sh`), every incoming Slack message — including owner DMs — currently gets queued with an hourglass reaction. That's exactly when you most need to talk to the bot to figure out what's going on.
- This change makes `COMMAND_SLUG=dm-reply` skip the resource gate in `run-claude.sh` so DMs always run immediately. Reserves implicit headroom for live debugging without any new config or detection machinery.
- Thread-aware queuing in `socket-listener.mjs` (one agent per thread) is unchanged — a DM thread with an active agent still queues the next reply until it finishes.

## Test plan

- [ ] DM the bot during normal load — verify it responds as before (eyes → check)
- [ ] Simulate saturation (e.g., temporarily lower `RESOURCE_MEMORY_THRESHOLD` env var) and DM the bot — verify it still responds and the log shows `BYPASS resource gate for dm-reply (owner DM)` in `dm-reply-*.log`
- [ ] Send a non-DM message (e.g., #slam-paws) under the same simulated saturation — verify it still gets queued with hourglass as before

https://claude.ai/code/session_01W9Fxi1v4ybJzhU2N8uC4xJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9Fxi1v4ybJzhU2N8uC4xJ)_