### PR TITLE
[codex] Fix James/Catherine gold session gates

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -109,7 +109,7 @@ const PLANNER_LINE_PREFIXES = [
   'i need to make sure both lists',
 ];
 
-function scrubVisibleAIText(text: string): { text: string; scrubbed: boolean } {
+export function scrubVisibleAIText(text: string): { text: string; scrubbed: boolean } {
   const before = text;
   const cleaned = text
     .split(/\r?\n/)
@@ -124,7 +124,7 @@ function scrubVisibleAIText(text: string): { text: string; scrubbed: boolean } {
   return { text: cleaned, scrubbed: cleaned !== before };
 }
 
-function isReadyForStage3RevealText(content: string): boolean {
+export function isReadyForStage3RevealText(content: string): boolean {
   const normalized = content.trim().toLowerCase();
   if (/\bnot\s+ready\b/.test(normalized) || /\b(?:don'?t|do not)\s+(?:want|feel ready)\b/.test(normalized)) {
     return false;

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1533,7 +1533,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     }, { isInvitationPhase });
 
     // Prompt already includes semantic tag format instructions via buildResponseProtocol()
-    // No tool use instruction needed - we parse <thinking>, <draft>, <dispatch> tags instead
+    // No tool use instruction needed - we parse <thinking>, <draft>, <dispatch>, and <needs> tags instead
 
     // Format context bundle and inject into last user message (includes notable facts)
     const formattedContext = formatContextForPrompt(contextBundle, {
@@ -1588,11 +1588,11 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     let streamError: Error | null = null;
 
     // Tag trap state - Claude outputs <thinking>...</thinking> first, which we hide
-    // After thinking, there may be <draft>...</draft> or <dispatch>...</dispatch> that we also hide
+    // After thinking, there may be <draft>, <dispatch>, or <needs> tags that we also hide
     let isInsideThinking = true;
-    let isTrappingTags = false; // After thinking, buffer to check for <draft>/<dispatch>
+    let isTrappingTags = false; // After thinking, buffer to check for hidden semantic tags
     let thinkingBuffer = '';
-    let tagTrapBuffer = ''; // Buffer for checking draft/dispatch tags after thinking
+    let tagTrapBuffer = ''; // Buffer for checking semantic tags after thinking
     let thinkingContent = ''; // Store hidden thinking for logging
     let draftContent = ''; // Store draft content for metadata
     let dispatchTagContent = ''; // Store dispatch tag content for handling
@@ -1717,7 +1717,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
               thinkingBuffer = '';
             }
           }
-          // PHASE 2: TAG TRAP - Buffer to catch <draft> and <dispatch> before streaming
+          // PHASE 2: TAG TRAP - Buffer to catch hidden semantic tags before streaming
           // The draft tag typically comes right after </thinking>, before response text
           else if (isTrappingTags) {
             tagTrapBuffer += event.text;
@@ -1731,8 +1731,9 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
             const hasNeedsEnd = tagTrapBuffer.includes('</needs>');
 
             // Check for partial tag starts at the end of buffer
-            // Matches: <, <d, <dr, </, </d, etc. - anything that could become <draft>, </draft>, <dispatch>, </dispatch>
-            const hasPotentialTagStart = /<\/?d[a-z]*$/i.test(tagTrapBuffer);
+            // Matches: <d..., <n..., </d..., </n..., etc. - anything that could become
+            // <draft>, </draft>, <dispatch>, </dispatch>, <needs>, or </needs>.
+            const hasPotentialTagStart = /<\/?(d|n)[a-z]*$/i.test(tagTrapBuffer);
 
             // If we see opening tags, wait for closing tags
             const waitingForDraft = hasDraftStart && !hasDraftEnd;
@@ -1751,7 +1752,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
             // Exit conditions:
             // - Not waiting for any tags to complete
             // - Have substantial response content (>50 chars that doesn't start with <)
-            // - No partial tag at the end that might become <draft> or <dispatch>
+            // - No partial tag at the end that might become a hidden semantic tag
             // OR buffer is too big (safety limit)
             const hasResponseContent = trimmedStripped.length > 50 && !trimmedStripped.startsWith('<');
             const safeToExit = !waitingForDraft && !waitingForDispatch && !waitingForNeeds && hasResponseContent && !hasPotentialTagStart;
@@ -1771,7 +1772,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
             const hasUnclosedDispatch = combined.includes('<dispatch>') && !combined.includes('</dispatch>');
             const hasUnclosedDraft = combined.includes('<draft>') && !combined.includes('</draft>');
             const hasUnclosedNeeds = combined.includes('<needs>') && !combined.includes('</needs>');
-            const hasPotentialTagStart = /<\/?d[a-z]*$/i.test(combined);
+            const hasPotentialTagStart = /<\/?(d|n)[a-z]*$/i.test(combined);
 
             if (hasUnclosedDispatch || hasUnclosedDraft || hasUnclosedNeeds || hasPotentialTagStart) {
               // Buffer and wait for closing tag

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -22,6 +22,7 @@ import {
   feelHeardRequestSchema,
   getMessagesQuerySchema,
   MessageRole,
+  NeedCategory,
 } from '@meet-without-fear/shared';
 import { notifyPartner, publishSessionEvent, notifySessionMembers, publishMessageAIResponse, publishMessageError, publishTopicFrameUpdated } from '../services/realtime';
 import { successResponse, errorResponse } from '../utils/response';
@@ -89,6 +90,148 @@ function getFallbackInitialMessage(
   }
 
   return `Hey ${userName}, what's on your mind?`;
+}
+
+const STAGE2_ROADMAP_COPY =
+  `Here's what comes next: there are a few more steps in this process. First, each of you tries to understand what the other person might be going through. Then you'll each explore what matters most to you, and eventually use that to get clearer about what is possible next, whether together or separately.`;
+
+function scrubVisibleAIText(text: string): { text: string; scrubbed: boolean } {
+  const before = text;
+  const cleaned = text
+    .split(/\r?\n/)
+    .filter((line) => {
+      const trimmed = line.trim().toLowerCase();
+      return !(
+        trimmed.startsWith('i should') ||
+        trimmed.startsWith('so both lists should') ||
+        trimmed.startsWith('— so both lists should') ||
+        trimmed.startsWith("here's my plan") ||
+        trimmed.startsWith('the prompt says') ||
+        trimmed.startsWith('i need to ')
+      );
+    })
+    .join('\n')
+    .replace(/\bI should\b/gi, '')
+    .replace(/\bso both lists should be available\b/gi, '');
+
+  return { text: cleaned, scrubbed: cleaned !== before };
+}
+
+function isReadyForStage3RevealText(content: string): boolean {
+  const normalized = content.trim().toLowerCase();
+  return /\b(i'?m|i am|we are)?\s*ready\b/.test(normalized) &&
+    /(list|lists|needs|side by side|reveal|see them|see it|show)/.test(normalized);
+}
+
+async function getStage3GateResponse(sessionId: string, userId: string): Promise<string | null> {
+  const partnerId = await getPartnerUserId(sessionId, userId);
+  const progress = await prisma.stageProgress.findUnique({
+    where: {
+      sessionId_userId_stage: {
+        sessionId,
+        userId,
+        stage: 3,
+      },
+    },
+  });
+  if (!progress) return null;
+
+  const vessel = await prisma.userVessel.findUnique({
+    where: { userId_sessionId: { userId, sessionId } },
+    include: { identifiedNeeds: { orderBy: { createdAt: 'asc' } } },
+  });
+  const needs = vessel?.identifiedNeeds ?? [];
+  const gates = progress.gatesSatisfied as Record<string, unknown> | null;
+  const ownShared = gates?.needsShared === true;
+  const ownConfirmed = gates?.needsConfirmed === true || (needs.length > 0 && needs.every((need) => need.confirmed));
+
+  if (needs.length === 0) {
+    return "Let's first put words to what matters most for you here. What do you need in order to feel clear, grounded, or able to move forward from this?";
+  }
+
+  if (!ownConfirmed) {
+    return "I've captured a draft of what matters to you. Please review and confirm your needs before we move any further.";
+  }
+
+  if (!ownShared) {
+    return "Your needs are ready for your review. If they still feel right, you can choose to share them for the side-by-side step.";
+  }
+
+  if (!partnerId) {
+    return "Your needs are shared. We'll wait until your partner has shared theirs before showing anything side by side.";
+  }
+
+  const partnerProgress = await prisma.stageProgress.findUnique({
+    where: {
+      sessionId_userId_stage: {
+        sessionId,
+        userId: partnerId,
+        stage: 3,
+      },
+    },
+  });
+  const partnerGates = partnerProgress?.gatesSatisfied as Record<string, unknown> | null;
+  if (partnerGates?.needsShared !== true) {
+    return "Your needs are shared. We'll wait until your partner has shared theirs before showing anything side by side.";
+  }
+
+  return "Both needs lists are ready to review side by side. Take a look at them and notice what stands out before deciding whether they feel accurate.";
+}
+
+async function persistStage3ProposedNeeds(
+  sessionId: string,
+  userId: string,
+  proposedNeeds: Array<{ need: string; category: string; description: string; evidence: string[] }>
+): Promise<boolean> {
+  const validNeeds = proposedNeeds.filter((need) =>
+    need.need &&
+    need.description &&
+    Object.values(NeedCategory).includes(need.category as NeedCategory)
+  );
+  if (validNeeds.length === 0) return false;
+
+  const vessel = await prisma.userVessel.upsert({
+    where: { userId_sessionId: { userId, sessionId } },
+    create: { userId, sessionId },
+    update: {},
+  });
+
+  const existing = await prisma.identifiedNeed.count({ where: { vesselId: vessel.id } });
+  if (existing > 0) return false;
+
+  await prisma.identifiedNeed.createMany({
+    data: validNeeds.map((need) => ({
+      vesselId: vessel.id,
+      need: need.description || need.need,
+      category: need.category as NeedCategory,
+      evidence: need.evidence,
+      aiConfidence: 0.85,
+      confirmed: false,
+    })),
+  });
+
+  const progress = await prisma.stageProgress.findUnique({
+    where: { sessionId_userId_stage: { sessionId, userId, stage: 3 } },
+  });
+  if (progress) {
+    await prisma.stageProgress.update({
+      where: { id: progress.id },
+      data: {
+        gatesSatisfied: {
+          ...((progress.gatesSatisfied as Record<string, unknown> | null) ?? {}),
+          needsCaptured: true,
+          needsCapturedAt: new Date().toISOString(),
+        },
+      },
+    });
+  }
+
+  await publishSessionEvent(sessionId, 'session.needs_extracted' as any, {
+    stage: 3,
+    forUserId: userId,
+  });
+
+  return true;
 }
 
 // ============================================================================
@@ -444,9 +587,9 @@ export async function confirmFeelHeard(
         if (aiResponse) {
           // Parse the semantic tag response (micro-tag format)
           const parsed = parseMicroTagResponse(aiResponse);
-          transitionContent = parsed.response.trim() || `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\nHere's what comes next: there are a few more steps in this process. First, each of you tries to understand what the other person might be going through. Then you'll each explore what matters most to you, and eventually work on a way forward together.\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partnerName || 'your partner'} might be experiencing, even though you might still be upset with them. I know that's a strange ask. But there's a lot of research showing that when each person genuinely tries to see what the other is going through, it's one of the strongest things you can do to actually work things out. It's a guess, not a test — you don't have to get it right. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partnerName || 'your partner'} in all of this?`;
+          transitionContent = parsed.response.trim() || `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\n${STAGE2_ROADMAP_COPY}\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partnerName || 'your partner'} might be experiencing, even though you might still be upset with them. I know that's a strange ask. But there's a lot of research showing that when each person genuinely tries to see what the other is going through, it's one of the strongest things you can do to actually work things out. It's a guess, not a test — you don't have to get it right. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partnerName || 'your partner'} in all of this?`;
         } else {
-          transitionContent = `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\nHere's what comes next: there are a few more steps in this process. First, each of you tries to understand what the other person might be going through. Then you'll each explore what matters most to you, and eventually work on a way forward together.\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partnerName || 'your partner'} might be experiencing, even though you might still be upset with them. I know that's a strange ask. But there's a lot of research showing that when each person genuinely tries to see what the other is going through, it's one of the strongest things you can do to actually work things out. It's a guess, not a test — you don't have to get it right. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partnerName || 'your partner'} in all of this?`;
+          transitionContent = `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\n${STAGE2_ROADMAP_COPY}\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partnerName || 'your partner'} might be experiencing, even though you might still be upset with them. I know that's a strange ask. But there's a lot of research showing that when each person genuinely tries to see what the other is going through, it's one of the strongest things you can do to actually work things out. It's a guess, not a test — you don't have to get it right. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partnerName || 'your partner'} in all of this?`;
         }
 
         // Save the transition message to the database as Stage 2
@@ -1144,6 +1287,32 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       },
     });
 
+    if (currentStage === 3 && isReadyForStage3RevealText(content)) {
+      const gateResponse = await getStage3GateResponse(sessionId, user.id);
+      if (gateResponse) {
+        const aiMessage = await prisma.message.create({
+          data: {
+            sessionId,
+            senderId: null,
+            forUserId: user.id,
+            role: 'AI',
+            content: gateResponse,
+            stage: 3,
+          },
+        });
+
+        if (!clientDisconnected) {
+          sendSSE(res, { event: 'chunk', data: { text: gateResponse } });
+          sendSSE(res, { event: 'metadata', data: { metadata: {} } });
+          sendSSE(res, { event: 'text_complete', data: { metadata: {} } });
+          sendSSE(res, { event: 'complete', data: { messageId: aiMessage.id, metadata: {} } });
+        }
+        res.end();
+        logger.info(`[sendMessageStream:${requestId}] Stage 3 ready text handled via gate response`);
+        return;
+      }
+    }
+
     // =========================================================================
     // Get conversation history for context (summary-aware)
     // =========================================================================
@@ -1427,6 +1596,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     let thinkingContent = ''; // Store hidden thinking for logging
     let draftContent = ''; // Store draft content for metadata
     let dispatchTagContent = ''; // Store dispatch tag content for handling
+    let needsTagContent = ''; // Store hidden Stage 3 needs block for parsing
     let isDispatchMessage = false; // Track if this is a dispatch response (skip processing)
 
     try {
@@ -1463,13 +1633,17 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
           .replace(/<thinking>[\s\S]*/gi, '')                // Unclosed thinking (strip to end)
           .replace(/<\/thinking>/gi, '')                     // Orphaned closing tag
           .replace(/<draft>[\s\S]*?<\/draft>/gi, '')
-          .replace(/<dispatch>[\s\S]*?<\/dispatch>/gi, '');
+          .replace(/<dispatch>[\s\S]*?<\/dispatch>/gi, '')
+          .replace(/<needs>[\s\S]*?<\/needs>/gi, '');
 
         // Trim LEADING whitespace only on the FIRST chunk (after </thinking> tag removal)
         // This removes newlines at the start without breaking word spacing in subsequent chunks
         if (!firstChunkTime && cleanText.length > 0) {
           cleanText = cleanText.trimStart();
         }
+
+        const scrubbed = scrubVisibleAIText(cleanText);
+        cleanText = scrubbed.text;
 
         if (cleanText.length > 0) {
           if (!firstChunkTime) firstChunkTime = Date.now();
@@ -1496,11 +1670,18 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
           logger.info(`[sendMessageStream:${requestId}] [DISPATCH TAG]:`, dispatchTagContent);
         }
 
+        const needsMatch = buffer.match(/<needs>[\s\S]*?<\/needs>/i);
+        if (needsMatch) {
+          needsTagContent = needsMatch[0];
+          logger.info(`[sendMessageStream:${requestId}] [HIDDEN NEEDS BLOCK]`);
+        }
+
         // Return text with all tags stripped
         // Do NOT use .trim() - it breaks word spacing between chunks
         return buffer
           .replace(/<draft>[\s\S]*?<\/draft>/gi, '')
-          .replace(/<dispatch>[\s\S]*?<\/dispatch>/gi, '');
+          .replace(/<dispatch>[\s\S]*?<\/dispatch>/gi, '')
+          .replace(/<needs>[\s\S]*?<\/needs>/gi, '');
       };
 
       for await (const event of streamGenerator) {
@@ -1546,6 +1727,8 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
             const hasDraftEnd = tagTrapBuffer.includes('</draft>');
             const hasDispatchStart = tagTrapBuffer.includes('<dispatch>');
             const hasDispatchEnd = tagTrapBuffer.includes('</dispatch>');
+            const hasNeedsStart = tagTrapBuffer.includes('<needs>');
+            const hasNeedsEnd = tagTrapBuffer.includes('</needs>');
 
             // Check for partial tag starts at the end of buffer
             // Matches: <, <d, <dr, </, </d, etc. - anything that could become <draft>, </draft>, <dispatch>, </dispatch>
@@ -1554,13 +1737,15 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
             // If we see opening tags, wait for closing tags
             const waitingForDraft = hasDraftStart && !hasDraftEnd;
             const waitingForDispatch = hasDispatchStart && !hasDispatchEnd;
+            const waitingForNeeds = hasNeedsStart && !hasNeedsEnd;
 
             // Process buffer and check if we can exit:
             // 1. Strip any complete tags from buffer
             // 2. Check if remaining content looks like response text (not starting with <)
             const strippedBuffer = tagTrapBuffer
               .replace(/<draft>[\s\S]*?<\/draft>/gi, '')
-              .replace(/<dispatch>[\s\S]*?<\/dispatch>/gi, '');
+              .replace(/<dispatch>[\s\S]*?<\/dispatch>/gi, '')
+              .replace(/<needs>[\s\S]*?<\/needs>/gi, '');
             const trimmedStripped = strippedBuffer.trim();
 
             // Exit conditions:
@@ -1569,7 +1754,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
             // - No partial tag at the end that might become <draft> or <dispatch>
             // OR buffer is too big (safety limit)
             const hasResponseContent = trimmedStripped.length > 50 && !trimmedStripped.startsWith('<');
-            const safeToExit = !waitingForDraft && !waitingForDispatch && hasResponseContent && !hasPotentialTagStart;
+            const safeToExit = !waitingForDraft && !waitingForDispatch && !waitingForNeeds && hasResponseContent && !hasPotentialTagStart;
 
             if (safeToExit || tagTrapBuffer.length > 2000) {
               isTrappingTags = false;
@@ -1585,9 +1770,10 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
             // Check if we have unclosed tags that need buffering
             const hasUnclosedDispatch = combined.includes('<dispatch>') && !combined.includes('</dispatch>');
             const hasUnclosedDraft = combined.includes('<draft>') && !combined.includes('</draft>');
+            const hasUnclosedNeeds = combined.includes('<needs>') && !combined.includes('</needs>');
             const hasPotentialTagStart = /<\/?d[a-z]*$/i.test(combined);
 
-            if (hasUnclosedDispatch || hasUnclosedDraft || hasPotentialTagStart) {
+            if (hasUnclosedDispatch || hasUnclosedDraft || hasUnclosedNeeds || hasPotentialTagStart) {
               // Buffer and wait for closing tag
               tagTrapBuffer = combined;
             } else {
@@ -1645,7 +1831,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       // The thinking content has flags like FeelHeardCheck:Y, ReadyShare:Y
       // The accumulated text may contain <draft>...</draft> that needs stripping
       // =========================================================================
-      const fullResponse = `<thinking>${thinkingContent}</thinking>\n${accumulatedText}`;
+      const fullResponse = `<thinking>${thinkingContent}</thinking>\n${needsTagContent}\n${accumulatedText}`;
       const parsed = parseMicroTagResponse(fullResponse);
 
       // Extract metadata from parsed response
@@ -1653,6 +1839,9 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       metadata.offerReadyToShare = parsed.offerReadyToShare;
       if (parsed.proposedStrategies.length > 0) {
         metadata.proposedStrategies = parsed.proposedStrategies;
+      }
+      if (parsed.proposedNeeds.length > 0) {
+        metadata.proposedNeeds = parsed.proposedNeeds;
       }
 
       // Use draftContent captured during streaming (more reliable than re-parsing)
@@ -1673,7 +1862,8 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       });
 
       // Clean accumulated text (strip <draft> and <dispatch> tags if they leaked through)
-      accumulatedText = parsed.response;
+      const scrubbedResponse = scrubVisibleAIText(parsed.response);
+      accumulatedText = scrubbedResponse.text;
 
       // =========================================================================
       // DISPATCH HANDLING: If dispatch tag detected, get and stream dispatched response
@@ -1722,9 +1912,12 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       // user message and shows "Message not sent"), inject a warm fallback so
       // the conversation continues smoothly.
       if (!accumulatedText.trim()) {
-        const fallback = 'I\'m here with you. Could you tell me more about what you\'re experiencing?';
+        const fallback = currentStage === 3
+          ? (await getStage3GateResponse(sessionId, user.id)) || 'What feels most important for you to name right now?'
+          : 'I\'m here with you. Could you tell me more about what you\'re experiencing?';
         logger.warn(`[sendMessageStream:${requestId}] Empty AI response after tag stripping — using fallback`, {
           dispatchTag: dispatchTag ?? null,
+          scrubbedPlannerText: scrubbedResponse.scrubbed,
         });
         sendSSE(res, { event: 'chunk', data: { text: fallback } });
         accumulatedText = fallback;
@@ -1775,6 +1968,10 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       res.end();
       logger.info(`[sendMessageStream:${requestId}] ========== SSE STREAM ENDED (ERROR) ==========`);
       return;
+    }
+
+    if (currentStage === 3 && metadata.proposedNeeds && metadata.proposedNeeds.length > 0) {
+      metadata.needsCaptured = await persistStage3ProposedNeeds(sessionId, user.id, metadata.proposedNeeds);
     }
 
     // =========================================================================

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -95,20 +95,27 @@ function getFallbackInitialMessage(
 const STAGE2_ROADMAP_COPY =
   `Here's what comes next: there are a few more steps in this process. First, each of you tries to understand what the other person might be going through. Then you'll each explore what matters most to you, and eventually use that to get clearer about what is possible next, whether together or separately.`;
 
+const DEFAULT_STAGE3_NEEDS_AI_CONFIDENCE = 0.85;
+const PLANNER_LINE_PREFIXES = [
+  'i should',
+  'so both lists should',
+  '— so both lists should',
+  "here's my plan",
+  'the prompt says',
+  'i need to follow',
+  'i need to present',
+  'i need to check the prompt',
+  'i need to use the prompt',
+  'i need to make sure both lists',
+];
+
 function scrubVisibleAIText(text: string): { text: string; scrubbed: boolean } {
   const before = text;
   const cleaned = text
     .split(/\r?\n/)
     .filter((line) => {
       const trimmed = line.trim().toLowerCase();
-      return !(
-        trimmed.startsWith('i should') ||
-        trimmed.startsWith('so both lists should') ||
-        trimmed.startsWith('— so both lists should') ||
-        trimmed.startsWith("here's my plan") ||
-        trimmed.startsWith('the prompt says') ||
-        trimmed.startsWith('i need to ')
-      );
+      return !PLANNER_LINE_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
     })
     .join('\n')
     .replace(/\bI should\b/gi, '')
@@ -119,6 +126,9 @@ function scrubVisibleAIText(text: string): { text: string; scrubbed: boolean } {
 
 function isReadyForStage3RevealText(content: string): boolean {
   const normalized = content.trim().toLowerCase();
+  if (/\bnot\s+ready\b/.test(normalized) || /\b(?:don'?t|do not)\s+(?:want|feel ready)\b/.test(normalized)) {
+    return false;
+  }
   return /\b(i'?m|i am|we are)?\s*ready\b/.test(normalized) &&
     /(list|lists|needs|side by side|reveal|see them|see it|show)/.test(normalized);
 }
@@ -190,43 +200,68 @@ async function persistStage3ProposedNeeds(
   );
   if (validNeeds.length === 0) return false;
 
-  const vessel = await prisma.userVessel.upsert({
-    where: { userId_sessionId: { userId, sessionId } },
-    create: { userId, sessionId },
-    update: {},
-  });
+  let persisted = false;
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      persisted = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        const vessel = await tx.userVessel.upsert({
+          where: { userId_sessionId: { userId, sessionId } },
+          create: { userId, sessionId },
+          update: {},
+        });
 
-  const existing = await prisma.identifiedNeed.count({ where: { vesselId: vessel.id } });
-  if (existing > 0) return false;
+        const existing = await tx.identifiedNeed.count({ where: { vesselId: vessel.id } });
+        if (existing > 0) return false;
 
-  await prisma.identifiedNeed.createMany({
-    data: validNeeds.map((need) => ({
-      vesselId: vessel.id,
-      need: need.description || need.need,
-      category: need.category as NeedCategory,
-      evidence: need.evidence,
-      aiConfidence: 0.85,
-      confirmed: false,
-    })),
-  });
+        await tx.identifiedNeed.createMany({
+          data: validNeeds.map((need) => ({
+            vesselId: vessel.id,
+            need: need.description || need.need,
+            category: need.category as NeedCategory,
+            evidence: need.evidence,
+            aiConfidence: DEFAULT_STAGE3_NEEDS_AI_CONFIDENCE,
+            confirmed: false,
+          })),
+        });
 
-  const progress = await prisma.stageProgress.findUnique({
-    where: { sessionId_userId_stage: { sessionId, userId, stage: 3 } },
-  });
-  if (progress) {
-    await prisma.stageProgress.update({
-      where: { id: progress.id },
-      data: {
-        gatesSatisfied: {
-          ...((progress.gatesSatisfied as Record<string, unknown> | null) ?? {}),
-          needsCaptured: true,
-          needsCapturedAt: new Date().toISOString(),
-        },
-      },
-    });
+        const progress = await tx.stageProgress.findUnique({
+          where: { sessionId_userId_stage: { sessionId, userId, stage: 3 } },
+        });
+        if (progress) {
+          await tx.stageProgress.update({
+            where: { id: progress.id },
+            data: {
+              gatesSatisfied: {
+                ...((progress.gatesSatisfied as Record<string, unknown> | null) ?? {}),
+                needsCaptured: true,
+                needsCapturedAt: new Date().toISOString(),
+              },
+            },
+          });
+        }
+
+        return true;
+      }, {
+        isolationLevel: 'Serializable',
+      });
+      break;
+    } catch (error) {
+      const isSerializationConflict =
+        error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034';
+      if (!isSerializationConflict || attempt === 2) {
+        throw error;
+      }
+      logger.warn('Retrying Stage 3 needs persistence after serialization conflict', {
+        sessionId,
+        userId,
+        attempt,
+      });
+    }
   }
 
-  await publishSessionEvent(sessionId, 'session.needs_extracted' as any, {
+  if (!persisted) return false;
+
+  await publishSessionEvent(sessionId, 'session.needs_extracted', {
     stage: 3,
     forUserId: userId,
   });

--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -1664,9 +1664,6 @@ Respond in JSON format:
       messages.push({ id: msg.id, content: msg.content, timestamp: msg.timestamp, forUserId: uid });
     }
 
-    // Use first message as representative for the event payload
-    const message = messages[0];
-
     // 4. Update Stage Progress for both to Stage 3
     // Backfill missing prior stage records (defensive — handles cases where
     // session initialization failed to create StageProgress atomically)
@@ -1735,17 +1732,21 @@ Respond in JSON format:
 
     // 5. Notify Realtime
     // Notify session channel that stage changed
-    if (partnerId && message) {
+    if (partnerId && messages.length > 0) {
       await publishSessionEvent(sessionId, 'partner.stage_completed', {
         previousStage: 2,
         currentStage: 3,
         userId,
         triggeredByUserId: userId,
-        message: {
-          id: message.id,
-          content: message.content,
-          timestamp: message.timestamp
-        }
+        messagesByUserId: Object.fromEntries(messages.map((message) => [
+          message.forUserId,
+          {
+            id: message.id,
+            content: message.content,
+            timestamp: message.timestamp,
+            forUserId: message.forUserId,
+          },
+        ])),
       });
     }
 

--- a/backend/src/controllers/stage3.ts
+++ b/backend/src/controllers/stage3.ts
@@ -625,7 +625,7 @@ export async function consentToShareNeeds(
 
     // If both have shared, notify clients that the side-by-side reveal is ready.
     if (partnerShared && partnerId) {
-      await publishSessionEvent(sessionId, 'session.needs_reveal_ready' as any, {
+      await publishSessionEvent(sessionId, 'session.needs_reveal_ready', {
         stage: 3,
         needsRevealReady: true,
       });
@@ -745,7 +745,7 @@ export async function validateNeeds(req: Request, res: Response): Promise<void> 
     const partnerValidated = await hasPartnerValidatedNeeds(sessionId, user.id);
     const partnerId = await getPartnerUserId(sessionId, user.id);
     if (partnerId) {
-      await notifyPartner(sessionId, partnerId, 'partner.needs_validated' as any, {
+      await notifyPartner(sessionId, partnerId, 'partner.needs_validated', {
         stage: 3,
         validatedBy: user.id,
         validated,

--- a/backend/src/controllers/stage3.ts
+++ b/backend/src/controllers/stage3.ts
@@ -790,7 +790,7 @@ export async function validateNeeds(req: Request, res: Response): Promise<void> 
       const transitionContent =
         'You have both checked the needs lists and marked them valid. Now move to strategies that can honor what each of you needs.';
 
-      const transitionMessages: Array<{ id: string; content: string; timestamp: Date }> = [];
+      const transitionMessages: Array<{ id: string; content: string; timestamp: Date; forUserId: string }> = [];
       for (const uid of [user.id, partnerId]) {
         const message = await prisma.message.create({
           data: {
@@ -802,22 +802,23 @@ export async function validateNeeds(req: Request, res: Response): Promise<void> 
             stage: 4,
           },
         });
-        transitionMessages.push({ id: message.id, content: message.content, timestamp: message.timestamp });
+        transitionMessages.push({ id: message.id, content: message.content, timestamp: message.timestamp, forUserId: uid });
       }
 
-      const firstMessage = transitionMessages[0];
       await publishSessionEvent(sessionId, 'partner.stage_completed', {
         previousStage: 3,
         currentStage: 4,
         userId: user.id,
         triggeredByUserId: user.id,
-        message: firstMessage
-          ? {
-              id: firstMessage.id,
-              content: firstMessage.content,
-              timestamp: firstMessage.timestamp,
-            }
-          : undefined,
+        messagesByUserId: Object.fromEntries(transitionMessages.map((message) => [
+          message.forUserId,
+          {
+            id: message.id,
+            content: message.content,
+            timestamp: message.timestamp,
+            forUserId: message.forUserId,
+          },
+        ])),
       });
     }
 
@@ -1036,14 +1037,25 @@ export async function getNeedsComparison(
 
     const [myNeeds, partnerNeeds] = await Promise.all([
       prisma.identifiedNeed.findMany({
-        where: { vesselId: myVessel.id },
+        where: { vesselId: myVessel.id, confirmed: true },
         orderBy: { createdAt: 'asc' },
       }),
       prisma.identifiedNeed.findMany({
-        where: { vesselId: partnerVessel.id },
+        where: { vesselId: partnerVessel.id, confirmed: true },
         orderBy: { createdAt: 'asc' },
       }),
     ]);
+
+    if (myNeeds.length === 0 || partnerNeeds.length === 0) {
+      successResponse(res, {
+        myNeeds: [],
+        partnerNeeds: [],
+        commonGround: [],
+        analysisComplete: false,
+        noOverlap: false,
+      });
+      return;
+    }
 
     const partnerProgress = await prisma.stageProgress.findUnique({
       where: {

--- a/backend/src/routes/__tests__/messages.test.ts
+++ b/backend/src/routes/__tests__/messages.test.ts
@@ -4,6 +4,8 @@ import {
   sendMessage,
   confirmFeelHeard,
   getConversationHistory,
+  scrubVisibleAIText,
+  isReadyForStage3RevealText,
 } from '../../controllers/messages';
 import { prisma } from '../../lib/prisma';
 
@@ -27,6 +29,11 @@ jest.mock('../../services/partner-session-classifier', () => ({
 // Mock bedrock
 jest.mock('../../lib/bedrock', () => ({
   getSonnetResponse: jest.fn().mockResolvedValue('Mock response'),
+  getSonnetStreamingResponse: jest.fn(),
+  BrainActivityCallType: {
+    ORCHESTRATED_RESPONSE: 'ORCHESTRATED_RESPONSE',
+  },
+  isMockLLMEnabled: jest.fn().mockReturnValue(false),
 }));
 
 // Mock brain service
@@ -110,6 +117,46 @@ describe('Messages API (Fire-and-Forget)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('planner text safety helpers', () => {
+    describe('scrubVisibleAIText', () => {
+      it('removes visible planner lines and flags the scrub', () => {
+        const result = scrubVisibleAIText([
+          'I should compare both lists before showing anything.',
+          'That sounds like a need for more steadiness.',
+          "Here's my plan: reveal the comparison.",
+        ].join('\n'));
+
+        expect(result.scrubbed).toBe(true);
+        expect(result.text).toBe('That sounds like a need for more steadiness.');
+      });
+
+      it('preserves normal facilitation that starts with I need to', () => {
+        const text = 'I need to make sure I am capturing this right: you want steadiness before deciding.';
+
+        expect(scrubVisibleAIText(text)).toEqual({
+          text,
+          scrubbed: false,
+        });
+      });
+    });
+
+    describe('isReadyForStage3RevealText', () => {
+      it('detects ready requests that mention needs reveal context', () => {
+        expect(isReadyForStage3RevealText("I'm ready to see the needs lists")).toBe(true);
+        expect(isReadyForStage3RevealText('We are ready for the side by side reveal')).toBe(true);
+      });
+
+      it('does not treat negated ready language as a reveal request', () => {
+        expect(isReadyForStage3RevealText("I'm not ready to see the lists")).toBe(false);
+        expect(isReadyForStage3RevealText("I don't want to show the needs yet")).toBe(false);
+      });
+
+      it('requires reveal context to avoid hijacking generic ready messages', () => {
+        expect(isReadyForStage3RevealText("Yes, I'm ready")).toBe(false);
+      });
+    });
   });
 
   describe('POST /sessions/:id/messages (sendMessage - DEPRECATED)', () => {

--- a/backend/src/services/push.ts
+++ b/backend/src/services/push.ts
@@ -56,6 +56,10 @@ export const PUSH_MESSAGES: Record<SessionEvent, { title: string; body: string }
     title: 'Needs shared',
     body: 'Your partner shared their identified needs.',
   },
+  'partner.needs_validated': {
+    title: 'Needs review updated',
+    body: 'Your partner responded to the needs comparison.',
+  },
   'partner.ranking_submitted': {
     title: 'Ranking submitted',
     body: 'Your partner submitted their strategy rankings.',

--- a/backend/src/services/realtime.ts
+++ b/backend/src/services/realtime.ts
@@ -36,6 +36,7 @@ export type SessionEvent = Extract<
   | 'partner.skipped_refinement'
   | 'partner.needs_confirmed'
   | 'partner.needs_shared'
+  | 'partner.needs_validated'
   | 'partner.ranking_submitted'
   | 'partner.ready_to_rank'
   | 'partner.consent_granted'

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -1165,6 +1165,12 @@ Your job is to CRAFT a feelings-focused message that ${userName} would say direc
    - 1-3 sentences maximum
    - Address the most important gap in understanding
 
+6. PRESERVES ACCOUNTABILITY AND SAFETY
+   - If anger, temper, volatility, escalation, or loss of control is part of the conflict, never imply ${userName} cannot control themselves
+   - Do not ask ${partnerName} to accept unsafe behavior or minimize harm
+   - It is okay to name defensiveness or anger, but pair it with ownership (for example: "my anger is still mine to handle")
+   - Recognition needs must never override ${partnerName}'s need for safety or boundaries
+
 IMPORTANT GUIDELINES:
 - Never start with confrontational phrases like "Look," or "Listen,"
 - Never include accusations or blame

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -35,6 +35,8 @@ function buildResponseProtocol(stage: number, options?: {
     flags.push('FeelHeardCheck: [Y/N]');
   } else if (stage === 2) {
     flags.push('ReadyShare: [Y/N]');
+  } else if (stage === 3) {
+    flags.push('NeedsReady: [Y/N]');
   } else if (stage === 4) {
     flags.push('StrategyProposed: [Y/N]');
   }
@@ -58,16 +60,26 @@ ProposedStrategy: 10-minute check-in after dinner each night for one week
 ProposedStrategy: Sunday evening phone call to plan the week ahead`
     : '';
 
+  const needsSection = stage === 3
+    ? `\nIf NeedsReady is Y, include a hidden needs block immediately after </thinking>:
+<needs>
+[
+  {"need":"short label", "category":"SAFETY|CONNECTION|AUTONOMY|RECOGNITION|MEANING|FAIRNESS", "description":"the user's words for this need", "evidence":["brief quote or paraphrase from this user's messages"]}
+]
+</needs>
+Only include needs this user clearly named or accepted. Never include partner needs.`
+    : '';
+
   return `
 OUTPUT FORMAT:
 <thinking>
 Mode: [WITNESS|PERSPECTIVE|NEEDS|REPAIR|ONBOARDING|DISPATCH]
 ${flags.join('\n')}
 Strategy: [brief]${strategySection}
-</thinking>${draftSection}
+</thinking>${draftSection}${needsSection}
 
 Then write the user-facing response (plain text, no tags).
-IMPORTANT: All metadata (FeelHeardCheck, ReadyShare, Mode, etc.) belongs ONLY inside <thinking>. The user-facing response must be purely conversational — no brackets, flags, or annotations.
+IMPORTANT: All metadata (FeelHeardCheck, ReadyShare, NeedsReady, Mode, etc.) belongs ONLY inside hidden tags. The user-facing response must be purely conversational — no brackets, flags, annotations, planning, or "I should" language.
 
 OFF-RAMPS (only when needed):
 - If asked how this works / process: <dispatch>EXPLAIN_PROCESS</dispatch>
@@ -800,8 +812,13 @@ FORBIDDEN in Stage 3:
 - Introducing needs the user hasn't expressed. No suggesting additional needs beyond what they've named.
 - Identifying, labeling, or analyzing common ground or overlap between the two needs lists. That insight belongs to the users, not the AI.
 - Leading the user toward any particular conclusion about the relationship between the needs lists.
+- Saying both users are ready, promising side-by-side lists, or referencing partner needs unless backend-provided state has already made both lists visible in the UI.
+- Visible planning or hidden-reasoning leakage, including phrases like "I should", "so both lists should", "the prompt says", or "here's my plan".
 
 No-hallucination guard: Use the user's exact words when reflecting needs. Never add context, feelings, or details they didn't provide.
+
+NEEDS CAPTURE:
+When ${context.userName} has clearly landed on their own needs and you present a clean summary for review, set NeedsReady:Y and include the hidden <needs> block. In visible text, say you have captured a draft of what matters to them for their review. Do not say anything about sharing, partner readiness, or side-by-side reveal.
 
 Length: default 1–3 sentences. Go longer only if they explicitly ask for help or detail.
 ${LATERAL_PROBING_GUIDANCE}
@@ -937,7 +954,7 @@ Your message should cover these things in a natural, conversational flow — not
 
 1. VALIDATE: Acknowledge what ${userName} just did — they shared something difficult, stayed with it, and let themselves be heard. That took real honesty.
 
-2. BRIEF ROADMAP: Give ${userName} a sense of the journey ahead. There are a few more steps: first, each person tries to understand what the other might be going through. Then you'll each figure out what you actually need. And eventually, you'll work on a way forward together. Keep this to 1-2 sentences — it's a preview, not a syllabus.
+2. BRIEF ROADMAP: Give ${userName} a sense of the journey ahead. There are a few more steps: first, each person tries to understand what the other might be going through. Then you'll each figure out what you actually need. Eventually, you'll use that to get clearer about what is possible next, whether together or separately. Keep this to 1-2 sentences — it's a preview, not a syllabus.
 
 3. FRAME THE NEXT STEP: Be upfront that what comes next might feel a little unusual. You're going to ask ${userName} to try to imagine what ${partnerName} might be going through — even though ${userName} might still be upset with them. Name that this is a strange ask.
 

--- a/backend/src/services/stage-tools.ts
+++ b/backend/src/services/stage-tools.ts
@@ -65,6 +65,13 @@ export interface SessionStateToolInput {
   offerReadyToShare?: boolean;
   proposedEmpathyStatement?: string;
   proposedStrategies?: string[];
+  proposedNeeds?: Array<{
+    need: string;
+    category: string;
+    description: string;
+    evidence: string[];
+  }>;
+  needsCaptured?: boolean;
   /** Stage 0: AI's proposed topic frame extracted from <draft> tag */
   topicFrame?: string;
 }

--- a/backend/src/utils/__tests__/micro-tag-parser.test.ts
+++ b/backend/src/utils/__tests__/micro-tag-parser.test.ts
@@ -98,6 +98,59 @@ Let me explain how this works.`;
       expect(result.dispatchTag).toBe('EXPLAIN_PROCESS');
     });
 
+    it('extracts proposed needs from a hidden needs JSON block', () => {
+      const raw = `<thinking>NeedsReady:Y</thinking>
+
+<needs>
+[
+  {
+    "need": "safety",
+    "category": "SAFETY",
+    "description": "I need steadiness before deciding what comes next.",
+    "evidence": ["I feel scared when things escalate"]
+  },
+  {
+    "need": "recognition",
+    "category": "RECOGNITION",
+    "description": "I need my effort to be seen.",
+    "evidence": []
+  }
+]
+</needs>
+
+I captured a draft of what matters to you for review.`;
+
+      const result = parseMicroTagResponse(raw);
+
+      expect(result.response).toBe('I captured a draft of what matters to you for review.');
+      expect(result.response).not.toContain('<needs>');
+      expect(result.proposedNeeds).toEqual([
+        {
+          need: 'safety',
+          category: 'SAFETY',
+          description: 'I need steadiness before deciding what comes next.',
+          evidence: ['I feel scared when things escalate'],
+        },
+        {
+          need: 'recognition',
+          category: 'RECOGNITION',
+          description: 'I need my effort to be seen.',
+          evidence: [],
+        },
+      ]);
+    });
+
+    it('ignores malformed needs JSON and still strips the hidden block', () => {
+      const raw = `<thinking>NeedsReady:Y</thinking>
+<needs>{not valid json</needs>
+Let's keep exploring what matters most.`;
+
+      const result = parseMicroTagResponse(raw);
+
+      expect(result.response).toBe("Let's keep exploring what matters most.");
+      expect(result.proposedNeeds).toEqual([]);
+    });
+
     it('handles response with no tags gracefully', () => {
       const raw = 'Just a plain response with no tags.';
       const result = parseMicroTagResponse(raw);

--- a/backend/src/utils/micro-tag-parser.ts
+++ b/backend/src/utils/micro-tag-parser.ts
@@ -29,6 +29,13 @@ export interface ParsedMicroTagResponse {
   offerReadyToShare: boolean;
   /** Extracted from thinking: ProposedStrategy lines (Stage 4) */
   proposedStrategies: string[];
+  /** Extracted from Stage 3 <needs> JSON block or ProposedNeed lines */
+  proposedNeeds: Array<{
+    need: string;
+    category: string;
+    description: string;
+    evidence: string[];
+  }>;
 }
 
 /**
@@ -40,6 +47,7 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
   const thinkingMatch = rawResponse.match(/<thinking>([\s\S]*?)<\/thinking>/i);
   const draftMatch = rawResponse.match(/<draft>([\s\S]*?)<\/draft>/i);
   const dispatchMatch = rawResponse.match(/<dispatch>([\s\S]*?)<\/dispatch>/i);
+  const needsMatch = rawResponse.match(/<needs>([\s\S]*?)<\/needs>/i);
 
   const thinking = thinkingMatch?.[1]?.trim() ?? '';
   const draft = draftMatch?.[1]?.trim() ?? null;
@@ -50,6 +58,7 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
     .replace(/<thinking>[\s\S]*?<\/thinking>/gi, '')
     .replace(/<draft>[\s\S]*?<\/draft>/gi, '')
     .replace(/<dispatch>[\s\S]*?<\/dispatch>/gi, '')
+    .replace(/<needs>[\s\S]*?<\/needs>/gi, '')
     .trim();
 
   // If everything landed inside tags, leave response empty and let the caller
@@ -79,6 +88,41 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
     }
   }
 
+  const proposedNeeds: ParsedMicroTagResponse['proposedNeeds'] = [];
+  if (needsMatch?.[1]) {
+    try {
+      const parsedNeeds = JSON.parse(needsMatch[1].trim()) as unknown;
+      if (Array.isArray(parsedNeeds)) {
+        for (const item of parsedNeeds) {
+          if (!item || typeof item !== 'object') continue;
+          const record = item as Record<string, unknown>;
+          const need = typeof record.need === 'string' ? record.need.trim() : '';
+          const category = typeof record.category === 'string' ? record.category.trim() : '';
+          const description = typeof record.description === 'string' ? record.description.trim() : need;
+          const evidence = Array.isArray(record.evidence)
+            ? record.evidence.filter((entry): entry is string => typeof entry === 'string')
+            : [];
+          if (need && category && description) {
+            proposedNeeds.push({ need, category, description, evidence });
+          }
+        }
+      }
+    } catch (error) {
+      logger.warn('[micro-tag-parser] Failed to parse <needs> block', { error });
+    }
+  }
+
+  const needRegex = /ProposedNeed:\s*([^|]+)\|([^|]+)\|(.+)/gi;
+  let needMatch: RegExpExecArray | null;
+  while ((needMatch = needRegex.exec(thinking)) !== null) {
+    const need = needMatch[1].trim();
+    const category = needMatch[2].trim();
+    const description = needMatch[3].trim();
+    if (need && category && description) {
+      proposedNeeds.push({ need, category, description, evidence: [] });
+    }
+  }
+
   // 4. Compatibility fallback: JSON output (legacy stages may emit empathy as JSON)
   if (!thinking && !draft && responseText.startsWith('{')) {
     try {
@@ -95,6 +139,7 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
         offerFeelHeardCheck,
         offerReadyToShare,
         proposedStrategies,
+        proposedNeeds,
       };
     } catch {
       // Fall through to raw responseText
@@ -110,5 +155,6 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
     offerFeelHeardCheck,
     offerReadyToShare,
     proposedStrategies,
+    proposedNeeds,
   };
 }

--- a/docs/product/james-catherine-gold-session-bug-handoff-2026-05-04.md
+++ b/docs/product/james-catherine-gold-session-bug-handoff-2026-05-04.md
@@ -1,0 +1,473 @@
+# James/Catherine Gold Session Bug Handoff - 2026-05-04
+
+## James-Side Report
+
+### Session Context
+
+- Scenario: James/Catherine no-shared-agreement benchmark.
+- Codex role: James only.
+- App: local E2E/no-Clerk web bundle on `http://localhost:8082`.
+- James URL:
+  `http://localhost:8082/session/cmoqxuweg00bxpx2vti5d7jvg?e2e-user-id=cmoqxuw0b00brpx2vsake9pb9&e2e-user-email=james-gold-1777883375@e2e.test`
+- Catherine direct E2E URL:
+  `http://localhost:8082/session/cmoqxuweg00bxpx2vti5d7jvg?e2e-user-id=cmoqxuw1w00bspx2vws01qi88&e2e-user-email=catherine-gold-1777883375@e2e.test`
+- Session id: `cmoqxuweg00bxpx2vti5d7jvg`.
+
+### 1. E2E Auth Identity Cache Drift
+
+Status: patched locally during this session.
+
+What happened:
+- Opening an E2E URL on the normal `8081` bundle showed generic `Partner` instead of Catherine.
+- The same session on `8082` E2E mode showed `Catherine` correctly.
+- Root cause found in `mobile/src/providers/E2EAuthProvider.tsx`: `getE2EUserFromURL()` returned `cachedE2EUserInfo` before reading explicit URL params, so the first E2E identity could bleed into later navigations.
+
+Patch applied:
+- Explicit `e2e-user-id` / `e2e-user-email` URL params now override the cached identity.
+- Cache is still used as fallback when client-side navigation drops query params.
+
+Verification:
+- `npm --workspace mobile run check` passed.
+- Repo-wide lint with `--max-warnings=0` still fails on existing warnings unrelated to this patch.
+
+Likely follow-up:
+- Add a focused test for switching E2E identities by URL param in the same web runtime.
+
+### 2. Skill/Run Setup Footgun: `8081` Normal Bundle Does Not Honor E2E Mode Reliably
+
+What happened:
+- Initial local app on `8081` accepted E2E query params syntactically but behaved like the normal bundle.
+- Correct behavior required starting `8082` with:
+  `EXPO_PUBLIC_E2E_MODE=true EXPO_PUBLIC_API_URL=http://localhost:3000 npx expo start --web --port 8082 --no-dev`
+
+Expected:
+- Gold-session tester runs should prefer `8082` E2E mode even if `8081` is already running.
+
+Suggested skill/doc note:
+- If the in-app browser is blank and a no-Clerk session is requested, start/use `8082`; do not trust E2E query params on a normal `8081` web bundle.
+
+### 3. Stage 2 -> Stage 3 Realtime/Stale UI
+
+What happened:
+- After both empathy attempts were validated, backend had advanced both users to Stage 3:
+  - `myProgress.stage: 3`
+  - `partnerProgress.stage: 3`
+  - session status `ACTIVE`
+- James UI remained on Stage 2 / `Walking in Their Shoes` until browser reload.
+- After reload, James correctly saw Stage 3 / `What Matters Most`.
+
+Expected:
+- James UI should transition live to Stage 3 when backend progress advances.
+
+Evidence:
+- Before reload, UI still showed Stage 2 while `/api/sessions/:id/progress` returned Stage 3 for both users.
+- Reload fixed the displayed stage.
+
+Likely fix areas:
+- Realtime stage-progress invalidation/subscription.
+- Mobile session query invalidation after empathy validation/reveal completion.
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- backend realtime publish path for Stage 2 completion/Stage 3 creation.
+
+### 4. Stage 3 Premature “Both Lists Are Ready” Prompt
+
+What happened:
+- James completed his Stage 3 needs exploration.
+- MWF said: “Catherine has been doing the same work on her side. You’re both ready to see what each of you needs. When you’re ready, I’ll show you both lists side by side.”
+- Backend contradicted this:
+  - James progress: Stage 3 `IN_PROGRESS`
+  - Catherine progress: Stage 3 `IN_PROGRESS`
+  - `/needs`: `needs: []`, `extracting: false`, `synthesizedAt: null`
+  - `/needs/comparison`: `myNeeds: []`, `partnerNeeds: []`, `analysisComplete: false`
+
+Expected:
+- MWF should not promise side-by-side needs until both users have completed the documented Stage 3 gates.
+- If only James is ready, UI should clearly say he is waiting for Catherine or show the correct one-sided review/confirm gate.
+
+Impact:
+- Serious Stage 3 process/gating bug.
+- Especially risky for James/Catherine benchmark because it creates false readiness and can imply mutual progress/agreement before Catherine has completed her side.
+
+Likely fix areas:
+- Stage 3 prompt contract in `backend/src/services/stage-prompts.ts`.
+- Message controller/orchestrator stage routing in `backend/src/controllers/messages.ts` and/or `backend/src/services/ai-orchestrator.ts`.
+- Stage 3 gate/status helpers in `backend/src/controllers/stage3.ts`.
+- Mobile waiting state helpers:
+  - `mobile/src/utils/getWaitingStatus.ts`
+  - `mobile/src/config/waitingStatusConfig.ts`
+  - `mobile/src/utils/chatUIState.ts`
+
+### 5. “I’m Ready” Routed As Normal Chat Instead Of Reveal/Extraction Gate
+
+What happened:
+- After the premature prompt, James sent: “I’m ready to see the lists.”
+- Backend saved the user message as Stage 3 chat.
+- AI replied with generic fallback: “I’m here with you. Could you tell me more about what you’re experiencing?”
+- Needs extraction/reveal did not run.
+
+Expected:
+- There should be an explicit CTA/gate for needs review/confirmation/reveal.
+- If conversational “ready” is supported, it should map to the same backend action as the CTA.
+- If the reveal is not actually available, the prompt should not ask for readiness.
+
+Evidence:
+- Latest messages showed the “I’m ready” user message followed by the fallback AI response.
+- `/needs` and `/needs/comparison` remained empty after waiting.
+
+Likely fix areas:
+- Stage 3 transition/gate handling in `backend/src/controllers/messages.ts`.
+- Explicit CTA rendering in `mobile/src/screens/UnifiedSessionScreen.tsx`.
+- Stage 3 needs extraction endpoint invocation and UI state.
+
+### 6. Ghost Typing / Pending Dots Can Stick After Invalid Stage 3 Ready Path
+
+What happened:
+- User observed ghost typing dots after the invalid “I’m ready” path.
+- No meaningful response or reveal came back.
+- Backend state showed no extraction in progress: `extracting: false`.
+
+Expected:
+- Typing/pending UI should resolve when the request completes, errors, or falls through.
+- If no backend operation is running, UI should not show a persistent typing indicator.
+
+Likely fix areas:
+- Streaming/pending state cleanup in:
+  - `mobile/src/hooks/useStreamingMessage.ts`
+  - `mobile/src/hooks/useUnifiedSession.ts`
+  - `mobile/src/components/ChatInterface.tsx`
+- Error/fallback path in message send mutation.
+
+### 7. Internal Implementation Language Leaks To User
+
+What happened:
+- User-facing copy displayed “internal reconciler” in multiple places, including:
+  - Share suggestion modal: “Our internal reconciler has reviewed...”
+  - After resubmitting empathy draft: “The internal reconciler will review your updated statement...”
+
+Expected:
+- User-facing copy should not expose implementation names.
+- Suggested replacement language: “I’ll review this” / “I’ll check whether this gets closer to what Catherine shared” / “I’ll help compare the two perspectives.”
+
+Impact:
+- UI polish/product trust issue.
+- Also violates explicit gold-session watch item: no internal implementation language in user-facing copy.
+
+Likely fix areas:
+- Reconciler/share offer copy in backend and mobile:
+  - `backend/src/services/reconciler/*`
+  - `backend/src/services/stage-prompts.ts`
+  - `mobile/src/screens/UnifiedSessionScreen.tsx`
+  - sharing/reconciler UI components.
+
+### 8. Share Suggestion Draft Could Excuse Escalation
+
+What happened:
+- James was offered a draft:
+  “...that erasure makes me feel cornered and furious in ways I can’t always control.”
+- This phrasing risks excusing volatility or asking Catherine to accept lack of control.
+- We refined it to:
+  “When conflicts happen, I feel like our entire six years together gets erased and I’m reduced to just ‘the guy with the temper.’ That’s when I get most defensive and angry—but I know my anger is still mine to handle.”
+
+Expected:
+- James drafts should preserve his experience while maintaining accountability for escalation.
+- For this benchmark, drafts should not minimize volatility or blur safety boundaries.
+
+Likely fix areas:
+- Reconciler/share suggestion prompt instructions.
+- Safety/accountability wording constraints for James/Catherine-like scenarios.
+
+### 9. Stage 3 Prompt Is Mildly Resolution-Biased For No-Agreement Benchmark
+
+What happened:
+- Stage 3 opened with:
+  “What do you need most from this situation to feel resolved and move forward together?”
+- In James/Catherine, Catherine may not want repair/reconciliation. The benchmark expects no forced shared agreement and dignified individual outcomes.
+
+Expected:
+- Stage 3 should support “move forward” without assuming “together.”
+- Better wording: “What do you need most from this situation to feel clear, grounded, or able to move forward - whether together or separately?”
+
+Likely fix areas:
+- Stage 3 opening prompt in `backend/src/services/stage-prompts.ts`.
+- Any Stage 3 UI copy that assumes repair or shared agreement.
+
+### 10. Activity/Drawer UX Confusion
+
+What happened:
+- “Open exchange history” drawer remained open while chat input and modals were also active, making current state hard to inspect.
+- Text click on “Close exchange history” did not dismiss at first; role-based button click did.
+- It was easy to confuse the history drawer with current gate modals.
+
+Expected:
+- Drawer close behavior should be reliable.
+- Current action gate should not be visually obscured by exchange history.
+
+Likely fix areas:
+- Activity drawer/modal layering and close hit target.
+- `mobile/src/components/ActivityDrawer.tsx`
+- `mobile/src/components/ActivityMenuModal.tsx`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+
+### Gold-Alignment Notes
+
+Worked well:
+- Stage 1 James track listened without flattening his defensiveness.
+- Stage 2 helped James move from “she thinks I’m the problem” toward understanding Catherine’s exhausted/sad clarity and safety needs.
+- Catherine’s empathy statement for James was strong: it named his fear of not being enough while preserving Catherine’s boundary that understanding volatility does not make escalation safe.
+- Stage 3 James needs exploration handled non-guaranteed outcome well once in the conversation.
+
+Main failing area:
+- Product/state gating around Stage 3 is not trustworthy. The AI can say both users are ready even when backend needs are empty and Catherine has not completed her side.
+
+### Suggested First Fix Order
+
+1. Remove all user-facing “internal reconciler” copy.
+2. Fix Stage 3 prompt/gate contract so side-by-side reveal is never promised until backend gates are satisfied.
+3. Ensure Stage 3 readiness has an explicit CTA and backend action, not free-text “I’m ready” chat.
+4. Fix realtime invalidation for Stage 2 -> Stage 3 transition.
+5. Add regression coverage for James/Catherine no-shared-agreement path:
+   - no forced “move forward together” copy,
+   - no needs reveal before both users complete/confirm/share,
+   - no AI-authored common-ground truth before consented reveal,
+   - no internal implementation terms in UI.
+
+## Catherine-Side Report
+
+### Session Context
+
+- Scenario: James/Catherine golden no-shared-agreement path.
+- Codex role: Catherine only.
+- Session ID: `cmoqxuweg00bxpx2vti5d7jvg`.
+- Catherine URL: `http://localhost:8082/session/cmoqxuweg00bxpx2vti5d7jvg?e2e-user-id=cmoqxnltn008mpx2vwfmaewai&e2e-user-email=catherine@e2e.test`
+- Backend: local E2E auth bypass, API on `localhost:3000`, mobile web on `localhost:8082`.
+- Main benchmark: support a dignified no-agreement path without forcing repair, leaking private/internal state, or advancing Stage 3 without confirmed, user-controlled needs.
+
+### Summary
+
+The Catherine-side run mostly preserved the no-forced-agreement posture in prompt behavior, especially once Stage 3 reached the needs comparison. The run still exposed product/state and prompt-output bugs that should be fixed before trusting the flow:
+
+- Internal implementation language is shown to users.
+- A Stage 3 prompt leaked model/planner text directly into chat.
+- Reconciler refinement instructions are persisted/displayed as normal user chat.
+- Catherine briefly saw a partner-addressed Stage 3 prompt on her authenticated URL.
+- Stage 2/3 waiting states and CTAs can become stale until reload.
+- Stage 3 presented side-by-side needs without persisting `IdentifiedNeed` records or clear Stage 3 gates.
+
+### C1. Internal Reconciler Language Appears In User-Facing Copy
+
+Type: Prompt / UI copy.
+
+Evidence:
+
+- Stage 2 share suggestion dialog showed: `Our internal reconciler has reviewed...`
+- Stage 2 post-resubmit message showed: `The internal reconciler will review your updated statement...`
+- Similar James-side copy appeared in DB messages.
+
+Expected:
+
+- User-facing copy should describe the facilitator/process, not implementation internals.
+- Example direction: "I've reviewed what each of you shared..." or "I'll check whether this helps them feel understood..."
+
+Likely fix locations:
+
+- `backend/src/services/stage-prompts.ts`
+- `backend/src/controllers/stage2.ts`
+- Stage 2 reconciler response templates/services.
+
+### C2. Prompt/Planner Text Leaked Into Stage 3 Side-By-Side Reveal
+
+Type: Serious prompt bug.
+
+Evidence from Catherine chat:
+
+```text
+— so both lists should be available. I should present both lists side by side and open with a noticing question. Here's what matters to each of you:
+```
+
+Expected:
+
+- The message should start directly with user-facing facilitation, e.g. "Here's what matters to each of you..."
+- No hidden reasoning, planning, or instruction text should be emitted.
+
+Likely fix locations:
+
+- `backend/src/services/stage-prompts.ts`
+- `backend/src/controllers/stage3.ts`
+- Model output post-processing / prompt contract for Stage 3 needs reveal.
+
+### C3. Refinement Instructions Are Displayed As Normal Chat Messages
+
+Type: UI / message-model / privacy-boundary bug.
+
+Evidence:
+
+```text
+Refine empathy draft: Make this less diagnosing and less absolute...
+Refine empathy draft: Remove the phrase about facing something unbearably painful...
+```
+
+Expected:
+
+- Draft/refinement control instructions should be private tool/control input, not regular conversation turns.
+- They should not appear as user-authored chat content in the main session timeline or exchange history.
+
+Likely fix locations:
+
+- `backend/src/controllers/stage2.ts`
+- `backend/src/controllers/messages.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- Message role/schema handling if refinement needs a separate non-chat role.
+
+### C4. Catherine Briefly Saw A Stage 3 Prompt Addressed To James
+
+Type: Realtime / cache / isolation bug.
+
+Evidence:
+
+- On Catherine's authenticated URL, immediately after Stage 2 completion, browser displayed:
+
+```text
+James, thank you for taking the time to really understand Catherine's experience. Now I'd like to invite you...
+```
+
+- Reload corrected it to:
+
+```text
+Catherine, thank you for taking the time to truly understand where James is coming from...
+```
+
+Expected:
+
+- Catherine should never see a partner-addressed AI message as her active prompt.
+- `forUserId` isolation should be respected across realtime transitions without requiring reload.
+
+Likely fix locations:
+
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `backend/src/services/realtime.ts`
+- `backend/src/controllers/messages.ts`
+
+### C5. Stale/Misleading Stage 2 Wait State Until Reload
+
+Type: UI state / realtime / stage-gate bug.
+
+Evidence:
+
+- After Catherine shared her empathy statement, UI said both users would read and validate statements, but DB showed both attempts still `AWAITING_SHARING`.
+- Chat input was still visible during "Checking how well you captured their perspective..."
+- Reload changed the UI to the correct next action: `Help James understand you better`.
+
+Expected:
+
+- UI should show the current reconciler state without reload.
+- If blocked, input should be hidden/disabled unless a real user action is expected.
+- Copy should not claim validation is next when the backend requires context-sharing/refinement first.
+
+Likely fix locations:
+
+- `mobile/src/utils/getWaitingStatus.ts`
+- `mobile/src/config/waitingStatusConfig.ts`
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `backend/src/services/realtime.ts`
+
+### C6. Stage 3 Needs Were Shown But Not Persisted As `IdentifiedNeed`
+
+Type: Backend state / Stage 3 gate bug.
+
+Evidence:
+
+- After Catherine completed Stage 3 needs articulation and side-by-side reveal, DB showed Stage 3 still `IN_PROGRESS` with `gates: null`.
+- `UserVessel.identifiedNeeds` was empty for both Catherine and James, despite the UI presenting side-by-side needs for both users.
+
+Expected:
+
+- Stage 3 needs should be captured in structured state before side-by-side reveal.
+- Gates should distinguish at least:
+  - needs captured/confirmed by user
+  - consent to reveal
+  - side-by-side reveal shown
+  - user noticing/validation complete
+- The UI should not present AI-synthesized needs as product truth without confirmed/persisted needs records.
+
+Likely fix locations:
+
+- `backend/src/controllers/stage3.ts`
+- `backend/src/services/stage-prompts.ts`
+- `backend/prisma/schema.prisma` usage around `UserVessel` / `IdentifiedNeed`
+- `mobile/src/hooks/useStages.ts`
+
+### C7. Stage 3 Reveal May Be Triggered By Chat Text Instead Of Explicit Consent CTA
+
+Type: UX / consent-gate bug.
+
+Evidence:
+
+- After MWF said it would show side-by-side needs "when you're ready," no dedicated CTA appeared in the DOM.
+- Sending `I'm ready to see them side by side.` in chat triggered the reveal.
+
+Expected:
+
+- Side-by-side needs reveal should use an explicit consent/continue CTA when possible.
+- Chat text should not be the only apparent mechanism for a privacy-sensitive reveal step.
+
+Likely fix locations:
+
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `mobile/src/hooks/useStages.ts`
+- `backend/src/controllers/stage3.ts`
+
+### C8. Stage 2/3 Language Still Sometimes Implies "Moving Forward Together"
+
+Type: Prompt-quality issue.
+
+Evidence:
+
+- Stage 2 intro said users would "eventually work on a way forward together."
+- Catherine explicitly had to clarify that "moving forward together" may not mean staying together.
+
+Expected:
+
+- James/Catherine no-agreement path should avoid implying repair, reconciliation, or shared agreement.
+- Better language: "move toward clarity about what is possible" or "decide what, if anything, can be done next."
+
+Likely fix locations:
+
+- `backend/src/services/stage-prompts.ts`
+- Stage 2 and Stage 3 transition prompts.
+
+### Catherine-Side Gold-Alignment Notes
+
+What worked well:
+
+- Stage 1 listened to Catherine without asking her to soften or reconcile.
+- Stage 2 allowed Catherine to recognize James's perspective while preserving that volatility was not safe.
+- Stage 3 eventually honored non-agreement: it named that James's needs are about recognition while Catherine's are about safety and whether she can stay.
+- The facilitator explicitly accepted that no shared agreement may be the honest outcome.
+
+What still needs protection:
+
+- Do not convert Catherine's safety/accountability needs into a neat shared overlap.
+- Do not treat James's need for recognition as requiring Catherine to minimize harm.
+- Do not reveal side-by-side needs until both users' needs are user-confirmed and consented.
+
+### Catherine-Side Reproduction Checks
+
+DB query pattern:
+
+```bash
+cd /Users/shantam/Software/meet-without-fear/backend
+npx tsx -e 'import "dotenv/config"; import { PrismaClient } from "@prisma/client"; (async()=>{ const prisma=new PrismaClient(); const sessionId="cmoqxuweg00bxpx2vti5d7jvg"; const progress=await prisma.stageProgress.findMany({where:{sessionId},include:{user:true},orderBy:[{stage:"asc"},{userId:"asc"}]}); const vessels=await prisma.userVessel.findMany({where:{sessionId},include:{user:true,identifiedNeeds:{orderBy:{createdAt:"asc"}}}}); console.log(JSON.stringify({progress:progress.map(p=>({user:p.user.name,stage:p.stage,status:p.status,gates:p.gatesSatisfied,completedAt:p.completedAt})), vessels:vessels.map(v=>({user:v.user.name,needs:v.identifiedNeeds.map(n=>({need:n.need,category:n.category,confirmed:n.confirmed,createdAt:n.createdAt}))}))},null,2)); await prisma.$disconnect(); })().catch(e=>{console.error(e);process.exit(1);});'
+```
+
+Expected future test assertions:
+
+- No user-visible message contains `internal reconciler`, `I should`, or other model/planner language.
+- Refinement controls do not produce normal `USER` chat messages.
+- Catherine never sees `forUserId=James` AI content as her active prompt after realtime transitions.
+- Waiting states hide chat input unless user action is valid.
+- Stage 3 side-by-side reveal requires persisted, confirmed, consented needs for both users.
+- No-agreement path remains valid through Stage 3/4.

--- a/mobile/src/components/ActivityDrawer.tsx
+++ b/mobile/src/components/ActivityDrawer.tsx
@@ -450,7 +450,7 @@ export function ActivityDrawer({
 
   return (
     <View
-      style={[StyleSheet.absoluteFill, { zIndex: 100, elevation: 100 }]}
+      style={[StyleSheet.absoluteFill, { zIndex: 80, elevation: 80 }]}
       pointerEvents="auto"
       testID={testID}
     >
@@ -483,6 +483,16 @@ export function ActivityDrawer({
           <View {...panResponder.panHandlers} style={styles.dragHandleArea}>
             <View style={styles.dragHandle} />
           </View>
+
+          <Pressable
+            style={styles.closeHistoryButton}
+            onPress={closeDrawer}
+            accessibilityRole="button"
+            accessibilityLabel="Close exchange history"
+            testID="activity-drawer-close"
+          >
+            <Text style={styles.closeHistoryText}>Close exchange history</Text>
+          </Pressable>
 
           {/* Header */}
           <Text
@@ -613,6 +623,19 @@ const styles = StyleSheet.create({
     color: colors.textPrimary,
     paddingHorizontal: 16,
     paddingBottom: 12,
+  },
+  closeHistoryButton: {
+    marginHorizontal: 16,
+    marginBottom: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+    borderRadius: 8,
+    backgroundColor: colors.bgSecondary,
+  },
+  closeHistoryText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.textPrimary,
   },
   sectionHeader: {
     fontSize: 11,

--- a/mobile/src/components/ViewEmpathyStatementDrawer.tsx
+++ b/mobile/src/components/ViewEmpathyStatementDrawer.tsx
@@ -181,15 +181,17 @@ export function ViewEmpathyStatementDrawer({
             ) : (
               <View style={styles.footer}>
                 <View style={styles.actionButtons}>
-                  <TouchableOpacity
-                    style={styles.refineButton}
-                    onPress={() => setIsRefining(true)}
-                    testID="refine-empathy-button"
-                    activeOpacity={0.8}
-                  >
-                    <MessageCircle color={colors.textSecondary} size={20} />
-                    <Text style={styles.refineButtonText}>Refine further</Text>
-                  </TouchableOpacity>
+                  {onSendRefinement && (
+                    <TouchableOpacity
+                      style={styles.refineButton}
+                      onPress={() => setIsRefining(true)}
+                      testID="refine-empathy-button"
+                      activeOpacity={0.8}
+                    >
+                      <MessageCircle color={colors.textSecondary} size={20} />
+                      <Text style={styles.refineButtonText}>Refine further</Text>
+                    </TouchableOpacity>
+                  )}
                   <TouchableOpacity
                     style={styles.shareButton}
                     onPress={onShare}

--- a/mobile/src/config/waitingStatusConfig.ts
+++ b/mobile/src/config/waitingStatusConfig.ts
@@ -179,12 +179,22 @@ export const WAITING_STATUS_CONFIG: Record<NonNullable<WaitingStatusState>, Wait
   // Stage 3: Waiting for partner to confirm their needs
   'needs-pending': {
     showBanner: true,
-    hideInput: false,  // Users can chat while waiting for partner
+    hideInput: true,
     showInnerThoughts: false,
     isActionRequired: false,
     showSpinner: false,
     showKeepChattingAction: false,
     bannerText: (p) => `${p} is exploring what matters to them.`,
+  },
+
+  'needs-waiting-for-partner': {
+    showBanner: true,
+    hideInput: true,
+    showInnerThoughts: false,
+    isActionRequired: false,
+    showSpinner: false,
+    showKeepChattingAction: false,
+    bannerText: (p) => `${p} is deciding what they are ready to share.`,
   },
 
   // Stage 3: Waiting for partner to confirm common ground

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -106,6 +106,7 @@ export interface UseChatUIStateProps {
   allNeedsConfirmed: boolean;
   needsAvailable: boolean;
   needsShared: boolean;
+  needsRevealReady: boolean;
   hasConfirmedNeedsLocal: boolean;
   commonGroundCount: number;
   commonGroundAvailable: boolean;
@@ -202,6 +203,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     allNeedsConfirmed,
     needsAvailable,
     needsShared,
+    needsRevealReady,
     hasConfirmedNeedsLocal,
     commonGroundCount,
     commonGroundAvailable,
@@ -236,7 +238,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     shareOffer: shareOfferData ? {
       hasSuggestion: shareOfferData.hasSuggestion,
     } : undefined,
-    needs: { allConfirmed: allNeedsConfirmed },
+    needs: { allConfirmed: allNeedsConfirmed, shared: needsShared, revealReady: needsRevealReady },
     commonGround: {
       count: commonGroundCount,
       allConfirmedByMe: commonGroundAllConfirmedByMe,
@@ -279,6 +281,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     needsAvailable,
     allNeedsConfirmed,
     needsShared,
+    needsRevealReady,
     hasConfirmedNeedsLocal,
 
     // Stage 3: Common Ground
@@ -298,6 +301,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     allNeedsConfirmed,
     needsAvailable,
     needsShared,
+    needsRevealReady,
     hasConfirmedNeedsLocal,
     commonGroundCount,
     commonGroundAvailable,

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -52,6 +52,13 @@ export interface StreamMetadata {
   offerReadyToShare?: boolean;
   proposedEmpathyStatement?: string | null;
   proposedStrategies?: string[];
+  proposedNeeds?: Array<{
+    need: string;
+    category: string;
+    description: string;
+    evidence: string[];
+  }>;
+  needsCaptured?: boolean;
   topicFrame?: string | null;
   analysis?: string;
 }
@@ -362,6 +369,23 @@ export function useStreamingMessage(
       queryClient.invalidateQueries({ queryKey: timelineKeys.infinite(sessionId) });
     },
     [queryClient, removeMessagesFromCache]
+  );
+
+  const invalidateAfterSuccessfulStream = useCallback(
+    (sessionId: string, stage?: Stage) => {
+      queryClient.invalidateQueries({ queryKey: messageKeys.infinite(sessionId) });
+      queryClient.invalidateQueries({ queryKey: timelineKeys.infinite(sessionId) });
+      if (stage === Stage.PERSPECTIVE_STRETCH) {
+        queryClient.invalidateQueries({ queryKey: stageKeys.empathyStatus(sessionId) });
+      }
+      if (stage === Stage.NEED_MAPPING) {
+        queryClient.invalidateQueries({ queryKey: stageKeys.needs(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.needsComparison(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+        queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
+      }
+    },
+    [queryClient]
   );
 
   /**
@@ -684,6 +708,9 @@ export function useStreamingMessage(
             if (currentStage === Stage.PERSPECTIVE_STRETCH) {
               queryClient.invalidateQueries({ queryKey: stageKeys.empathyStatus(sessionId) });
             }
+            if (currentStage === Stage.NEED_MAPPING) {
+              invalidateAfterSuccessfulStream(sessionId, currentStage);
+            }
 
             // Mark streaming as complete - cursor stops immediately
             textCompleteReceivedRef.current = true;
@@ -699,6 +726,10 @@ export function useStreamingMessage(
         // The streaming UI has already stopped via text_complete
         es.addEventListener('complete', (event) => {
           // Clear any pending throttled update (in case text_complete wasn't received)
+          if (fallbackTimerRef.current) {
+            clearTimeout(fallbackTimerRef.current);
+            fallbackTimerRef.current = null;
+          }
           if (pendingUpdateRef.current) {
             clearTimeout(pendingUpdateRef.current);
             pendingUpdateRef.current = null;
@@ -728,6 +759,9 @@ export function useStreamingMessage(
                 // Refresh empathy status (fallback path)
                 if (currentStage === Stage.PERSPECTIVE_STRETCH) {
                   queryClient.invalidateQueries({ queryKey: stageKeys.empathyStatus(sessionId) });
+                }
+                if (currentStage === Stage.NEED_MAPPING) {
+                  invalidateAfterSuccessfulStream(sessionId, currentStage);
                 }
 
                 setStatus('complete');
@@ -782,7 +816,7 @@ export function useStreamingMessage(
         onError?.(error as Error);
       }
     },
-    [addMessageToCache, updateMessageInCache, cleanupFailedStream, handleMetadata, queryClient, onComplete, onError]
+    [addMessageToCache, updateMessageInCache, cleanupFailedStream, handleMetadata, invalidateAfterSuccessfulStream, queryClient, onComplete, onError]
   );
 
   /**

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -288,10 +288,12 @@ export function useUnifiedSession(
   // Derive needs state for gating common ground query
   const needsForGating = needsData?.needs ?? [];
   const allNeedsConfirmedForGating = needsForGating.length > 0 && needsForGating.every((n) => n.confirmed);
+  const myNeedsSharedForGating =
+    (progressData?.myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsShared === true;
 
   const { data: needsComparisonData } = useNeedsComparison(
     sessionId,
-    allNeedsConfirmedForGating && !accessDenied
+    !accessDenied && (allNeedsConfirmedForGating || myNeedsSharedForGating)
   );
 
   // Stage 4: Strategies - always fetch to avoid waterfall
@@ -363,6 +365,11 @@ export function useUnifiedSession(
       if (sessionId && metadata.topicFrame) {
         queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
         queryClient.invalidateQueries({ queryKey: sessionKeys.sessionInvitation(sessionId) });
+      }
+      if (sessionId && metadata.needsCaptured) {
+        queryClient.invalidateQueries({ queryKey: stageKeys.needs(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+        queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
       }
     },
     [sessionId, saveDraft, setStreamTriggeredFeelHeard, setAiRecommendsReadyToShare,

--- a/mobile/src/providers/E2EAuthProvider.tsx
+++ b/mobile/src/providers/E2EAuthProvider.tsx
@@ -40,7 +40,6 @@ let cachedE2EUserInfo: { id: string; email: string } | null = null;
  * Caches the result so client-side navigation doesn't lose the params.
  */
 function getE2EUserFromURL(): { id: string; email: string } | null {
-  if (cachedE2EUserInfo) return cachedE2EUserInfo;
   if (Platform.OS !== 'web') return null;
 
   try {
@@ -57,7 +56,7 @@ function getE2EUserFromURL(): { id: string; email: string } | null {
     // Ignore - not in web environment
   }
 
-  return null;
+  return cachedE2EUserInfo;
 }
 
 interface E2EAuthProviderProps {

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -114,7 +114,7 @@ const STAGE_FRIENDLY_NAMES: Record<number, string> = {
   [Stage.WITNESS]: 'Your Story',
   [Stage.PERSPECTIVE_STRETCH]: 'Walking in Their Shoes',
   [Stage.NEED_MAPPING]: 'What Matters Most',
-  [Stage.STRATEGIC_REPAIR]: 'Moving Forward Together',
+  [Stage.STRATEGIC_REPAIR]: 'What Comes Next',
   [Stage.INFORMED_EMPATHY]: 'Deeper Understanding',
 };
 
@@ -480,25 +480,11 @@ export function UnifiedSessionScreen({
         if (data.empathyStatus) {
           queryClient.setQueryData(stageKeys.empathyStatus(sessionId), data.empathyStatus);
         }
-        // Update sessionKeys.state with new stage from event
-        if (data.currentStage !== undefined) {
-          queryClient.setQueryData(sessionKeys.state(sessionId), (old: any) => {
-            if (!old) return old;
-            return {
-              ...old,
-              progress: old.progress ? {
-                ...old.progress,
-                partnerProgress: old.progress.partnerProgress ? {
-                  ...old.progress.partnerProgress,
-                  stage: data.currentStage,
-                } : old.progress.partnerProgress,
-              } : old.progress,
-            };
-          });
-        }
-        // Also add transition message to cache if included in event
-        if (data.message) {
-          const message = data.message as { id: string; content: string; timestamp: string };
+        const messagesByUserId = data.messagesByUserId as Record<string, { id: string; content: string; timestamp: string; forUserId?: string }> | undefined;
+        const addressedMessage = user?.id && messagesByUserId ? messagesByUserId[user.id] : undefined;
+        const legacyMessage = data.message as { id: string; content: string; timestamp: string; forUserId?: string } | undefined;
+        const message = addressedMessage || (legacyMessage?.forUserId === user?.id ? legacyMessage : undefined);
+        if (message) {
           const newMessage = {
             id: message.id,
             content: message.content,
@@ -507,6 +493,7 @@ export function UnifiedSessionScreen({
             role: 'AI' as const,
             sessionId,
             senderId: null,
+            forUserId: message.forUserId ?? user?.id,
           };
           queryClient.setQueryData(messageKeys.infinite(sessionId), (old: any) => {
             if (!old || old.pages.length === 0) {
@@ -520,7 +507,11 @@ export function UnifiedSessionScreen({
             return { ...old, pages: updatedPages };
           });
         }
-        queryClient.refetchQueries({ queryKey: stageKeys.progress(sessionId) });
+        queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+        queryClient.invalidateQueries({ queryKey: messageKeys.infinite(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.empathyStatus(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.partnerEmpathy(sessionId) });
       }
 
       if (event === 'partner.advanced') {
@@ -673,13 +664,26 @@ export function UnifiedSessionScreen({
         // Partner confirmed their identified needs
         console.log('[UnifiedSessionScreen] Partner confirmed needs');
         queryClient.invalidateQueries({ queryKey: stageKeys.needs(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.needsComparison(sessionId) });
         queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+        queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
       }
 
       if (eventName === 'partner.needs_shared') {
         // Partner consented to share their needs
         console.log('[UnifiedSessionScreen] Partner shared needs');
+        queryClient.invalidateQueries({ queryKey: stageKeys.needs(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.needsComparison(sessionId) });
         queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+        queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
+      }
+
+      if (eventName === 'session.needs_reveal_ready') {
+        console.log('[UnifiedSessionScreen] Needs reveal ready');
+        queryClient.invalidateQueries({ queryKey: stageKeys.needs(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.needsComparison(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+        queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
       }
 
       if (eventName === 'session.common_ground_ready') {
@@ -1062,6 +1066,7 @@ export function UnifiedSessionScreen({
       showFeelHeardPanel: shouldShowFeelHeard,
       showShareSuggestionPanel: shouldShowShareSuggestion,
       showNeedsReviewPanel: shouldShowNeedsReview,
+      showNeedsSharePanel: shouldShowNeedsShare,
       showCommonGroundPanel: shouldShowCommonGround,
     },
   } = useChatUIState({
@@ -1114,6 +1119,7 @@ export function UnifiedSessionScreen({
     allNeedsConfirmed,
     needsAvailable: (needs?.length ?? 0) > 0,
     needsShared: (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsShared === true,
+    needsRevealReady: (needsComparisonData?.myNeeds?.length ?? 0) > 0 && (needsComparisonData?.partnerNeeds?.length ?? 0) > 0,
     hasConfirmedNeedsLocal: completedActions.has('confirmed-needs'),
     commonGroundCount: commonGround?.length ?? 0,
     commonGroundAvailable: (needsComparisonData?.myNeeds?.length ?? 0) > 0 && (needsComparisonData?.partnerNeeds?.length ?? 0) > 0,
@@ -1226,7 +1232,7 @@ export function UnifiedSessionScreen({
   const readyToShowEmpathy = shouldShowEmpathyPanel;
   const readyToShowFeelHeard = shouldShowFeelHeard;
   const readyToShowShareSuggestion = shouldShowShareSuggestion;
-  const readyToShowNeedsReview = shouldShowNeedsReview;
+  const readyToShowNeedsReview = shouldShowNeedsReview || shouldShowNeedsShare;
   const readyToShowCommonGround = shouldShowCommonGround;
   const readyToShowWaitingBanner = shouldShowWaitingBanner;
 
@@ -2211,6 +2217,7 @@ export function UnifiedSessionScreen({
               <TouchableOpacity
                 style={styles.needsReviewButton}
                 onPress={() => {
+                  setShowActivityMenu(false);
                   setNeedsDrawerMode('needs');
                   setShowNeedsDrawer(true);
                 }}
@@ -2219,6 +2226,44 @@ export function UnifiedSessionScreen({
               >
                 <Text style={styles.needsReviewButtonText}>
                   Review and confirm your needs
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </Animated.View>
+        );
+
+      case 'needs-share':
+        return (
+          <Animated.View
+            style={{
+              opacity: needsReviewAnim,
+              maxHeight: needsReviewAnim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0, 100],
+              }),
+              transform: [{
+                translateY: needsReviewAnim.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [20, 0],
+                }),
+              }],
+              overflow: 'hidden',
+            }}
+            pointerEvents="auto"
+          >
+            <View style={styles.needsReviewContainer}>
+              <TouchableOpacity
+                style={styles.needsReviewButton}
+                onPress={() => {
+                  setShowActivityMenu(false);
+                  setNeedsDrawerMode('needs');
+                  setShowNeedsDrawer(true);
+                }}
+                activeOpacity={0.7}
+                testID="needs-share-button"
+              >
+                <Text style={styles.needsReviewButtonText}>
+                  Share my needs
                 </Text>
               </TouchableOpacity>
             </View>
@@ -2248,6 +2293,7 @@ export function UnifiedSessionScreen({
               <TouchableOpacity
                 style={styles.needsReviewButton}
                 onPress={() => {
+                  setShowActivityMenu(false);
                   setNeedsDrawerMode('comparison');
                   setShowNeedsDrawer(true);
                 }}
@@ -2683,15 +2729,6 @@ export function UnifiedSessionScreen({
               // 3. When API responds, replace optimistic with real message + AI response
               handleShareEmpathy(statementToShare);
             }
-          }}
-          onSendRefinement={(message) => {
-            const refined =
-              message.trim().toLowerCase().startsWith('refine empathy draft')
-                ? message
-                : `Refine empathy draft: ${message}`;
-            // Prefix to make intent clear to the AI/prompt that this is a draft update
-            sendMessage(refined);
-            setShowEmpathyDrawer(false);
           }}
           onClose={() => setShowEmpathyDrawer(false)}
         />

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -616,7 +616,7 @@ describe('Needs Review Panel Visibility', () => {
     expect(result.panels.showNeedsReviewPanel).toBe(false);
   });
 
-  it('still shows after needs are confirmed so the user can share explicitly', () => {
+  it('shows needs-share after needs are confirmed so the user can share explicitly', () => {
     const inputs = createInputs({
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
@@ -628,8 +628,9 @@ describe('Needs Review Panel Visibility', () => {
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showNeedsReviewPanel).toBe(true);
-    expect(result.aboveInputPanel).toBe('needs-review');
+    expect(result.panels.showNeedsReviewPanel).toBe(false);
+    expect(result.panels.showNeedsSharePanel).toBe(true);
+    expect(result.aboveInputPanel).toBe('needs-share');
   });
 
   it('does not show when needs are already shared', () => {

--- a/mobile/src/utils/__tests__/getWaitingStatus.test.ts
+++ b/mobile/src/utils/__tests__/getWaitingStatus.test.ts
@@ -253,14 +253,14 @@ describe('Priority 4: Stage 2 (Empathy)', () => {
 // ============================================================================
 
 describe('Priority 5: Stage 3 (Needs)', () => {
-  it('returns needs-pending when all needs confirmed but no common ground yet', () => {
+  it('returns needs-waiting-for-partner when needs are shared but reveal is not ready yet', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.NEED_MAPPING,
-      needs: { allConfirmed: true },
+      needs: { allConfirmed: true, shared: true, revealReady: false },
       commonGround: { count: 0 },
     });
 
-    expect(computeWaitingStatus(inputs)).toBe('needs-pending');
+    expect(computeWaitingStatus(inputs)).toBe('needs-waiting-for-partner');
   });
 
   it('does not return needs-pending when in Stage 2 (stage gate)', () => {

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -35,6 +35,7 @@ export type AboveInputPanel =
   | 'feel-heard' // Feel heard confirmation panel
   | 'share-suggestion' // Share suggestion from reconciler (Subject side)
   | 'needs-review' // Needs review panel (Stage 3: confirm identified needs)
+  | 'needs-share' // Needs share panel (Stage 3: consent to reveal own confirmed needs)
   | 'needs-reveal-validation' // Needs reveal validation panel (Stage 3)
   | 'waiting-banner' // General waiting banner
   | 'compact-agreement-bar' // Compact agreement bar during onboarding
@@ -106,6 +107,7 @@ export interface ChatUIStateInputs extends WaitingStatusInputs {
   needsAvailable: boolean; // Needs have been extracted and are available for review
   allNeedsConfirmed: boolean; // All identified needs confirmed by user
   needsShared: boolean; // User has consented to share needs
+  needsRevealReady: boolean; // Both users have shared and comparison can be shown
   hasConfirmedNeedsLocal: boolean; // Local latch to prevent panel flash after confirming
 
   // Stage 3: Needs reveal validation. These field names are kept as
@@ -147,6 +149,7 @@ export interface ChatUIState {
     showFeelHeardPanel: boolean;
     showShareSuggestionPanel: boolean;
     showNeedsReviewPanel: boolean;
+    showNeedsSharePanel: boolean;
     showCommonGroundPanel: boolean;
     showWaitingBanner: boolean;
     showCompactAgreementBar: boolean;
@@ -349,7 +352,6 @@ function computeShowNeedsReviewPanel(inputs: ChatUIStateInputs): boolean {
     needsAvailable,
     allNeedsConfirmed,
     needsShared,
-    hasConfirmedNeedsLocal,
     sessionStatus,
   } = inputs;
 
@@ -362,18 +364,33 @@ function computeShowNeedsReviewPanel(inputs: ChatUIStateInputs): boolean {
     return false;
   }
 
-  // Local latch: once the user shares, hide panel immediately.
-  if (hasConfirmedNeedsLocal && needsShared) {
-    return false;
-  }
-
   // Already shared - reveal/waiting state owns the next step.
-  if (needsShared) {
+  if (needsShared || allNeedsConfirmed) {
     return false;
   }
 
   // Must have needs to show
   return needsAvailable;
+}
+
+function computeShowNeedsSharePanel(inputs: ChatUIStateInputs): boolean {
+  const {
+    myStage,
+    needsAvailable,
+    allNeedsConfirmed,
+    needsShared,
+    needsRevealReady,
+    hasConfirmedNeedsLocal,
+    sessionStatus,
+  } = inputs;
+
+  if (sessionStatus === SessionStatus.RESOLVED) return false;
+
+  const currentStage = myStage ?? Stage.ONBOARDING;
+  if (currentStage !== Stage.NEED_MAPPING) return false;
+  if (!needsAvailable || !allNeedsConfirmed) return false;
+  if (needsShared || needsRevealReady || hasConfirmedNeedsLocal) return false;
+  return true;
 }
 
 /**
@@ -385,6 +402,7 @@ function computeShowNeedsRevealValidationPanel(inputs: ChatUIStateInputs): boole
   const {
     myStage,
     commonGroundAvailable,
+    needsRevealReady,
     commonGroundNoOverlap,
     commonGroundAllConfirmedByMe,
     commonGroundAllConfirmedByBoth,
@@ -409,6 +427,10 @@ function computeShowNeedsRevealValidationPanel(inputs: ChatUIStateInputs): boole
   // Already confirmed by both or by me - no need to show
   if (commonGroundAllConfirmedByBoth || commonGroundAllConfirmedByMe) {
     return false;
+  }
+
+  if (needsRevealReady) {
+    return true;
   }
 
   // Legacy no-overlap state is treated as validation-ready for compatibility.
@@ -475,12 +497,17 @@ function computeAboveInputPanel(
     return 'needs-review';
   }
 
-  // Priority 7: Needs reveal validation panel (Stage 3)
+  // Priority 7: Needs share panel (Stage 3)
+  if (panels.showNeedsSharePanel) {
+    return 'needs-share';
+  }
+
+  // Priority 8: Needs reveal validation panel (Stage 3)
   if (panels.showCommonGroundPanel) {
     return 'needs-reveal-validation';
   }
 
-  // Priority 8: Waiting banner
+  // Priority 9: Waiting banner
   if (panels.showWaitingBanner) {
     return 'waiting-banner';
   }
@@ -540,6 +567,14 @@ function computeShouldHideInput(
     return true;
   }
 
+  if (
+    aboveInputPanel === 'needs-review' ||
+    aboveInputPanel === 'needs-share' ||
+    aboveInputPanel === 'needs-reveal-validation'
+  ) {
+    return true;
+  }
+
   // Note: hasUnviewedSharedContext no longer hides input.
   // The notification popup already surfaces the shared context to the user,
   // so requiring them to also open the Activity menu is unnecessary friction.
@@ -555,6 +590,15 @@ function computeShouldHideInput(
     inputs.empathyDraft === undefined &&
     inputs.empathyStatus === undefined &&
     !hasShareSuggestion
+  ) {
+    return true;
+  }
+
+  if (
+    currentStage === Stage.NEED_MAPPING &&
+    inputs.needsShared &&
+    !inputs.needsRevealReady &&
+    !inputs.commonGroundAvailable
   ) {
     return true;
   }
@@ -604,6 +648,7 @@ export function computeChatUIState(inputs: ChatUIStateInputs): ChatUIState {
   const showFeelHeardPanel = computeShowFeelHeardPanel(inputs);
   const showShareSuggestionPanel = computeShowShareSuggestionPanel(inputs);
   const showNeedsReviewPanel = computeShowNeedsReviewPanel(inputs);
+  const showNeedsSharePanel = computeShowNeedsSharePanel(inputs);
   const showCommonGroundPanel = computeShowNeedsRevealValidationPanel(inputs);
   const showWaitingBanner = computeShouldShowWaitingBanner(waitingStatus);
   const showCompactAgreementBar = isInOnboardingUnsigned;
@@ -616,6 +661,7 @@ export function computeChatUIState(inputs: ChatUIStateInputs): ChatUIState {
     showFeelHeardPanel,
     showShareSuggestionPanel,
     showNeedsReviewPanel,
+    showNeedsSharePanel,
     showCommonGroundPanel,
     showWaitingBanner,
     showCompactAgreementBar,
@@ -704,6 +750,7 @@ export function createDefaultChatUIStateInputs(): ChatUIStateInputs {
     needsAvailable: false,
     allNeedsConfirmed: false,
     needsShared: false,
+    needsRevealReady: false,
     hasConfirmedNeedsLocal: false,
 
     // Stage 3: Needs reveal validation

--- a/mobile/src/utils/getWaitingStatus.ts
+++ b/mobile/src/utils/getWaitingStatus.ts
@@ -22,6 +22,7 @@ export type WaitingStatusState =
   | 'empathy-pending' // Stage 2: Waiting for partner to share empathy
   | 'partner-considering-perspective' // Stage 2: Partner felt heard, now building empathy for you (good alignment)
   | 'needs-pending' // Stage 3: Waiting for partner to confirm needs
+  | 'needs-waiting-for-partner' // Stage 3: User shared needs, waiting for partner to share
   | 'common-ground-pending' // Stage 3: Waiting for partner to confirm common ground
   | 'ranking-pending' // Stage 4: Waiting for partner to submit ranking
   | 'partner-signed' // Partner has signed compact (transient)
@@ -76,6 +77,8 @@ export interface WaitingStatusInputs {
   // Stage 3: Needs confirmation state
   needs: {
     allConfirmed: boolean;
+    shared?: boolean;
+    revealReady?: boolean;
   };
 
   // Stage 3: Common ground discovery
@@ -219,8 +222,13 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
 
   // --- Priority 5: Stage 3 (Needs) ---
   // Only show needs-pending when in Stage 3, needs confirmed, and no common ground yet
-  if (myStage === Stage.NEED_MAPPING && needs.allConfirmed && commonGround.count === 0) {
-    return 'needs-pending';
+  if (
+    myStage === Stage.NEED_MAPPING &&
+    needs.shared &&
+    !needs.revealReady &&
+    commonGround.count === 0
+  ) {
+    return 'needs-waiting-for-partner';
   }
 
   // Transition: Partner confirmed needs and common ground discovered

--- a/shared/src/dto/realtime.ts
+++ b/shared/src/dto/realtime.ts
@@ -90,6 +90,9 @@ export type SessionEventType =
   // Stage 3: Need Mapping events
   | 'partner.needs_confirmed' // Partner confirmed their identified needs
   | 'partner.needs_shared' // Partner consented to share needs
+  | 'partner.needs_validated' // Partner validated or rejected side-by-side needs
+  | 'session.needs_extracted' // AI extracted candidate needs for one participant
+  | 'session.needs_reveal_ready' // Both participants shared needs; comparison can be revealed
   // Stage 4: Strategic Repair events
   | 'partner.ranking_submitted'
   | 'partner.ready_to_rank'

--- a/shared/src/enums.ts
+++ b/shared/src/enums.ts
@@ -57,7 +57,7 @@ export const STAGE_FRIENDLY_NAMES: Record<Stage, string> = {
   [Stage.WITNESS]: 'Your Story',
   [Stage.PERSPECTIVE_STRETCH]: 'Walking in Their Shoes',
   [Stage.NEED_MAPPING]: 'What Matters Most',
-  [Stage.STRATEGIC_REPAIR]: 'Moving Forward Together',
+  [Stage.STRATEGIC_REPAIR]: 'What Comes Next',
   [Stage.INFORMED_EMPATHY]: 'Deeper Understanding',
 };
 


### PR DESCRIPTION
## Summary

This PR implements the James/Catherine gold-session reliability pass from `docs/product/james-catherine-gold-session-bug-handoff-2026-05-04.md`.

The internal reviewer/reconciler wording concern is intentionally deferred to a separate product-copy pass. This PR only changes copy where needed to avoid planner-text leaks and forced "together"/repair assumptions.

## Bug List Covered

- E2E setup/cache drift: explicit E2E URL params now override cached identity in the web runtime, and the handoff doc records that no-Clerk gold sessions should use the `8082` E2E bundle.
- Stage 2 -> Stage 3 realtime isolation: stage completion events no longer broadcast one representative transition message; clients only insert messages addressed to the current user and otherwise refetch state/messages/progress.
- Stage 3 reveal gates: needs comparison now depends on both users having confirmed/consented needs, and the chat-side "I'm ready" path follows the same backend gate contract as the CTA flow.
- Stage 3 UI/input state: added explicit review, share, waiting-for-partner, and reveal-validation states; chat input hides when the valid next action is a gate CTA or waiting.
- Prompt/planner safety: tightened Stage 3 instructions, added visible output scrubbing for planner phrases, removed forced "way forward together" framing, and constrained James share suggestions to preserve accountability and safety.
- Refinement control messages: drawer refinement no longer injects `Refine empathy draft:` into the normal chat timeline/history.
- Streaming cleanup: terminal stream paths invalidate Stage 3 state and remove empty placeholders more consistently.
- Activity drawer UX: current gate drawers close/override the exchange-history drawer, and the drawer close action is now a full-width accessible target.

## Reviewer Ask

Slam Paws: please review this specifically against the bug list in the handoff doc and verify that the issues found in the James/Catherine run are actually fixed, not just covered by optimistic UI changes. In particular, please check the live Stage 2 -> Stage 3 transition, Catherine not seeing James-addressed prompts, Stage 3 reveal gates, refinement-history leakage, and no-agreement copy posture.

## Validation

- `npm --workspace backend test -- stage3 stage2 --runInBand`
- `npm --workspace mobile test -- chatUIState getWaitingStatus --runInBand`
- `npm --workspace backend run check`
- `npm --workspace mobile run check`
- `git diff --check`

Not run in this pass: full two-browser James/Catherine E2E playthrough.
