### PR TITLE
Add beforeSend PII scrubbing to mobile Sentry

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -18,10 +18,45 @@ import { NativeAppBanner } from '@/src/components/NativeAppBanner';
 import { E2EAuthProvider, isE2EMode } from '@/src/providers/E2EAuthProvider';
 import { useOTAUpdate } from '@/src/hooks/useOTAUpdate';
 
+/** Keys that may contain user names / PII — strip from Sentry context. */
+const PII_KEYS = new Set([
+  'name', 'firstName', 'guesser', 'subject',
+  'guesserName', 'subjectName', 'partnerName',
+  'userName', 'userAName', 'userBName',
+]);
+
+function stripPiiFromRecord(data: Record<string, unknown>): void {
+  for (const key of Object.keys(data)) {
+    if (PII_KEYS.has(key)) {
+      delete data[key];
+    }
+  }
+}
+
 Sentry.init({
   dsn: process.env.EXPO_PUBLIC_SENTRY_DSN ?? '',
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.2,
+  sendDefaultPii: false,
   enabled: !__DEV__,
+  beforeSend(event) {
+    if (event.extra) {
+      stripPiiFromRecord(event.extra as Record<string, unknown>);
+    }
+    if (event.breadcrumbs) {
+      for (const breadcrumb of event.breadcrumbs) {
+        if (breadcrumb.data) {
+          stripPiiFromRecord(breadcrumb.data);
+        }
+      }
+    }
+    return event;
+  },
+  beforeBreadcrumb(breadcrumb) {
+    if (breadcrumb.data) {
+      stripPiiFromRecord(breadcrumb.data);
+    }
+    return breadcrumb;
+  },
 });
 
 // Prevent splash screen from auto-hiding


### PR DESCRIPTION
## Changes
- Add: `beforeSend` hook mirroring backend's PII key stripping (strips `name`, `firstName`, `guesser`, `subject`, `guesserName`, `subjectName`, `partnerName`, `userName`, `userAName`, `userBName` from `event.extra` and breadcrumb data)
- Add: `beforeBreadcrumb` hook for real-time PII filtering on navigation/screen breadcrumbs
- Fix: Reduce `tracesSampleRate` from `1.0` to `0.2` (80% reduction in trace volume)
- Add: `sendDefaultPii: false` as defense-in-depth

Related to #333

## Provenance
- **Channel:** Security audit
- **Requested by:** Weekly security audit (2026-05-04)
- **Original message:** Issue #333 — Mobile Sentry has no beforeSend PII scrubbing

## Docs updated
No doc changes needed — security hardening of existing Sentry config only