### PR TITLE
Add requireAuth middleware to memories routes

### DIFF
--- a/backend/src/routes/memories.ts
+++ b/backend/src/routes/memories.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { requireAuth } from '../middleware/auth';
 import {
   listMemories,
   createMemory,
@@ -13,6 +14,9 @@ import {
 } from '../controllers/memories';
 
 const router = Router();
+
+// All memories routes require authentication
+router.use(requireAuth);
 
 // GET /memories - List all user memories
 router.get('/', listMemories);


### PR DESCRIPTION
## Changes
- Add: `requireAuth` middleware to memories router, matching the pattern used by all other route modules
- Fix: Route-layer authentication enforcement was missing — previously relied solely on controller-level `getUser()` checks

Related to #331

## Provenance
- **Channel:** GitHub Issue
- **Requested by:** Security audit (automated)
- **Original message:** Weekly security audit flagged `/memories` routes as the only module without `requireAuth` middleware

## Docs updated
No doc changes needed — middleware-only change with no API surface modifications