### PR TITLE
fix(invitations): default to production URL when env vars are unset

### DIFF
--- a/backend/src/utils/__tests__/urls.test.ts
+++ b/backend/src/utils/__tests__/urls.test.ts
@@ -1,0 +1,66 @@
+import { createInvitationUrl, getWebsiteUrl } from '../urls';
+
+describe('urls', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.WEBSITE_URL;
+    delete process.env.APP_URL;
+    delete process.env.NODE_ENV;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('getWebsiteUrl', () => {
+    it('uses WEBSITE_URL when set', () => {
+      process.env.WEBSITE_URL = 'https://example.com';
+      expect(getWebsiteUrl()).toBe('https://example.com');
+    });
+
+    it('uses APP_URL when WEBSITE_URL is not set', () => {
+      process.env.APP_URL = 'https://legacy.example.com';
+      expect(getWebsiteUrl()).toBe('https://legacy.example.com');
+    });
+
+    it('prefers WEBSITE_URL over APP_URL', () => {
+      process.env.WEBSITE_URL = 'https://new.example.com';
+      process.env.APP_URL = 'https://legacy.example.com';
+      expect(getWebsiteUrl()).toBe('https://new.example.com');
+    });
+
+    it('returns localhost only when NODE_ENV is explicitly development', () => {
+      process.env.NODE_ENV = 'development';
+      expect(getWebsiteUrl()).toBe('http://localhost:3001');
+    });
+
+    it('returns the production URL when NODE_ENV is production', () => {
+      process.env.NODE_ENV = 'production';
+      expect(getWebsiteUrl()).toBe('https://meetwithoutfear.com');
+    });
+
+    it('returns the production URL when NODE_ENV is unset (safe default)', () => {
+      expect(getWebsiteUrl()).toBe('https://meetwithoutfear.com');
+    });
+
+    it('returns the production URL for unknown NODE_ENV values', () => {
+      process.env.NODE_ENV = 'staging';
+      expect(getWebsiteUrl()).toBe('https://meetwithoutfear.com');
+    });
+  });
+
+  describe('createInvitationUrl', () => {
+    it('appends the invitation id to the website URL', () => {
+      process.env.WEBSITE_URL = 'https://example.com';
+      expect(createInvitationUrl('abc-123')).toBe('https://example.com/invitation/abc-123');
+    });
+
+    it('uses the production URL when env vars are unset', () => {
+      expect(createInvitationUrl('abc-123')).toBe(
+        'https://meetwithoutfear.com/invitation/abc-123',
+      );
+    });
+  });
+});

--- a/backend/src/utils/urls.ts
+++ b/backend/src/utils/urls.ts
@@ -20,9 +20,14 @@ export function getWebsiteUrl(): string {
     return process.env.APP_URL;
   }
 
-  // Use environment-aware defaults
-  const isDevelopment = process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
-  return isDevelopment ? 'http://localhost:3001' : 'https://meetwithoutfear.com';
+  // Only fall back to localhost when we explicitly know we're in development.
+  // Any other case (production, test, or unset NODE_ENV) must use the
+  // production URL so a missing env var can never leak localhost links to users.
+  if (process.env.NODE_ENV === 'development') {
+    return 'http://localhost:3001';
+  }
+
+  return 'https://meetwithoutfear.com';
 }
 
 /**

--- a/render.yaml
+++ b/render.yaml
@@ -8,3 +8,7 @@ services:
     startCommand: cd backend && npx prisma migrate deploy && node dist/backend/src/server.js
     envVars:
       - fromGroup: be-heard-api-env
+      - key: NODE_ENV
+        value: production
+      - key: WEBSITE_URL
+        value: https://meetwithoutfear.com


### PR DESCRIPTION
In production on Render, neither WEBSITE_URL nor NODE_ENV were set in
the env group, so getWebsiteUrl() hit the development fallback and
generated invitation links pointing at http://localhost:3001.

Invert the default: only return localhost when NODE_ENV is explicitly
"development". Production, test, and unset NODE_ENV all fall through to
the production URL — a missing env var can no longer leak localhost
links to users.

Also pin NODE_ENV=production and WEBSITE_URL in render.yaml as
defense-in-depth so the requirement is documented in the repo.

https://claude.ai/code/session_01HkZ4XBEBRnJjd7B7LofrFk