### PR TITLE
[codex] Fix Adam/Eve gold session gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ backend/prisma/*.db-journal
 
 # Database snapshots
 backend/snapshots/snapshot-*.sql
+backend/.backups/
 
 # Secrets - never commit these
 *.pem
@@ -73,6 +74,7 @@ planning-docs-bundle.md
 .claude/settings.local.json
 .claude/*.local.md
 .claude/lisa-draft.md
+.claude/worktrees/
 .mcp.json
 claude-flow.config.json
 .swarm/

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -442,6 +442,8 @@ Generate a brief, specific suggestion for what ${subject.name} could share to he
 IMPORTANT GUIDELINES for the suggestion:
 - Never start with confrontational phrases like "Look," or "Listen,"
 - Focus on sharing ${subject.name}'s experience, not making claims about ${guesser.name}'s behavior
+- Do not say or imply what ${guesser.name} thinks, believes, or has already understood
+- Do not escalate ambiguity into permanent rupture, departure, rejection, or leaving unless ${subject.name} explicitly said that
 - Use "I" statements, never "you" accusations
 - Keep the tone warm and vulnerable, not defensive or aggressive
 

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -1898,6 +1898,8 @@ IMPORTANT PRINCIPLES:
 - Never suggest sharing sensitive information the person didn't already express
 - The suggested share focus should reference content ${context.subjectName} already shared in witnessing
 - Don't create new interpretations - only reference what was actually said
+- Phrase the suggested share focus as subject-owned context, not as what ${context.guesserName} thinks or has already understood
+- Do not frame the share focus as departure, rejection, or a permanent break unless ${context.subjectName} explicitly said that
 - Err on the side of OFFER_OPTIONAL rather than OFFER_SHARING - let people choose
 - If the gap is about context/history that wasn't shared, acknowledge that honestly`;
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "npm run set-local-ip && expo start",
     "start:clear": "npm run set-local-ip && expo start --clear",
+    "start:e2e": "EXPO_PUBLIC_E2E_MODE=true EXPO_PUBLIC_API_URL=http://localhost:3000 expo start --web --port 8082 --clear --no-dev",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",

--- a/mobile/src/components/ShareTopicDrawer.tsx
+++ b/mobile/src/components/ShareTopicDrawer.tsx
@@ -62,8 +62,8 @@ export function ShareTopicDrawer({
 
   // Action-specific suffix text
   const actionSuffix = action === 'OFFER_SHARING'
-    ? 'you share more about:'
-    : 'you might consider sharing about:';
+    ? 'sharing more about this:'
+    : 'sharing a little more about this:';
 
   const handleDecline = () => {
     // Show confirmation dialog before declining
@@ -123,8 +123,8 @@ export function ShareTopicDrawer({
 
             {/* Intro text */}
             <Text style={styles.intro}>
-              We reviewed what {partnerName} is imagining you are feeling,
-              noted some of the things you have talked about, and suggest that{' '}
+              There may be context that would help {partnerName} understand
+              this more accurately. You can choose whether you want help{' '}
               <Text style={[styles.actionText, { color: actionTextColor }]}>
                 {actionSuffix}
               </Text>

--- a/mobile/src/components/__tests__/ShareTopicDrawer.copy.test.ts
+++ b/mobile/src/components/__tests__/ShareTopicDrawer.copy.test.ts
@@ -10,4 +10,14 @@ describe('ShareTopicDrawer copy', () => {
 
     expect(source.toLowerCase()).not.toContain('internal reconciler');
   });
+
+  it('does not present partner interpretation as product truth', () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'ShareTopicDrawer.tsx'),
+      'utf8'
+    );
+
+    expect(source).toContain('There may be context that would help');
+    expect(source).not.toContain('what {partnerName} is imagining');
+  });
 });

--- a/mobile/src/config/waitingStatusConfig.ts
+++ b/mobile/src/config/waitingStatusConfig.ts
@@ -86,6 +86,18 @@ export const WAITING_STATUS_CONFIG: Record<NonNullable<WaitingStatusState>, Wait
     bannerSubtext: "Once they share, you'll both be able to reflect on what each other shared.",
   },
 
