### PR TITLE
docs: sync 7 docs with 24h code changes (incremental audit 2026-05-04)

### DIFF
--- a/docs/architecture/backend-overview.md
+++ b/docs/architecture/backend-overview.md
@@ -3,7 +3,7 @@ title: Architecture
 sidebar_position: 2
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-04-27
+updated: 2026-05-04
 status: living
 ---
 # Architecture
@@ -198,7 +198,7 @@ status: living
 - Mobile: Zod schemas in shared contracts; React Hook Form for UI validation
 
 **Authentication:**
-- Backend: Clerk JWT in `Authorization: Bearer` header; middleware extracts + verifies with `verifyToken()` (from @clerk/express). When `E2E_AUTH_BYPASS=true` **and** `NODE_ENV !== 'production'`, the middleware also accepts `x-e2e-user-id` and `x-e2e-user-email` headers and resolves them to a DB user instead of a Clerk session. A startup assertion in `server.ts` prevents the server from starting if `E2E_AUTH_BYPASS=true` is set in a production environment.
+- Backend: Clerk JWT in `Authorization: Bearer` header; middleware extracts + verifies with `verifyToken()` (from @clerk/express). After JWT verification the middleware uses a **two-path user lookup** to avoid Clerk API rate limits (429): it first queries the DB by `clerkId` (fast path — no Clerk API call); only when no DB record exists does it call `clerkClient.users.getUser()` to fetch the profile from Clerk (slow path, first-time users only). When `E2E_AUTH_BYPASS=true` **and** `NODE_ENV !== 'production'`, the middleware also accepts `x-e2e-user-id` and `x-e2e-user-email` headers and resolves them to a DB user instead of a Clerk session. A startup assertion in `server.ts` prevents the server from starting if `E2E_AUTH_BYPASS=true` is set in a production environment.
 - Mobile: Clerk Expo SDK manages tokens; `useAuth()` hook provides `token` for API calls; E2E mode sends the `x-e2e-user-id` / `x-e2e-user-email` headers described above instead of a Clerk token.
 
 **Rate Limiting:**

--- a/docs/backend/api/invitations.md
+++ b/docs/backend/api/invitations.md
@@ -3,6 +3,7 @@ title: Invitations API
 sidebar_position: 3
 description: Invitation acceptance and management for session partners.
 slug: /backend/api/invitations
+updated: 2026-05-04
 ---
 # Invitations API
 
@@ -33,6 +34,8 @@ interface InvitationDTO {
   };
   name: string | null;
   status: InvitationStatus;  // PENDING, ACCEPTED, DECLINED, EXPIRED
