### PR TITLE
[codex] Fix feel-heard panel and failed stream cleanup

### DIFF
--- a/backend/src/middleware/__tests__/auth.test.ts
+++ b/backend/src/middleware/__tests__/auth.test.ts
@@ -198,7 +198,7 @@ describe('Auth Middleware', () => {
     });
 
     it('handles concurrent create race (P2002 fallback)', async () => {
-      const { Prisma } = jest.requireActual('@prisma/client');
+      const { PrismaClientKnownRequestError } = jest.requireActual('@prisma/client/runtime/library');
       mockVerifyToken.mockResolvedValue({ sub: 'clerk-race-user' });
       mockGetUser.mockResolvedValue({
         firstName: 'Race',
@@ -210,7 +210,7 @@ describe('Auth Middleware', () => {
       (prisma.user.findUnique as jest.Mock)
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(raceUser);
-      const p2002Error = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', { code: 'P2002', clientVersion: '5.0.0' });
+      const p2002Error = new PrismaClientKnownRequestError('Unique constraint failed', { code: 'P2002', clientVersion: '5.0.0' });
       (prisma.user.create as jest.Mock).mockRejectedValue(p2002Error);
 
       const req = createMockRequest({
@@ -224,6 +224,48 @@ describe('Auth Middleware', () => {
       expect(prisma.user.findUnique).toHaveBeenCalledTimes(2);
       expect(next).toHaveBeenCalled();
       expect(req.user).toEqual(raceUser);
+    });
+
+    it('uses an existing local user when Clerk profile lookup fails', async () => {
+      mockVerifyToken.mockResolvedValue({ sub: 'clerk-user-123' });
+      mockGetUser.mockRejectedValue(new Error('Clerk unavailable'));
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer valid-clerk-token' },
+      });
+      const { res, statusMock } = createMockResponse();
+      const next = jest.fn();
+
+      await requireAuth(req as Request, res as Response, next);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { clerkId: 'clerk-user-123' },
+      });
+      expect(prisma.user.update).not.toHaveBeenCalled();
+      expect(prisma.user.create).not.toHaveBeenCalled();
+      expect(statusMock).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+      expect(req.user).toEqual(mockUser);
+      expect(req.clerkUserId).toBe('clerk-user-123');
+    });
+
+    it('fails when Clerk profile lookup fails for an unknown user', async () => {
+      const clerkError = new Error('Clerk unavailable');
+      mockVerifyToken.mockResolvedValue({ sub: 'clerk-new-user' });
+      mockGetUser.mockRejectedValue(clerkError);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer valid-clerk-token' },
+      });
+      const { res } = createMockResponse();
+      const next = jest.fn();
+
+      await requireAuth(req as Request, res as Response, next);
+
+      expect(next).toHaveBeenCalledWith(clerkError);
+      expect(req.user).toBeUndefined();
     });
   });
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -9,7 +9,7 @@ import { Request, Response, NextFunction } from 'express';
 import { UnauthorizedError, ForbiddenError } from './errors';
 import { prisma } from '../lib/prisma';
 import { ApiResponse, ErrorCode } from '@meet-without-fear/shared';
-import { Prisma } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { logger } from '../lib/logger';
 
 // ============================================================================
