### PR TITLE
[codex] Fix feel-heard panel and failed stream cleanup

### DIFF
--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -12,8 +12,8 @@
 import { Request, Response } from 'express';
 import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
-import { EmpathyStatus } from '@prisma/client';
 import {
+  EmpathyStatus,
   MessageRole,
   saveEmpathyDraftRequestSchema,
   consentToShareRequestSchema,
@@ -603,6 +603,69 @@ export async function consentToShare(
       return;
     }
 
+    // Get partner ID from session data
+    const partnerId = getPartnerUserIdFromSession(session, user.id);
+
+    const respondWithExistingAttempt = async (existingAttempt: {
+      id: string;
+      content: string;
+      sharedAt: Date;
+      status: EmpathyStatus;
+    }) => {
+      const [partnerAttempt, existingEmpathyMessage] = await Promise.all([
+        partnerId
+          ? prisma.empathyAttempt.findFirst({
+            where: {
+              sessionId,
+              sourceUserId: partnerId,
+            },
+          })
+          : Promise.resolve(null),
+        prisma.message.findFirst({
+          where: {
+            sessionId,
+            senderId: user.id,
+            forUserId: user.id,
+            role: 'EMPATHY_STATEMENT',
+            stage: 2,
+          },
+          orderBy: { timestamp: 'desc' },
+        }),
+      ]);
+
+      successResponse(res, {
+        consented: true,
+        consentedAt: existingAttempt.sharedAt.toISOString(),
+        partnerConsented: !!partnerAttempt,
+        canReveal: !!partnerAttempt && consent,
+        status: existingAttempt.status,
+        empathyMessage: {
+          id: existingEmpathyMessage?.id ?? existingAttempt.id,
+          content: existingEmpathyMessage?.content ?? existingAttempt.content,
+          timestamp: (existingEmpathyMessage?.timestamp ?? existingAttempt.sharedAt).toISOString(),
+          stage: existingEmpathyMessage?.stage ?? 2,
+        },
+        transitionMessage: null,
+      });
+    };
+
+    // Idempotency: if this user already shared an empathy attempt, treat a
+    // retry/double-click as success instead of creating duplicate consent
+    // records and returning a conflict.
+    const existingAttempt = await prisma.empathyAttempt.findFirst({
+      where: {
+        sessionId,
+        sourceUserId: user.id,
+        status: { not: 'REFINING' },
+      },
+      orderBy: { sharedAt: 'desc' },
+    });
+
+    if (existingAttempt) {
+      await respondWithExistingAttempt(existingAttempt);
+      return;
+    }
+
     // Create consent record
     await prisma.consentRecord.create({
       data: {
@@ -633,14 +696,19 @@ export async function consentToShare(
     } catch (err: any) {
       // Unique constraint violation (P2002) — duplicate empathy attempt for this user+session
       if (err?.code === 'P2002') {
+        const concurrentAttempt = await prisma.empathyAttempt.findFirst({
+          where: { sessionId, sourceUserId: user.id },
+          orderBy: { sharedAt: 'desc' },
+        });
+        if (concurrentAttempt) {
+          await respondWithExistingAttempt(concurrentAttempt);
+          return;
+        }
         errorResponse(res, 'CONFLICT', 'Empathy attempt already exists for this session', 409);
         return;
       }
       throw err;
     }
-
-    // Get partner ID from session data
-    const partnerId = getPartnerUserIdFromSession(session, user.id);
 
     // Get partner name for messages
     let partnerName: string | undefined;
@@ -1529,7 +1597,7 @@ async function triggerStage3Transition(sessionId: string, userId: string, partne
       select: { id: true, firstName: true, name: true }
     });
 
-    const userMap = new Map(users.map(u => [u.id, u.firstName || u.name || 'User']));
+    const userMap = new Map(users.map((u: { id: string; firstName: string | null; name: string | null }) => [u.id, u.firstName || u.name || 'User']));
     const nameA = userMap.get(userId) || 'User';
     const nameB = partnerId ? (userMap.get(partnerId) || 'Partner') : 'Partner';
 

--- a/backend/src/middleware/__tests__/auth.test.ts
+++ b/backend/src/middleware/__tests__/auth.test.ts
@@ -198,7 +198,7 @@ describe('Auth Middleware', () => {
     });
 
     it('handles concurrent create race (P2002 fallback)', async () => {
-      const { Prisma } = jest.requireActual('@prisma/client');
+      const { PrismaClientKnownRequestError } = jest.requireActual('@prisma/client/runtime/library');
       mockVerifyToken.mockResolvedValue({ sub: 'clerk-race-user' });
       mockGetUser.mockResolvedValue({
         firstName: 'Race',
@@ -210,7 +210,7 @@ describe('Auth Middleware', () => {
       (prisma.user.findUnique as jest.Mock)
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(raceUser);
-      const p2002Error = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', { code: 'P2002', clientVersion: '5.0.0' });
+      const p2002Error = new PrismaClientKnownRequestError('Unique constraint failed', { code: 'P2002', clientVersion: '5.0.0' });
       (prisma.user.create as jest.Mock).mockRejectedValue(p2002Error);
 
       const req = createMockRequest({
@@ -224,6 +224,48 @@ describe('Auth Middleware', () => {
       expect(prisma.user.findUnique).toHaveBeenCalledTimes(2);
       expect(next).toHaveBeenCalled();
       expect(req.user).toEqual(raceUser);
+    });
+
+    it('uses an existing local user when Clerk profile lookup fails', async () => {
+      mockVerifyToken.mockResolvedValue({ sub: 'clerk-user-123' });
+      mockGetUser.mockRejectedValue(new Error('Clerk unavailable'));
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer valid-clerk-token' },
+      });
+      const { res, statusMock } = createMockResponse();
+      const next = jest.fn();
+
+      await requireAuth(req as Request, res as Response, next);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { clerkId: 'clerk-user-123' },
+      });
+      expect(prisma.user.update).not.toHaveBeenCalled();
+      expect(prisma.user.create).not.toHaveBeenCalled();
+      expect(statusMock).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+      expect(req.user).toEqual(mockUser);
+      expect(req.clerkUserId).toBe('clerk-user-123');
+    });
+
+    it('fails when Clerk profile lookup fails for an unknown user', async () => {
+      const clerkError = new Error('Clerk unavailable');
+      mockVerifyToken.mockResolvedValue({ sub: 'clerk-new-user' });
+      mockGetUser.mockRejectedValue(clerkError);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer valid-clerk-token' },
+      });
+      const { res } = createMockResponse();
+      const next = jest.fn();
+
+      await requireAuth(req as Request, res as Response, next);
+
+      expect(next).toHaveBeenCalledWith(clerkError);
+      expect(req.user).toBeUndefined();
     });
   });
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -9,7 +9,7 @@ import { Request, Response, NextFunction } from 'express';
 import { UnauthorizedError, ForbiddenError } from './errors';
 import { prisma } from '../lib/prisma';
 import { ApiResponse, ErrorCode } from '@meet-without-fear/shared';
-import { Prisma } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { logger } from '../lib/logger';
 
 // ============================================================================
@@ -100,7 +100,7 @@ async function handleE2EAuthBypass(req: Request): Promise<boolean> {
     });
   } catch (error) {
     // Guard against transient unique conflicts (parallel E2E requests)
-    if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== 'P2002') {
+    if (!(error instanceof PrismaClientKnownRequestError) || error.code !== 'P2002') {
       throw error;
     }
 
@@ -200,7 +200,7 @@ async function handleClerkAuth(
       });
     } catch (error) {
       // Concurrent create race: another request inserted first
-      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      if (error instanceof PrismaClientKnownRequestError && error.code === 'P2002') {
         user = await prisma.user.findUnique({ where: { clerkId: clerkUserId } });
         if (!user) throw error;
       } else {

--- a/backend/src/routes/__tests__/stage2.test.ts
+++ b/backend/src/routes/__tests__/stage2.test.ts
@@ -343,6 +343,59 @@ describe('Stage 2 API', () => {
         })
       );
     });