+  // Stage 2: User has validated partner's empathy; partner still needs to validate user's empathy.
+  'partner-validating-empathy': {
+    showBanner: true,
+    hideInput: true,
+    showInnerThoughts: true,
+    isActionRequired: false,
+    showSpinner: false,
+    showKeepChattingAction: true,
+    bannerText: (p) => `${p} is reviewing what you shared.`,
+    bannerSubtext: "Once they respond, you'll both be ready for the next step.",
+  },
+
   // Stage 2: System review is running; block input until the next action is known.
   'reconciler-analyzing': {
     showBanner: true,
@@ -205,6 +217,17 @@ export const WAITING_STATUS_CONFIG: Record<NonNullable<WaitingStatusState>, Wait
     showSpinner: false,
     showKeepChattingAction: false,
     bannerText: (p) => `${p} is reviewing common ground.`,
+  },
+
+  // Stage 3: User validated the side-by-side needs reveal; partner still needs to validate.
+  'partner-validating-needs': {
+    showBanner: true,
+    hideInput: true,
+    showInnerThoughts: false,
+    isActionRequired: false,
+    showSpinner: false,
+    showKeepChattingAction: false,
+    bannerText: (p) => `${p} is reviewing the needs you both shared.`,
   },
 
   // Stage 4: Waiting for partner to submit strategy rankings

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -86,6 +86,8 @@ export interface UseChatUIStateProps {
     hasNewSharedContext?: boolean;
     hasUnviewedSharedContext?: boolean;
     myAttempt?: { status?: string; content?: string };
+    myValidation?: { validated?: boolean };
+    partnerValidated?: boolean;
     messageCountSinceSharedContext?: number;
   } | undefined;
   empathyDraftData: {
@@ -231,6 +233,8 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
       hasNewSharedContext: empathyStatusData.hasNewSharedContext,
       myAttemptStatus: empathyStatusData.myAttempt?.status,
     } : undefined,
