### PR TITLE
fix(bot): pass THREAD_TS to prevent false queue cancellations

### DIFF
--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -495,11 +495,19 @@ function dispatchAgent(channel, ts, config, promptContent, provenance = {}, tKey
     args = [...sessionArgs, config.commandSlug, '', promptFile, ts];
   }
 
+  // Extract thread_ts from tKey so run-claude.sh can pass it to the queue.
+  // Without this, queued thread replies have no thread_ts and the
+  // process-queue cancellation check uses conversations.history (which
+  // doesn't return threaded replies), falsely concluding the message was
+  // deleted and cancelling the job (#562 follow-up).
+  const threadTs = tKey ? (tKey.split(':')[1] || '') : '';
+
   const env = {
     ...process.env,
     SLAM_BOT: '1',
     PRIORITY: 'high',
     CHANNEL: channel,
+    THREAD_TS: threadTs,
     PROVENANCE_CHANNEL: provenance.channel || '',
     PROVENANCE_REQUESTER: provenance.requester || '',
     PROVENANCE_MESSAGE: provenance.message || '',
@@ -507,7 +515,6 @@ function dispatchAgent(channel, ts, config, promptContent, provenance = {}, tKey
 
   // MWF session thread context for state file lookup
   if (config.workspace === 'mwf-session' && tKey) {
-    const threadTs = tKey.split(':')[1] || '';
     env.MWF_THREAD_TS = threadTs;
     env.MWF_CHANNEL = channel;
     env.MWF_ENTRY_STAGE = threadTs === ts ? '0-onboarding' : 'route';


### PR DESCRIPTION
## Summary

• Thread replies that get queued (due to resource constraints) were being falsely cancelled by the process-queue's message-existence check
• Root cause: `dispatchAgent()` didn't pass `THREAD_TS` env var to `run-claude.sh`, so queued entries had no thread context
• The cancellation check used `conversations.history` (doesn't return thread replies) instead of `conversations.replies`, concluding the message was "deleted"
• Fix: extract `thread_ts` from `tKey` and pass it as `THREAD_TS` env var

## Impact

At least 3 messages were dropped in the last 24h due to this bug — all thread replies that hit the resource gate during a high-memory period.

## Provenance

• Channel: DM (Shantam)
• Requester: Shantam (U0AD3TF2U7L)
• Trigger: "Seems like the bot is not responding to things"

## Test plan

- [ ] Verify queued thread replies now include `thread_ts` in the queue JSON
- [ ] Verify process-queue uses `conversations.replies` for thread replies
- [ ] Monitor next high-memory queueing event to confirm no false cancellations

🤖 Generated with [Claude Code](https://claude.com/claude-code)