+
+    it('treats duplicate consent for an existing empathy attempt as idempotent success', async () => {
+      const req = mockRequest({
+        body: { consent: true },
+      });
+      const res = mockResponse();
+      const sharedAt = new Date('2026-05-04T07:03:30.502Z');
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue({
+        stage: 2,
+        status: 'IN_PROGRESS',
+      });
+      (prisma.empathyDraft.findUnique as jest.Mock).mockResolvedValue({
+        id: 'draft-1',
+        content: 'Ready content',
+        readyToShare: true,
+      });
+      (prisma.empathyAttempt.findFirst as jest.Mock)
+        .mockResolvedValueOnce({
+          id: 'attempt-1',
+          content: 'Ready content',
+          sharedAt,
+          status: 'HELD',
+        })
+        .mockResolvedValueOnce(null);
+      (prisma.message.findFirst as jest.Mock).mockResolvedValue({
+        id: 'message-1',
+        content: 'Ready content',
+        timestamp: sharedAt,
+        stage: 2,
+      });
+
+      await consentToShare(req, res);
+
+      expect(prisma.consentRecord.create).not.toHaveBeenCalled();
+      expect(prisma.empathyAttempt.create).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalledWith(409);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            consented: true,
+            consentedAt: sharedAt.toISOString(),
+            status: 'HELD',
+            empathyMessage: expect.objectContaining({
+              id: 'message-1',
+              content: 'Ready content',
+            }),
+          }),
+        })
+      );
+    });
   });
 
   describe('GET /sessions/:id/empathy/partner (getPartnerEmpathy)', () => {

--- a/backend/src/services/account-deletion.ts
+++ b/backend/src/services/account-deletion.ts
@@ -74,7 +74,7 @@ export async function deleteAccountWithNotifications(
     sessionsAbandoned++;
 
     // Notify partner that the session has been abandoned
-    const partner = session.relationship.members.find((m) => m.userId !== userId);
+    const partner = session.relationship.members.find((m: { userId: string }) => m.userId !== userId);
     if (partner) {
       try {
         await publishSessionEvent(session.id, 'session.abandoned', {

--- a/backend/src/services/conversation-summarizer.ts
+++ b/backend/src/services/conversation-summarizer.ts
@@ -13,9 +13,8 @@
 
 import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
-import { getHaikuJson } from '../lib/bedrock';
+import { getHaikuJson, BrainActivityCallType } from '../lib/bedrock';
 import { estimateTokens } from '../utils/token-budget';
-import { BrainActivityCallType } from '@prisma/client';
 
 // ============================================================================
 // Types
@@ -80,6 +79,21 @@ export interface SummarizationHints {
    */
   partnerStatus?: 'not_joined' | 'in_progress' | 'completed';
 }
+
+type SummaryMessageRecord = {
+  role: string;
+  content: string;
+  timestamp: Date;
+};
+
+type RelationshipMemberWithUser = {
+  userId: string;
+  nickname?: string | null;
+  user: {
+    name: string | null;
+    firstName: string | null;
+  };
+};
 
 // ============================================================================
 // Configuration
@@ -294,7 +308,7 @@ export async function updateSessionSummary(
     // Check if we actually need to summarize
     const existingSummary = vessel.conversationSummary as string | null;
     const totalTokens = session.messages.reduce(
-      (sum, msg) => sum + estimateTokens(msg.content),
+      (sum: number, msg: SummaryMessageRecord) => sum + estimateTokens(msg.content),
       0
     );
     if (!needsSummarization(messageCount, existingSummary ?? undefined, totalTokens)) {
@@ -302,8 +316,8 @@ export async function updateSessionSummary(
     }
 
     // Get user and partner names
-    const currentMember = session.relationship.members.find((m) => m.userId === userId);
-    const partnerMember = session.relationship.members.find((m) => m.userId !== userId);
+    const currentMember = session.relationship.members.find((m: RelationshipMemberWithUser) => m.userId === userId);
+    const partnerMember = session.relationship.members.find((m: RelationshipMemberWithUser) => m.userId !== userId);
     const userName = currentMember?.user.name || currentMember?.user.firstName || 'User';
     const partnerName = partnerMember?.user.name || partnerMember?.nickname || 'Partner';
 
@@ -323,7 +337,7 @@ export async function updateSessionSummary(
 
     // Generate summary
     const summaryResult = await generateConversationSummary(
-      messagesToSummarize.map((m) => ({
+      messagesToSummarize.map((m: SummaryMessageRecord) => ({
         role: m.role === 'USER' ? 'user' as const : 'assistant' as const,
         content: m.content,
         timestamp: m.timestamp,
@@ -723,7 +737,7 @@ export async function updateInnerThoughtsSummary(
 
     // Generate summary
     const summaryResult = await generateInnerThoughtsSummary(
-      messagesToSummarize.map((m) => ({
+      messagesToSummarize.map((m: SummaryMessageRecord) => ({
         role: m.role === 'USER' ? 'user' as const : 'assistant' as const,
         content: m.content,
         timestamp: m.timestamp,

--- a/backend/src/services/empathy-state-machine.ts
+++ b/backend/src/services/empathy-state-machine.ts
@@ -20,7 +20,7 @@
  *   REVEALED → REFINING (recipient sends validation feedback)
  */
 
-import { EmpathyStatus } from '@prisma/client';
+import { EmpathyStatus } from '@meet-without-fear/shared';
 
 /** Events that trigger empathy status transitions */
 export type EmpathyEvent =

--- a/backend/src/services/realtime.ts
+++ b/backend/src/services/realtime.ts
@@ -298,13 +298,13 @@ export async function notifySessionMembers(
 
     // Publish to each member's user channel (except the excluded user)
     const memberIds = session.relationship.members
-      .map((m) => m.userId)
-      .filter((id) => id !== excludeUserId);
+      .map((m: { userId: string }) => m.userId)
+      .filter((id: string) => id !== excludeUserId);
 
     logger.info(`[notifySessionMembers] Publishing to ${memberIds.length} members: ${memberIds.join(', ')}`);
 
     await Promise.all(
-      memberIds.map((userId) =>
+      memberIds.map((userId: string) =>
         publishUserEvent(userId, 'session.updated', { sessionId })
       )
     );

--- a/backend/src/services/reconciler/analysis.ts
+++ b/backend/src/services/reconciler/analysis.ts
@@ -8,8 +8,7 @@
 import { prisma } from '../../lib/prisma';
 import { logger } from '../../lib/logger';
 import { MessageRole } from '@meet-without-fear/shared';
-import { getSonnetResponse, getHaikuJson } from '../../lib/bedrock';
-import { BrainActivityCallType } from '@prisma/client';
+import { getSonnetResponse, getHaikuJson, BrainActivityCallType } from '../../lib/bedrock';
 import { getCurrentUserId } from '../../lib/request-context';
 import {
   buildReconcilerPrompt,
@@ -23,6 +22,11 @@ import type {
 // ============================================================================
 // Types (shared across reconciler modules)
 // ============================================================================
+
+type StageOneMessageForThemes = {
+  content: string;
+  extractedEmotions: string[] | null;
+};
 
 export interface UserInfo {
   id: string;
@@ -153,12 +157,12 @@ export async function getWitnessingContent(
   });
 
   // Combine all messages
-  const userMessages = messages.map((m) => m.content).join('\n\n');
+  const userMessages = messages.map((m: StageOneMessageForThemes) => m.content).join('\n\n');
 
   // Extract unique themes/emotions
   const themes = new Set<string>();
-  messages.forEach((m) => {
-    m.extractedEmotions?.forEach((e) => themes.add(e));
+  messages.forEach((m: StageOneMessageForThemes) => {
+    m.extractedEmotions?.forEach((e: string) => themes.add(e));
   });
 
   // If no extracted emotions, try to extract key themes using AI (quick analysis)

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -8,6 +8,7 @@
 import { prisma } from '../../lib/prisma';
 import { logger } from '../../lib/logger';
 import { EmpathyStatus, MessageRole } from '@meet-without-fear/shared';
+import type { Prisma } from '@prisma/client';
 import { getSonnetResponse } from '../../lib/bedrock';
 import { transition } from '../empathy-state-machine';
 import {
@@ -689,7 +690,7 @@ export async function respondToShareSuggestion(
     logger.info('User declined share offer, marking guesser empathy as READY', { userId });
 
     // Wrap decline DB writes in a transaction for consistency
-    await prisma.$transaction(async (tx: typeof prisma) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       // Idempotency guard: only update if still in OFFERED/PENDING state
       const updated = await tx.reconcilerShareOffer.updateMany({
         where: {
@@ -810,7 +811,7 @@ export async function respondToShareSuggestion(
   const subjectCurrentStage = subjectProgress?.stage ?? 2;
 
   // Wrap all DB writes in a transaction for atomicity
-  await prisma.$transaction(async (tx: typeof prisma) => {
+  await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const now = new Date();
 
     // Idempotency guard: only update if still in OFFERED/PENDING state

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -7,9 +7,8 @@
 
 import { prisma } from '../../lib/prisma';
 import { logger } from '../../lib/logger';
-import { MessageRole } from '@meet-without-fear/shared';
+import { EmpathyStatus, MessageRole } from '@meet-without-fear/shared';
 import { getSonnetResponse } from '../../lib/bedrock';
-import { EmpathyStatus } from '@prisma/client';
 import { transition } from '../empathy-state-machine';
 import {
   buildShareOfferPrompt,
@@ -23,6 +22,11 @@ import type {
   ReconcilerResult,
   ShareOfferMessage,
 } from '@meet-without-fear/shared';
+
+type ConversationPromptMessage = {
+  role: string;
+  content: string;
+};
 
 import {
   type UserInfo,
@@ -116,9 +120,9 @@ export async function generatePostShareContinuation(
   // Convert to format expected by prompt (reverse to chronological order)
   // Only include USER and AI messages - exclude EMPATHY_STATEMENT, SHARED_CONTEXT, etc.
   const conversationHistory = recentMessages
-    .filter(m => m.role === 'USER' || m.role === 'AI')
+    .filter((m: ConversationPromptMessage) => m.role === 'USER' || m.role === 'AI')
     .reverse()
-    .map(m => ({
+    .map((m: ConversationPromptMessage) => ({
       role: (m.role === 'USER' ? 'user' : 'assistant') as 'user' | 'assistant',
       content: m.content,
     }));
@@ -129,12 +133,12 @@ export async function generatePostShareContinuation(
   // We don't need full memory/pattern context for post-share continuation
   const minimalContextBundle: ContextBundle = {
     conversationContext: {
-      recentTurns: conversationHistory.map((m) => ({
+      recentTurns: conversationHistory.map((m: { role: 'user' | 'assistant'; content: string }) => ({
         role: m.role,
         content: m.content,
         timestamp: new Date().toISOString(), // Approximate
       })),
-      turnCount: conversationHistory.filter(m => m.role === 'user').length,
+      turnCount: conversationHistory.filter((m: { role: 'user' | 'assistant'; content: string }) => m.role === 'user').length,
       sessionDurationMinutes: 0, // Not critical for this use case
     },
     emotionalThread: {
@@ -166,7 +170,7 @@ export async function generatePostShareContinuation(
   const promptContext: PromptContext = {
     userName: subjectName,
     partnerName,
-    turnCount: conversationHistory.filter(m => m.role === 'user').length,
+    turnCount: conversationHistory.filter((m: { role: 'user' | 'assistant'; content: string }) => m.role === 'user').length,
     emotionalIntensity: 5, // Default moderate
     contextBundle: minimalContextBundle,
     justSharedWithPartner: {
@@ -685,7 +689,7 @@ export async function respondToShareSuggestion(
     logger.info('User declined share offer, marking guesser empathy as READY', { userId });
 
     // Wrap decline DB writes in a transaction for consistency
-    await prisma.$transaction(async (tx) => {
+    await prisma.$transaction(async (tx: typeof prisma) => {
       // Idempotency guard: only update if still in OFFERED/PENDING state
       const updated = await tx.reconcilerShareOffer.updateMany({
         where: {
@@ -806,7 +810,7 @@ export async function respondToShareSuggestion(
   const subjectCurrentStage = subjectProgress?.stage ?? 2;
 
   // Wrap all DB writes in a transaction for atomicity
-  await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async (tx: typeof prisma) => {
     const now = new Date();
 
     // Idempotency guard: only update if still in OFFERED/PENDING state

--- a/backend/src/services/reconciler/state.ts
+++ b/backend/src/services/reconciler/state.ts
@@ -8,6 +8,7 @@
 import { prisma } from '../../lib/prisma';
 import { logger } from '../../lib/logger';
 import { EmpathyStatus, MessageRole } from '@meet-without-fear/shared';
+import type { Prisma } from '@prisma/client';
 import { publishMessageAIResponse } from '../realtime';
 import { transition } from '../empathy-state-machine';
 import {
@@ -77,7 +78,7 @@ async function markEmpathyReady(
   // Wrap state transition + status update + message creation in a transaction
   // to ensure atomicity — a partial write here could leave the attempt READY
   // without a corresponding alignment message, or vice versa.
-  const savedMessage = await prisma.$transaction(async (tx: typeof prisma) => {
+  const savedMessage = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     // Validate state transition before updating
     const attempt = await tx.empathyAttempt.findFirst({
       where: { sessionId, sourceUserId: guesserId },
@@ -314,7 +315,7 @@ export async function runReconcilerForDirection(
   // The read (for state-machine validation) and write must be in one transaction
   // to prevent a concurrent caller from seeing stale status.
   logger.info('Updating empathy status to AWAITING_SHARING', { guesserId: guesserInfo.id });
-  await prisma.$transaction(async (tx: typeof prisma) => {
+  await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const attemptForAwait = await tx.empathyAttempt.findFirst({
       where: { sessionId, sourceUserId: guesserId },
     });
@@ -394,7 +395,7 @@ export async function checkAndRevealBothIfReady(sessionId: string): Promise<bool
   // Use a Serializable transaction to prevent the TOCTOU race where two
   // concurrent callers both read "both READY" and both try to reveal.
   // Serializable isolation ensures the read-check-write is atomic.
-  const revealed = await prisma.$transaction(async (tx: typeof prisma) => {
+  const revealed = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     // Get both empathy attempts for this session
     const attempts = await tx.empathyAttempt.findMany({
       where: { sessionId },

--- a/backend/src/services/reconciler/state.ts
+++ b/backend/src/services/reconciler/state.ts
@@ -7,8 +7,7 @@
 
 import { prisma } from '../../lib/prisma';
 import { logger } from '../../lib/logger';
-import { MessageRole } from '@meet-without-fear/shared';
-import { EmpathyStatus, Prisma } from '@prisma/client';
+import { EmpathyStatus, MessageRole } from '@meet-without-fear/shared';
 import { publishMessageAIResponse } from '../realtime';
 import { transition } from '../empathy-state-machine';
 import {
@@ -19,6 +18,16 @@ import type {
   ReconcilerResult,
   ReconcilerSummary,
 } from '@meet-without-fear/shared';
+
+type EmpathyAttemptState = {
+  sourceUserId: string | null;
+  status: string;
+};
+
+type ReconcilerResultWithOffer = {
+  recommendedAction: string;
+  shareOffer?: { status: string } | null;
+};
 
 import {
   type UserInfo,
@@ -68,7 +77,7 @@ async function markEmpathyReady(
   // Wrap state transition + status update + message creation in a transaction
   // to ensure atomicity — a partial write here could leave the attempt READY
   // without a corresponding alignment message, or vice versa.
-  const savedMessage = await prisma.$transaction(async (tx) => {
+  const savedMessage = await prisma.$transaction(async (tx: typeof prisma) => {
     // Validate state transition before updating
     const attempt = await tx.empathyAttempt.findFirst({
       where: { sessionId, sourceUserId: guesserId },
@@ -305,7 +314,7 @@ export async function runReconcilerForDirection(
   // The read (for state-machine validation) and write must be in one transaction
   // to prevent a concurrent caller from seeing stale status.
   logger.info('Updating empathy status to AWAITING_SHARING', { guesserId: guesserInfo.id });
-  await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async (tx: typeof prisma) => {
     const attemptForAwait = await tx.empathyAttempt.findFirst({
       where: { sessionId, sourceUserId: guesserId },
     });
@@ -385,7 +394,7 @@ export async function checkAndRevealBothIfReady(sessionId: string): Promise<bool
   // Use a Serializable transaction to prevent the TOCTOU race where two
   // concurrent callers both read "both READY" and both try to reveal.
   // Serializable isolation ensures the read-check-write is atomic.
-  const revealed = await prisma.$transaction(async (tx) => {
+  const revealed = await prisma.$transaction(async (tx: typeof prisma) => {
     // Get both empathy attempts for this session
     const attempts = await tx.empathyAttempt.findMany({
       where: { sessionId },
@@ -397,9 +406,9 @@ export async function checkAndRevealBothIfReady(sessionId: string): Promise<bool
     }
 
     // Check if both are in READY status
-    const bothReady = attempts.every((a) => a.status === 'READY');
+    const bothReady = attempts.every((a: EmpathyAttemptState) => a.status === 'READY');
     if (!bothReady) {
-      const statuses = Object.fromEntries(attempts.map((a) => [a.sourceUserId, a.status]));
+      const statuses = Object.fromEntries(attempts.map((a: EmpathyAttemptState) => [a.sourceUserId, a.status]));
       logger.debug('Not both READY yet', { statuses });
       return null;
     }
@@ -429,7 +438,7 @@ export async function checkAndRevealBothIfReady(sessionId: string): Promise<bool
 
     return attempts;
   }, {
-    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    isolationLevel: 'Serializable',
   });
 
   if (!revealed) {
@@ -490,7 +499,7 @@ export async function getReconcilerStatus(sessionId: string): Promise<{
 
   // Count pending share offers (status = OFFERED)
   const pendingShareOffers = results.filter(
-    (r) => r.shareOffer?.status === 'OFFERED'
+    (r: ReconcilerResultWithOffer) => r.shareOffer?.status === 'OFFERED'
   ).length;
 
   // Ready for Stage 3 if:
@@ -501,7 +510,7 @@ export async function getReconcilerStatus(sessionId: string): Promise<{
     results.length === 2 &&
     pendingShareOffers === 0 &&
     results.every(
-      (r) =>
+      (r: ReconcilerResultWithOffer) =>
         r.recommendedAction === 'PROCEED' ||
         !r.shareOffer ||
         r.shareOffer.status === 'ACCEPTED' ||

--- a/backend/src/utils/session.ts
+++ b/backend/src/utils/session.ts
@@ -77,7 +77,7 @@ export async function getPartnerUserId(
   }
 
   const partnerMember = session.relationship.members.find(
-    (m) => m.userId !== currentUserId
+    (m: { userId: string }) => m.userId !== currentUserId
   );
 
   return partnerMember?.userId ?? null;

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -60,9 +60,9 @@ export interface UseChatUIStateProps {
 
   // Invitation phase
   // The invitation panel opens when the topic frame is confirmed and the
-  // user has not dismissed it. Stage 0→1 advancement is chained off topic
-  // confirmation; the invitation panel is purely a share affordance.
+  // invitation has not been confirmed/sent yet.
   hasTopicConfirmed: boolean;
+  invitationConfirmed: boolean;
   invitationPanelDismissed: boolean;
   isConfirmingInvitation: boolean;
 
@@ -182,6 +182,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     partnerProgress,
     compactMySigned,
     hasTopicConfirmed,
+    invitationConfirmed,
     invitationPanelDismissed,
     isConfirmingInvitation,
     topicFrameProposed,
@@ -254,6 +255,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     compactMySigned,
     myProgress,
     hasTopicConfirmed,
+    invitationConfirmed,
     invitationPanelDismissed,
     isConfirmingInvitation,
     topicFrameProposed,
@@ -314,6 +316,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     compactMySigned,
     myProgress,
     hasTopicConfirmed,
+    invitationConfirmed,
     invitationPanelDismissed,
     isConfirmingInvitation,
     topicFrameProposed,

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -139,6 +139,7 @@ export function useStreamingMessage(
 
   // Ref to track optimistic user message ID for replacement
   const optimisticUserIdRef = useRef<string>('');
+  const activeUserMessageIdRef = useRef<string>('');
 
   // Refs for throttled cache updates (reduces stuttering)
   const lastCacheUpdateRef = useRef<number>(0);
@@ -292,6 +293,78 @@ export function useStreamingMessage(
   );
 
   /**
+   * Remove optimistic/placeholder messages from the cache after a failed stream.
+   */
+  const removeMessagesFromCache = useCallback(
+    (sessionId: string, messageIds: string[], stage?: Stage) => {
+      const ids = new Set(messageIds.filter(Boolean));
+      if (ids.size === 0) return;
+
+      const updateCache = (old: GetMessagesResponse | undefined) => {
+        if (!old) return old;
+        return {
+          ...old,
+          messages: (old.messages || []).filter((message) => !ids.has(message.id)),
+        };
+      };
+
+      const updateInfiniteCache = (
+        old: InfiniteData<GetMessagesResponse> | undefined
+      ): InfiniteData<GetMessagesResponse> | undefined => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            messages: (page.messages || []).filter((message) => !ids.has(message.id)),
+          })),
+        };
+      };
+
+      queryClient.setQueryData<GetMessagesResponse>(
+        messageKeys.list(sessionId),
+        updateCache
+      );
+      queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
+        messageKeys.infinite(sessionId),
+        updateInfiniteCache
+      );
+
+      if (stage !== undefined) {
+        queryClient.setQueryData<GetMessagesResponse>(
+          messageKeys.list(sessionId, stage),
+          updateCache
+        );
+        queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
+          messageKeys.infinite(sessionId, stage),
+          updateInfiniteCache
+        );
+      }
+    },
+    [queryClient]
+  );
+
+  const cleanupFailedStream = useCallback(
+    (sessionId: string, stage?: Stage) => {
+      removeMessagesFromCache(
+        sessionId,
+        [activeUserMessageIdRef.current, optimisticUserIdRef.current, aiMessageIdRef.current],
+        stage
+      );
+
+      activeUserMessageIdRef.current = '';
+      optimisticUserIdRef.current = '';
+      aiMessageIdRef.current = '';
+      accumulatedTextRef.current = '';
+
+      queryClient.invalidateQueries({ queryKey: messageKeys.list(sessionId) });
+      queryClient.invalidateQueries({ queryKey: messageKeys.infinite(sessionId) });
+      queryClient.invalidateQueries({ queryKey: timelineKeys.infinite(sessionId) });
+    },
+    [queryClient, removeMessagesFromCache]
+  );
+
+  /**
    * Handle metadata from the AI response
    */
   const handleMetadata = useCallback(
@@ -378,6 +451,7 @@ export function useStreamingMessage(
       accumulatedTextRef.current = '';
       aiMessageIdRef.current = `streaming-${Date.now()}`;
       optimisticUserIdRef.current = `optimistic-user-${Date.now()}`;
+      activeUserMessageIdRef.current = optimisticUserIdRef.current;
       textCompleteReceivedRef.current = false;
 
       // Create optimistic user message
@@ -441,9 +515,7 @@ export function useStreamingMessage(
             // Close the stuck connection
             eventSourceRef.current.close();
             eventSourceRef.current = null;
-            // Invalidate queries to fetch latest state from server
-            queryClient.invalidateQueries({ queryKey: messageKeys.infinite(sessionId) });
-            queryClient.invalidateQueries({ queryKey: timelineKeys.infinite(sessionId) });
+            cleanupFailedStream(sessionId, currentStage);
             // Transition to idle so typing indicator disappears
             setStatus('idle');
           }
@@ -475,6 +547,7 @@ export function useStreamingMessage(
             const data = JSON.parse(event.data) as UserMessageEvent;
             // Update optimistic message with server timestamp (keep same ID for React key stability)
             if (optimisticUserIdRef.current) {
+              activeUserMessageIdRef.current = optimisticUserIdRef.current;
               updateMessageInCache(sessionId, optimisticUserIdRef.current, {
                 timestamp: data.timestamp,
                 content: data.content, // In case server modified content
@@ -688,6 +761,7 @@ export function useStreamingMessage(
 
           const errorMsg = 'message' in event ? event.message : 'Connection error';
           console.error('[useStreamingMessage] SSE error:', errorMsg);
+          cleanupFailedStream(sessionId, currentStage);
           setErrorMessage(errorMsg);
           setStatus('error');
           onError?.(new Error(errorMsg));
@@ -702,12 +776,13 @@ export function useStreamingMessage(
 
       } catch (error) {
         console.error('[useStreamingMessage] Error:', error);
+        cleanupFailedStream(sessionId, currentStage);
         setErrorMessage((error as Error).message || 'Failed to send message');
         setStatus('error');
         onError?.(error as Error);
       }
     },
-    [addMessageToCache, updateMessageInCache, handleMetadata, queryClient, onComplete, onError]
+    [addMessageToCache, updateMessageInCache, cleanupFailedStream, handleMetadata, queryClient, onComplete, onError]
   );
 
   /**

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1075,6 +1075,7 @@ export function UnifiedSessionScreen({
     partnerProgress,
     compactMySigned: compactData?.mySigned,
     hasTopicConfirmed: topicFrameConfirmed,
+    invitationConfirmed,
     // Local dismissal latch — the panel hides as soon as the user taps
     // "Later" (or after a successful share, if the screen wants to stash it).
     invitationPanelDismissed,

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -83,19 +83,37 @@ describe('Above Input Panel Priority', () => {
     expect(result.aboveInputPanel).toBe('compact-agreement-bar');
   });
 
-  it('shows invitation panel for inviter once topic is confirmed', () => {
+  it('shows invitation panel for inviter once topic is confirmed but invitation is not', () => {
     const inputs = createInputs({
       myStage: Stage.WITNESS,
       compactMySigned: true,
       myProgress: { stage: Stage.WITNESS },
       isInviter: true,
       hasTopicConfirmed: true,
+      invitationConfirmed: false,
       invitationPanelDismissed: false,
       isConfirmingInvitation: false,
     });
 
     const result = computeChatUIState(inputs);
     expect(result.aboveInputPanel).toBe('invitation');
+  });
+
+  it('does not let a confirmed invitation block feel-heard', () => {
+    const inputs = createInputs({
+      myStage: Stage.WITNESS,
+      compactMySigned: true,
+      myProgress: { stage: Stage.WITNESS },
+      isInviter: true,
+      hasTopicConfirmed: true,
+      invitationConfirmed: true,
+      invitationPanelDismissed: false,
+      showFeelHeardConfirmation: true,
+      feelHeardConfirmedAt: null,
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.aboveInputPanel).toBe('feel-heard');
   });
 
   it('does not show invitation panel for invitee', () => {
@@ -215,6 +233,7 @@ describe('Above Input Panel Priority', () => {
       myProgress: { stage: Stage.WITNESS },
       isInviter: true,
       hasTopicConfirmed: true,
+      invitationConfirmed: false,
       invitationPanelDismissed: false,
       showFeelHeardConfirmation: true,
       feelHeardConfirmedAt: null,

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -62,9 +62,9 @@ export interface ChatUIStateInputs extends WaitingStatusInputs {
 
   // Invitation phase
   // The invitation panel opens once the topic frame has been confirmed and
-  // the user hasn't dismissed it. Stage 0→1 advancement is chained to topic
-  // confirmation in the screen, so `invitationConfirmed` no longer gates UI.
+  // the invitation has not been confirmed/sent yet.
   hasTopicConfirmed: boolean;
+  invitationConfirmed: boolean;
   invitationPanelDismissed: boolean;
   isConfirmingInvitation: boolean;
 
@@ -232,16 +232,17 @@ function computeShowInvitationPanel(inputs: ChatUIStateInputs): boolean {
   const {
     isInviter,
     hasTopicConfirmed,
+    invitationConfirmed,
     invitationPanelDismissed,
     isConfirmingInvitation,
   } = inputs;
 
-  // The invitation panel opens once the inviter has confirmed the topic
-  // frame. The user can dismiss it ("Later"); subsequent re-sharing lives
-  // in the Activity Drawer.
+  // The invitation panel should not reserve the above-input slot after the
+  // invitation is confirmed; otherwise it blocks later panels like feel-heard.
   return !!(
     isInviter &&
     hasTopicConfirmed &&
+    !invitationConfirmed &&
     !invitationPanelDismissed &&
     !isConfirmingInvitation
   );
@@ -679,6 +680,7 @@ export function createDefaultChatUIStateInputs(): ChatUIStateInputs {
     compactMySigned: undefined,
     myProgress: undefined,
     hasTopicConfirmed: false,
+    invitationConfirmed: false,
     invitationPanelDismissed: false,
     isConfirmingInvitation: false,
     topicFrameProposed: null,


### PR DESCRIPTION
## Summary
- Stop confirmed invitations from reserving the above-input slot and hiding the Stage 1 feel-heard panel.
- Roll back optimistic user/AI placeholder messages when an SSE stream fails or times out, so failed sends do not leave indefinite ghost typing dots.
- Make Stage 2 empathy consent idempotent when a share retry/double-click arrives after an empathy attempt already exists.
- Keep auth/stage2 test compatibility stable on current main with narrow Prisma enum/runtime imports and explicit callback types.

## Root Cause
The feel-heard offer was correctly persisted as `feelHeardCheckOffered: true`, but the mobile panel priority selector still chose `invitation` for inviters with a confirmed topic. That `invitation` case now renders nothing because the invitation flow moved to a modal, so the invisible invitation slot blocked the visible feel-heard panel.

The failed send was separate: backend auth returned 500 before the stream controller ran, and the mobile stream error handler only set error state. Because the optimistic user message remained in React Query, `ChatInterface` still saw the last message as `USER` and kept rendering the typing indicator.

The empathy consent 409 was another retry/idempotency bug: the first share had succeeded and created a `HELD` empathy attempt, but duplicate share clicks retried `POST /empathy/consent`. The endpoint created another consent record before hitting the unique empathy-attempt constraint, then returned 409. It now detects existing attempts and returns the existing shared message as success.

## Validation
- `npm --workspace=@meet-without-fear/backend test -- stage2.test.ts --runInBand`
- `npm --workspace=@meet-without-fear/backend test -- auth.test.ts --runInBand`
- `npm --workspace=@meet-without-fear/mobile test -- chatUIState --runInBand`
- `npm --workspace=@meet-without-fear/mobile run check`
