### PR TITLE
fix(mobile): prevent network error storm on PERSPECTIVE_STRETCH stage load

### DIFF
--- a/mobile/src/hooks/useSharingStatus.ts
+++ b/mobile/src/hooks/useSharingStatus.ts
@@ -83,11 +83,15 @@ export interface SharingStatusData {
 // Hook
 // ============================================================================
 
-export function useSharingStatus(sessionId: string | undefined): SharingStatusData {
-  // Compose existing hooks
-  const empathyStatusQuery = useEmpathyStatus(sessionId);
-  const shareOfferQuery = useShareOffer(sessionId);
-  const partnerEmpathyQuery = usePartnerEmpathy(sessionId);
+export function useSharingStatus(
+  sessionId: string | undefined,
+  options?: { enabled?: boolean },
+): SharingStatusData {
+  const enabled = options?.enabled ?? true;
+  // Compose existing hooks — gate by enabled to prevent network storm when not in Stage 2
+  const empathyStatusQuery = useEmpathyStatus(sessionId, { enabled });
+  const shareOfferQuery = useShareOffer(sessionId, { enabled });
+  const partnerEmpathyQuery = usePartnerEmpathy(sessionId, { enabled });
 
   const empathyStatus = empathyStatusQuery.data;
   const shareOfferData = shareOfferQuery.data;

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -129,7 +129,7 @@ export function useEmpathyStatus(
       return get<EmpathyExchangeStatusResponse>(`/sessions/${sessionId}/empathy/status`);
     },
     enabled: !!sessionId,
-    staleTime: 5_000,
+    staleTime: 15_000, // Ably events push updates; no need to refetch aggressively
     ...options,
   });
 }
@@ -151,7 +151,7 @@ export function useShareOffer(
       return get<GetShareSuggestionResponse>(`/sessions/${sessionId}/reconciler/share-offer`);
     },
     enabled: !!sessionId,
-    staleTime: 0, // Always check for fresh offer
+    staleTime: 15_000, // Ably events push updates via setQueryData; no need to refetch aggressively
     ...options,
   });
 }

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -261,10 +261,12 @@ export function useUnifiedSession(sessionId: string | undefined) {
     { enabled: !!sessionId }
   );
 
-  // Stage 2: Empathy - always fetch to avoid waterfall
-  // API returns null/empty when not in stage 2+, and React Query caches efficiently
-  const { data: empathyDraftData } = useEmpathyDraft(sessionId);
-  const { data: partnerEmpathyData } = usePartnerEmpathy(sessionId);
+  // Stage 2: Empathy - only fetch when user reaches Stage 2+
+  // Gating prevents a network error storm: multiple queries with aggressive staleTime
+  // all firing simultaneously on stage load, each retrying on failure.
+  const isStage2OrLater = !!sessionId && currentStage >= Stage.PERSPECTIVE_STRETCH;
+  const { data: empathyDraftData } = useEmpathyDraft(sessionId, { enabled: isStage2OrLater });
+  const { data: partnerEmpathyData } = usePartnerEmpathy(sessionId, { enabled: isStage2OrLater });
   const partnerEmpathy = partnerEmpathyData?.attempt ?? null;
 
   // Stage 3: Needs - always fetch to avoid waterfall
@@ -284,9 +286,9 @@ export function useUnifiedSession(sessionId: string | undefined) {
   const { data: revealData } = useStrategiesReveal(sessionId);
   const { data: agreementsData } = useAgreements(sessionId);
 
-  // Empathy Reconciler Data
-  const { data: empathyStatusData } = useEmpathyStatus(sessionId);
-  const { data: shareOfferData } = useShareOffer(sessionId);
+  // Empathy Reconciler Data - gated by stage to prevent unnecessary requests
+  const { data: empathyStatusData } = useEmpathyStatus(sessionId, { enabled: isStage2OrLater });
+  const { data: shareOfferData } = useShareOffer(sessionId, { enabled: isStage2OrLater });
   const { mutate: respondToShareOffer } = useRespondToShareOffer();
 
   // -------------------------------------------------------------------------

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -46,7 +46,7 @@ import { RefineInvitationDrawer } from '../components/RefineInvitationDrawer';
 import { GuidedDraftChatModal } from '../components/GuidedDraftChatModal';
 
 import { useUnifiedSession, InlineChatCard } from '../hooks/useUnifiedSession';
-import { useGenerateTopicFrame, useConfirmTopicFrame } from '../hooks/useSessions';
+import { useSessionState, useGenerateTopicFrame, useConfirmTopicFrame } from '../hooks/useSessions';
 import { useValidationFeedbackCoachChat } from '../hooks/useRefinementChat';
 import { useChatUIState } from '../hooks/useChatUIState';
 import { createInvitationLink } from '../hooks/useInvitation';
@@ -169,8 +169,14 @@ export function UnifiedSessionScreen({
   const { showError } = useToast();
   const topicFrameRequestedRef = useRef(false);
 
-  // Sharing status for header button
-  const sharingStatus = useSharingStatus(sessionId);
+  // Determine stage early to gate Stage 2 queries (prevents network error storm)
+  // React Query deduplicates this with the same call inside useUnifiedSession
+  const { data: earlyStateData } = useSessionState(sessionId);
+  const earlyStage = earlyStateData?.progress?.myProgress?.stage ?? Stage.ONBOARDING;
+  const isStage2OrLater = earlyStage >= Stage.PERSPECTIVE_STRETCH;
+
+  // Sharing status for header button — gated by stage
+  const sharingStatus = useSharingStatus(sessionId, { enabled: isStage2OrLater });
   // Server-side pending actions for badge count (replaces client-side computation)
   const pendingActionsQuery = usePendingActions(sessionId);
 


### PR DESCRIPTION
## Changes
- Fix: Increase `staleTime` on `useShareOffer` (0 → 15s) and `useEmpathyStatus` (5s → 15s) — Ably events push real-time updates via `setQueryData`, so aggressive polling was unnecessary and created cascading refetch storms
- Fix: Gate Stage 2 queries (`empathyDraft`, `partnerEmpathy`, `empathyStatus`, `shareOffer`) by current stage in `useUnifiedSession`, preventing them from firing during Stages 0-1
- Fix: Add `enabled` parameter to `useSharingStatus` so `UnifiedSessionScreen` can gate its Stage 2 queries by stage too, preventing duplicate ungated query observers from overriding the gating in `useUnifiedSession`

Related to #169

## Root Cause
When entering PERSPECTIVE_STRETCH (Stage 2), multiple queries with `staleTime: 0` and `staleTime: 5_000` fired simultaneously on every mount and app-focus event. With React Query's default retry (3× with exponential backoff), any transient network error cascaded into 20+ concurrent requests — a "network error storm." Additionally, these Stage 2 queries fired for ALL stages (0-4), creating unnecessary load even for users in Stage 0/1.

## Provenance
- **Channel:** #most-important-thing
- **Requested by:** Darryl Finkton Jr (U0ASRE7NZL7)
- **Original message:** Evening check-in strategy briefing (2026-04-20)

## Docs updated
No doc changes needed — query configuration change only, no API or architectural changes.