+    myValidation: empathyStatusData?.myValidation,
+    partnerValidated: empathyStatusData?.partnerValidated,
     empathyDraft: empathyDraftData ? {
       alreadyConsented: empathyDraftData.alreadyConsented,
     } : undefined,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1207,6 +1207,8 @@ export function UnifiedSessionScreen({
         status: empathyStatusData.myAttempt.status,
         content: empathyStatusData.myAttempt.content,
       } : undefined,
+      myValidation: sharingStatus.myValidation,
+      partnerValidated: sharingStatus.partnerValidated,
       messageCountSinceSharedContext: empathyStatusData.messageCountSinceSharedContext,
     } : undefined,
     empathyDraftData: empathyDraftData ? {
@@ -1337,7 +1339,7 @@ export function UnifiedSessionScreen({
   const readyToShowEmpathy = shouldShowEmpathyPanel;
   const readyToShowFeelHeard = shouldShowFeelHeard;
   const readyToShowShareSuggestion = shouldShowShareSuggestion;
-  const readyToShowNeedsReview = shouldShowNeedsReview || shouldShowNeedsShare;
+  const readyToShowNeedsReview = shouldShowNeedsReview || shouldShowNeedsShare || shouldShowCommonGround;
   const readyToShowCommonGround = shouldShowCommonGround;
   const readyToShowWaitingBanner = shouldShowWaitingBanner;
 
@@ -1823,6 +1825,14 @@ export function UnifiedSessionScreen({
   const handleShareInvitation = useCallback(async (): Promise<boolean> => {
     if (!invitationUrl) return false;
     try {
+      if (process.env.EXPO_PUBLIC_E2E_MODE === 'true') {
+        console.log('[UnifiedSessionScreen] E2E mode: treating invitation as shared', {
+          sessionId,
+          invitationUrl,
+        });
+        return true;
+      }
+
       const shareMessage = buildInvitationShareText(invitationUrl);
       const result = await Share.share(
         Platform.OS === 'web'
@@ -2760,8 +2770,7 @@ export function UnifiedSessionScreen({
           hideInput={
             // Use derived hideInput logic from useChatUIState
             // Never hide when empathy review panel is showing (user still needs to interact)
-            // Never hide when needs/common ground panels are showing (Stage 3 interaction)
-            !shouldShowEmpathyPanel && !shouldShowNeedsReview && !shouldShowCommonGround && derivedShouldHideInput
+            !shouldShowEmpathyPanel && derivedShouldHideInput
           }
           validationCards={validationCards}
           onValidateAccurate={handleValidationAccurate}
@@ -3056,8 +3065,12 @@ export function UnifiedSessionScreen({
                   styles.invitationModalButton,
                   styles.invitationModalButtonPrimary,
                 ]}
-                onPress={() => {
-                  void handleShareInvitation();
+                onPress={async () => {
+                  const didShare = await handleShareInvitation();
+                  if (didShare) {
+                    setInvitationPanelDismissed(true);
+                    handleConfirmInvitationMessage();
+                  }
                 }}
                 accessibilityRole="button"
                 accessibilityLabel="Share invitation"

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -344,6 +344,31 @@ describe('Input Hiding (shouldHideInput)', () => {
     expect(result.shouldHideInput).toBe(true);
   });
 
+  it('hides input after validating no-overlap revealed needs while partner has not', () => {
+    const inputs = createInputs({
+      myStage: Stage.NEED_MAPPING,
+      compactMySigned: true,
+      myProgress: { stage: Stage.NEED_MAPPING },
+      allNeedsConfirmed: true,
+      needsShared: true,
+      needsRevealReady: true,
+      needs: { allConfirmed: true, shared: true, revealReady: true },
+      commonGroundAvailable: true,
+      commonGroundCount: 0,
+      commonGround: {
+        count: 0,
+        allConfirmedByMe: true,
+        allConfirmedByBoth: false,
+      },
+      commonGroundAllConfirmedByMe: true,
+      commonGroundAllConfirmedByBoth: false,
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.waitingStatus).toBe('partner-validating-needs');
+    expect(result.shouldHideInput).toBe(true);
+  });
+
   it('shows input during normal conversation', () => {
     const inputs = createInputs({
       myStage: Stage.WITNESS,

--- a/mobile/src/utils/__tests__/getWaitingStatus.test.ts
+++ b/mobile/src/utils/__tests__/getWaitingStatus.test.ts
@@ -246,6 +246,21 @@ describe('Priority 4: Stage 2 (Empathy)', () => {
 
     expect(computeWaitingStatus(inputs)).toBe('partner-shared-empathy');
   });
+
+  it('returns partner-validating-empathy after I validate partner and wait for partner to validate me', () => {
+    const inputs = createDefaultInputs({
+      myStage: Stage.PERSPECTIVE_STRETCH,
+      partnerStage: Stage.PERSPECTIVE_STRETCH,
+      hasPartnerEmpathy: true,
+      empathyStatus: {
+        myAttemptStatus: 'REVEALED',
+      },
+      myValidation: { validated: true },
+      partnerValidated: false,
+    });
+
+    expect(computeWaitingStatus(inputs)).toBe('partner-validating-empathy');
+  });
 });
 
 // ============================================================================
@@ -292,6 +307,20 @@ describe('Priority 5: Stage 3 (Needs)', () => {
     });
 
     expect(computeWaitingStatus(inputs)).toBe('partner-confirmed-needs');
+  });
+
+  it('returns partner-validating-needs after I validate revealed needs and wait for partner', () => {
+    const inputs = createDefaultInputs({
+      myStage: Stage.NEED_MAPPING,
+      needs: { allConfirmed: true, shared: true, revealReady: true },
+      commonGround: {
+        count: 0,
+        allConfirmedByMe: true,
+        allConfirmedByBoth: false,
+      },
+    });
+
+    expect(computeWaitingStatus(inputs)).toBe('partner-validating-needs');
   });
 });
 

--- a/mobile/src/utils/getWaitingStatus.ts
+++ b/mobile/src/utils/getWaitingStatus.ts
@@ -21,9 +21,11 @@ export type WaitingStatusState =
   | 'witness-pending' // Stage 1: Waiting for partner to complete witness
   | 'empathy-pending' // Stage 2: Waiting for partner to share empathy
   | 'partner-considering-perspective' // Stage 2: Partner felt heard, now building empathy for you (good alignment)
+  | 'partner-validating-empathy' // Stage 2: User validated partner empathy, waiting for partner to validate theirs
   | 'needs-pending' // Stage 3: Waiting for partner to confirm needs
   | 'needs-waiting-for-partner' // Stage 3: User shared needs, waiting for partner to share
   | 'common-ground-pending' // Stage 3: Waiting for partner to confirm common ground
+  | 'partner-validating-needs' // Stage 3: User validated revealed needs, waiting for partner
   | 'ranking-pending' // Stage 4: Waiting for partner to submit ranking
   | 'partner-signed' // Partner has signed compact (transient)
   | 'partner-completed-witness' // Partner completed witness stage (transient)
@@ -60,6 +62,10 @@ export interface WaitingStatusInputs {
     myAttemptStatus?: string; // 'REVEALED', 'NEEDS_WORK', etc.
     myAttemptRevisionCount?: number; // Number of times empathy was revised
   } | undefined;
+  myValidation?: {
+    validated?: boolean;
+  } | undefined;
+  partnerValidated?: boolean;
 
   // Stage 2: Empathy draft state
   empathyDraft: {
@@ -220,6 +226,18 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
     return 'partner-shared-empathy';
   }
 
+  // User has validated the partner's empathy attempt, but the partner has not
+  // validated the user's revealed attempt yet. There is no useful freeform
+  // user action here; the next gate belongs to the partner.
+  if (
+    myStage === Stage.PERSPECTIVE_STRETCH &&
+    empathyStatus?.myAttemptStatus === 'REVEALED' &&
+    inputs.myValidation?.validated &&
+    inputs.partnerValidated === false
+  ) {
+    return 'partner-validating-empathy';
+  }
+
   // --- Priority 5: Stage 3 (Needs) ---
   // User has confirmed their needs locally but has not shared them yet. Hide
   // freeform input while the review/share controls own the next step.
@@ -251,6 +269,19 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
   // Common ground confirmed by me, waiting for partner
   if (myStage === Stage.NEED_MAPPING && commonGround.count > 0 && commonGround.allConfirmedByMe && !commonGround.allConfirmedByBoth) {
     return 'common-ground-pending';
+  }
+
+  // Needs reveal validated by me, waiting for partner. This covers the current
+  // side-by-side needs reveal, including the no-overlap path where there are
+  // revealed needs but no generated CommonGround rows.
+  if (
+    myStage === Stage.NEED_MAPPING &&
+    needs.shared &&
+    needs.revealReady &&
+    commonGround.allConfirmedByMe &&
+    !commonGround.allConfirmedByBoth
+  ) {
+    return 'partner-validating-needs';
   }
 
   // --- Priority 6: Stage 4 (Strategies) ---

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev": "concurrently \"npm run dev:api\" \"sleep 2 && npm run dev:mobile\"",
     "dev:mobile": "npm --workspace mobile run start",
     "dev:mobile:clear": "npm --workspace mobile run start:clear",
+    "dev:mobile:e2e": "npm --workspace mobile run start:e2e",
     "dev:api": "npm run dev:watch --workspace=backend",
     "test": "npm --workspaces run test --if-present",
     "check": "npm --workspaces run check --if-present",


### PR DESCRIPTION
## Summary

- Fixes gold-session gate handling so Stage 2/3 waiting states hide chat input when the next action belongs to a partner or structured milestone.
- Fixes the Stage 3 needs reveal CTA animation target so `Review needs together` remains clickable.
- Neutralizes Stage 2 share-suggestion copy/prompting to avoid presenting partner interpretation as product truth.
- Adds a deterministic local E2E mobile web start script for `localhost:8082`.

## Root Cause

- Stage 3 reveal reused the needs panel animation, but the animation target omitted the reveal-validation panel, leaving the CTA visually present with a collapsed hit target.
- Some waiting gates did not model post-validation partner-owned states, and the screen-level hide-input override let Stage 3 milestone panels keep freeform chat visible.
- Share-suggestion UX and prompts could overstate the partner perspective before the normal validation flow had earned it.

## Validation

- `npm --workspace mobile test -- getWaitingStatus chatUIState ShareTopicDrawer.copy --runInBand`
- `npm --workspace mobile run check`
- `npm --workspace backend run check`
- `npm --workspace backend test -- reconciler --runInBand`