+  messageConfirmed: boolean;          // true once inviter confirms invitation sent
+  messageConfirmedAt: string | null;  // ISO timestamp of confirmation, or null
   createdAt: string;
   expiresAt: string;
   session: {
@@ -139,9 +142,15 @@ interface AcceptInvitationResponse {
 }
 ```
 
+### Preconditions
+
+Acceptance is only permitted when **both** of the following are true on the session:
+- `topicFrameConfirmedAt` is set (inviter confirmed the AI-proposed topic frame)
+- `Invitation.messageConfirmed = true` (inviter confirmed the invitation was sent)
+
 ### Side Effects
 
-1. Session transitions out of `INVITED` toward `ACTIVE` (sessions are `CREATED` at session creation, move to `INVITED` once the inviter confirms the invitation message, then `ACTIVE` on accept).
+1. Session transitions out of `INVITED` toward `ACTIVE` (sessions are `CREATED` at session creation, move to `INVITED` at topic-frame confirmation, then `ACTIVE` on accept).
 2. Inviter receives push notification + Ably realtime event on their user channel.
 3. The accepter's `StageProgress` row for Stage 0 is created here. The inviter's `StageProgress` row was already created when the session was originally created.
 4. `SharedVessel` was already created at session creation; no new vessel is created on accept.

--- a/docs/backend/api/sessions.md
+++ b/docs/backend/api/sessions.md
@@ -3,6 +3,7 @@ title: Sessions API
 sidebar_position: 2
 description: Session creation, listing, and lifecycle management.
 slug: /backend/api/sessions
+updated: 2026-05-04
 ---
 # Sessions API
 
@@ -110,9 +111,9 @@ curl -X POST /api/v1/sessions \
 
 ### Session lifecycle
 
-`CREATED → INVITED → ACTIVE → ARCHIVED | ABANDONED`. There are no pause/resume states. `CREATED` flips to `INVITED` once the inviter confirms the invitation message; `INVITED` flips to `ACTIVE` when the partner accepts.
+`CREATED → INVITED → ACTIVE → ARCHIVED | ABANDONED`. There are no pause/resume states. `CREATED` flips to `INVITED` when the inviter confirms the AI-proposed topic frame (`POST /sessions/:id/topic-frame/confirm`); `INVITED` flips to `ACTIVE` when the partner accepts.
 
-> **Background AI**: After the inviter confirms the invitation message (`POST /sessions/:id/invitation/confirm`), the HTTP response returns immediately and the backend fires an AI transition message generation + Ably session-event publish asynchronously (fire-and-forget).
+> **Background AI**: After the inviter confirms the invitation was sent (`POST /sessions/:id/invitation/confirm`), the HTTP response returns immediately and the backend fires an AI transition message generation + Ably session-event publish asynchronously (fire-and-forget).
 
 ---
 
@@ -188,11 +189,9 @@ The frontend doesn't reconstruct session state from `GET /sessions/:id` alone. U
 | `POST` | `/api/v1/sessions/:id/resolve` | Resolve session. Requires at least one `AGREED` agreement exists in the shared vessel; returns `VALIDATION_ERROR` otherwise |
 | `POST` | `/api/v1/sessions/:id/viewed` | Mark the session as viewed (clears unread flags) |
 | `POST` | `/api/v1/sessions/:id/share-tab-viewed` | Mark the Sharing tab as viewed |
-| `GET`  | `/api/v1/sessions/:id/invitation` | Get the current draft invitation message (inviter only) |
-| `PUT`  | `/api/v1/sessions/:id/invitation/message` | Replace the draft invitation message |
-| `POST` | `/api/v1/sessions/:id/invitation/confirm` | Confirm the invitation message; requires a finalized topic frame and transitions session `CREATED → INVITED` |
-| `POST` | `/api/v1/sessions/:id/topic-frame/generate` | AI-generate and store a proposed neutral 3-5 word topic frame from user 1's Stage 0 invitation draft (creator only) |
-| `POST` | `/api/v1/sessions/:id/topic-frame/confirm` | Confirm the proposed frame or steer the AI toward a revised frame; persists `Session.topicFrameConfirmedAt` (creator only) |
+| `GET`  | `/api/v1/sessions/:id/invitation` | Get the current invitation state (inviter only) |
+| `POST` | `/api/v1/sessions/:id/invitation/confirm` | Confirm the invitation was sent; sets `Invitation.messageConfirmed = true` (idempotent) |
+| `POST` | `/api/v1/sessions/:id/topic-frame/confirm` | Lock the AI-proposed topic frame (no body required, idempotent); persists `Session.topicFrameConfirmedAt` and transitions session `CREATED → INVITED` (creator only) |
 | `GET`  | `/api/v1/sessions/:id/inner-thoughts` | Fetch the linked Inner Thoughts entry (if any) |
 
 > **Stage gates** (code: `STAGE_GATES`): Stage 0 requires `compactSigned`; Stage 1 requires `feelHeardConfirmed`; later stages have their own gate keys. `/progress` surfaces which gates the caller and the partner still need to satisfy.

--- a/docs/backend/api/sessions.md
+++ b/docs/backend/api/sessions.md
@@ -111,7 +111,7 @@ curl -X POST /api/v1/sessions \
 
 ### Session lifecycle
 
-`CREATED → INVITED → ACTIVE → ARCHIVED | ABANDONED`. There are no pause/resume states. `CREATED` flips to `INVITED` when the inviter confirms the AI-proposed topic frame (`POST /sessions/:id/topic-frame/confirm`); `INVITED` flips to `ACTIVE` when the partner accepts.
+Primary path: `CREATED → INVITED → ACTIVE → RESOLVED | ARCHIVED | ABANDONED`. `CREATED` flips to `INVITED` when the inviter confirms the AI-proposed topic frame (`POST /sessions/:id/topic-frame/confirm`); `INVITED` flips to `ACTIVE` when the partner accepts. Active sessions can also temporarily enter `PAUSED` or `WAITING`.
 
 > **Background AI**: After the inviter confirms the invitation was sent (`POST /sessions/:id/invitation/confirm`), the HTTP response returns immediately and the backend fires an AI transition message generation + Ably session-event publish asynchronously (fire-and-forget).
 
@@ -185,6 +185,8 @@ The frontend doesn't reconstruct session state from `GET /sessions/:id` alone. U
 | `GET`  | `/api/v1/sessions/:id/state` | Consolidated session + stage + gate state |
 | `GET`  | `/api/v1/sessions/:id/timeline` | Ordered ChatItem timeline (messages + indicators) |
 | `GET`  | `/api/v1/sessions/:id/progress` | Per-user `StageProgress` + gate satisfaction |
+| `POST` | `/api/v1/sessions/:id/pause` | Pause an active session for a cooling period |
+| `POST` | `/api/v1/sessions/:id/resume` | Resume a paused session |
 | `POST` | `/api/v1/sessions/:id/stages/advance` | Advance the caller's stage when all gates for the current stage are satisfied |
 | `POST` | `/api/v1/sessions/:id/resolve` | Resolve session. Requires at least one `AGREED` agreement exists in the shared vessel; returns `VALIDATION_ERROR` otherwise |
 | `POST` | `/api/v1/sessions/:id/viewed` | Mark the session as viewed (clears unread flags) |
@@ -198,7 +200,7 @@ The frontend doesn't reconstruct session state from `GET /sessions/:id` alone. U
 
 ### Pause / Resume
 
-Not implemented. Sessions cannot be paused. For cooling-off, users can stop messaging — all state persists, and the session remains in `ACTIVE` until archived, abandoned, or resolved.
+Pause/resume is implemented for cooling-off. `POST /sessions/:id/pause` moves an active session to `PAUSED`; `POST /sessions/:id/resume` moves a paused session back to `ACTIVE`. The session data and stage progress persist across the pause.
 
 ---
 

--- a/docs/backend/data-model/prisma-schema.md
+++ b/docs/backend/data-model/prisma-schema.md
@@ -3,6 +3,7 @@ title: Prisma Schema
 sidebar_position: 1
 description: Core Vessel Architecture tables plus pointers to the rest of the Prisma schema (Inner Work, reconciler, memory, needs/people, telemetry).
 slug: /backend/data-model/prisma-schema
+updated: 2026-05-04
 ---
 # Prisma Schema
 
@@ -125,6 +126,39 @@ enum SessionStatus {
 }
 ```
 
+### Invitation
+
+Tracks the Stage 0 invitation flow — created when the initiating user confirms their message and sends an invite link to their partner.
+
+```prisma
+model Invitation {
+  id                 String           @id @default(cuid())
+  session            Session          @relation(fields: [sessionId], references: [id])
+  sessionId          String
+  invitedBy          User             @relation("InvitedBy", fields: [invitedById], references: [id])
+  invitedById        String
+  name               String?          // Display name for the invited person
+  messageConfirmed   Boolean          @default(false) // User confirmed the invitation message
+  messageConfirmedAt DateTime?        // When the user confirmed the message (for chat indicator positioning)
+  status             InvitationStatus @default(PENDING)
+  createdAt          DateTime         @default(now())
+  expiresAt          DateTime
+  acceptedAt         DateTime?
+  declinedAt         DateTime?
+  declineReason      String?
+
+  @@index([sessionId])
+  @@index([status])
+}
+
+enum InvitationStatus {
+  PENDING   // Sent, awaiting partner action
+  ACCEPTED  // Partner joined the session
+  DECLINED  // Partner explicitly declined
+  EXPIRED   // Partner did not respond before expiresAt
+}
+```
+
 ### Stage Tracking: No Session.currentStage
 
 **Important**: We intentionally do NOT have a `Session.currentStage` field.
@@ -166,14 +200,32 @@ model UserVessel {
   updatedAt DateTime @updatedAt
 
   // Private content
-  events           UserEvent[]
+  events            UserEvent[]
   emotionalReadings EmotionalReading[]
-  identifiedNeeds  IdentifiedNeed[]
-  boundaries       Boundary[]
-  documents        UserDocument[]
+  identifiedNeeds   IdentifiedNeed[]
+  boundaries        Boundary[]
+  documents         UserDocument[]
 
-  // Embedding for semantic search within user's own content
-  embedding        Unsupported("vector(1536)")?
+  // Rolling conversation summary for long sessions
+  // Stores JSON: { text, keyThemes, emotionalJourney, unresolvedTopics }
+  conversationSummary String? @db.Text
+
+  // Session-level content embedding for semantic search
+  // Embeds combined facts + summary; replaces per-message embedding (fact-ledger architecture)
+  contentEmbedding Unsupported("vector(1024)")?
+
+  // === Session Read State ===
+  lastViewedAt         DateTime? // When the user last opened this session's chat (used for unread indicator)
+  lastSeenChatItemId   String?   // ID of the last chat item the user saw (for "new messages" line placement)
+  lastViewedShareTabAt DateTime? // When the user last viewed the Share/Partner tab
+
+  // When this user removed the session from their conversation list (partner may still retain access)
+  archivedAt DateTime?
+
+  // === Notable Facts ===
+  // AI-extracted structured facts (format: [{ category, fact }])
+  // Updated by Haiku after each message; reduces chat history in prompts
+  notableFacts Json?
 
   @@unique([userId, sessionId])
 }

--- a/docs/backend/data-model/prisma-schema.md
+++ b/docs/backend/data-model/prisma-schema.md
@@ -128,14 +128,14 @@ enum SessionStatus {
 
 ### Invitation
 
-Tracks the Stage 0 invitation flow — created when the initiating user confirms their message and sends an invite link to their partner.
+Tracks the Stage 0 invitation flow. The row is created with the session, then topic-frame confirmation makes the invitation acceptable and invitation confirmation records the inviter's share/continue action.
 
 ```prisma
 model Invitation {
   id                 String           @id @default(cuid())
-  session            Session          @relation(fields: [sessionId], references: [id])
+  session            Session          @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   sessionId          String
-  invitedBy          User             @relation("InvitedBy", fields: [invitedById], references: [id])
+  invitedBy          User             @relation("InvitedBy", fields: [invitedById], references: [id], onDelete: Cascade)
   invitedById        String
   name               String?          // Display name for the invited person
   messageConfirmed   Boolean          @default(false) // User confirmed the invitation message

--- a/docs/deployment/render-config.md
+++ b/docs/deployment/render-config.md
@@ -3,6 +3,7 @@ title: Render Configuration
 sidebar_position: 2
 description: Render.com service definitions for Meet Without Fear.
 slug: /deployment/render-config
+updated: 2026-05-04
 ---
 # Render Configuration
 
@@ -23,6 +24,10 @@ services:
     startCommand: cd backend && npx prisma migrate deploy && node dist/backend/src/server.js
     envVars:
       - fromGroup: be-heard-api-env
+      - key: NODE_ENV
+        value: production
+      - key: WEBSITE_URL
+        value: https://meetwithoutfear.com
 ```
 
 ### Key facts from this blueprint

--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -2,7 +2,7 @@
 title: Chat Interface
 sidebar_position: 3
 description: The primary conversation interface where users interact with the AI.
-updated: 2026-05-02
+updated: 2026-05-04
 status: living
 ---
 # Chat Interface
@@ -57,7 +57,7 @@ Characteristics:
 - Subtle background color
 - AI avatar/icon
 - A typing indicator ("ghost dots") appears while the user is waiting for the AI's reply — it's derived from cache state (the last message role is `USER`, meaning the AI hasn't answered yet) and from pending mutations like `isFetchingInitialMessage` / `isConfirmingFeelHeard` / `isSharingEmpathy` / `isConfirmingInvitation`. Dots hide as soon as the first AI chunk arrives via SSE / Ably.
-- **AI error feedback**: when an Ably `onAIError` event arrives (e.g. the backend failed to process the user's message), the optimistic message is rolled back (dots hide automatically) and a toast is shown: *"Something went wrong — Your message could not be processed. Please try again."* This is triggered via `useToast().showError` in `UnifiedSessionScreen`.
+- **AI error feedback**: when the SSE stream emits an error event (`EventSource.addEventListener('error', ...)`), `cleanupFailedStream()` is called — it removes the optimistic message from cache and resets status to idle — then a toast is shown: *"Something went wrong — Your message could not be processed. Please try again."* This is triggered via `useToast().showError` in `UnifiedSessionScreen`. A **15-second fallback timeout** is also active: if streaming stalls and does not complete within 15 seconds, the connection is closed and the same `cleanupFailedStream()` path runs, removing optimistic messages and returning state to idle.
 
 ### User Message
 

--- a/docs/product/stages/stage-0-onboarding.md
+++ b/docs/product/stages/stage-0-onboarding.md
@@ -1,19 +1,21 @@
 ---
 title: "Stage 0: Onboarding"
 sidebar_position: 3
-description: Welcome both parties with a brief warm opening and secure acknowledgment before entering the conversation.
+description: Welcome both parties with a brief warm opening, AI-proposed topic frame confirmation, and invitation sharing before entering the conversation.
+updated: 2026-05-04
 ---
 # Stage 0: Onboarding
 
 ## Purpose
 
-Welcome users with a brief, warm opening and secure acknowledgment before entering the conversation.
+Welcome the inviter with a brief, warm opening, collaboratively arrive at a neutral topic frame for the conversation, and coordinate the invitation to the other party — before either user enters the structured conversation stages.
 
 ## AI Goal
 
 - Briefly explain the private chat format
 - Reassure users that nothing is shared without consent
-- Get a simple "Ready" acknowledgment to proceed
+- Propose a neutral 3-5 word topic frame inline (via `<draft>` tag) that captures the situation without blame
+- Guide the inviter to confirm the topic frame and then share the invitation with their partner
 
 ## Opening Message
 
@@ -33,16 +35,33 @@ This message:
 
 ## Flow
 
+The inviter and invitee each have a distinct path through Stage 0.
+
+**Inviter path:**
 ```mermaid
 flowchart TD
-    Entry[User enters system] --> Welcome[AI welcome message]
-    Welcome --> Ready{User taps Ready?}
-    Ready -->|Yes| Acknowledged[Record acknowledgment]
+    Entry[Inviter starts session] --> Welcome[AI welcome message]
+    Welcome --> Convo[Inviter describes situation in chat]
+    Convo --> Propose[AI proposes neutral 3-5 word topic frame inline]
+    Propose --> Confirm{Inviter confirms topic frame?}
+    Confirm -->|Yes| TopicLocked[Topic frame locked; session moves CREATED → INVITED]
+    TopicLocked --> Modal[Invitation modal opens]
+    Modal --> Share[Inviter shares link via iMessage / WhatsApp / etc.]
+    Share --> InviteConfirm[Inviter confirms invitation sent]
+    InviteConfirm --> WaitInvitee[Waiting for invitee to accept]
+    WaitInvitee --> Advance[Both advance to Stage 1]
+```
 
-    Acknowledged --> WaitOther{Other acknowledged?}
-    WaitOther -->|Yes| Advance[Advance to Stage 1]
-    WaitOther -->|No| Wait[Waiting room]
-    Wait --> Notify[Notify when other acknowledges]
+**Invitee path:**
+```mermaid
+flowchart TD
+    Link[Invitee receives link] --> Preview[Preview invitation with topic frame]
+    Preview --> Accept[Invitee accepts invitation]
+    Accept --> Welcome2[AI welcome message for invitee]
+    Welcome2 --> WaitInviter{Inviter ready?}
+    WaitInviter -->|Yes| Advance[Both advance to Stage 1]
+    WaitInviter -->|No| Wait[Waiting room]
+    Wait --> Notify[Notify when inviter is ready]
     Notify --> Advance
 ```
 
@@ -68,7 +87,10 @@ flowchart TB
 
 ## Success Criteria
 
-Both users must acknowledge the opening message.
+- Inviter has confirmed the AI-proposed topic frame (`topicFrameConfirmedAt` set on session)
+- Inviter has confirmed the invitation was sent (`Invitation.messageConfirmed = true`)
+- Invitee has accepted the invitation
+- Both users have acknowledged the opening message in their respective Stage 0 chats
 
 ## Failure Paths
 
@@ -82,6 +104,8 @@ Both users must acknowledge the opening message.
 ## Data Captured
 
 - Acknowledgment timestamp for each user
+- Topic frame text and `topicFrameConfirmedAt` timestamp
+- `Invitation.messageConfirmed` flag and `messageConfirmedAt` timestamp
 - Any concerns raised (for improving onboarding)
 - Invitation/acceptance timing
 

--- a/docs/product/stages/stage-0-onboarding.md
+++ b/docs/product/stages/stage-0-onboarding.md
@@ -77,10 +77,13 @@ flowchart TB
 
         subgraph Content[Main Content]
             Message[AI welcome message with typewriter effect]
+            TopicDraft[Neutral topic frame proposal]
         end
 
         subgraph Actions[Actions]
-            Ready[Ready / Let's go button]
+            ConfirmTopic[Confirm topic frame]
+            ShareInvite[Share invitation]
+            ConfirmInvite[Confirm invitation sent]
         end
     end
 ```
@@ -88,9 +91,10 @@ flowchart TB
 ## Success Criteria
 
 - Inviter has confirmed the AI-proposed topic frame (`topicFrameConfirmedAt` set on session)
-- Inviter has confirmed the invitation was sent (`Invitation.messageConfirmed = true`)
+- Invitation is ready to accept (`Invitation.messageConfirmed = true` and session status is `INVITED`)
+- Inviter has completed their Stage 0 gate by confirming the invitation/share step
 - Invitee has accepted the invitation
-- Both users have acknowledged the opening message in their respective Stage 0 chats
+- Both users have Stage 0 progress created/completed as appropriate before entering Stage 1
 
 ## Failure Paths
 
@@ -103,9 +107,9 @@ flowchart TB
 
 ## Data Captured
 
-- Acknowledgment timestamp for each user
 - Topic frame text and `topicFrameConfirmedAt` timestamp
 - `Invitation.messageConfirmed` flag and `messageConfirmedAt` timestamp
+- Stage 0 progress/gates for each participant
 - Any concerns raised (for improving onboarding)
 - Invitation/acceptance timing
 
@@ -118,7 +122,7 @@ flowchart TB
 
 ### Backend Implementation
 
-- [Stage 0 API](../backend/api/stage-0.md) - Onboarding acknowledgment endpoints
+- [Stage 0 API](../backend/api/stage-0.md) - Stage 0 gates and progress endpoints
 - [Stage 0 Prompt](../backend/prompts/stage-0-opening.md) - Opening message template
 - [Retrieval Contracts](../backend/state-machine/retrieval-contracts.md#stage-0-onboarding)
 


### PR DESCRIPTION
## Changes

- **Add**: `messageConfirmed`/`messageConfirmedAt` fields and dual-precondition acceptance docs to `invitations.md`
- **Fix**: Remove defunct `PUT /invitation/message` and `POST /topic-frame/generate` endpoints from `sessions.md`; correct `CREATED→INVITED` transition point
- **Rewrite**: Stage 0 onboarding doc to reflect new topic-articulation + invitation flow (was simple acknowledgment)
- **Add**: Two-path auth strategy docs (fast path: DB lookup; slow path: Clerk API for new users) to `backend-overview.md`
- **Add**: 7 missing `UserVessel` fields (incl. `archivedAt`) + full `Invitation` model to `prisma-schema.md`
- **Fix**: Missing `NODE_ENV`/`WEBSITE_URL` hardcoded env vars in `render-config.md`
- **Fix**: Correct stream error source (SSE not Ably) + add 15s fallback timeout docs to `chat-interface.md`

## Provenance
- **Channel:** cron / audit-docs
- **Requested by:** automated nightly incremental audit
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs skill → incremental stage

## Docs updated
- `docs/backend/api/invitations.md`
- `docs/backend/api/sessions.md`
- `docs/product/stages/stage-0-onboarding.md`
- `docs/architecture/backend-overview.md`
- `docs/backend/data-model/prisma-schema.md`
- `docs/deployment/render-config.md`
- `docs/mobile/wireframes/chat-interface.md`