### PR TITLE
Fix slam-bot false-positive Claude auth alerts

### DIFF
--- a/scripts/ec2-bot/scripts/run-claude.sh
+++ b/scripts/ec2-bot/scripts/run-claude.sh
@@ -134,7 +134,12 @@ if [ -n "$ERROR_MSG" ]; then
   exit 1
 fi
 
-if echo "$TAIL" | grep -qiE "login|sign in|authenticate|expired|unauthorized|APIError.*401"; then
+# Auth-failure detection: match only distinctive Claude CLI auth-error strings,
+# anchored to line start, in the last 50 lines (real failures abort at the end).
+# Avoids false positives from agent output that merely *mentions* words like
+# "login" or "expired" (e.g. reviewing code with `last_login_at`).
+TAIL_END=$(echo "$TAIL" | tail -50)
+if echo "$TAIL_END" | grep -qE "^(Error: )?(Invalid API key|Please run /login|Please run \`claude login\`|OAuth token (has )?expired|Credentials (file )?(are |is )?invalid|Authentication failed|Not authenticated|API Error: 401)"; then
   curl -s -X POST https://slack.com/api/chat.postMessage \
     -H "Authorization: Bearer $SLACK_BOT_TOKEN" -H "Content-Type: application/json" \
     -d "{\"channel\":\"$BOT_OPS_CHANNEL_ID\",\"text\":\"🚨 Slam Paws: Claude auth failed running '$COMMAND_SLUG'. SSH in and run 'claude' to re-authenticate.\"}"
@@ -142,7 +147,7 @@ if echo "$TAIL" | grep -qiE "login|sign in|authenticate|expired|unauthorized|API
   exit 1
 fi
 
-if echo "$TAIL" | grep -qiE "gh auth|token.*expired|Bad credentials"; then
+if echo "$TAIL_END" | grep -qE "^(Error: )?(gh auth|Bad credentials|HTTP 401: Bad credentials|GH_TOKEN.*expired)"; then
   curl -s -X POST https://slack.com/api/chat.postMessage \
     -H "Authorization: Bearer $SLACK_BOT_TOKEN" -H "Content-Type: application/json" \
     -d "{\"channel\":\"$BOT_OPS_CHANNEL_ID\",\"text\":\"🚨 Slam Paws: GitHub token expired running '$COMMAND_SLUG'. SSH in and update GH_TOKEN.\"}"


### PR DESCRIPTION
## Summary
- The auth-failure detector in `scripts/ec2-bot/scripts/run-claude.sh` greps agent output with a loose word-list (`login|sign in|authenticate|expired|unauthorized|APIError.*401`). Any agent run that *mentions* those words triggers a "🚨 Claude auth failed" alert to #bot-ops and aborts with exit 1, even though credentials are fine.
- Confirmed false positive earlier today: `ws-pr-reviewer` was reviewing code referencing `last_login_at` (Mixpanel property) — the word `login` matched and fired the alert. Same pattern caused 9 spurious alerts in `auth-failures.log` today.
- Tightened both the Claude and `gh` auth checks: anchored to line start, matching only distinctive CLI auth-error strings (`Invalid API key`, `Please run /login`, `OAuth token has expired`, `API Error: 401`, `Bad credentials`, etc.), and limited to the last 50 lines of output (real failures abort at the end).

## Test plan
- [ ] CI passes
- [ ] After merge: confirm scheduled workspace runs (`pr-reviewer`, `bug-fix`, `daily-strategy`) no longer post the 🚨 alert when their output mentions auth-related vocabulary
- [ ] Real auth failure path remains caught — verifiable next time the OAuth token genuinely expires (or by simulating with an invalid `~/.claude/.credentials.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)