### PR TITLE
[codex] Fix invitation chat flow and session deletion

### DIFF
--- a/backend/prisma/migrations/20260504120000_add_user_vessel_archived_at/migration.sql
+++ b/backend/prisma/migrations/20260504120000_add_user_vessel_archived_at/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "UserVessel" ADD COLUMN "archivedAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -359,6 +359,9 @@ model UserVessel {
   // When the user last viewed the Share/Partner tab
   // Used to determine "seen" status for shared content (empathy, context)
   lastViewedShareTabAt DateTime?
+  // When this user removed the session from their own conversation list.
+  // The partner may still retain their own vessel and access.
+  archivedAt           DateTime?
 
   // === Notable Facts ===
   // AI-extracted structured facts about the user's situation, emotions, and circumstances

--- a/backend/src/controllers/invitations.ts
+++ b/backend/src/controllers/invitations.ts
@@ -64,6 +64,12 @@ export async function listSessions(req: Request, res: Response): Promise<void> {
             some: { userId: user.id },
           },
         },
+        userVessels: {
+          some: {
+            userId: user.id,
+            archivedAt: null,
+          },
+        },
         ...(status && { status: status as 'INVITED' | 'ACTIVE' | 'PAUSED' | 'RESOLVED' | 'ABANDONED' }),
       },
       include: {

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -81,7 +81,7 @@ function getFallbackInitialMessage(
   const partner = partnerName || 'them';
 
   if (isInvitee) {
-    return `Hey ${userName}, thanks for accepting ${partner}'s invitation to talk. What's been on your mind about things with ${partner}?`;
+    return `I'd like to hear your side now. What's been happening from your point of view with ${partner}?`;
   }
 
   if (isInvitationPhase) {
@@ -926,7 +926,7 @@ export async function getInitialMessage(
     } else {
       prompt = buildInitialMessagePrompt(
         currentStage,
-        { userName, partnerName, isInvitee, innerThoughtsContext },
+        { userName, partnerName, isInvitee, topicFrame: session.topicFrame, innerThoughtsContext },
         isInvitationPhase
       );
     }

--- a/backend/src/controllers/session-state.ts
+++ b/backend/src/controllers/session-state.ts
@@ -118,6 +118,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
           },
         },
         select: {
+          lastViewedAt: true,
           lastSeenChatItemId: true,
         },
       }),
@@ -290,6 +291,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
         },
         createdAt: session.createdAt.toISOString(),
         resolvedAt: session.resolvedAt?.toISOString() ?? null,
+        lastViewedAt: userVessel?.lastViewedAt?.toISOString() ?? null,
         lastSeenChatItemId: userVessel?.lastSeenChatItemId ?? null,
       },
 

--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -890,5 +890,24 @@ describe('Stage Prompts Service', () => {
 
       expect(prompt).toContain('your partner');
     });
+
+    it('invitee opener continues after the topic card instead of greeting again', () => {
+      const prompt = buildInitialMessagePrompt(
+        1,
+        {
+          userName: 'Jason',
+          partnerName: 'Shantam',
+          isInvitee: true,
+          topicFrame: 'Giving each other heads up before stopping by',
+        },
+        false
+      );
+
+      expect(prompt).toContain('TOPIC ALREADY SHOWN ABOVE THIS MESSAGE');
+      expect(prompt).toContain('Giving each other heads up before stopping by');
+      expect(prompt).toContain('Does NOT greet them by name');
+      expect(prompt).toContain('Does NOT say "thanks for accepting"');
+      expect(prompt).not.toContain('Hey Jason, thanks for accepting');
+    });
   });
 });