@@ -100,7 +100,7 @@ async function handleE2EAuthBypass(req: Request): Promise<boolean> {
     });
   } catch (error) {
     // Guard against transient unique conflicts (parallel E2E requests)
-    if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== 'P2002') {
+    if (!(error instanceof PrismaClientKnownRequestError) || error.code !== 'P2002') {
       throw error;
     }
 
@@ -200,7 +200,7 @@ async function handleClerkAuth(
       });
     } catch (error) {
       // Concurrent create race: another request inserted first
-      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      if (error instanceof PrismaClientKnownRequestError && error.code === 'P2002') {
         user = await prisma.user.findUnique({ where: { clerkId: clerkUserId } });
         if (!user) throw error;
       } else {

--- a/backend/src/services/account-deletion.ts
+++ b/backend/src/services/account-deletion.ts
@@ -74,7 +74,7 @@ export async function deleteAccountWithNotifications(
     sessionsAbandoned++;
 
     // Notify partner that the session has been abandoned
-    const partner = session.relationship.members.find((m) => m.userId !== userId);
+    const partner = session.relationship.members.find((m: { userId: string }) => m.userId !== userId);
     if (partner) {
       try {
         await publishSessionEvent(session.id, 'session.abandoned', {

--- a/backend/src/services/realtime.ts
+++ b/backend/src/services/realtime.ts
@@ -298,13 +298,13 @@ export async function notifySessionMembers(
 
     // Publish to each member's user channel (except the excluded user)
     const memberIds = session.relationship.members
-      .map((m) => m.userId)
-      .filter((id) => id !== excludeUserId);
+      .map((m: { userId: string }) => m.userId)
+      .filter((id: string) => id !== excludeUserId);
 
     logger.info(`[notifySessionMembers] Publishing to ${memberIds.length} members: ${memberIds.join(', ')}`);
 
     await Promise.all(
-      memberIds.map((userId) =>
+      memberIds.map((userId: string) =>
         publishUserEvent(userId, 'session.updated', { sessionId })
       )
     );

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -60,9 +60,9 @@ export interface UseChatUIStateProps {
 
   // Invitation phase
   // The invitation panel opens when the topic frame is confirmed and the
-  // user has not dismissed it. Stage 0→1 advancement is chained off topic
-  // confirmation; the invitation panel is purely a share affordance.
+  // invitation has not been confirmed/sent yet.
   hasTopicConfirmed: boolean;
+  invitationConfirmed: boolean;
   invitationPanelDismissed: boolean;
   isConfirmingInvitation: boolean;
 
@@ -182,6 +182,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     partnerProgress,
     compactMySigned,
     hasTopicConfirmed,
+    invitationConfirmed,
     invitationPanelDismissed,
     isConfirmingInvitation,
     topicFrameProposed,
@@ -254,6 +255,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     compactMySigned,
     myProgress,
     hasTopicConfirmed,
+    invitationConfirmed,
     invitationPanelDismissed,
     isConfirmingInvitation,
     topicFrameProposed,
@@ -314,6 +316,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     compactMySigned,
     myProgress,
     hasTopicConfirmed,
+    invitationConfirmed,
     invitationPanelDismissed,
     isConfirmingInvitation,
     topicFrameProposed,

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -139,6 +139,7 @@ export function useStreamingMessage(
 
   // Ref to track optimistic user message ID for replacement
   const optimisticUserIdRef = useRef<string>('');
+  const activeUserMessageIdRef = useRef<string>('');
 
   // Refs for throttled cache updates (reduces stuttering)
   const lastCacheUpdateRef = useRef<number>(0);
@@ -292,6 +293,78 @@ export function useStreamingMessage(
   );
 
   /**
+   * Remove optimistic/placeholder messages from the cache after a failed stream.
+   */
+  const removeMessagesFromCache = useCallback(
+    (sessionId: string, messageIds: string[], stage?: Stage) => {
+      const ids = new Set(messageIds.filter(Boolean));
+      if (ids.size === 0) return;
+
+      const updateCache = (old: GetMessagesResponse | undefined) => {
+        if (!old) return old;
+        return {
+          ...old,
+          messages: (old.messages || []).filter((message) => !ids.has(message.id)),
+        };
+      };
+
+      const updateInfiniteCache = (
+        old: InfiniteData<GetMessagesResponse> | undefined
+      ): InfiniteData<GetMessagesResponse> | undefined => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            messages: (page.messages || []).filter((message) => !ids.has(message.id)),
+          })),
+        };
+      };
+
+      queryClient.setQueryData<GetMessagesResponse>(
+        messageKeys.list(sessionId),
+        updateCache
+      );
+      queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
+        messageKeys.infinite(sessionId),
+        updateInfiniteCache
+      );
+
+      if (stage !== undefined) {
+        queryClient.setQueryData<GetMessagesResponse>(
+          messageKeys.list(sessionId, stage),
+          updateCache
+        );
+        queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
+          messageKeys.infinite(sessionId, stage),
+          updateInfiniteCache
+        );
+      }
+    },
+    [queryClient]
+  );
+
+  const cleanupFailedStream = useCallback(
+    (sessionId: string, stage?: Stage) => {
+      removeMessagesFromCache(
+        sessionId,
+        [activeUserMessageIdRef.current, optimisticUserIdRef.current, aiMessageIdRef.current],
+        stage
+      );
+
+      activeUserMessageIdRef.current = '';
+      optimisticUserIdRef.current = '';
+      aiMessageIdRef.current = '';
+      accumulatedTextRef.current = '';
+
+      queryClient.invalidateQueries({ queryKey: messageKeys.list(sessionId) });
+      queryClient.invalidateQueries({ queryKey: messageKeys.infinite(sessionId) });
+      queryClient.invalidateQueries({ queryKey: timelineKeys.infinite(sessionId) });
+    },
+    [queryClient, removeMessagesFromCache]
+  );
+
+  /**
    * Handle metadata from the AI response
    */
   const handleMetadata = useCallback(
@@ -378,6 +451,7 @@ export function useStreamingMessage(
       accumulatedTextRef.current = '';
       aiMessageIdRef.current = `streaming-${Date.now()}`;
       optimisticUserIdRef.current = `optimistic-user-${Date.now()}`;
+      activeUserMessageIdRef.current = optimisticUserIdRef.current;
       textCompleteReceivedRef.current = false;
 
       // Create optimistic user message
@@ -441,9 +515,7 @@ export function useStreamingMessage(
             // Close the stuck connection
             eventSourceRef.current.close();
             eventSourceRef.current = null;
-            // Invalidate queries to fetch latest state from server
-            queryClient.invalidateQueries({ queryKey: messageKeys.infinite(sessionId) });
-            queryClient.invalidateQueries({ queryKey: timelineKeys.infinite(sessionId) });
+            cleanupFailedStream(sessionId, currentStage);
             // Transition to idle so typing indicator disappears
             setStatus('idle');
           }
@@ -475,6 +547,7 @@ export function useStreamingMessage(
             const data = JSON.parse(event.data) as UserMessageEvent;
             // Update optimistic message with server timestamp (keep same ID for React key stability)
             if (optimisticUserIdRef.current) {
+              activeUserMessageIdRef.current = optimisticUserIdRef.current;
               updateMessageInCache(sessionId, optimisticUserIdRef.current, {
                 timestamp: data.timestamp,
                 content: data.content, // In case server modified content
@@ -688,6 +761,7 @@ export function useStreamingMessage(
 
           const errorMsg = 'message' in event ? event.message : 'Connection error';
           console.error('[useStreamingMessage] SSE error:', errorMsg);
+          cleanupFailedStream(sessionId, currentStage);
           setErrorMessage(errorMsg);
           setStatus('error');
           onError?.(new Error(errorMsg));
@@ -702,12 +776,13 @@ export function useStreamingMessage(
 
       } catch (error) {
         console.error('[useStreamingMessage] Error:', error);
+        cleanupFailedStream(sessionId, currentStage);
         setErrorMessage((error as Error).message || 'Failed to send message');
         setStatus('error');
         onError?.(error as Error);
       }
     },
-    [addMessageToCache, updateMessageInCache, handleMetadata, queryClient, onComplete, onError]
+    [addMessageToCache, updateMessageInCache, cleanupFailedStream, handleMetadata, queryClient, onComplete, onError]
   );
 
   /**

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1074,6 +1074,7 @@ export function UnifiedSessionScreen({
     partnerProgress,
     compactMySigned: compactData?.mySigned,
     hasTopicConfirmed: topicFrameConfirmed,
+    invitationConfirmed,
     // Local dismissal latch — the panel hides as soon as the user taps
     // "Later" (or after a successful share, if the screen wants to stash it).
     invitationPanelDismissed,

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -83,19 +83,37 @@ describe('Above Input Panel Priority', () => {
     expect(result.aboveInputPanel).toBe('compact-agreement-bar');
   });
 
-  it('shows invitation panel for inviter once topic is confirmed', () => {
+  it('shows invitation panel for inviter once topic is confirmed but invitation is not', () => {
     const inputs = createInputs({
       myStage: Stage.WITNESS,
       compactMySigned: true,
       myProgress: { stage: Stage.WITNESS },
       isInviter: true,
       hasTopicConfirmed: true,
+      invitationConfirmed: false,
       invitationPanelDismissed: false,
       isConfirmingInvitation: false,
     });
 
     const result = computeChatUIState(inputs);
     expect(result.aboveInputPanel).toBe('invitation');
+  });
+
+  it('does not let a confirmed invitation block feel-heard', () => {
+    const inputs = createInputs({
+      myStage: Stage.WITNESS,
+      compactMySigned: true,
+      myProgress: { stage: Stage.WITNESS },
+      isInviter: true,
+      hasTopicConfirmed: true,
+      invitationConfirmed: true,
+      invitationPanelDismissed: false,
+      showFeelHeardConfirmation: true,
+      feelHeardConfirmedAt: null,
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.aboveInputPanel).toBe('feel-heard');
   });
 
   it('does not show invitation panel for invitee', () => {
@@ -215,6 +233,7 @@ describe('Above Input Panel Priority', () => {
       myProgress: { stage: Stage.WITNESS },
       isInviter: true,
       hasTopicConfirmed: true,
+      invitationConfirmed: false,
       invitationPanelDismissed: false,
       showFeelHeardConfirmation: true,
       feelHeardConfirmedAt: null,

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -62,9 +62,9 @@ export interface ChatUIStateInputs extends WaitingStatusInputs {
 
   // Invitation phase
   // The invitation panel opens once the topic frame has been confirmed and
-  // the user hasn't dismissed it. Stage 0→1 advancement is chained to topic
-  // confirmation in the screen, so `invitationConfirmed` no longer gates UI.
+  // the invitation has not been confirmed/sent yet.
   hasTopicConfirmed: boolean;
+  invitationConfirmed: boolean;
   invitationPanelDismissed: boolean;
   isConfirmingInvitation: boolean;
 
@@ -232,16 +232,17 @@ function computeShowInvitationPanel(inputs: ChatUIStateInputs): boolean {
   const {
     isInviter,
     hasTopicConfirmed,
+    invitationConfirmed,
     invitationPanelDismissed,
     isConfirmingInvitation,
   } = inputs;
 
-  // The invitation panel opens once the inviter has confirmed the topic
-  // frame. The user can dismiss it ("Later"); subsequent re-sharing lives
-  // in the Activity Drawer.
+  // The invitation panel should not reserve the above-input slot after the
+  // invitation is confirmed; otherwise it blocks later panels like feel-heard.
   return !!(
     isInviter &&
     hasTopicConfirmed &&
+    !invitationConfirmed &&
     !invitationPanelDismissed &&
     !isConfirmingInvitation
   );
@@ -679,6 +680,7 @@ export function createDefaultChatUIStateInputs(): ChatUIStateInputs {
     compactMySigned: undefined,
     myProgress: undefined,
     hasTopicConfirmed: false,
+    invitationConfirmed: false,
     invitationPanelDismissed: false,
     isConfirmingInvitation: false,
     topicFrameProposed: null,


### PR DESCRIPTION
## Summary
- Stop confirmed invitations from reserving the above-input slot and hiding the Stage 1 feel-heard panel.
- Roll back optimistic user/AI placeholder messages when an SSE stream fails or times out, so failed sends do not leave indefinite ghost typing dots.
- Keep the rebased auth fast path stable by using the Prisma runtime error class and adding coverage for Clerk profile lookup failure paths.
- Add narrow TypeScript annotations for rebased mainline files that blocked backend auth test compilation.

## Root Cause
The feel-heard offer was correctly persisted as `feelHeardCheckOffered: true`, but the mobile panel priority selector still chose `invitation` for inviters with a confirmed topic. That `invitation` case now renders nothing because the invitation flow moved to a modal, so the invisible invitation slot blocked the visible feel-heard panel.

The later failed send was a separate issue: the live backend returned 500 during auth before the stream controller ran, and the mobile stream error handler only set error state. Because the optimistic user message remained in React Query, `ChatInterface` still saw the last message as `USER` and kept rendering the typing indicator.

## Validation
- `npm --workspace=@meet-without-fear/backend test -- auth.test.ts --runInBand`
- `npm --workspace=@meet-without-fear/mobile test -- chatUIState --runInBand`
- `npm --workspace=@meet-without-fear/mobile run check`
