### PR TITLE
Remove real name and email from Mixpanel profile properties

### DIFF
--- a/mobile/src/components/MixpanelInitializer.tsx
+++ b/mobile/src/components/MixpanelInitializer.tsx
@@ -130,8 +130,6 @@ export function MixpanelInitializer() {
         });
 
         setUserProperties({
-          name: user.fullName || user.firstName || 'User',
-          email: user.emailAddresses?.[0]?.emailAddress,
           last_login_at: new Date().toISOString(),
         });
       }


### PR DESCRIPTION
## Changes
- Remove: `name` and `email` from Mixpanel `setUserProperties` in `MixpanelInitializer.tsx`
- Retain: `last_login_at` as the only profile property (non-PII)
- Users continue to be identified by pseudonymous Clerk user ID only

## Audit scope
- Reviewed all Mixpanel calls across `mobile/src/` and `website/` — no other PII leaks found
- Website `trackSignIn` only sends `user_id`, `method`, and `provider` — clean
- Backend has no Mixpanel integration — clean

Related to #332

## Provenance
- **Channel:** GitHub issue
- **Requested by:** Security audit (automated)
- **Original message:** Weekly security audit flagged PII in Mixpanel profile properties

## Docs updated
No doc changes needed — no docs map to `MixpanelInitializer.tsx` and no architectural change