--- a/backend/src/services/session-deletion.ts
+++ b/backend/src/services/session-deletion.ts
@@ -109,8 +109,30 @@ export async function deleteSessionForUser(
     where: { sessionId, userId },
   });
   if (userVessel) {
-    await prisma.userVessel.delete({
+    await prisma.userEvent.deleteMany({ where: { vesselId: userVessel.id } });
+    await prisma.emotionalReading.deleteMany({ where: { vesselId: userVessel.id } });
+    await prisma.identifiedNeed.deleteMany({ where: { vesselId: userVessel.id } });
+    await prisma.boundary.deleteMany({ where: { vesselId: userVessel.id } });
+    await prisma.userDocument.deleteMany({ where: { vesselId: userVessel.id } });
+    await prisma.userVessel.update({
       where: { id: userVessel.id },
+      data: {
+        archivedAt: new Date(),
+        conversationSummary: null,
+        notableFacts: undefined,
+        lastViewedAt: null,
+        lastSeenChatItemId: null,
+        lastViewedShareTabAt: null,
+      },
+    });
+    dataRecordsDeleted += 1;
+  } else {
+    await prisma.userVessel.create({
+      data: {
+        sessionId,
+        userId,
+        archivedAt: new Date(),
+      },
     });
     dataRecordsDeleted += 1;
   }

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -410,6 +410,8 @@ export interface InitialMessageContext {
   partnerName?: string;
   /** Whether the user is the invitee (joined via invitation from partner) */
   isInvitee?: boolean;
+  /** Brief topic shown to the invitee before the first Stage 1 AI message */
+  topicFrame?: string | null;
   /** Context from an Inner Thoughts session that originated this partner session */
   innerThoughtsContext?: {
     summary: string;
@@ -976,27 +978,32 @@ export function buildInitialMessagePrompt(
 ): string {
   const partnerName = context.partnerName || 'your partner';
 
-  // Invitee joining session - welcome them and prompt to talk about the inviter
+  // Invitee joining session - continue from the already-visible topic card.
   if (context.isInvitee) {
-    return `You are Meet Without Fear, a Process Guardian. ${context.userName} has just accepted an invitation from ${partnerName} to have a meaningful conversation.
+    const topicContext = context.topicFrame
+      ? `\nTOPIC ALREADY SHOWN ABOVE THIS MESSAGE:\n"${context.topicFrame}"\n`
+      : '';
+
+    return `You are Meet Without Fear, a Process Guardian. ${context.userName} has accepted an invitation from ${partnerName} to have a meaningful conversation.
 
 ${SIMPLE_LANGUAGE_PROMPT}
 ${PRIVACY_GUIDANCE}
 
 CONTEXT:
-${partnerName} reached out to ${context.userName} through this app because they wanted to have a real conversation about something between them. ${context.userName} has accepted the invitation and is ready to begin.
+${partnerName} reached out to ${context.userName} through this app because they wanted to have a real conversation about something between them. The app has already shown ${context.userName} a topic card from ${partnerName}'s side before this message.${topicContext}
 
 YOUR TASK:
-Generate a warm, welcoming message (2-3 sentences) that:
-1. Welcomes them to the conversation
-2. Acknowledges that ${partnerName} reached out to them
-3. Gently asks what's going on from their perspective with ${partnerName}
+Generate a warm continuation message (1-2 sentences) that:
+1. Does NOT greet them by name.
+2. Does NOT say "thanks for accepting", "welcome", or repeat that they accepted an invitation.
+3. Briefly says you want to hear their side now.
+4. Gently asks what's happening from their perspective with ${partnerName}.
 
-Be warm and curious - make them feel safe to share. Don't be clinical or overly formal. The goal is to help them feel comfortable opening up about their side of whatever is happening with ${partnerName}.
+Be warm and curious - make them feel safe to share. Don't be clinical or overly formal. The goal is to help them feel comfortable opening up about their side of whatever is happening with ${partnerName}. This message appears after the topic card, so it should read like the next thing in the chat, not the first thing on the screen.
 
 EXAMPLE GOOD MESSAGES:
-- "Hey ${context.userName}, thanks for accepting ${partnerName}'s invitation to talk. I'm here to help both of you feel heard. What's been on your mind about things with ${partnerName}?"
-- "Welcome, ${context.userName}. ${partnerName} wanted to have a real conversation with you, and you showed up - that takes courage. What's going on between you two from your perspective?"
+- "I'd like to hear your side now. What's been happening from your point of view with ${partnerName}?"
+- "Now that you've seen what ${partnerName} wants to work through, tell me what this looks like from your side."
 
 ${buildResponseProtocol(-1)}`;
   }

--- a/mobile/app/(auth)/(tabs)/sessions.tsx
+++ b/mobile/app/(auth)/(tabs)/sessions.tsx
@@ -8,7 +8,9 @@ import {
   ActivityIndicator,
   Animated,
   Alert,
+  Platform,
 } from 'react-native';
+import type { PointerEvent as RNPointerEvent } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Plus, Trash2 } from 'lucide-react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -21,6 +23,9 @@ import { SessionStatus } from '@meet-without-fear/shared';
 import { createStyles } from '@/src/theme/styled';
 import { colors } from '@/src/theme';
 
+const SWIPE_PRESS_BLOCK_MS = 650;
+const SWIPE_CANCEL_DISTANCE = 8;
+
 /**
  * Sessions tab screen
  * Lists all user's sessions with swipe-to-delete
@@ -31,6 +36,9 @@ export default function SessionsScreen() {
   const { data, isLoading, refetch, isRefetching } = useSessions();
   const deleteSession = useDeleteSession();
   const swipeableRefs = useRef<Map<string, Swipeable>>(new Map());
+  const swipePressBlockUntilRef = useRef(0);
+  const swipeStartRefs = useRef<Map<string, { x: number; y: number }>>(new Map());
+  const [openSwipeableId, setOpenSwipeableId] = useState<string | null>(null);
 
   // Animation refs for optimistic delete with slide-up
   const animationRefs = useRef<Record<string, { opacity: Animated.Value; height: Animated.Value }>>({});
@@ -57,9 +65,41 @@ export default function SessionsScreen() {
     router.push('/session/new');
   };
 
-  const handleSessionPress = (sessionId: string) => {
+  const handleSessionPress = useCallback((sessionId: string) => {
+    if (openSwipeableId === sessionId || Date.now() < swipePressBlockUntilRef.current) {
+      swipeableRefs.current.get(sessionId)?.close();
+      setOpenSwipeableId((current) => current === sessionId ? null : current);
+      return;
+    }
+
     router.push(`/session/${sessionId}`);
-  };
+  }, [openSwipeableId, router]);
+
+  const blockPressAfterSwipe = useCallback((sessionId?: string) => {
+    swipePressBlockUntilRef.current = Date.now() + SWIPE_PRESS_BLOCK_MS;
+    if (sessionId) {
+      setOpenSwipeableId(sessionId);
+    }
+  }, []);
+
+  const handleSwipePointerStart = useCallback((sessionId: string, x: number, y: number) => {
+    swipeStartRefs.current.set(sessionId, { x, y });
+  }, []);
+
+  const handleSwipePointerMove = useCallback((sessionId: string, x: number, y: number) => {
+    const start = swipeStartRefs.current.get(sessionId);
+    if (!start) return;
+
+    const dx = Math.abs(x - start.x);
+    const dy = Math.abs(y - start.y);
+    if (dx > SWIPE_CANCEL_DISTANCE && dx > dy) {
+      blockPressAfterSwipe(sessionId);
+    }
+  }, [blockPressAfterSwipe]);
+
+  const handleSwipePointerEnd = useCallback((sessionId: string) => {
+    swipeStartRefs.current.delete(sessionId);
+  }, []);
 
   // All sessions can be deleted
   const canDelete = (status: SessionStatus): boolean => {
@@ -90,55 +130,65 @@ export default function SessionsScreen() {
         ? `Delete your session with ${partnerName}? Your partner will be notified and can keep their own data.`
         : `Delete your session with ${partnerName}?`;
 
+      const deleteAfterConfirm = () => {
+        // Mark session as deleting immediately
+        setDeletingSessions(prev => new Set(prev).add(session.id));
+
+        const animationValues = getAnimationValues(session.id);
+
+        // Use measured height for collapse animation
+        const measuredHeight = layoutHeightsRef.current[session.id] || 100;
+        animationValues.height.setValue(measuredHeight);
+
+        // Run fade and height collapse simultaneously
+        Animated.parallel([
+          Animated.timing(animationValues.opacity, {
+            toValue: 0,
+            duration: 200,
+            useNativeDriver: false,
+          }),
+          Animated.timing(animationValues.height, {
+            toValue: 0,
+            duration: 300,
+            useNativeDriver: false,
+          }),
+        ]).start(async () => {
+          // After animation completes, delete from backend
+          try {
+            await deleteSession.mutateAsync({ sessionId: session.id });
+            // Clean up animation refs
+            delete animationRefs.current[session.id];
+            delete layoutHeightsRef.current[session.id];
+          } catch (error) {
+            console.error('Failed to delete session:', error);
+            // Reset animations if deletion failed
+            animationValues.opacity.setValue(1);
+            animationValues.height.setValue(measuredHeight);
+            Alert.alert('Error', 'Failed to delete session. Please try again.');
+          } finally {
+            setDeletingSessions(prev => {
+              const newSet = new Set(prev);
+              newSet.delete(session.id);
+              return newSet;
+            });
+          }
+        });
+      };
+
+      if (Platform.OS === 'web') {
+        const confirmed = typeof globalThis.confirm === 'function'
+          ? globalThis.confirm(message)
+          : true;
+        if (confirmed) deleteAfterConfirm();
+        return;
+      }
+
       Alert.alert('Delete Session', message, [
         { text: 'Cancel', style: 'cancel' },
         {
           text: 'Delete',
           style: 'destructive',
-          onPress: () => {
-            // Mark session as deleting immediately
-            setDeletingSessions(prev => new Set(prev).add(session.id));
-
-            const animationValues = getAnimationValues(session.id);
-
-            // Use measured height for collapse animation
-            const measuredHeight = layoutHeightsRef.current[session.id] || 100;
-            animationValues.height.setValue(measuredHeight);
-
-            // Run fade and height collapse simultaneously
-            Animated.parallel([
-              Animated.timing(animationValues.opacity, {
-                toValue: 0,
-                duration: 200,
-                useNativeDriver: false,
-              }),
-              Animated.timing(animationValues.height, {
-                toValue: 0,
-                duration: 300,
-                useNativeDriver: false,
-              }),
-            ]).start(async () => {
-              // After animation completes, delete from backend
-              try {
-                await deleteSession.mutateAsync({ sessionId: session.id });
-                // Clean up animation refs
-                delete animationRefs.current[session.id];
-                delete layoutHeightsRef.current[session.id];
-              } catch (error) {
-                console.error('Failed to delete session:', error);
-                // Reset animations if deletion failed
-                animationValues.opacity.setValue(1);
-                animationValues.height.setValue(measuredHeight);
-                Alert.alert('Error', 'Failed to delete session. Please try again.');
-              } finally {
-                setDeletingSessions(prev => {
-                  const newSet = new Set(prev);
-                  newSet.delete(session.id);
-                  return newSet;
-                });
-              }
-            });
-          },
+          onPress: deleteAfterConfirm,
         },
       ]);
     },
@@ -184,7 +234,43 @@ export default function SessionsScreen() {
     ({ item }: { item: SessionSummaryDTO }) => {
       const isDeletable = canDelete(item.status);
       const isDeleting = deletingSessions.has(item.id);
+      const isSwipeOpen = openSwipeableId === item.id;
       const animationValues = getAnimationValues(item.id);
+
+      if (Platform.OS === 'web' && isDeletable) {
+        return (
+          <Animated.View
+            onLayout={(e) => {
+              const h = e.nativeEvent.layout.height;
+              if (h > 0) layoutHeightsRef.current[item.id] = h;
+            }}
+            style={[
+              styles.webSessionRow,
+              {
+                opacity: animationValues.opacity,
+                ...(isDeleting ? { height: animationValues.height, overflow: 'hidden' as const } : {}),
+              },
+            ]}
+          >
+            <TouchableOpacity
+              style={styles.webSessionPressArea}
+              onPress={() => handleSessionPress(item.id)}
+              disabled={isDeleting}
+            >
+              <SessionCard session={item} noMargin />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.webDeleteButton}
+              onPress={() => handleDelete(item)}
+              disabled={isDeleting}
+              accessibilityRole="button"
+              accessibilityLabel="Delete session"
+            >
+              <Trash2 color="#FFFFFF" size={20} />
+            </TouchableOpacity>
+          </Animated.View>
+        );
+      }
 
       const content = isDeletable ? (
         <Swipeable
@@ -200,8 +286,28 @@ export default function SessionsScreen() {
           }
           overshootRight={false}
           rightThreshold={40}
+          onSwipeableOpenStartDrag={() => {
+            blockPressAfterSwipe(item.id);
+          }}
+          onSwipeableWillOpen={() => {
+            blockPressAfterSwipe(item.id);
+            for (const [sessionId, ref] of swipeableRefs.current) {
+              if (sessionId !== item.id) ref.close();
+            }
+            setOpenSwipeableId(item.id);
+          }}
+          onSwipeableOpen={() => {
+            blockPressAfterSwipe(item.id);
+            setOpenSwipeableId(item.id);
+          }}
+          onSwipeableWillClose={() => {
+            blockPressAfterSwipe();
+          }}
+          onSwipeableClose={() => {
+            setOpenSwipeableId((current) => current === item.id ? null : current);
+          }}
         >
-          <TouchableOpacity onPress={() => handleSessionPress(item.id)} disabled={isDeleting}>
+          <TouchableOpacity onPress={() => handleSessionPress(item.id)} disabled={isDeleting || isSwipeOpen}>
             <SessionCard session={item} noMargin />
           </TouchableOpacity>
         </Swipeable>
@@ -223,12 +329,29 @@ export default function SessionsScreen() {
               ...(isDeleting ? { height: animationValues.height, overflow: 'hidden' } : {}),
             },
           ]}
+          onPointerDownCapture={(e: RNPointerEvent) => {
+            handleSwipePointerStart(item.id, e.nativeEvent.pageX, e.nativeEvent.pageY);
+          }}
+          onPointerMoveCapture={(e: RNPointerEvent) => {
+            handleSwipePointerMove(item.id, e.nativeEvent.pageX, e.nativeEvent.pageY);
+          }}
+          onPointerUpCapture={() => handleSwipePointerEnd(item.id)}
+          onPointerCancelCapture={() => handleSwipePointerEnd(item.id)}
         >
           {content}
         </Animated.View>
       );
     },
-    [renderRightActions, handleSessionPress, deletingSessions]
+    [
+      renderRightActions,
+      handleSessionPress,
+      deletingSessions,
+      openSwipeableId,
+      blockPressAfterSwipe,
+      handleSwipePointerEnd,
+      handleSwipePointerMove,
+      handleSwipePointerStart,
+    ]
   );
 
   const renderEmptyState = () => (
@@ -371,5 +494,21 @@ const useStyles = () =>
       fontSize: 12,
       fontWeight: '600',
       marginTop: 4,
+    },
+    webSessionRow: {
+      flexDirection: 'row',
+      alignItems: 'stretch',
+      gap: t.spacing.xs,
+    },
+    webSessionPressArea: {
+      flex: 1,
+      minWidth: 0,
+    },
+    webDeleteButton: {
+      width: 48,
+      borderRadius: t.radius.lg,
+      backgroundColor: t.colors.error,
+      alignItems: 'center',
+      justifyContent: 'center',
     },
   }));

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -68,7 +68,12 @@ export interface ChatCustomCardItem {
   type: 'custom-card';
   id: string;
   timestamp: string;
-  render: () => React.ReactNode;
+  /** Whether this card participates in the same animation queue as AI messages. */
+  animate?: boolean;
+  render: (options?: {
+    skipAnimation: boolean;
+    onAnimationComplete?: () => void;
+  }) => React.ReactNode;
 }
 
 export type ChatListItem = ChatMessage | ChatIndicatorItem | ChatValidationCardItem | ChatCustomCardItem | CustomEmptyStateItem;
@@ -147,6 +152,8 @@ interface ChatInterfaceProps {
   onVoicePress?: () => void;
   /** ID of the last chat item the user has seen - used to show "New messages" separator */
   lastSeenChatItemId?: string | null;
+  /** Server-backed timestamp from before this screen marked the session viewed. */
+  lastViewedAt?: string | null;
   /** Callback when "Context shared" indicator is tapped - navigates to Sharing Status
    * @param timestamp - The timestamp of the shared context (for scrolling to it)
    */
@@ -197,6 +204,7 @@ export function ChatInterface({
   skipInitialHistory = false,
   partnerName,
   lastSeenChatItemId,
+  lastViewedAt,
   onContextSharedPress,
   validationCards,
   onValidateAccurate,
@@ -226,8 +234,8 @@ export function ChatInterface({
   // 2. Cache-First behavior (deriving from last message role)
   const showTypingIndicator = isLoading || isWaitingForAI;
 
-  // Track the ID of the message currently being animated via typewriter
-  const [animatingMessageId, setAnimatingMessageId] = useState<string | null>(null);
+  // Track the ID of the chat item currently being animated.
+  const [animatingItemId, setAnimatingItemId] = useState<string | null>(null);
 
   // Speech functionality
   const { isSpeaking, currentId, toggle: toggleSpeech } = useSpeech();
@@ -235,8 +243,8 @@ export function ChatInterface({
   // Track messages that have already been auto-spoken (to avoid re-speaking)
   const spokenMessageIdsRef = useRef<Set<string>>(new Set());
 
-  // Track messages that have completed typewriter animation (separate from initial load)
-  const animatedMessageIdsRef = useRef<Set<string>>(new Set());
+  // Track items that have completed animation during this mount.
+  const animatedItemIdsRef = useRef<Set<string>>(new Set());
 
   // STABLE SORT: Ensure order never flip-flops if timestamps are identical
   const listItems = useMemo((): ChatListItem[] => {
@@ -292,7 +300,7 @@ export function ChatInterface({
     }
 
     return items;
-  }, [messages, indicators, validationCards, customCards, customEmptyState, lastSeenChatItemId]);
+  }, [messages, indicators, validationCards, customCards, customEmptyState, lastSeenChatItemId, lastViewedAt]);
 
   const scrollMetricsRef = useRef({
     offset: 0,
@@ -379,6 +387,54 @@ export function ChatInterface({
     prevCustomEmptyStateRef.current = customEmptyState;
   }, [customEmptyState]);
 
+  const lastViewedAtTime = useMemo(() => {
+    if (!lastViewedAt) return null;
+    const time = new Date(lastViewedAt).getTime();
+    return Number.isFinite(time) ? time : null;
+  }, [lastViewedAt]);
+
+  const lastSeenItemIndex = useMemo(() => {
+    if (!lastSeenChatItemId) return -1;
+    return listItems.findIndex((item) => item.id === lastSeenChatItemId);
+  }, [listItems, lastSeenChatItemId]);
+
+  const isAtOrBeforeSeenBoundary = useCallback((item: ChatListItem, index: number) => {
+    if (lastSeenItemIndex >= 0 && index >= lastSeenItemIndex) {
+      return true;
+    }
+
+    if (lastViewedAtTime !== null && 'timestamp' in item && item.timestamp) {
+      const itemTime = new Date(item.timestamp).getTime();
+      if (Number.isFinite(itemTime) && itemTime <= lastViewedAtTime) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [lastSeenItemIndex, lastViewedAtTime]);
+
+  const shouldAnimateItem = useCallback((item: ChatListItem, index: number) => {
+    if (isIndicator(item) || isValidationCard(item) || isCustomEmptyState(item)) return false;
+    if (animatedItemIdsRef.current.has(item.id)) return false;
+    if (isAtOrBeforeSeenBoundary(item, index)) return false;
+
+    if (isCustomCard(item)) {
+      return item.animate === true;
+    }
+
+    const message = item as ChatMessage;
+    if (message.role === MessageRole.USER) return false;
+    if (message.id.startsWith('optimistic-')) return false;
+
+    // If there is no server read boundary yet, fall back to the original
+    // mount snapshot so loaded history does not animate on first render.
+    if (lastSeenItemIndex < 0 && lastViewedAtTime === null && mountSnapshotIdsRef.current.has(message.id)) {
+      return false;
+    }
+
+    return true;
+  }, [isAtOrBeforeSeenBoundary, lastSeenItemIndex, lastViewedAtTime]);
+
   // Auto-speech: speak new AI messages when enabled
   useEffect(() => {
     if (!isAutoSpeechEnabled || messages.length === 0) return;
@@ -387,8 +443,9 @@ export function ChatInterface({
     const newAIMessage = messages.find((m) => {
       if (m.role === MessageRole.USER) return false;
       if (m.id.startsWith('optimistic-')) return false;
-      if (mountSnapshotIdsRef.current.has(m.id)) return false;
       if (spokenMessageIdsRef.current.has(m.id)) return false;
+      const itemIndex = listItems.findIndex((item) => item.id === m.id);
+      if (itemIndex >= 0 && !shouldAnimateItem(m, itemIndex)) return false;
       return true;
     });
 
@@ -402,7 +459,7 @@ export function ChatInterface({
       toggleSpeech(newAIMessage.content, newAIMessage.id);
     }, 500);
     return () => clearTimeout(timer);
-  }, [messages, isAutoSpeechEnabled, toggleSpeech]);
+  }, [messages, listItems, isAutoSpeechEnabled, toggleSpeech, shouldAnimateItem]);
 
   // Handle speaker button press
   const handleSpeakerPress = useCallback(
@@ -415,22 +472,14 @@ export function ChatInterface({
   // Find the OLDEST non-user message that should animate
   // Sequential animation: oldest to newest (top to bottom visually)
   const nextAnimatableMessageId = useMemo(() => {
-    if (animatingMessageId !== null) return null;
+    if (animatingItemId !== null) return null;
 
     // listItems is sorted newest first (descending by timestamp)
     // Iterate from the END (oldest) to find the oldest animatable message
     for (let i = listItems.length - 1; i >= 0; i--) {
       const item = listItems[i];
-      if (isIndicator(item)) continue;
-      if (isValidationCard(item)) continue;
-      if (isCustomEmptyState(item) || isCustomCard(item)) continue;
-      const message = item as ChatMessage;
-      if (message.role === MessageRole.USER) continue;
-      if (message.id.startsWith('optimistic-')) continue;
-      // Skip messages in the mount snapshot (present on first render)
-      if (mountSnapshotIdsRef.current.has(message.id)) continue;
-      // Skip messages that have already completed animation
-      if (animatedMessageIdsRef.current.has(message.id)) continue;
+      if (!shouldAnimateItem(item, i)) continue;
+
       // Skip if a user message exists after this AI message chronologically
       // (user already saw and responded — no need to animate)
       let hasUserResponseAfter = false;
@@ -443,16 +492,16 @@ export function ChatInterface({
         }
       }
       if (hasUserResponseAfter) continue;
-      return message.id;
+      return item.id;
     }
     return null;
-  }, [listItems, animatingMessageId]);
+  }, [listItems, animatingItemId, shouldAnimateItem]);
 
   // Notify parent when typewriter state changes
   useEffect(() => {
-    const isAnimating = animatingMessageId !== null;
+    const isAnimating = animatingItemId !== null;
     onTypewriterStateChange?.(isAnimating);
-  }, [animatingMessageId, onTypewriterStateChange]);
+  }, [animatingItemId, onTypewriterStateChange]);
 
   const renderItem: ListRenderItem<ChatListItem> = useCallback(({ item }) => {
     // 1. Render Custom Empty State (Compact)
@@ -499,24 +548,33 @@ export function ChatInterface({
 
     // 4. Render Custom Cards
     if (isCustomCard(item)) {
-      return <>{item.render()}</>;
+      const itemIndex = listItems.findIndex((listItem) => listItem.id === item.id);
+      const shouldAnimate = itemIndex >= 0 ? shouldAnimateItem(item, itemIndex) : false;
+      const isNextAnimatable = item.id === nextAnimatableMessageId;
+
+      return (
+        <>
+          {item.render({
+            skipAnimation: !shouldAnimate || !isNextAnimatable,
+            onAnimationComplete: shouldAnimate && isNextAnimatable ? () => {
+              animatedItemIdsRef.current.add(item.id);
+              setAnimatingItemId(null);
+              onTypewriterComplete?.();
+            } : undefined,
+          })}
+        </>
+      );
     }
 
     // 5. Render Messages
     // At this point, item must be a ChatMessage (we've already handled indicators, validation cards, custom cards, and custom empty state)
     const message = item as ChatMessage;
     
-    const isInSnapshot = mountSnapshotIdsRef.current.has(message.id);
-    const hasAlreadyAnimated = animatedMessageIdsRef.current.has(message.id);
-    const isCurrentlyAnimating = message.id === animatingMessageId;
-    const isOptimisticMessage = message.id.startsWith('optimistic-');
+    const itemIndex = listItems.findIndex((listItem) => listItem.id === message.id);
+    const isCurrentlyAnimating = message.id === animatingItemId;
     const isAIMessage = message.role !== MessageRole.USER;
 
-    // Animate if: AI message, not in mount snapshot, not already animated, not optimistic
-    const shouldAnimateTypewriter = isAIMessage &&
-      !isInSnapshot &&
-      !hasAlreadyAnimated &&
-      !isOptimisticMessage;
+    const shouldAnimateTypewriter = itemIndex >= 0 ? shouldAnimateItem(message, itemIndex) : false;
 
     // Track animation for the next message in queue (oldest unanimatied)
     const isNextAnimatable = message.id === nextAnimatableMessageId;
@@ -535,10 +593,10 @@ export function ChatInterface({
       <>
         <ChatBubble
           message={bubbleMessage}
-          onAnimationStart={isNextAnimatable ? () => setAnimatingMessageId(message.id) : undefined}
+          onAnimationStart={isNextAnimatable ? () => setAnimatingItemId(message.id) : undefined}
           onAnimationComplete={(isNextAnimatable || isCurrentlyAnimating) ? () => {
-            animatedMessageIdsRef.current.add(message.id);
-            setAnimatingMessageId(null);
+            animatedItemIdsRef.current.add(message.id);
+            setAnimatingItemId(null);
             onTypewriterComplete?.();
           } : undefined}
           isSpeaking={isSpeaking && currentId === message.id}
@@ -548,7 +606,7 @@ export function ChatInterface({
         {renderMessageExtra?.(message)}
       </>
     );
-  }, [nextAnimatableMessageId, animatingMessageId, onTypewriterComplete, isSpeaking, currentId, handleSpeakerPress, customEmptyState, styles, partnerName, renderMessageExtra, onValidateAccurate, onValidateNotQuite]);
+  }, [listItems, shouldAnimateItem, nextAnimatableMessageId, animatingItemId, onTypewriterComplete, isSpeaking, currentId, handleSpeakerPress, customEmptyState, styles, partnerName, renderMessageExtra, onValidateAccurate, onValidateNotQuite]);
 
   const keyExtractor = useCallback((item: ChatListItem) => item.id, []);
 

--- a/mobile/src/components/SessionDrawer/index.tsx
+++ b/mobile/src/components/SessionDrawer/index.tsx
@@ -23,6 +23,7 @@ import {
   Platform,
   useWindowDimensions,
 } from 'react-native';
+import type { PointerEvent as RNPointerEvent } from 'react-native';
 import { Drawer } from 'react-native-drawer-layout';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
@@ -41,6 +42,8 @@ import { SessionStatus } from '@meet-without-fear/shared';
 // The drawer must not exceed that column, or `react-native-drawer-layout`'s
 // `left: calc(width * -1)` offset pushes it off-screen.
 const WEB_COLUMN_MAX_WIDTH = 480;
+const SWIPE_PRESS_BLOCK_MS = 650;
+const SWIPE_CANCEL_DISTANCE = 8;
 
 // ============================================================================
 // Session Section Types
@@ -69,6 +72,9 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
   }, [isOpen, refetch]);
   const deleteSession = useDeleteSession();
   const swipeableRefs = useRef<Map<string, Swipeable>>(new Map());
+  const swipePressBlockUntilRef = useRef(0);
+  const swipeStartRefs = useRef<Map<string, { x: number; y: number }>>(new Map());
+  const [openSwipeableId, setOpenSwipeableId] = useState<string | null>(null);
 
   // Animation refs for optimistic delete
   const animationRefs = useRef<Record<string, { opacity: Animated.Value; height: Animated.Value }>>({});
@@ -114,11 +120,43 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
 
   const handleSessionPress = useCallback(
     (sessionId: string) => {
+      if (openSwipeableId === sessionId || Date.now() < swipePressBlockUntilRef.current) {
+        swipeableRefs.current.get(sessionId)?.close();
+        setOpenSwipeableId((current) => current === sessionId ? null : current);
+        return;
+      }
+
       onClose();
       router.push(`/session/${sessionId}`);
     },
-    [onClose, router]
+    [onClose, openSwipeableId, router]
   );
+
+  const blockPressAfterSwipe = useCallback((sessionId?: string) => {
+    swipePressBlockUntilRef.current = Date.now() + SWIPE_PRESS_BLOCK_MS;
+    if (sessionId) {
+      setOpenSwipeableId(sessionId);
+    }
+  }, []);
+
+  const handleSwipePointerStart = useCallback((sessionId: string, x: number, y: number) => {
+    swipeStartRefs.current.set(sessionId, { x, y });
+  }, []);
+
+  const handleSwipePointerMove = useCallback((sessionId: string, x: number, y: number) => {
+    const start = swipeStartRefs.current.get(sessionId);
+    if (!start) return;
+
+    const dx = Math.abs(x - start.x);
+    const dy = Math.abs(y - start.y);
+    if (dx > SWIPE_CANCEL_DISTANCE && dx > dy) {
+      blockPressAfterSwipe(sessionId);
+    }
+  }, [blockPressAfterSwipe]);
+
+  const handleSwipePointerEnd = useCallback((sessionId: string) => {
+    swipeStartRefs.current.delete(sessionId);
+  }, []);
 
   const handleNewSession = useCallback(() => {
     onClose();
@@ -135,46 +173,56 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
         ? `This will end your session with ${partnerName} and remove it from your list. They will be notified.`
         : `Remove this conversation with ${partnerName} from your list?`;
 
+      const deleteAfterConfirm = () => {
+        setDeletingSessions((prev) => new Set(prev).add(session.id));
+        const animationValues = getAnimationValues(session.id);
+        const measuredHeight = layoutHeightsRef.current[session.id] || 80;
+        animationValues.height.setValue(measuredHeight);
+
+        Animated.parallel([
+          Animated.timing(animationValues.opacity, {
+            toValue: 0,
+            duration: 200,
+            useNativeDriver: false,
+          }),
+          Animated.timing(animationValues.height, {
+            toValue: 0,
+            duration: 300,
+            useNativeDriver: false,
+          }),
+        ]).start(async () => {
+          try {
+            await deleteSession.mutateAsync({ sessionId: session.id });
+            delete animationRefs.current[session.id];
+            delete layoutHeightsRef.current[session.id];
+          } catch {
+            animationValues.opacity.setValue(1);
+            animationValues.height.setValue(measuredHeight);
+            Alert.alert('Error', 'Failed to delete conversation.');
+          } finally {
+            setDeletingSessions((prev) => {
+              const newSet = new Set(prev);
+              newSet.delete(session.id);
+              return newSet;
+            });
+          }
+        });
+      };
+
+      if (Platform.OS === 'web') {
+        const confirmed = typeof globalThis.confirm === 'function'
+          ? globalThis.confirm(message)
+          : true;
+        if (confirmed) deleteAfterConfirm();
+        return;
+      }
+
       Alert.alert('Delete Conversation', message, [
         { text: 'Cancel', style: 'cancel' },
         {
           text: 'Delete',
           style: 'destructive',
-          onPress: () => {
-            setDeletingSessions((prev) => new Set(prev).add(session.id));
-            const animationValues = getAnimationValues(session.id);
-            const measuredHeight = layoutHeightsRef.current[session.id] || 80;
-            animationValues.height.setValue(measuredHeight);
-
-            Animated.parallel([
-              Animated.timing(animationValues.opacity, {
-                toValue: 0,
-                duration: 200,
-                useNativeDriver: false,
-              }),
-              Animated.timing(animationValues.height, {
-                toValue: 0,
-                duration: 300,
-                useNativeDriver: false,
-              }),
-            ]).start(async () => {
-              try {
-                await deleteSession.mutateAsync({ sessionId: session.id });
-                delete animationRefs.current[session.id];
-                delete layoutHeightsRef.current[session.id];
-              } catch {
-                animationValues.opacity.setValue(1);
-                animationValues.height.setValue(measuredHeight);
-                Alert.alert('Error', 'Failed to delete conversation.');
-              } finally {
-                setDeletingSessions((prev) => {
-                  const newSet = new Set(prev);
-                  newSet.delete(session.id);
-                  return newSet;
-                });
-              }
-            });
-          },
+          onPress: deleteAfterConfirm,
         },
       ]);
     },
@@ -210,7 +258,45 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
   const renderItem = useCallback(
     ({ item }: { item: SessionSummaryDTO }) => {
       const isDeleting = deletingSessions.has(item.id);
+      const isSwipeOpen = openSwipeableId === item.id;
       const animationValues = getAnimationValues(item.id);
+
+      if (Platform.OS === 'web') {
+        return (
+          <Animated.View
+            onLayout={(e) => {
+              const h = e.nativeEvent.layout.height;
+              if (h > 0) layoutHeightsRef.current[item.id] = h;
+            }}
+            style={[
+              styles.webSessionRow,
+              {
+                opacity: animationValues.opacity,
+                ...(isDeleting ? { height: animationValues.height, overflow: 'hidden' as const } : {}),
+              },
+            ]}
+          >
+            <TouchableOpacity
+              style={styles.webSessionPressArea}
+              onPress={() => handleSessionPress(item.id)}
+              onLongPress={() => handleDelete(item)}
+              delayLongPress={500}
+              disabled={isDeleting}
+            >
+              <SessionCard session={item} noMargin />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.webDeleteButton}
+              onPress={() => handleDelete(item)}
+              disabled={isDeleting}
+              accessibilityRole="button"
+              accessibilityLabel="Delete conversation"
+            >
+              <Trash2 color="#FFFFFF" size={20} />
+            </TouchableOpacity>
+          </Animated.View>
+        );
+      }
 
       return (
         <Animated.View
@@ -224,6 +310,14 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
               ...(isDeleting ? { height: animationValues.height, overflow: 'hidden' } : {}),
             },
           ]}
+          onPointerDownCapture={(e: RNPointerEvent) => {
+            handleSwipePointerStart(item.id, e.nativeEvent.pageX, e.nativeEvent.pageY);
+          }}
+          onPointerMoveCapture={(e: RNPointerEvent) => {
+            handleSwipePointerMove(item.id, e.nativeEvent.pageX, e.nativeEvent.pageY);
+          }}
+          onPointerUpCapture={() => handleSwipePointerEnd(item.id)}
+          onPointerCancelCapture={() => handleSwipePointerEnd(item.id)}
         >
           <Swipeable
             ref={(ref) => {
@@ -233,12 +327,32 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
             renderRightActions={(progress, dragX) => renderRightActions(progress, dragX, item)}
             overshootRight={false}
             rightThreshold={40}
+            onSwipeableOpenStartDrag={() => {
+              blockPressAfterSwipe(item.id);
+            }}
+            onSwipeableWillOpen={() => {
+              blockPressAfterSwipe(item.id);
+              for (const [sessionId, ref] of swipeableRefs.current) {
+                if (sessionId !== item.id) ref.close();
+              }
+              setOpenSwipeableId(item.id);
+            }}
+            onSwipeableOpen={() => {
+              blockPressAfterSwipe(item.id);
+              setOpenSwipeableId(item.id);
+            }}
+            onSwipeableWillClose={() => {
+              blockPressAfterSwipe();
+            }}
+            onSwipeableClose={() => {
+              setOpenSwipeableId((current) => current === item.id ? null : current);
+            }}
           >
             <TouchableOpacity
               onPress={() => handleSessionPress(item.id)}
               onLongPress={() => handleDelete(item)}
               delayLongPress={500}
-              disabled={isDeleting}
+              disabled={isDeleting || isSwipeOpen}
             >
               <SessionCard session={item} noMargin />
             </TouchableOpacity>
@@ -246,7 +360,17 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
         </Animated.View>
       );
     },
-    [deletingSessions, handleSessionPress, handleDelete, renderRightActions]
+    [
+      deletingSessions,
+      handleSessionPress,
+      handleDelete,
+      handleSwipePointerEnd,
+      handleSwipePointerMove,
+      handleSwipePointerStart,
+      blockPressAfterSwipe,
+      openSwipeableId,
+      renderRightActions,
+    ]
   );
 
   const renderSectionHeader = useCallback(
@@ -453,5 +577,21 @@ const useStyles = () =>
       width: 70,
       borderTopRightRadius: t.radius.lg,
       borderBottomRightRadius: t.radius.lg,
+    },
+    webSessionRow: {
+      flexDirection: 'row',
+      alignItems: 'stretch',
+      gap: t.spacing.xs,
+    },
+    webSessionPressArea: {
+      flex: 1,
+      minWidth: 0,
+    },
+    webDeleteButton: {
+      width: 48,
+      borderRadius: t.radius.lg,
+      backgroundColor: '#E53935',
+      alignItems: 'center',
+      justifyContent: 'center',
     },
   }));

--- a/mobile/src/hooks/useSessions.ts
+++ b/mobile/src/hooks/useSessions.ts
@@ -935,7 +935,7 @@ export function useMarkSessionViewed(sessionId: string | undefined) {
       queryClient.invalidateQueries({ queryKey: sessionKeys.unreadCount() });
       // Update session state directly instead of invalidating to avoid race conditions
       // with other mutations (like confirmInvitation) that use optimistic updates.
-      // Only update lastSeenChatItemId which is what markViewed actually changes.
+      // Keep read state in sync for unread badges and animation boundaries.
       queryClient.setQueryData<SessionStateResponse>(
         sessionKeys.state(sessionId || ''),
         (old) => {
@@ -944,6 +944,7 @@ export function useMarkSessionViewed(sessionId: string | undefined) {
             ...old,
             session: {
               ...old.session,
+              lastViewedAt: data.lastViewedAt,
               lastSeenChatItemId: data.lastSeenChatItemId,
             },
           };

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -407,7 +407,18 @@ export function useUnifiedSession(
     // with older pages first: [page2, page1, page0].flatMap(p => p.messages)
     const pages = messagesData?.pages;
     if (!pages || pages.length === 0) return [];
-    return [...pages].reverse().flatMap(page => page.messages);
+    const seenIds = new Set<string>();
+    const dedupedMessages = [];
+
+    for (const page of [...pages].reverse()) {
+      for (const message of page.messages) {
+        if (seenIds.has(message.id)) continue;
+        seenIds.add(message.id);
+        dedupedMessages.push(message);
+      }
+    }
+
+    return dedupedMessages;
   }, [messagesData]);
 
   // -------------------------------------------------------------------------

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -434,18 +434,23 @@ export function useUnifiedSession(
   // Use undefined as initial state to indicate "not yet loaded" vs null meaning "never viewed"
   const initialLastSeenChatItemIdRef = useRef<string | null | undefined>(undefined);
   const [lastSeenChatItemIdForSeparator, setLastSeenChatItemIdForSeparator] = useState<string | null | undefined>(undefined);
+  const initialLastViewedAtRef = useRef<string | null | undefined>(undefined);
+  const [lastViewedAtForAnimation, setLastViewedAtForAnimation] = useState<string | null | undefined>(undefined);
 
   // Capture initial value when session loads (before marking viewed)
   useEffect(() => {
     if (
       session?.lastSeenChatItemId !== undefined &&
+      session?.lastViewedAt !== undefined &&
       initialLastSeenChatItemIdRef.current === undefined &&
       !hasMarkedViewed.current
     ) {
       initialLastSeenChatItemIdRef.current = session.lastSeenChatItemId;
+      initialLastViewedAtRef.current = session.lastViewedAt;
       setLastSeenChatItemIdForSeparator(session.lastSeenChatItemId);
+      setLastViewedAtForAnimation(session.lastViewedAt);
     }
-  }, [session?.lastSeenChatItemId]);
+  }, [session?.lastSeenChatItemId, session?.lastViewedAt]);
 
   useEffect(() => {
     // Only mark viewed once per session load, when we have messages
@@ -468,7 +473,9 @@ export function useUnifiedSession(
   useEffect(() => {
     hasMarkedViewed.current = false;
     initialLastSeenChatItemIdRef.current = undefined;
+    initialLastViewedAtRef.current = undefined;
     setLastSeenChatItemIdForSeparator(null);
+    setLastViewedAtForAnimation(undefined);
   }, [sessionId]);
 
   // Only show 'Partner' fallback after data has loaded, otherwise show empty string
@@ -1147,6 +1154,7 @@ export function useUnifiedSession(
     // This is the lastSeenChatItemId from BEFORE the user opened the session
     // It's cleared after markViewed is called so new messages don't show a separator
     lastSeenChatItemIdForSeparator,
+    lastViewedAtForAnimation,
 
     // Pagination for loading older messages
     fetchMoreMessages: fetchNextPage,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -163,54 +163,33 @@ function timestampBeforeChatStart(timestamp?: string | null): string {
 }
 
 function InviteeTopicIntroCard({
-  sessionId,
   partnerName,
   topicFrame,
+  skipAnimation,
+  onAnimationComplete,
 }: {
-  sessionId: string;
   partnerName: string;
   topicFrame: string;
+  skipAnimation: boolean;
+  onAnimationComplete?: () => void;
 }) {
   const styles = useStyles();
-  const storageKey = `invitee-topic-intro-played:${sessionId}`;
-  const [hasCheckedPlayback, setHasCheckedPlayback] = useState(false);
-  const [skipAnimation, setSkipAnimation] = useState(false);
-  const [showTopic, setShowTopic] = useState(false);
-  const [showOutro, setShowOutro] = useState(false);
-  const topicOpacity = useRef(new Animated.Value(0)).current;
+  const [showTopic, setShowTopic] = useState(skipAnimation);
+  const [showOutro, setShowOutro] = useState(skipAnimation);
+  const topicOpacity = useRef(new Animated.Value(skipAnimation ? 1 : 0)).current;
   const introCompletedRef = useRef(false);
   const topicCompletedRef = useRef(false);
+  const outroCompletedRef = useRef(false);
 
   const introText = `Before we begin, this is what ${partnerName || 'your partner'} would like to work through with you:`;
   const outroText = "This is how things look from their side right now. You don't need to agree with it, respond to it, or do anything with it yet. Instead, I'd like to know what is happening from your point of view.";
 
   useEffect(() => {
-    let isMounted = true;
-
-    AsyncStorage.getItem(storageKey)
-      .then((value) => {
-        if (!isMounted) return;
-
-        const alreadyPlayed = value === 'true';
-        setSkipAnimation(alreadyPlayed);
-        setShowTopic(alreadyPlayed);
-        setShowOutro(alreadyPlayed);
-        topicOpacity.setValue(alreadyPlayed ? 1 : 0);
-        setHasCheckedPlayback(true);
-
-        if (!alreadyPlayed) {
-          AsyncStorage.setItem(storageKey, 'true').catch(() => {});
-        }
-      })
-      .catch(() => {
-        if (!isMounted) return;
-        setHasCheckedPlayback(true);
-      });
-
-    return () => {
-      isMounted = false;
-    };
-  }, [storageKey, topicOpacity]);
+    if (!skipAnimation) return;
+    setShowTopic(true);
+    setShowOutro(true);
+    topicOpacity.setValue(1);
+  }, [skipAnimation, topicOpacity]);
 
   const handleIntroComplete = useCallback(() => {
     if (introCompletedRef.current) return;
@@ -228,9 +207,11 @@ function InviteeTopicIntroCard({
     });
   }, [topicOpacity]);
 
-  if (!hasCheckedPlayback) {
-    return null;
-  }
+  const handleOutroComplete = useCallback(() => {
+    if (outroCompletedRef.current) return;
+    outroCompletedRef.current = true;
+    onAnimationComplete?.();
+  }, [onAnimationComplete]);
 
   return (
     <View style={styles.inviteeTopicAckBody} testID="invitee-topic-ack-body">
@@ -258,6 +239,7 @@ function InviteeTopicIntroCard({
           wordDelay={45}
           fadeDuration={120}
           skipAnimation={skipAnimation}
+          onComplete={handleOutroComplete}
         />
       ) : null}
     </View>
@@ -312,6 +294,7 @@ export function UnifiedSessionScreen({
 
     // Unread tracking
     lastSeenChatItemIdForSeparator,
+    lastViewedAtForAnimation,
 
     // Overlay state
     activeOverlay,
@@ -1798,14 +1781,16 @@ export function UnifiedSessionScreen({
     return [{
       type: 'custom-card',
       id: 'invitee-topic-frame-card',
+      animate: true,
       timestamp: timestampBeforeChatStart(
         compactData.mySignedAt || invitation?.acceptedAt || session?.createdAt
       ),
-      render: () => (
+      render: (options) => (
         <InviteeTopicIntroCard
-          sessionId={sessionId}
           partnerName={partnerName || 'your partner'}
           topicFrame={topicFrame}
+          skipAnimation={options?.skipAnimation ?? true}
+          onAnimationComplete={options?.onAnimationComplete}
         />
       ),
     }];
@@ -2542,6 +2527,7 @@ export function UnifiedSessionScreen({
           // Uses captured value from before session was marked viewed, so new messages
           // arriving while viewing don't trigger a separator
           lastSeenChatItemId={lastSeenChatItemIdForSeparator}
+          lastViewedAt={lastViewedAtForAnimation}
           // Open activity menu when "Context shared" or "Empathy shared" indicator is tapped
           onContextSharedPress={() => {
             setShowActivityMenu(true);

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -163,13 +163,18 @@ function timestampBeforeChatStart(timestamp?: string | null): string {
 }
 
 function InviteeTopicIntroCard({
+  sessionId,
   partnerName,
   topicFrame,
 }: {
+  sessionId: string;
   partnerName: string;
   topicFrame: string;
 }) {
   const styles = useStyles();
+  const storageKey = `invitee-topic-intro-played:${sessionId}`;
+  const [hasCheckedPlayback, setHasCheckedPlayback] = useState(false);
+  const [skipAnimation, setSkipAnimation] = useState(false);
   const [showTopic, setShowTopic] = useState(false);
   const [showOutro, setShowOutro] = useState(false);
   const topicOpacity = useRef(new Animated.Value(0)).current;
@@ -178,6 +183,34 @@ function InviteeTopicIntroCard({
 
   const introText = `Before we begin, this is what ${partnerName || 'your partner'} would like to work through with you:`;
   const outroText = "This is how things look from their side right now. You don't need to agree with it, respond to it, or do anything with it yet. Instead, I'd like to know what is happening from your point of view.";
+
+  useEffect(() => {
+    let isMounted = true;
+
+    AsyncStorage.getItem(storageKey)
+      .then((value) => {
+        if (!isMounted) return;
+
+        const alreadyPlayed = value === 'true';
+        setSkipAnimation(alreadyPlayed);
+        setShowTopic(alreadyPlayed);
+        setShowOutro(alreadyPlayed);
+        topicOpacity.setValue(alreadyPlayed ? 1 : 0);
+        setHasCheckedPlayback(true);
+
+        if (!alreadyPlayed) {
+          AsyncStorage.setItem(storageKey, 'true').catch(() => {});
+        }
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setHasCheckedPlayback(true);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [storageKey, topicOpacity]);
 
   const handleIntroComplete = useCallback(() => {
     if (introCompletedRef.current) return;
@@ -195,6 +228,10 @@ function InviteeTopicIntroCard({
     });
   }, [topicOpacity]);
 
+  if (!hasCheckedPlayback) {
+    return null;
+  }
+
   return (
     <View style={styles.inviteeTopicAckBody} testID="invitee-topic-ack-body">
       <TypewriterText
@@ -202,6 +239,7 @@ function InviteeTopicIntroCard({
         style={styles.inviteeTopicAckText}
         wordDelay={45}
         fadeDuration={120}
+        skipAnimation={skipAnimation}
         onComplete={handleIntroComplete}
       />
 
@@ -219,6 +257,7 @@ function InviteeTopicIntroCard({
           style={styles.inviteeTopicAckText}
           wordDelay={45}
           fadeDuration={120}
+          skipAnimation={skipAnimation}
         />
       ) : null}
     </View>
@@ -1764,6 +1803,7 @@ export function UnifiedSessionScreen({
       ),
       render: () => (
         <InviteeTopicIntroCard
+          sessionId={sessionId}
           partnerName={partnerName || 'your partner'}
           topicFrame={topicFrame}
         />

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -8,7 +8,7 @@
 
 import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { View, Text, ActivityIndicator, TouchableOpacity, Animated, Modal, AppState, Keyboard, Platform, Share } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useQueryClient } from '@tanstack/react-query';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 // useRouter removed - share navigation replaced by ActivityDrawer
@@ -256,6 +256,7 @@ export function UnifiedSessionScreen({
   onStageComplete,
 }: UnifiedSessionScreenProps) {
   const styles = useStyles();
+  const insets = useSafeAreaInsets();
   const { user, updateUser } = useAuth();
   const { mutate: updateMood } = useUpdateMood();
   const queryClient = useQueryClient();
@@ -2886,7 +2887,12 @@ export function UnifiedSessionScreen({
           testID="share-later-tooltip-overlay"
         >
           <View
-            style={styles.shareLaterTooltipBubble}
+            style={[
+              styles.shareLaterTooltipBubble,
+              Platform.OS !== 'web' && {
+                top: insets.top + 56,
+              },
+            ]}
             testID="share-later-tooltip"
           >
             <Text style={styles.shareLaterTooltipText}>

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -42,6 +42,7 @@ import { ActivityDrawer } from '../components/ActivityDrawer';
 import { NeedsDrawer, NeedsDrawerMode } from '../components/NeedsDrawer';
 import { RefinementModalScreen } from './RefinementModalScreen';
 import { GuidedDraftChatModal } from '../components/GuidedDraftChatModal';
+import { TypewriterText } from '../components/TypewriterText';
 
 import { useUnifiedSession, InlineChatCard } from '../hooks/useUnifiedSession';
 import { useConfirmTopicFrame } from '../hooks/useSessions';
@@ -159,6 +160,69 @@ function timestampBeforeChatStart(timestamp?: string | null): string {
   if (!Number.isFinite(time)) return timestamp;
 
   return new Date(time - 2000).toISOString();
+}
+
+function InviteeTopicIntroCard({
+  partnerName,
+  topicFrame,
+}: {
+  partnerName: string;
+  topicFrame: string;
+}) {
+  const styles = useStyles();
+  const [showTopic, setShowTopic] = useState(false);
+  const [showOutro, setShowOutro] = useState(false);
+  const topicOpacity = useRef(new Animated.Value(0)).current;
+  const introCompletedRef = useRef(false);
+  const topicCompletedRef = useRef(false);
+
+  const introText = `Before we begin, this is what ${partnerName || 'your partner'} would like to work through with you:`;
+  const outroText = "This is how things look from their side right now. You don't need to agree with it, respond to it, or do anything with it yet. Instead, I'd like to know what is happening from your point of view.";
+
+  const handleIntroComplete = useCallback(() => {
+    if (introCompletedRef.current) return;
+    introCompletedRef.current = true;
+    setShowTopic(true);
+
+    Animated.timing(topicOpacity, {
+      toValue: 1,
+      duration: 350,
+      useNativeDriver: true,
+    }).start(() => {
+      if (topicCompletedRef.current) return;
+      topicCompletedRef.current = true;
+      setShowOutro(true);
+    });
+  }, [topicOpacity]);
+
+  return (
+    <View style={styles.inviteeTopicAckBody} testID="invitee-topic-ack-body">
+      <TypewriterText
+        text={introText}
+        style={styles.inviteeTopicAckText}
+        wordDelay={45}
+        fadeDuration={120}
+        onComplete={handleIntroComplete}
+      />
+
+      {showTopic ? (
+        <Animated.View style={[styles.inviteeTopicAckFrameWrap, { opacity: topicOpacity }]}>
+          <Text style={styles.inviteeTopicAckFrame} testID="invitee-topic-text">
+            {topicFrame}
+          </Text>
+        </Animated.View>
+      ) : null}
+
+      {showOutro ? (
+        <TypewriterText
+          text={outroText}
+          style={styles.inviteeTopicAckText}
+          wordDelay={45}
+          fadeDuration={120}
+        />
+      ) : null}
+    </View>
+  );
 }
 
 // ============================================================================
@@ -1689,27 +1753,6 @@ export function UnifiedSessionScreen({
     return <CompactChatItem testID="inline-compact" isFirstSession={isFirstSession} />;
   }, [isFirstSession]);
 
-  // Invitee Stage 0 topic-acknowledgement message body.
-  // Rendered in the message area (not in the bottom bar) per spec:
-  // intro line + topic frame with breathing room + closing line.
-  const inviteeTopicAckEmptyStateElement = useMemo(() => {
-    return (
-      <View style={styles.inviteeTopicAckBody} testID="invitee-topic-ack-body">
-        <Text style={styles.inviteeTopicAckText}>
-          {`Before we begin, this is what ${partnerName || 'your partner'} would like to work through with you:`}
-        </Text>
-        <View style={styles.inviteeTopicAckFrameWrap}>
-          <Text style={styles.inviteeTopicAckFrame} testID="invitee-topic-text">
-            {topicFrame ?? ''}
-          </Text>
-        </View>
-        <Text style={styles.inviteeTopicAckText}>
-          {"This is how things look from their side right now. You don't need to agree with it, respond to it, or do anything with it yet. Instead, I'd like to know what is happening from your point of view."}
-        </Text>
-      </View>
-    );
-  }, [styles, partnerName, topicFrame]);
-
   const inviteeOpeningCards = useMemo((): ChatCustomCardItem[] => {
     if (isInviter || !compactData?.mySigned || !topicFrame) return [];
 
@@ -1719,16 +1762,21 @@ export function UnifiedSessionScreen({
       timestamp: timestampBeforeChatStart(
         compactData.mySignedAt || invitation?.acceptedAt || session?.createdAt
       ),
-      render: () => inviteeTopicAckEmptyStateElement,
+      render: () => (
+        <InviteeTopicIntroCard
+          partnerName={partnerName || 'your partner'}
+          topicFrame={topicFrame}
+        />
+      ),
     }];
   }, [
     isInviter,
     compactData?.mySigned,
     compactData?.mySignedAt,
     topicFrame,
+    partnerName,
     invitation?.acceptedAt,
     session?.createdAt,
-    inviteeTopicAckEmptyStateElement,
   ]);
 
   // -------------------------------------------------------------------------

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -14,7 +14,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 // useRouter removed - share navigation replaced by ActivityDrawer
 import { Stage, MessageRole, StrategyPhase, SessionStatus, MemorySuggestion, ConfirmAgreementResponse, MAX_AGREEMENTS, EmpathyStatus } from '@meet-without-fear/shared';
 
-import { ChatInterface, ChatMessage, ChatIndicatorItem, ChatValidationCardItem } from '../components/ChatInterface';
+import { ChatInterface, ChatMessage, ChatIndicatorItem, ChatValidationCardItem, ChatCustomCardItem } from '../components/ChatInterface';
 import { SessionChatHeader } from '../components/SessionChatHeader';
 import { FeelHeardConfirmation } from '../components/FeelHeardConfirmation';
 import { BreathingExercise } from '../components/BreathingExercise';
@@ -151,6 +151,16 @@ function deriveChapterMarkers(
   return markers;
 }
 
+function timestampBeforeChatStart(timestamp?: string | null): string {
+  const fallback = new Date(0).toISOString();
+  if (!timestamp) return fallback;
+
+  const time = new Date(timestamp).getTime();
+  if (!Number.isFinite(time)) return timestamp;
+
+  return new Date(time - 2000).toISOString();
+}
+
 // ============================================================================
 // Component
 // ============================================================================
@@ -172,11 +182,6 @@ export function UnifiedSessionScreen({
   const pendingActionsQuery = usePendingActions(sessionId);
 
   // Real-time presence tracking
-
-  // Invitee Stage 0 topic-ack flag — local UI state.
-  // Declared early so it can flow into useUnifiedSession (which uses it to
-  // defer the Stage 0/1 initial AI message fetch for the invitee).
-  const [inviteeAckDone, setInviteeAckDone] = useState(false);
 
   const {
     // Loading
@@ -291,10 +296,7 @@ export function UnifiedSessionScreen({
     // Session viewed tracking
     markSessionViewed,
 
-    // Stage advancement (used by invitee topic-ack Ready button)
-    advanceStage,
-    triggerInitialMessage,
-  } = useUnifiedSession(sessionId, { inviteeTopicAcked: inviteeAckDone });
+  } = useUnifiedSession(sessionId);
 
   // AI message handler for fire-and-forget pattern
   const { addAIMessage, handleAIMessageError } = useAIMessageHandler();
@@ -777,8 +779,6 @@ export function UnifiedSessionScreen({
   // -------------------------------------------------------------------------
   const [invitationPanelDismissed, setInvitationPanelDismissed] = useState(false);
 
-  // (inviteeAckDone is declared above, before useUnifiedSession.)
-
   // Tooltip shown after "Later" — points at the book icon to teach the user
   // they can share later from the activity drawer. Session-local only.
   const [showShareLaterTooltip, setShowShareLaterTooltip] = useState(false);
@@ -959,17 +959,9 @@ export function UnifiedSessionScreen({
   // The optimistic updates in mutation hooks (onMutate) ensure panels hide immediately.
   // No latch refs needed - if API fails, onError rolls back the cache and panel reappears.
   const isInviter = invitation?.isInviter ?? true;
-  // Invitee Stage 0 topic-ack screen is active when:
-  //   - user is the invitee
-  //   - compact has been signed (welcome step is done)
-  //   - they haven't tapped the topic-ack Ready button yet
-  //   - no chat messages exist yet (so this never triggers on later opens)
-  const inviteeTopicAckPending =
-    !isInviter &&
-    !!compactData?.mySigned &&
-    !inviteeAckDone &&
-    messages.length === 0 &&
-    !!topicFrame;
+  // Invitee topic context now renders as a chronological chat card. There is
+  // no second Ready gate after signing the opening agreement.
+  const inviteeTopicAckPending = false;
   const {
     waitingStatus,
     shouldShowWaitingBanner,
@@ -1064,14 +1056,6 @@ export function UnifiedSessionScreen({
   // Latch if mutation is in flight (backup for immediate feedback)
   if (isConfirmingFeelHeard && !hasEverConfirmedFeelHeard.current) {
     hasEverConfirmedFeelHeard.current = true;
-  }
-
-  // Once compact is signed, keep showing the indicator even during re-renders
-  const hasEverSignedCompact = useRef(false);
-
-  // Update ref when compact is signed
-  if (compactData?.mySigned && !hasEverSignedCompact.current) {
-    hasEverSignedCompact.current = true;
   }
 
   // Animation for the invitation panel slide-up
@@ -1262,17 +1246,11 @@ export function UnifiedSessionScreen({
         messageConfirmedAt: invitation.messageConfirmedAt,
         acceptedAt: invitation.acceptedAt,
       } : undefined,
-      compact: compactData ? {
-        // Use refs as backup to prevent flickering during mutation
-        mySigned: hasEverSignedCompact.current || compactData.mySigned || isSigningCompact,
-        mySignedAt: compactData.mySignedAt ?? (hasEverSignedCompact.current || compactData.mySigned || isSigningCompact ? session?.createdAt : null),
-      } : undefined,
       milestones: {
         // Use ref as backup to prevent flickering during mutation
         feelHeardConfirmedAt: milestones?.feelHeardConfirmedAt ??
           (hasEverConfirmedFeelHeard.current || isConfirmingFeelHeard ? new Date().toISOString() : null),
       },
-      sessionCreatedAt: session?.createdAt,
       mySharedAt: empathyStatusData?.mySharedAt,
     };
 
@@ -1338,7 +1316,7 @@ export function UnifiedSessionScreen({
     allIndicators.push(...chapterIndicators);
 
     return allIndicators;
-  }, [isInviter, session?.status, session?.createdAt, invitation?.messageConfirmedAt, invitation?.acceptedAt, compactData?.mySigned, compactData?.mySignedAt, isSigningCompact, milestones?.feelHeardConfirmedAt, isConfirmingFeelHeard, messages, user?.id, partnerName, empathyStatusData?.mySharedAt, empathyStatusData?.myAttempt?.status, empathyStatusData?.myAttempt?.revealedAt, shareOfferData?.hasSuggestion, shareOfferData?.suggestion, myProgress?.stage]);
+  }, [isInviter, session?.status, invitation?.messageConfirmedAt, invitation?.acceptedAt, milestones?.feelHeardConfirmedAt, isConfirmingFeelHeard, messages, user?.id, partnerName, empathyStatusData?.mySharedAt, empathyStatusData?.myAttempt?.status, empathyStatusData?.myAttempt?.revealedAt, shareOfferData?.hasSuggestion, shareOfferData?.suggestion, myProgress?.stage]);
 
 
 
@@ -1732,6 +1710,27 @@ export function UnifiedSessionScreen({
     );
   }, [styles, partnerName, topicFrame]);
 
+  const inviteeOpeningCards = useMemo((): ChatCustomCardItem[] => {
+    if (isInviter || !compactData?.mySigned || !topicFrame) return [];
+
+    return [{
+      type: 'custom-card',
+      id: 'invitee-topic-frame-card',
+      timestamp: timestampBeforeChatStart(
+        compactData.mySignedAt || invitation?.acceptedAt || session?.createdAt
+      ),
+      render: () => inviteeTopicAckEmptyStateElement,
+    }];
+  }, [
+    isInviter,
+    compactData?.mySigned,
+    compactData?.mySignedAt,
+    topicFrame,
+    invitation?.acceptedAt,
+    session?.createdAt,
+    inviteeTopicAckEmptyStateElement,
+  ]);
+
   // -------------------------------------------------------------------------
   // Render Overlays
   // -------------------------------------------------------------------------
@@ -1978,25 +1977,6 @@ export function UnifiedSessionScreen({
             isPending={isSigningCompact}
             isFirstSession={isFirstSession}
             testID="compact-agreement-bar"
-          />
-        );
-
-      case 'invitee-topic-ack':
-        return (
-          <CompactAgreementBar
-            onSign={() => {
-              // Mark ack done so the topic-ack panel hides and the input
-              // un-hides. Trigger the Stage 0/1 initial AI message and
-              // advance to Stage 1 server-side (idempotent — server already
-              // auto-advanced this user when both sides signed).
-              setInviteeAckDone(true);
-              triggerInitialMessage();
-              if (sessionId) advanceStage({ sessionId });
-            }}
-            isPending={false}
-            isFirstSession={true}
-            buttonLabel="Ready"
-            testID="invitee-topic-ack-bar"
           />
         );
 
@@ -2478,15 +2458,12 @@ export function UnifiedSessionScreen({
           onContextSharedPress={() => {
             setShowActivityMenu(true);
           }}
+          customCards={inviteeOpeningCards}
           // Show compact as custom empty state during onboarding when not signed.
-          // For the invitee on Stage 0 topic-ack, show the topic-ack body
-          // instead (renders inside the messages area, with a Ready bar below).
           customEmptyState={
             isInOnboardingUnsigned
               ? compactEmptyStateElement
-              : aboveInputPanel === 'invitee-topic-ack'
-                ? inviteeTopicAckEmptyStateElement
-                : undefined
+              : undefined
           }
           renderAboveInput={aboveInputPanel ? renderAboveInput : undefined}
           renderBelowChat={(inlineCards.length > 0 || memorySuggestion) ? () => (
@@ -2874,7 +2851,7 @@ export function UnifiedSessionScreen({
           setShowActivityMenu(false);
           setShowEmpathyDrawer(true);
         }}
-        topicFrame={isInviter && topicFrameConfirmed ? (topicFrame || undefined) : undefined}
+        topicFrame={topicFrameConfirmed ? (topicFrame || undefined) : undefined}
         invitationTimestamp={isInviter ? (invitation?.messageConfirmedAt || undefined) : undefined}
         partnerAccepted={partnerAccepted}
         onShareInvitation={

--- a/mobile/src/utils/chatListSelector.ts
+++ b/mobile/src/utils/chatListSelector.ts
@@ -126,7 +126,7 @@ export interface SessionIndicatorData {
 export function deriveIndicators(data: SessionIndicatorData): IndicatorItem[] {
   const items: IndicatorItem[] = [];
 
-  const { isInviter, invitation, compact, milestones, sessionCreatedAt } = data;
+  const { isInviter, invitation, milestones } = data;
 
   // ---------------------------------------------------------------------------
   // Invitation Sent Indicator (for inviters)
@@ -154,23 +154,6 @@ export function deriveIndicators(data: SessionIndicatorData): IndicatorItem[] {
       id: 'invitation-accepted',
       timestamp: invitation.acceptedAt,
     });
-  }
-
-  // ---------------------------------------------------------------------------
-  // Compact Signed Indicator
-  // ---------------------------------------------------------------------------
-  // Shows when the current user has signed the curiosity compact.
-  // Uses mySignedAt from compact cache, with sessionCreatedAt as fallback for older sessions.
-  if (compact?.mySigned) {
-    const compactSignedAt = compact.mySignedAt ?? sessionCreatedAt;
-    if (compactSignedAt) {
-      items.push({
-        type: 'indicator',
-        indicatorType: 'compact-signed',
-        id: 'compact-signed',
-        timestamp: compactSignedAt,
-      });
-    }
   }
 
   // ---------------------------------------------------------------------------
@@ -365,4 +348,3 @@ export function isWaitingForAIResponse(messages: CacheMessage[]): boolean {
   // If the last message is from the user, we're waiting for AI
   return lastMessage.role === MessageRole.USER;
 }
-

--- a/shared/src/dto/session-state.ts
+++ b/shared/src/dto/session-state.ts
@@ -40,6 +40,8 @@ export interface SessionStateResponse {
     };
     createdAt: string;
     resolvedAt: string | null;
+    // When the user last viewed this session (for cross-device animation/read boundaries)
+    lastViewedAt: string | null;
     // ID of last chat item seen (for "new messages" line placement)
     lastSeenChatItemId: string | null;
   };


### PR DESCRIPTION
## Summary
- Move invitee opening context and topic into the chat stream and remove the extra topic-ready step after compact signing.
- Remove the `Compact Signed` timeline indicator and show the topic in the activity drawer for both inviter and invitee.
- Fix web session deletion so delete controls do not navigate, persist deleted sessions with per-user archival, and prevent duplicate chat keys from repeated message ids.

## Root Cause
Invitee onboarding context was rendered as transient stage UI instead of chronological chat content. Session deletion hid rows locally but the backend still listed sessions through relationship membership. The chat list also trusted paged message data without a final id dedupe.

## Validation
- `npm run check` in `mobile`
- `npm run check` in `backend`
- `npm test -- --runInBand src/services/__tests__/stage-prompts.test.ts` in `backend`
- `npx prisma migrate deploy` and `npx prisma migrate status` locally