### PR TITLE
fix(mobile): resolve Clerk headless OTA bundle import

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@clerk/clerk-expo": "^2.19.36",
+    "@clerk/clerk-js": "^5.125.10",
     "@expo/vector-icons": "^15.0.3",
     "@radix-ui/react-slot": "^1.2.0",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -262,6 +262,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@clerk/clerk-expo": "^2.19.36",
+        "@clerk/clerk-js": "^5.125.10",
         "@expo/vector-icons": "^15.0.3",
         "@radix-ui/react-slot": "^1.2.0",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -50663,6 +50664,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@clerk/clerk-js": {
+      "version": "5.125.10",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-js/-/clerk-js-5.125.10.tgz",
+      "integrity": "sha512-R0sZ5n4ND7xnHKkMoSuhcYa5+qcgHeYEsQ8eN0ti5hUgGH3LzQX1vJg0GHTEceJI68SrVETArRR7bxyMwS8QAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@base-org/account": "2.0.1",
+        "@clerk/localizations": "^3.37.5",
+        "@clerk/shared": "^3.47.5",
+        "@coinbase/wallet-sdk": "4.3.0",
+        "@emotion/cache": "11.11.0",
+        "@emotion/react": "11.11.1",
+        "@floating-ui/react": "0.27.12",
+        "@floating-ui/react-dom": "^2.1.3",
+        "@formkit/auto-animate": "^0.8.2",
+        "@solana/wallet-adapter-base": "0.9.27",
+        "@solana/wallet-adapter-react": "0.15.39",
+        "@solana/wallet-standard": "1.1.4",
+        "@stripe/stripe-js": "5.6.0",
+        "@swc/helpers": "^0.5.17",
+        "@tanstack/query-core": "5.87.4",
+        "@wallet-standard/core": "1.1.1",
+        "@zxcvbn-ts/core": "3.0.4",
+        "@zxcvbn-ts/language-common": "3.0.4",
+        "alien-signals": "2.0.6",
+        "browser-tabs-lock": "1.3.0",
+        "copy-to-clipboard": "3.3.3",
+        "core-js": "3.41.0",
+        "crypto-js": "^4.2.0",
+        "dequal": "2.0.3",
+        "input-otp": "1.4.2",
+        "qrcode.react": "4.2.0",
+        "regenerator-runtime": "0.14.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     }
   }


### PR DESCRIPTION
## Summary
- add @clerk/clerk-js as an explicit mobile dependency
- keep the lockfile focused so Metro can resolve @clerk/clerk-js/headless from @clerk/clerk-expo during iOS OTA export

## Verification
- npx npm@10 ci
- npm --workspace mobile run check
- cd mobile && npx expo export --platform ios --clear --output-dir /tmp/mwf-ios-export-test-ci