### PR TITLE
fix: invitee onboarding flow + invitation-readiness timing

### DIFF
--- a/backend/src/controllers/__tests__/topic-frame.test.ts
+++ b/backend/src/controllers/__tests__/topic-frame.test.ts
@@ -7,6 +7,9 @@ jest.mock('../../lib/prisma', () => ({
       findFirst: jest.fn(),
       update: jest.fn(),
     },
+    invitation: {
+      updateMany: jest.fn(),
+    },
   },
 }));
 
@@ -37,6 +40,7 @@ describe('confirmTopicFrame', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (isSessionCreator as jest.Mock).mockResolvedValue(true);
+    (prisma.invitation.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
   });
 
   it('flips topicFrameConfirmedAt and returns the topic frame', async () => {

--- a/backend/src/controllers/sessions.ts
+++ b/backend/src/controllers/sessions.ts
@@ -832,18 +832,27 @@ export async function confirmInvitationMessage(req: Request, res: Response): Pro
       return;
     }
 
-    // Already confirmed
+    // Idempotent short-circuit: only return early if Stage 0 is already
+    // marked completed for this user. messageConfirmed alone is no longer
+    // sufficient because confirmTopicFrame now flips it eagerly so the
+    // partner can accept the link before the inviter closes the share modal.
     if (invitation.messageConfirmed) {
-      successResponse(res, {
-        confirmed: true,
-        invitation: {
-          id: invitation.id,
-          messageConfirmed: true,
-          messageConfirmedAt: invitation.messageConfirmedAt?.toISOString() ?? null,
-          topicFrame: session.topicFrame ?? null,
-        },
+      const stage0 = await prisma.stageProgress.findFirst({
+        where: { sessionId, userId: user.id, stage: 0 },
+        select: { status: true },
       });
-      return;
+      if (stage0?.status === 'COMPLETED') {
+        successResponse(res, {
+          confirmed: true,
+          invitation: {
+            id: invitation.id,
+            messageConfirmed: true,
+            messageConfirmedAt: invitation.messageConfirmedAt?.toISOString() ?? null,
+            topicFrame: session.topicFrame ?? null,
+          },
+        });
+        return;
+      }
     }
 
     if (!session.topicFrame || !session.topicFrameConfirmedAt) {

--- a/backend/src/controllers/topic-frame.ts
+++ b/backend/src/controllers/topic-frame.ts
@@ -75,6 +75,23 @@ export async function confirmTopicFrame(req: Request, res: Response): Promise<vo
       logger.info(`[confirmTopicFrame] Topic frame confirmed for session ${sessionId}: "${updated.topicFrame}"`);
     }
 
+    // Make the invitation immediately acceptable. Mark the invitation row
+    // messageConfirmed and flip session.status to INVITED so the partner can
+    // join via the link as soon as the topic is locked — without waiting for
+    // the inviter to close the share modal. Stage advancement (Stage 0→1) and
+    // the AI transition message remain gated to confirmInvitationMessage,
+    // which the inviter triggers when they close the modal.
+    if (updated.status === 'CREATED') {
+      await prisma.session.update({
+        where: { id: sessionId },
+        data: { status: 'INVITED' },
+      });
+    }
+    await prisma.invitation.updateMany({
+      where: { sessionId, messageConfirmed: false },
+      data: { messageConfirmed: true, messageConfirmedAt: now },
+    });
+
     successResponse(res, {
       topicFrame: updated.topicFrame,
       confirmedAt: now.toISOString(),

--- a/mobile/src/components/CompactAgreementBar.tsx
+++ b/mobile/src/components/CompactAgreementBar.tsx
@@ -18,13 +18,10 @@ interface CompactAgreementBarProps {
   /** Whether this is the first session (affects button label) */
   isFirstSession?: boolean;
   /**
-   * If provided, the user is the invitee opening a session their partner
-   * created. The compact bar shows the partner-confirmed topic instead of
-   * the inviter welcome copy.
+   * Optional override for the button label. Used by callers that want a plain
+   * single-button bar (e.g. invitee topic acknowledgement Ready button).
    */
-  inviteeTopic?: string | null;
-  /** Partner's display name for invitee welcome */
-  partnerName?: string;
+  buttonLabel?: string;
   testID?: string;
 }
 
@@ -36,25 +33,15 @@ export function CompactAgreementBar({
   onSign,
   isPending = false,
   isFirstSession = true,
-  inviteeTopic,
-  partnerName,
+  buttonLabel,
   testID,
 }: CompactAgreementBarProps) {
   const styles = useStyles();
 
+  const label = buttonLabel ?? (isFirstSession ? 'Ready' : "Let's go");
+
   return (
     <View style={styles.container} testID={testID || 'compact-agreement-bar'}>
-      {inviteeTopic ? (
-        <>
-          <Text style={styles.welcomeText}>
-            {`Before we begin, this is what ${partnerName || 'your partner'} would like to work through with you:`}
-          </Text>
-          <Text style={styles.inviteeTopicText} testID="invitee-topic-text">{inviteeTopic}</Text>
-          <Text style={styles.welcomeText}>
-            {"This is how things look from their side right now. You don't need to agree with it, respond to it, or do anything with it yet. Instead, I'd like to know what's happening from your point of view. Ready?"}
-          </Text>
-        </>
-      ) : null}
       <TouchableOpacity
         style={[styles.readyButton, isPending && styles.readyButtonDisabled]}
         onPress={onSign}
@@ -64,7 +51,7 @@ export function CompactAgreementBar({
         testID="compact-sign-button"
       >
         <Text style={styles.readyButtonText}>
-          {isPending ? '...' : isFirstSession ? 'Ready' : "Let's go"}
+          {isPending ? '...' : label}
         </Text>
       </TouchableOpacity>
     </View>
@@ -84,21 +71,6 @@ const useStyles = () =>
       borderTopWidth: 1,
       borderTopColor: t.colors.border,
       alignItems: 'center',
-    },
-    welcomeText: {
-      color: t.colors.textPrimary,
-      fontSize: t.typography.fontSize.md,
-      lineHeight: 22,
-      textAlign: 'center',
-      marginBottom: t.spacing.md,
-    },
-    inviteeTopicText: {
-      color: t.colors.textPrimary,
-      fontSize: t.typography.fontSize.lg,
-      fontWeight: '600',
-      lineHeight: 26,
-      textAlign: 'center',
-      marginBottom: t.spacing.md,
     },
     readyButton: {
       backgroundColor: 'rgb(59, 130, 246)',

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -71,6 +71,9 @@ export interface UseChatUIStateProps {
   topicProposalDismissed: boolean;
   isConfirmingTopicFrame: boolean;
 
+  // Invitee Stage 0 topic acknowledgement (between sign-compact and Stage 1 chat)
+  inviteeTopicAckPending: boolean;
+
   // Stage 1: Feel heard
   showFeelHeardConfirmation: boolean;
   feelHeardConfirmedAt: string | null | undefined;
@@ -184,6 +187,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     topicFrameProposed,
     topicProposalDismissed,
     isConfirmingTopicFrame,
+    inviteeTopicAckPending,
     showFeelHeardConfirmation,
     feelHeardConfirmedAt,
     isConfirmingFeelHeard,
@@ -255,6 +259,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     topicFrameProposed,
     topicProposalDismissed,
     isConfirmingTopicFrame,
+    inviteeTopicAckPending,
     showFeelHeardConfirmation,
     feelHeardConfirmedAt,
     isConfirmingFeelHeard,
@@ -314,6 +319,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     topicFrameProposed,
     topicProposalDismissed,
     isConfirmingTopicFrame,
+    inviteeTopicAckPending,
     showFeelHeardConfirmation,
     feelHeardConfirmedAt,
     isConfirmingFeelHeard,

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -196,7 +196,15 @@ const initialState: UnifiedSessionState = {
 // Main Hook
 // ============================================================================
 
-export function useUnifiedSession(sessionId: string | undefined) {
+export function useUnifiedSession(
+  sessionId: string | undefined,
+  options?: { inviteeTopicAcked?: boolean }
+) {
+  // Whether the invitee has tapped "Ready" on the Stage 0 topic-ack screen.
+  // While false, we defer all auto-fetches of the initial Stage 0/1 AI message
+  // for the invitee so they don't see chat content before acknowledging the
+  // inviter's topic frame.
+  const inviteeTopicAcked = options?.inviteeTopicAcked ?? true;
   // Local state management
   const [state, dispatch] = useReducer(sessionReducer, initialState);
   const lastActivityTime = useRef<number>(Date.now());
@@ -562,6 +570,12 @@ export function useUnifiedSession(sessionId: string | undefined) {
     // Skip if still loading or during onboarding with unsigned compact
     const isOnboardingUnsigned = currentStage === Stage.ONBOARDING && !compactData?.mySigned;
 
+    // Defer initial-message fetch for the invitee while they are on the
+    // Stage 0 topic-acknowledgement screen. The screen flips
+    // `inviteeTopicAcked` to true once they tap Ready.
+    const isInviteeAwaitingTopicAck =
+      invitation && invitation.isInviter === false && !inviteeTopicAcked;
+
     if (
       !sessionId ||
       loadingSession ||
@@ -569,7 +583,8 @@ export function useUnifiedSession(sessionId: string | undefined) {
       loadingCompact ||
       hasFetchedInitialMessage.current ||
       isFetchingInitialMessage ||
-      isOnboardingUnsigned
+      isOnboardingUnsigned ||
+      isInviteeAwaitingTopicAck
     ) {
       return;
     }
@@ -592,6 +607,8 @@ export function useUnifiedSession(sessionId: string | undefined) {
     fetchInitialMessage,
     currentStage,
     compactData?.mySigned,
+    invitation,
+    inviteeTopicAcked,
   ]);
 
   // -------------------------------------------------------------------------
@@ -821,10 +838,18 @@ export function useUnifiedSession(sessionId: string | undefined) {
         { sessionId },
         {
           onSuccess: () => {
-            // Fetch initial message if none exist
+            // Fetch initial message if none exist. Skipped for the invitee
+            // while they're awaiting the Stage 0 topic-ack screen — they
+            // should see the inviter's topic before any AI message arrives.
             const messagesPages = messagesData?.pages;
             const hasMessages = messagesPages && messagesPages.some(page => page.messages.length > 0);
-            if (!hasMessages && !hasFetchedInitialMessage.current) {
+            const isInviteeAwaitingTopicAck =
+              invitation && invitation.isInviter === false && !inviteeTopicAcked;
+            if (
+              !isInviteeAwaitingTopicAck &&
+              !hasMessages &&
+              !hasFetchedInitialMessage.current
+            ) {
               hasFetchedInitialMessage.current = true;
               fetchInitialMessage({ sessionId });
             }
@@ -834,7 +859,7 @@ export function useUnifiedSession(sessionId: string | undefined) {
         }
       );
     },
-    [sessionId, signCompact, messagesData?.pages, fetchInitialMessage]
+    [sessionId, signCompact, messagesData?.pages, fetchInitialMessage, invitation, inviteeTopicAcked]
   );
 
   const handleConfirmInvitationMessage = useCallback(
@@ -1201,6 +1226,16 @@ export function useUnifiedSession(sessionId: string | undefined) {
     handleCreateAgreementFromOverlap,
     handleResolveSession,
     handleRespondToShareOffer,
+
+    // Stage advancement (used e.g. by invitee topic-ack Ready button)
+    advanceStage,
+    // Manual initial-message trigger (for callers using deferInitialMessage)
+    triggerInitialMessage: () => {
+      if (!sessionId) return;
+      if (hasFetchedInitialMessage.current) return;
+      hasFetchedInitialMessage.current = true;
+      fetchInitialMessage({ sessionId });
+    },
 
     // Utility actions
     showCooling: (show: boolean) =>

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -173,6 +173,10 @@ export function UnifiedSessionScreen({
 
   // Real-time presence tracking
 
+  // Invitee Stage 0 topic-ack flag — local UI state.
+  // Declared early so it can flow into useUnifiedSession (which uses it to
+  // defer the Stage 0/1 initial AI message fetch for the invitee).
+  const [inviteeAckDone, setInviteeAckDone] = useState(false);
 
   const {
     // Loading
@@ -286,7 +290,11 @@ export function UnifiedSessionScreen({
 
     // Session viewed tracking
     markSessionViewed,
-  } = useUnifiedSession(sessionId);
+
+    // Stage advancement (used by invitee topic-ack Ready button)
+    advanceStage,
+    triggerInitialMessage,
+  } = useUnifiedSession(sessionId, { inviteeTopicAcked: inviteeAckDone });
 
   // AI message handler for fire-and-forget pattern
   const { addAIMessage, handleAIMessageError } = useAIMessageHandler();
@@ -769,6 +777,8 @@ export function UnifiedSessionScreen({
   // -------------------------------------------------------------------------
   const [invitationPanelDismissed, setInvitationPanelDismissed] = useState(false);
 
+  // (inviteeAckDone is declared above, before useUnifiedSession.)
+
   // Tooltip shown after "Later" — points at the book icon to teach the user
   // they can share later from the activity drawer. Session-local only.
   const [showShareLaterTooltip, setShowShareLaterTooltip] = useState(false);
@@ -949,6 +959,17 @@ export function UnifiedSessionScreen({
   // The optimistic updates in mutation hooks (onMutate) ensure panels hide immediately.
   // No latch refs needed - if API fails, onError rolls back the cache and panel reappears.
   const isInviter = invitation?.isInviter ?? true;
+  // Invitee Stage 0 topic-ack screen is active when:
+  //   - user is the invitee
+  //   - compact has been signed (welcome step is done)
+  //   - they haven't tapped the topic-ack Ready button yet
+  //   - no chat messages exist yet (so this never triggers on later opens)
+  const inviteeTopicAckPending =
+    !isInviter &&
+    !!compactData?.mySigned &&
+    !inviteeAckDone &&
+    messages.length === 0 &&
+    !!topicFrame;
   const {
     waitingStatus,
     shouldShowWaitingBanner,
@@ -982,6 +1003,7 @@ export function UnifiedSessionScreen({
     topicFrameProposed: topicFrame ?? null,
     topicProposalDismissed,
     isConfirmingTopicFrame,
+    inviteeTopicAckPending,
     showFeelHeardConfirmation,
     feelHeardConfirmedAt: milestones?.feelHeardConfirmedAt,
     isConfirmingFeelHeard,
@@ -1689,6 +1711,27 @@ export function UnifiedSessionScreen({
     return <CompactChatItem testID="inline-compact" isFirstSession={isFirstSession} />;
   }, [isFirstSession]);
 
+  // Invitee Stage 0 topic-acknowledgement message body.
+  // Rendered in the message area (not in the bottom bar) per spec:
+  // intro line + topic frame with breathing room + closing line.
+  const inviteeTopicAckEmptyStateElement = useMemo(() => {
+    return (
+      <View style={styles.inviteeTopicAckBody} testID="invitee-topic-ack-body">
+        <Text style={styles.inviteeTopicAckText}>
+          {`Before we begin, this is what ${partnerName || 'your partner'} would like to work through with you:`}
+        </Text>
+        <View style={styles.inviteeTopicAckFrameWrap}>
+          <Text style={styles.inviteeTopicAckFrame} testID="invitee-topic-text">
+            {topicFrame ?? ''}
+          </Text>
+        </View>
+        <Text style={styles.inviteeTopicAckText}>
+          {"This is how things look from their side right now. You don't need to agree with it, respond to it, or do anything with it yet. Instead, I'd like to know what is happening from your point of view."}
+        </Text>
+      </View>
+    );
+  }, [styles, partnerName, topicFrame]);
+
   // -------------------------------------------------------------------------
   // Render Overlays
   // -------------------------------------------------------------------------
@@ -1934,9 +1977,26 @@ export function UnifiedSessionScreen({
             }}
             isPending={isSigningCompact}
             isFirstSession={isFirstSession}
-            inviteeTopic={!isInviter && topicFrameConfirmed ? topicFrame : undefined}
-            partnerName={partnerName}
             testID="compact-agreement-bar"
+          />
+        );
+
+      case 'invitee-topic-ack':
+        return (
+          <CompactAgreementBar
+            onSign={() => {
+              // Mark ack done so the topic-ack panel hides and the input
+              // un-hides. Trigger the Stage 0/1 initial AI message and
+              // advance to Stage 1 server-side (idempotent — server already
+              // auto-advanced this user when both sides signed).
+              setInviteeAckDone(true);
+              triggerInitialMessage();
+              if (sessionId) advanceStage({ sessionId });
+            }}
+            isPending={false}
+            isFirstSession={true}
+            buttonLabel="Ready"
+            testID="invitee-topic-ack-bar"
           />
         );
 
@@ -2418,9 +2478,15 @@ export function UnifiedSessionScreen({
           onContextSharedPress={() => {
             setShowActivityMenu(true);
           }}
-          // Show compact as custom empty state during onboarding when not signed
+          // Show compact as custom empty state during onboarding when not signed.
+          // For the invitee on Stage 0 topic-ack, show the topic-ack body
+          // instead (renders inside the messages area, with a Ready bar below).
           customEmptyState={
-            isInOnboardingUnsigned ? compactEmptyStateElement : undefined
+            isInOnboardingUnsigned
+              ? compactEmptyStateElement
+              : aboveInputPanel === 'invitee-topic-ack'
+                ? inviteeTopicAckEmptyStateElement
+                : undefined
           }
           renderAboveInput={aboveInputPanel ? renderAboveInput : undefined}
           renderBelowChat={(inlineCards.length > 0 || memorySuggestion) ? () => (
@@ -3096,6 +3162,32 @@ const useStyles = () =>
       fontWeight: '600' as const,
     },
 
+    inviteeTopicAckBody: {
+      paddingHorizontal: t.spacing.lg,
+      paddingTop: t.spacing.lg,
+      paddingBottom: t.spacing.md,
+    },
+    inviteeTopicAckText: {
+      fontSize: t.typography.fontSize.md,
+      lineHeight: 22,
+      color: t.colors.textPrimary,
+    },
+    inviteeTopicAckFrameWrap: {
+      paddingVertical: t.spacing.xl,
+      paddingHorizontal: t.spacing.md,
+      marginVertical: t.spacing.lg,
+      borderRadius: t.radius.md,
+      backgroundColor: t.colors.bgSecondary,
+      borderWidth: 1,
+      borderColor: t.colors.border,
+    },
+    inviteeTopicAckFrame: {
+      fontSize: t.typography.fontSize.lg,
+      color: t.colors.textPrimary,
+      fontWeight: '600' as const,
+      lineHeight: 28,
+      textAlign: 'center' as const,
+    },
     topicProposalContainer: {
       marginHorizontal: t.spacing.lg,
       marginTop: t.spacing.sm,

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -30,6 +30,7 @@ import { getWaitingStatusConfig, WaitingStatusConfig } from '../config/waitingSt
 export type AboveInputPanel =
   | 'topic-proposal' // AI-proposed topic awaiting Use/Refine (Stage 0, inviter)
   | 'invitation' // Invitation share panel for inviters
+  | 'invitee-topic-ack' // Invitee Stage 0 topic-acknowledgement Ready bar
   | 'empathy-statement' // Empathy statement review panel
   | 'feel-heard' // Feel heard confirmation panel
   | 'share-suggestion' // Share suggestion from reconciler (Subject side)
@@ -66,6 +67,11 @@ export interface ChatUIStateInputs extends WaitingStatusInputs {
   hasTopicConfirmed: boolean;
   invitationPanelDismissed: boolean;
   isConfirmingInvitation: boolean;
+
+  // Invitee Stage 0: topic-acknowledgement step. When true, the invitee has
+  // signed the compact and is on the topic-ack screen (showing the inviter's
+  // confirmed topicFrame with a Ready bar). Hides chat input.
+  inviteeTopicAckPending: boolean;
 
   // Stage 0: AI-proposed topic awaiting user decision (Use / Refine).
   // The topic-proposal panel appears for the inviter when the AI has emitted
@@ -136,6 +142,7 @@ export interface ChatUIState {
   panels: {
     showTopicProposalPanel: boolean;
     showInvitationPanel: boolean;
+    showInviteeTopicAckPanel: boolean;
     showEmpathyPanel: boolean;
     showFeelHeardPanel: boolean;
     showShareSuggestionPanel: boolean;
@@ -442,6 +449,11 @@ function computeAboveInputPanel(
     return 'invitation';
   }
 
+  // Priority 2b: Invitee topic acknowledgement (Stage 0, after compact signed)
+  if (panels.showInviteeTopicAckPanel) {
+    return 'invitee-topic-ack';
+  }
+
   // Priority 3: Feel heard panel (Stage 1)
   if (panels.showFeelHeardPanel) {
     return 'feel-heard';
@@ -522,6 +534,11 @@ function computeShouldHideInput(
     return true;
   }
 
+  // Invitee Stage 0 topic acknowledgement: hide input until they tap Ready
+  if (aboveInputPanel === 'invitee-topic-ack') {
+    return true;
+  }
+
   // Note: hasUnviewedSharedContext no longer hides input.
   // The notification popup already surfaces the shared context to the user,
   // so requiring them to also open the Activity menu is unnecessary friction.
@@ -581,6 +598,7 @@ export function computeChatUIState(inputs: ChatUIStateInputs): ChatUIState {
   // Step 3: Compute individual panel visibility
   const showTopicProposalPanel = computeShowTopicProposalPanel(inputs);
   const showInvitationPanel = computeShowInvitationPanel(inputs);
+  const showInviteeTopicAckPanel = !inputs.isInviter && inputs.inviteeTopicAckPending;
   const showEmpathyPanel = computeShowEmpathyPanel(inputs);
   const showFeelHeardPanel = computeShowFeelHeardPanel(inputs);
   const showShareSuggestionPanel = computeShowShareSuggestionPanel(inputs);
@@ -592,6 +610,7 @@ export function computeChatUIState(inputs: ChatUIStateInputs): ChatUIState {
   const panels = {
     showTopicProposalPanel,
     showInvitationPanel,
+    showInviteeTopicAckPanel,
     showEmpathyPanel,
     showFeelHeardPanel,
     showShareSuggestionPanel,
@@ -665,6 +684,7 @@ export function createDefaultChatUIStateInputs(): ChatUIStateInputs {
     topicFrameProposed: null,
     topicProposalDismissed: false,
     isConfirmingTopicFrame: false,
+    inviteeTopicAckPending: false,
     showFeelHeardConfirmation: false,
     feelHeardConfirmedAt: undefined,
     isConfirmingFeelHeard: false,

--- a/website/app/app/page.tsx
+++ b/website/app/app/page.tsx
@@ -3,5 +3,5 @@ import { redirect } from "next/navigation";
 // The native-app download page moved to /download. /app now funnels visitors
 // straight to the hosted web app so there's no install step in the way.
 export default function AppRedirect(): never {
-  redirect("https://app.meetwithoutfear.com/");
+  redirect(process.env.NEXT_PUBLIC_APP_URL || "https://app.meetwithoutfear.com/");
 }

--- a/website/app/invitation/[id]/page.tsx
+++ b/website/app/invitation/[id]/page.tsx
@@ -508,7 +508,7 @@ function SuccessState() {
           Your account has been created and linked to this session. Open the app to get started.
         </p>
         <a
-          href="https://app.meetwithoutfear.com/"
+          href={process.env.NEXT_PUBLIC_APP_URL || "https://app.meetwithoutfear.com/"}
           className="inline-flex items-center justify-center gap-2 bg-accent text-accent-foreground px-8 py-4 rounded-xl font-semibold text-lg hover:bg-accent/90 transition-all"
         >
           Open Meet Without Fear


### PR DESCRIPTION
## Summary
- **Invitee Stage 0 UX**: invitee now sees the same welcome → Ready → topic acknowledgement → Ready → Stage 1, with no Stage 0 chat. Chat input is hidden during the welcome/ack states; the auto initial-AI-message is suppressed.
- **Invitation readiness timing**: confirming the topic now also flips `invitation.messageConfirmed` and `session.status → INVITED`, so the partner can accept the invitation link the moment the inviter taps "Use this topic" — without waiting for them to close the share modal. Stage 0→1 advancement and the AI transition message stay gated to `confirmInvitationMessage` (fired when the inviter closes the modal).
- **Idempotent stage advancement**: `confirmInvitationMessage`'s early-return now keys off `StageProgress[stage=0].status === 'COMPLETED'` instead of `messageConfirmed`, so the eager flip above doesn't skip stage advancement.
- **Website**: replace hardcoded `https://app.meetwithoutfear.com/` in `/app` and `/invitation/[id]` with `NEXT_PUBLIC_APP_URL` (defaults to prod) so local dev can point at the local app.

## Test plan
- [ ] Inviter: start a session, chat until AI emits a `<draft>`, tap **Use this topic**. Modal opens; chat is idle (no new AI message). Tap Share → native share sheet. Tap × → modal closes, tooltip points at the book icon, chat advances to Stage 1.
- [ ] Invitee: open the invitation link in another browser. See "Ready to invite" link → Open Meet Without Fear → welcome screen → Ready → topic acknowledgement (with breathing room around the topic) → Ready → Stage 1.
- [ ] Invitee can accept the link as soon as the inviter taps Use this topic, even if the modal hasn't been closed.
- [ ] Local dev: `NEXT_PUBLIC_APP_URL=http://localhost:8081` in `website/.env.local` makes "Open Meet Without Fear" point at local Expo web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)