### PR TITLE
Fix Stage 4 strategy readiness sync

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -39,6 +39,7 @@ import { getMilestoneContext, getSharedContentContext } from '../services/shared
 import { CONTEXT_WINDOW, trimConversationHistory } from '../utils/token-budget';
 import { estimateContextSizes, finalizeTurnMetrics, recordContextSizes } from '../services/llm-telemetry';
 import { captureProposedNeedsForUser } from '../services/needs';
+import { filterNewStrategiesAgainstExisting } from '../utils/strategy-dedupe';
 
 // ============================================================================
 // Helpers
@@ -2050,15 +2051,20 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       // Deduplicate: check existing strategies to avoid duplicates from re-proposals
       const existingStrategies = await prisma.strategyProposal.findMany({
         where: { sessionId, createdByUserId: user.id },
-        select: { description: true },
+        select: { id: true, description: true },
       });
-      const existingDescriptions = new Set(existingStrategies.map((s) => s.description.toLowerCase()));
 
-      const newStrategies = metadata.proposedStrategies.filter(
-        (desc) => !existingDescriptions.has(desc.toLowerCase())
+      const { newStrategies, supersededIds } = filterNewStrategiesAgainstExisting(
+        existingStrategies,
+        metadata.proposedStrategies
       );
 
       if (newStrategies.length > 0) {
+        if (supersededIds.length > 0) {
+          await prisma.strategyProposal.deleteMany({
+            where: { id: { in: supersededIds } },
+          });
+        }
         await prisma.strategyProposal.createMany({
           data: newStrategies.map((description) => ({
             sessionId,
@@ -2069,6 +2075,14 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
           })),
         });
         logger.info(`[sendMessageStream:${requestId}] Created ${newStrategies.length} strategy proposals for user ${user.id}`);
+
+        const { publishSessionEvent } = await import('../services/realtime');
+        await publishSessionEvent(sessionId, 'session.strategies_updated', {
+          stage: 4,
+          updatedBy: user.id,
+          createdCount: newStrategies.length,
+          removedSupersededCount: supersededIds.length,
+        });
       }
     }
 

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -2060,23 +2060,24 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       );
 
       if (newStrategies.length > 0) {
-        if (supersededIds.length > 0) {
-          await prisma.strategyProposal.deleteMany({
-            where: { id: { in: supersededIds } },
+        await prisma.$transaction(async (tx) => {
+          if (supersededIds.length > 0) {
+            await tx.strategyProposal.deleteMany({
+              where: { id: { in: supersededIds } },
+            });
+          }
+          await tx.strategyProposal.createMany({
+            data: newStrategies.map((description) => ({
+              sessionId,
+              createdByUserId: user.id,
+              description,
+              needsAddressed: [],
+              source: 'AI_SUGGESTED' as const,
+            })),
           });
-        }
-        await prisma.strategyProposal.createMany({
-          data: newStrategies.map((description) => ({
-            sessionId,
-            createdByUserId: user.id,
-            description,
-            needsAddressed: [],
-            source: 'AI_SUGGESTED' as const,
-          })),
         });
         logger.info(`[sendMessageStream:${requestId}] Created ${newStrategies.length} strategy proposals for user ${user.id}`);
 
-        const { publishSessionEvent } = await import('../services/realtime');
         await publishSessionEvent(sessionId, 'session.strategies_updated', {
           stage: 4,
           updatedBy: user.id,

--- a/backend/src/controllers/session-state.ts
+++ b/backend/src/controllers/session-state.ts
@@ -33,6 +33,82 @@ interface CompactGates {
   signedAt?: string;
 }
 
+async function acceptPendingInvitationForE2ESession(
+  sessionId: string,
+  userId: string
+): Promise<boolean> {
+  if (process.env.E2E_AUTH_BYPASS !== 'true' || process.env.NODE_ENV === 'production') {
+    return false;
+  }
+
+  const invitation = await prisma.invitation.findFirst({
+    where: {
+      sessionId,
+      status: 'PENDING',
+      session: {
+        status: 'INVITED',
+        topicFrame: { not: null },
+        topicFrameConfirmedAt: { not: null },
+      },
+      NOT: { invitedById: userId },
+      messageConfirmed: true,
+      expiresAt: { gt: new Date() },
+    },
+    include: {
+      session: { select: { relationshipId: true } },
+    },
+  });
+
+  if (!invitation) {
+    return false;
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.relationshipMember.upsert({
+      where: {
+        relationshipId_userId: {
+          relationshipId: invitation.session.relationshipId,
+          userId,
+        },
+      },
+      create: {
+        relationshipId: invitation.session.relationshipId,
+        userId,
+      },
+      update: {},
+    });
+
+    await tx.invitation.update({
+      where: { id: invitation.id },
+      data: { status: 'ACCEPTED', acceptedAt: new Date() },
+    });
+
+    await tx.session.update({
+      where: { id: sessionId },
+      data: { status: 'ACTIVE' },
+    });
+
+    await tx.stageProgress.upsert({
+      where: { sessionId_userId_stage: { sessionId, userId, stage: 0 } },
+      create: { sessionId, userId, stage: 0, status: 'IN_PROGRESS' },
+      update: {},
+    });
+
+    await tx.userVessel.upsert({
+      where: { userId_sessionId: { userId, sessionId } },
+      create: { sessionId, userId },
+      update: {},
+    });
+  });
+
+  logger.info('[getSessionState] E2E auto-accepted pending session invitation', {
+    sessionId,
+    userId,
+    invitationId: invitation.id,
+  });
+  return true;
+}
+
 // ============================================================================
 // Main Controller
 // ============================================================================
@@ -126,6 +202,11 @@ export async function getSessionState(req: Request, res: Response): Promise<void
 
     // Check session exists
     if (!sessionWithRelations) {
+      const acceptedForE2E = await acceptPendingInvitationForE2ESession(sessionId, user.id);
+      if (acceptedForE2E) {
+        await getSessionState(req, res);
+        return;
+      }
       errorResponse(res, ErrorCode.NOT_FOUND, 'Session not found', 404);
       return;
     }

--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -160,6 +160,10 @@ export async function getStrategies(req: Request, res: Response): Promise<void> 
         const gates = p.gatesSatisfied as Record<string, unknown> | null;
         return gates?.readyToRank === true;
       });
+    const myProgress = allProgress.find((p) => p.userId === user.id);
+    const partnerProgress = allProgress.find((p) => p.userId !== user.id);
+    const myGates = myProgress?.gatesSatisfied as Record<string, unknown> | null;
+    const partnerGates = partnerProgress?.gatesSatisfied as Record<string, unknown> | null;
 
     const bothRanked = rankings.length >= 2;
 
@@ -179,6 +183,8 @@ export async function getStrategies(req: Request, res: Response): Promise<void> 
       strategies: shuffled,
       phase,
       aiSuggestionsAvailable: false,
+      myReadyToRank: myGates?.readyToRank === true,
+      partnerReadyToRank: partnerGates?.readyToRank === true,
     });
   } catch (error) {
     logger.error('[getStrategies] Error:', error);
@@ -1010,10 +1016,11 @@ export async function markReady(req: Request, res: Response): Promise<void> {
     }
 
     // Update gate
+    const readyAt = new Date().toISOString();
     const gatesSatisfied = {
       ...(progress?.gatesSatisfied as Record<string, unknown> | null || {}),
       readyToRank: true,
-      readyAt: new Date().toISOString(),
+      readyAt,
     } satisfies Prisma.InputJsonValue;
 
     await prisma.stageProgress.update({
@@ -1045,7 +1052,7 @@ export async function markReady(req: Request, res: Response): Promise<void> {
 
     successResponse(res, {
       ready: true,
-      readyAt: new Date().toISOString(),
+      readyAt,
       partnerReady,
       canStartRanking,
     });

--- a/backend/src/routes/__tests__/stage4.test.ts
+++ b/backend/src/routes/__tests__/stage4.test.ts
@@ -105,6 +105,10 @@ describe('Stage 4 API', () => {
         status: 'IN_PROGRESS',
         gatesSatisfied: {},
       });
+      (prisma.stageProgress.findMany as jest.Mock).mockResolvedValue([
+        { userId: mockUser.id, stage: 4, gatesSatisfied: { readyToRank: true } },
+        { userId: mockPartnerId, stage: 4, gatesSatisfied: null },
+      ]);
       // Mock returns only the selected fields (as Prisma would with select clause)
       (prisma.strategyProposal.findMany as jest.Mock).mockResolvedValue([
         {
@@ -132,6 +136,8 @@ describe('Stage 4 API', () => {
         expect.objectContaining({
           success: true,
           data: expect.objectContaining({
+            myReadyToRank: true,
+            partnerReadyToRank: false,
             strategies: expect.arrayContaining([
               expect.objectContaining({
                 id: expect.any(String),

--- a/backend/src/services/push.ts
+++ b/backend/src/services/push.ts
@@ -60,6 +60,10 @@ export const PUSH_MESSAGES: Record<SessionEvent, { title: string; body: string }
     title: 'Needs shared',
     body: 'Your partner shared their identified needs.',
   },
+  'session.strategies_updated': {
+    title: 'Ideas updated',
+    body: 'There are new ideas to review.',
+  },
   'partner.ranking_submitted': {
     title: 'Ranking submitted',
     body: 'Your partner submitted their strategy rankings.',

--- a/backend/src/services/realtime.ts
+++ b/backend/src/services/realtime.ts
@@ -38,6 +38,7 @@ export type SessionEvent = Extract<
   | 'partner.needs_shared'
   | 'partner.needs_validated'
   | 'session.needs_reveal_ready'
+  | 'session.strategies_updated'
   | 'partner.ranking_submitted'
   | 'partner.ready_to_rank'
   | 'partner.consent_granted'

--- a/backend/src/utils/__tests__/strategy-dedupe.test.ts
+++ b/backend/src/utils/__tests__/strategy-dedupe.test.ts
@@ -1,0 +1,44 @@
+import { filterNewStrategiesAgainstExisting, isSupersededStrategy } from '../strategy-dedupe';
+
+describe('strategy dedupe', () => {
+  it('marks shorter earlier proposal drafts as superseded by refined versions', () => {
+    expect(
+      isSupersededStrategy(
+        'Monthly low-stakes exploration plan where we pick one new experience together',
+        'Monthly low-stakes exploration plan where we pick one new experience together and Adam can say what feels exciting and what feels scary'
+      )
+    ).toBe(true);
+  });
+
+  it('keeps distinct proposals while returning superseded ids for replacements', () => {
+    const result = filterNewStrategiesAgainstExisting(
+      [
+        {
+          id: 'old-monthly',
+          description: 'Monthly low-stakes exploration plan where we pick one new experience together',
+        },
+        {
+          id: 'old-pause',
+          description: 'Use pause phrase when fear comes up during conversations about wanting or change',
+        },
+      ],
+      [
+        'Monthly low-stakes exploration plan where we pick one new experience together and Adam can say what feels exciting and what feels scary',
+        'Check in after one month',
+      ]
+    );
+
+    expect(result.supersededIds).toEqual(['old-monthly']);
+    expect(result.newStrategies).toHaveLength(2);
+  });
+
+  it('drops exact duplicates', () => {
+    const result = filterNewStrategiesAgainstExisting(
+      [{ id: 'existing', description: 'Check in after one month' }],
+      ['Check in after one month']
+    );
+
+    expect(result.supersededIds).toEqual([]);
+    expect(result.newStrategies).toEqual([]);
+  });
+});

--- a/backend/src/utils/strategy-dedupe.ts
+++ b/backend/src/utils/strategy-dedupe.ts
@@ -1,0 +1,42 @@
+export interface ExistingStrategyForDedupe {
+  id: string;
+  description: string;
+}
+
+function normalizeStrategy(value: string): string[] {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((word) => word.length > 2);
+}
+
+export function isSupersededStrategy(existing: string, next: string): boolean {
+  const existingWords = new Set(normalizeStrategy(existing));
+  const nextWords = new Set(normalizeStrategy(next));
+  if (existingWords.size === 0 || nextWords.size === 0) return false;
+  const intersection = [...existingWords].filter((word) => nextWords.has(word)).length;
+  const smallerSetSize = Math.min(existingWords.size, nextWords.size);
+  return intersection / smallerSetSize >= 0.65;
+}
+
+export function filterNewStrategiesAgainstExisting(
+  existingStrategies: ExistingStrategyForDedupe[],
+  proposedStrategies: string[]
+): { newStrategies: string[]; supersededIds: string[] } {
+  const supersededIds = new Set<string>();
+  const existingDescriptions = new Set(existingStrategies.map((s) => s.description.toLowerCase()));
+  const newStrategies = proposedStrategies.filter((desc) => {
+    if (existingDescriptions.has(desc.toLowerCase())) {
+      return false;
+    }
+    existingStrategies.forEach((existing) => {
+      if (isSupersededStrategy(existing.description, desc)) {
+        supersededIds.add(existing.id);
+      }
+    });
+    return true;
+  });
+
+  return { newStrategies, supersededIds: [...supersededIds] };
+}

--- a/docs/product/adam-eve-gold-session-stage4-issues-2026-05-05.md
+++ b/docs/product/adam-eve-gold-session-stage4-issues-2026-05-05.md
@@ -1,0 +1,462 @@
+# Adam/Eve Gold Session Stage 4 Issues - 2026-05-05
+
+Scenario: Adam/Eve successful-resolution benchmark
+Session ID: `cmoru5afm000bpxj2e3coa3ij`
+App: local E2E/no-Clerk web bundle on `http://localhost:8082`
+
+This report captures issues found during a two-Codex local E2E gold-session playthrough. This file starts with the Adam-side report. The Eve-side Codex session should append its section below.
+
+## Adam Side: Invitor
+
+Role: Adam, session creator/invitor
+Browser URL: `http://localhost:8082/session/cmoru5afm000bpxj2e3coa3ij?e2e-user-id=cmorpyyqi0002pxnt18abhy7t&e2e-user-email=adam@e2e.test`
+Partner: Eve, invitation acceptor
+
+### Summary
+
+This Adam/Eve run got farther than the previous Adam/Eve report in `docs/product/adam-eve-gold-session-issues.md`. Stage 3 completed for both users: needs were captured, confirmed, shared, validated, and both users reached Stage 4. That is a meaningful improvement over the earlier Adam-side blocker where `Review needs together` rendered but could not complete the Stage 3 validation gate.
+
+The run stopped in Stage 4. The UI showed `What Comes Next` and an `Ideas So Far` card, but Adam could not mark himself ready to rank. The visible card said strategies were still being gathered and rendered `Ready to Rank`, but the button behaved as inert/disabled. DB state contradicted the UI: six `StrategyProposal` rows existed, Eve already had `readyToRank: true`, and Adam's Stage 4 progress remained `IN_PROGRESS` with `gates: null`. Because Stage 4 ranking requires both users' `readyToRank` gates, Eve could not rank either.
+
+### Comparison Against Previous Gold-Run Notes
+
+Previous notes reviewed:
+- `docs/product/adam-eve-gold-session-issues.md`
+- `docs/product/james-catherine-gold-session-issues.md`
+- `docs/product/james-catherine-gold-session-bug-handoff-2026-05-04.md`
+- `docs/product/gold-flow-next-session-plan.md`
+- `docs/product/stage-4-tending-technical-spec.md`
+
+Fixed or improved in this Adam-side run:
+- Stage 3 completed through the intended gates for both users.
+- Adam's Stage 3 gates ended with `needsCaptured`, `needsConfirmed`, `needsShared`, and `needsValidated`.
+- Eve's Stage 3 gates also ended with `needsCaptured`, `needsConfirmed`, `needsShared`, and `needsValidated`.
+- Both users advanced to Stage 4 / `What Comes Next`.
+- The side-by-side needs reveal used needs language, not AI-authored common-ground truth.
+- No cross-user private prompt leak was observed on Adam's side.
+
+Still open from previous runs:
+- Current gate clarity remains weak. Old prompts and old stage separators remain near the bottom of the chat history, while the actual current action is presented as a small card near the input.
+- Chat input can remain visible in states where the app is not asking for chat input.
+- Realtime/cache state remains suspect: browser state can lag behind DB progress or show stale strategy counts.
+
+New issue from this Adam-side run:
+- Stage 4 strategy readiness is blocked because Adam's UI does not submit `POST /sessions/:id/strategies/ready` even though strategies exist and the card says `Ready to Rank`.
+
+### Current DB State At Stop
+
+Checked from local Prisma against `SESSION_ID=cmoru5afm000bpxj2e3coa3ij`.
+
+Session:
+- `status: ACTIVE`
+
+Adam:
+- Stage 0: `COMPLETED`
+- Stage 1: `COMPLETED`
+- Stage 2: `COMPLETED`, `empathyValidated: true`
+- Stage 3: `COMPLETED`, gates include:
+  - `needsCaptured: true`
+  - `needsConfirmed: true`
+  - `needsShared: true`
+  - `needsValidated: true`
+- Stage 4: `IN_PROGRESS`, `gates: null`
+
+Eve:
+- Stage 0: `COMPLETED`
+- Stage 1: `COMPLETED`
+- Stage 2: `COMPLETED`, `empathyValidated: true`
+- Stage 3: `COMPLETED`, gates include:
+  - `needsCaptured: true`
+  - `needsConfirmed: true`
+  - `needsShared: true`
+  - `needsValidated: true`
+- Stage 4: `IN_PROGRESS`, gates include:
+  - `readyToRank: true`
+  - `readyAt: 2026-05-05T00:02:34.533Z`
+
+Strategy state:
+- Six `StrategyProposal` rows existed.
+- No `StrategyRanking` rows existed.
+
+Strategy proposal descriptions in DB:
+- Monthly low-stakes exploration plan where we pick one new experience together (day trip, class, neighborhood visit, or weekend away)
+- Before deciding anything bigger, Adam shares what feels exciting and what feels scary
+- Use pause phrase "I am scared but I am still here" when fear comes up during conversations about wanting or change
+- Monthly low-stakes exploration plan where we pick one new experience together (day trip, class, neighborhood visit, or weekend away) and Adam can say what feels exciting and what feels scary before deciding anything bigger
+- Use pause phrase "I am scared but I am still here" so fear doesn't become shutdown and wanting doesn't become threat
+- Check in after one month, after trying one small exploration and using the pause phrase at least once
+
+### Issue 1: Adam Cannot Mark Ready To Rank Despite Existing Strategies
+
+Type: Stage 4 UI/backend state sync
+Severity: High
+
+What happened:
+Adam reached Stage 4 and the UI showed:
+- `What Comes Next`
+- `Ideas So Far`
+- `Strategies are being gathered from your conversation...`
+- `Ready to Rank`
+
+The `Ready to Rank` affordance did not submit Adam's readiness. After activation attempts and reloads, Adam's Stage 4 DB row still had `gates: null`.
+
+Evidence:
+- Browser showed Stage 4 / `What Comes Next`.
+- Browser showed `Ready to Rank`, but the surrounding copy still said strategies were being gathered.
+- DB had six `StrategyProposal` rows for the session.
+- DB had Eve Stage 4 `gates.readyToRank: true`.
+- DB had Adam Stage 4 `gates: null`.
+- DB had no `StrategyRanking` rows.
+
+Expected:
+Once strategies exist, Adam should be able to mark ready to rank through a clear enabled CTA. That should call `POST /sessions/:id/strategies/ready`, set Adam's Stage 4 `readyToRank: true`, and move both users into the ranking phase when Eve is already ready.
+
+Impact:
+Hard blocker. Eve cannot rank because Stage 4 ranking requires both users to be ready. The session is stuck after a successful Stage 3.
+
+Likely fix locations:
+- `mobile/src/hooks/useUnifiedSession.ts`
+  - strategy card creation uses `strategies.length` from client strategy query state.
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+  - `strategy-pool-preview` card disables the button when `strategyCount === 0`.
+  - `handleMarkReadyToRank` path and error handling.
+- `mobile/src/hooks/useStages.ts`
+  - `useMarkReadyToRank` mutation invalidates strategies/progress but cannot help if the button never fires.
+- `backend/src/controllers/stage4.ts`
+  - `GET /sessions/:id/strategies` computes phase from DB strategies and both users' `readyToRank` gates.
+  - `POST /sessions/:id/strategies/ready` sets `gatesSatisfied.readyToRank`.
+
+### Issue 2: Strategy Query/UI Count Contradicts DB Strategy Rows
+
+Type: Realtime/cache/query invalidation
+Severity: High
+
+What happened:
+Adam's UI behaved as if there were zero strategies (`Strategies are being gathered from your conversation...`), while DB already had six strategies. Because the client strategy count appeared to be zero, the `Ready to Rank` button looked present but was effectively disabled.
+
+Evidence:
+- UI copy: `Strategies are being gathered from your conversation...`
+- DOM snapshot still contained `Ready to Rank`.
+- `StrategyProposal` table had six rows for this session.
+- Stage 4 controller logic would return `COLLECTING` until both users are ready, but it should still return the existing strategies so the UI can show a nonzero count and enable the readiness CTA.
+
+Expected:
+The Stage 4 strategy query should reflect the DB proposal rows after AI strategy capture. If proposals are generated asynchronously, the UI should poll, subscribe, or invalidate when generation finishes. If strategy generation is incomplete, the UI should not show an actionable `Ready to Rank` label without explaining why it is disabled.
+
+Likely fix locations:
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `backend/src/controllers/stage4.ts`
+- backend realtime event for strategy proposal creation / generation completion
+
+### Issue 3: Stage 4 Readiness State Is Ambiguous To The User
+
+Type: UI clarity / state gate
+Severity: Medium
+
+What happened:
+Adam saw `Ready to Rank` and a freeform chat input, but there was no current AI prompt asking for a chat response and no visible explanation that the ranking CTA was disabled because the app believed zero strategies were loaded.
+
+Evidence:
+- Browser text showed `Ideas So Far`, `Strategies are being gathered from your conversation...`, `Ready to Rank`, and `Type a message...`.
+- Activating `Ready to Rank` did not change DB state.
+- The UI did not indicate whether Adam should wait, type another strategy, open a strategy pool, or retry.
+
+Expected:
+Stage 4 should make the current user-owned action explicit:
+- If strategies are still generating, show a waiting/generation state and hide or disable input with clear copy.
+- If strategies exist, show the strategy pool and an enabled `Ready to Rank` CTA.
+- If the app needs Adam to propose more strategies, ask for that in chat directly.
+- If Eve is already ready, show that Adam's readiness is the remaining gate.
+
+Likely fix locations:
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `mobile/src/utils/chatUIState.ts`
+- `mobile/src/utils/getWaitingStatus.ts`
+- `mobile/src/config/waitingStatusConfig.ts`
+- `mobile/src/components/StrategyPool.tsx`
+
+### Issue 4: Duplicate Or Superseded Strategy Proposals May Be Persisting
+
+Type: Stage 4 strategy capture / proposal lifecycle
+Severity: Medium
+
+What happened:
+DB contained six proposals that look like two generations of the same strategy set: an initial three, then a refined/composed three. If the UI query starts showing all six, users may rank duplicates or stale drafts.
+
+Evidence:
+- Two low-stakes exploration proposals exist, one shorter and one expanded.
+- Two pause-phrase proposals exist, one shorter and one expanded.
+- A one-month check-in proposal appears only in the later batch.
+
+Expected:
+If AI strategy generation revises the pool, superseded proposals should either be replaced, marked inactive, or hidden from ranking. If both batches are intentional, the UI should make the distinction clear.
+
+Likely fix locations:
+- `backend/src/controllers/stage4.ts`
+- Stage 4 strategy capture service/prompt parser
+- `StrategyProposal.status` semantics
+- `mobile/src/components/StrategyPool.tsx`
+
+### Issue 5: Stage 4 Still Uses Legacy Ranking Pool Instead Of The Planned Conversation-Led Inventory
+
+Type: Product/design debt
+Severity: Medium
+
+What happened:
+The flow reached the current legacy Stage 4 strategy-pool/ranking model. That model is expected from current code, but it does not yet match the direction in `docs/product/stage-4-tending-technical-spec.md`, which calls for conversation-led proposal inventory, needs coverage, and shared or individual closure outcomes.
+
+Evidence:
+- Stage 4 card was `Ideas So Far` / `Ready to Rank`.
+- Backend state used `StrategyProposal`, `StrategyRanking`, and `readyToRank`.
+- No needs-coverage audit or proposal inventory review appeared on Adam's side before the blocker.
+
+Expected:
+For the Adam/Eve successful-resolution benchmark, Stage 4 should eventually help the couple shape a small shared experiment while checking coverage of both users' needs. The current ranking gate can be a compatibility path, but it remains below the target gold flow.
+
+Likely fix locations:
+- `docs/product/stage-4-tending-technical-spec.md`
+- `backend/src/controllers/stage4.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `mobile/src/components/StrategyPool.tsx`
+- future Stage 4 state service and mobile cards
+
+### Gold Alignment Notes
+
+Worked well:
+- Stage 1 and Stage 2 kept the Adam/Eve core tension intact: Adam's stability need was treated as real, and Eve's growth/aliveness need was not treated as abandonment.
+- Adam was able to name that his shutdown is panic, not indifference.
+- Eve's shared context helped Adam see that his silence makes her feel cruel for wanting things.
+- Stage 3 needs were strong and gold-aligned on Adam's side: reassurance that growth does not mean abandonment, directness, permission to name fear, pacing, and enough ground to stay in the room.
+- Stage 3 needs were strong and gold-aligned on Eve's side as shown to Adam: autonomy to grow, Adam staying present, and small experiments that do not force Eve to choose between love and honesty.
+- The side-by-side needs reveal did not force artificial agreement; it showed distinct but potentially compatible needs.
+
+Risks:
+- Stage 4 readiness/ranking is currently a hard blocker after successful Stage 3 completion.
+- The UI makes the blocker look like user indecision rather than app state mismatch.
+- Strategy proposals may be duplicated or stale by the time ranking becomes available.
+- The current ranking model may overfocus on choosing options before a needs-coverage conversation has happened.
+
+## Eve Side: Invitation Acceptor
+
+Role: Eve, invitation acceptor
+Browser URL: `http://localhost:8082/session/cmoru5afm000bpxj2e3coa3ij?e2e-user-id=cmorpyysd0003pxntibmkhf9p&e2e-user-email=eve@e2e.test`
+Partner: Adam, session creator/invitor
+
+### Summary
+
+This Eve-side run also got farther than the previous Adam/Eve report in `docs/product/adam-eve-gold-session-issues.md`. In the prior run, Eve's qualitative flow was strong but the Stage 3 `Review needs together` CTA did not open the needs drawer, so Eve's side required a local API fallback to validate the reveal. In this run, Eve accepted the invitation, completed Stages 0 through 3 through the UI, opened the side-by-side needs review, validated Adam's needs, reached Stage 4, proposed strategies, added a one-month check-in, and successfully marked herself ready to rank.
+
+The run stopped for Eve in Stage 4 because Adam was not ready to rank. DB state showed Eve's Stage 4 gate had `readyToRank: true`, while Adam's Stage 4 row still had `gates: null`. Eve's browser did not make that state clear: after reload and after the readiness gate had already been recorded, the UI still showed `Ideas So Far`, `6 strategies ready to review`, `Ready to Rank`, and a freeform chat input instead of a clear waiting state that Adam's readiness was the remaining gate.
+
+Qualitatively, Eve stayed aligned with the Adam/Eve successful-resolution benchmark. She named aliveness, movement, and future openness without turning that into rejection of Adam. Stage 2 helped her recognize Adam's stillness as panic and protection. Stage 3 preserved distinct but compatible needs. Stage 4 produced a plausible shared experiment: monthly low-stakes exploration, Adam naming what feels exciting and scary before larger decisions, a pause phrase for fear, and a one-month check-in.
+
+### Comparison Against Previous Gold-Run Notes
+
+Previous notes reviewed:
+- `docs/product/adam-eve-gold-session-issues.md`
+- `docs/product/james-catherine-gold-session-issues.md`
+- `docs/product/james-catherine-gold-session-bug-handoff-2026-05-04.md`
+- `docs/product/gold-flow-next-session-plan.md`
+- `docs/product/stage-4-tending-technical-spec.md`
+
+Fixed or improved in this Eve-side run:
+- Stage 3 reveal/validation worked through the UI for Eve. `Review needs together` opened the side-by-side drawer, Eve could review Adam's needs, and `Validate needs` completed the gate without an API fallback.
+- Eve's Stage 3 gates ended with `needsCaptured`, `needsConfirmed`, `needsShared`, and `needsValidated`.
+- Both users advanced to Stage 4, which was not reached in the prior Eve-side run.
+- The needs reveal was needs-oriented and did not use legacy common-ground framing.
+- No cross-user private prompt leak was observed on Eve's side.
+- Stage 2 and Stage 3 waiting behavior was improved in several places. Eve saw explicit waiting copy such as Adam reviewing shared context or deciding whether Eve's understanding captured him, rather than only seeing an old prompt near an active input.
+- The Stage 2 share suggestion copy was less problematic than in the previous Eve report. The visible offer was framed as context that might help Adam understand more accurately, and the suggested focus stayed closer to the live cycle between Eve's wanting and Adam's fear.
+
+Still open from previous runs:
+- Current gate clarity remains weak. Old prompts and stage history stay visually close to the active card and input, making it hard to tell whether the current action is to type, click a CTA, or wait.
+- Chat input can still remain visible when the app is not actually asking for freeform chat input. The clearest reproduction in this run is Stage 4 after Eve had already marked ready to rank.
+- Realtime/cache state is still suspect. Eve's DB state had `readyToRank: true`, but Eve's UI continued to show the same `Ready to Rank` affordance and chat input.
+- Stage 4 still uses the legacy strategy pool/ranking path rather than the conversation-led proposal inventory and needs-coverage flow described in `docs/product/stage-4-tending-technical-spec.md`.
+- Local E2E session URLs remain fragile when servers are stopped or restarted. Restarting the backend and `8082` bundle recovered the session, but the browser first showed a mood check and then rehydrated into Stage 4.
+
+New Eve-side issues from this run:
+- The invitation acceptor URL did not leave Eve correctly joined at first. The browser showed `Partner`, the Ready action was suspicious/inert, DB state had the session `INVITED`, invitation `PENDING`, and Eve was not a relationship member. A direct invitation-accept API call fixed it and the UI then showed Adam and accepted invitation state.
+- Eve's Stage 4 readiness was recorded in DB, but the UI remained actionable and stale instead of showing that Eve was waiting for Adam.
+- Duplicate or superseded strategy proposals were persisted. Six proposals existed, including shorter and refined versions of the same monthly exploration and pause-phrase strategies.
+
+### Current DB State At Stop
+
+Checked from local Prisma against `SESSION_ID=cmoru5afm000bpxj2e3coa3ij`.
+
+Session:
+- `status: ACTIVE`
+
+Eve:
+- Stage 0: `COMPLETED`
+- Stage 1: `COMPLETED`
+- Stage 2: `COMPLETED`, `empathyValidated: true`
+- Stage 3: `COMPLETED`, gates include:
+  - `needsCaptured: true`
+  - `needsConfirmed: true`
+  - `needsShared: true`
+  - `needsValidated: true`
+- Stage 4: `IN_PROGRESS`, gates include:
+  - `readyToRank: true`
+  - `readyAt: 2026-05-05T00:02:34.533Z`
+
+Adam:
+- Stage 0: `COMPLETED`
+- Stage 1: `COMPLETED`
+- Stage 2: `COMPLETED`, `empathyValidated: true`
+- Stage 3: `COMPLETED`, gates include:
+  - `needsCaptured: true`
+  - `needsConfirmed: true`
+  - `needsShared: true`
+  - `needsValidated: true`
+- Stage 4: `IN_PROGRESS`, `gates: null`
+
+Strategy state:
+- Six `StrategyProposal` rows existed.
+- No `StrategyRanking` rows existed.
+
+Strategy proposal descriptions in DB:
+- Monthly low-stakes exploration plan where we pick one new experience together (day trip, class, neighborhood visit, or weekend away)
+- Before deciding anything bigger, Adam shares what feels exciting and what feels scary
+- Use pause phrase "I am scared but I am still here" when fear comes up during conversations about wanting or change
+- Monthly low-stakes exploration plan where we pick one new experience together (day trip, class, neighborhood visit, or weekend away) and Adam can say what feels exciting and what feels scary before deciding anything bigger
+- Use pause phrase "I am scared but I am still here" so fear doesn't become shutdown and wanting doesn't become threat
+- Check in after one month, after trying one small exploration and using the pause phrase at least once
+
+### Issue 6: Eve's E2E Invitation URL Did Not Accept Or Join The Session Reliably
+
+Type: E2E/local web invitation flow
+Severity: High
+
+What happened:
+Opening Eve's session URL with E2E user parameters did not initially put Eve into a correct accepted-member state. The UI showed `Partner` rather than Adam, and the session state looked suspicious before the manual fix. DB inspection confirmed the session was still `INVITED`, the invitation was `PENDING`, and Eve was not yet a relationship member. A direct `POST /api/invitations/:id/accept` as Eve fixed the state; after reload, the UI showed Adam and the accepted invitation state.
+
+Evidence:
+- Browser URL included Eve's E2E identity parameters.
+- UI initially showed `Partner`.
+- DB showed invitation `PENDING` and session `INVITED`.
+- DB showed Eve was not a relationship member.
+- After the invitation accept API call, DB showed invitation `ACCEPTED`, session `ACTIVE`, and both Adam and Eve as members.
+- Eve could then progress normally through the session.
+
+Expected:
+An E2E invitee URL should deterministically accept or route Eve through a visible accept step before showing session actions. The UI should not show Ready/session controls for an unaccepted invitee state, and it should not label the known partner as generic `Partner` once the invite URL includes enough identity to resolve the invitation.
+
+Impact:
+This is a setup blocker for repeatable gold-session testing and can mask product bugs as auth/session bugs. It also makes the invitee side appear logged in while not actually joined to the relationship/session.
+
+Likely fix locations:
+- E2E invitation/session entry route
+- No-Clerk auth bypass user hydration
+- Invitation accept hook or screen lifecycle
+- `backend/src/controllers/invitations*`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+
+### Issue 7: Eve Is Ready To Rank In DB But The UI Still Shows Ready Controls
+
+Type: Stage 4 UI/backend state sync
+Severity: High
+
+What happened:
+Eve clicked or activated `Ready to Rank` successfully enough for DB to record `gatesSatisfied.readyToRank: true`. After server restart and reload, Eve returned to Stage 4, but the UI still showed the strategy pool preview, `Ready to Rank`, and the freeform chat input. It did not clearly state that Eve was already ready and waiting for Adam.
+
+Evidence:
+- DB showed Eve Stage 4 `gates.readyToRank: true`.
+- DB showed Adam Stage 4 `gates: null`.
+- Browser still showed `Ideas So Far`, `6 strategies ready to review`, `View All`, `Ready to Rank`, and `Type a message...`.
+- No ranking rows existed, which is correct while Adam is not ready, but Eve's UI did not explain that this was a partner-readiness wait.
+
+Expected:
+Once Eve is ready, her UI should stop presenting the readiness CTA as the current action. It should show a waiting state such as Adam is reviewing or getting ready to rank, hide or disable the chat input unless the app explicitly asks for more strategy work, and preserve a non-actionable view of the strategy pool if useful.
+
+Impact:
+This makes a successful readiness submission look like it failed and invites duplicate action. It also obscures the real blocker: Adam's Stage 4 readiness gate.
+
+Likely fix locations:
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `mobile/src/utils/chatUIState.ts`
+- `mobile/src/utils/getWaitingStatus.ts`
+- `backend/src/controllers/stage4.ts`
+
+### Issue 8: Stage 4 Allows Duplicate/Superseded Strategy Proposals To Accumulate
+
+Type: Stage 4 strategy capture / proposal lifecycle
+Severity: Medium
+
+What happened:
+Eve proposed an initial strategy set and then refined it into a clearer combined plan with a check-in. DB retained both the earlier and refined versions. If ranking had unlocked, Eve and Adam may have been asked to rank duplicate or stale options.
+
+Evidence:
+- Two monthly exploration proposals existed: one shorter and one expanded to include Adam naming what feels exciting and scary.
+- Two pause-phrase proposals existed: one shorter and one refined around fear not becoming shutdown and wanting not becoming threat.
+- A check-in proposal existed as a later addition.
+- No proposal status distinction was visible in the UI at the stop point.
+
+Expected:
+The Stage 4 proposal lifecycle should distinguish active options from superseded drafts. If a strategy set is revised, older proposals should be replaced, marked inactive, or hidden from ranking. If accumulation is intentional, the UI should cluster or explain related proposals before ranking.
+
+Impact:
+Duplicate ranking options can create false preference data and make the final way-forward agreement feel mechanical instead of conversationally tended.
+
+Likely fix locations:
+- `backend/src/controllers/stage4.ts`
+- Stage 4 strategy capture/generation service
+- `StrategyProposal.status` handling
+- `mobile/src/components/StrategyPool.tsx`
+
+### Issue 9: Stage 4 Input Remains Ambiguous After Strategy Readiness
+
+Type: UI clarity / state gate
+Severity: Medium
+
+What happened:
+After Eve was already ready to rank, the chat input still appeared with `Type a message...`. The UI also still showed a Stage 4 prompt area and strategy controls. Nothing made clear whether Eve should type another strategy, wait for Adam, retry readiness, or open the strategy pool.
+
+Evidence:
+- Eve's Stage 4 DB gate had `readyToRank: true`.
+- Adam's Stage 4 DB gate was still missing.
+- Browser still showed active chat input and readiness controls.
+- No visible waiting banner identified Adam as the blocker.
+
+Expected:
+When the current user's only remaining action is waiting for the partner, the input should be hidden or explicitly reframed. If the product wants to allow additional optional strategy ideas after readiness, there should be an explicit "add another idea" affordance and readiness should either be revoked intentionally or remain clearly recorded.
+
+Impact:
+The user can accidentally type into a completed gate and contaminate the strategy pool after already signaling readiness. This is the Stage 4 version of the gate/input ambiguity documented in earlier Stage 2 and Stage 3 reports.
+
+Likely fix locations:
+- `mobile/src/utils/chatUIState.ts`
+- `mobile/src/hooks/useChatUIState.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `mobile/src/config/waitingStatusConfig.ts`
+
+### Gold Alignment Notes
+
+Worked well:
+- Eve's Stage 1 held the benchmark tension: she loves Adam and values their stability, but feels herself getting smaller around wanting more life, movement, and future openness.
+- Stage 2 helped Eve understand Adam's stillness as fear and protection, not indifference.
+- Eve's shared context was accurate to the gold transcript: wanting more does not mean she has decided to leave, but Adam's panic makes wanting feel cruel.
+- Eve's Stage 3 needs were strong: room to grow without it meaning rejection, Adam staying present when she wants more, and small experiments that do not force an immediate decision about the future.
+- Stage 4's strategy direction was well matched to both people: a low-stakes monthly exploration practice, Adam naming excitement and fear before larger decisions, a pause phrase for fear, and a one-month check-in.
+
+Risks:
+- The Stage 4 blocker prevents the pair from testing whether the strategy pool actually becomes a shared way-forward agreement.
+- The UI currently makes Eve's completed readiness look incomplete.
+- Duplicate proposals may muddy ranking if Adam's readiness blocker is fixed without proposal lifecycle cleanup.
+- The current ranking model still lacks the needs-coverage inventory called for in the Stage 4 tending technical spec.
+
+## Fix Notes
+
+- Issue 1: Fixed locally by making `Ready to Rank` update Stage 4 progress/strategy caches optimistically and by hiding the readiness CTA once the current user's `readyToRank` gate is true. PR: local Codex patch, link pending.
+- Issue 2: Fixed locally by publishing `session.strategies_updated` after Stage 4 strategy capture and refetching the strategy query on that event, so partner browsers stop holding a zero-count cache after DB rows exist. PR: local Codex patch, link pending.
+- Issue 3: Fixed locally by adding a Stage 4 `strategy-readiness-pending` waiting state that hides chat input while the user is ready and the partner is not. PR: local Codex patch, link pending.
+- Issue 4: Partially fixed locally by collapsing obvious superseded Stage 4 strategy drafts during micro-tag capture instead of retaining shorter duplicate drafts beside refined proposals. Full lifecycle/status modeling remains future Stage 4 inventory work. PR: local Codex patch, link pending.
+- Issue 5: Not fully redesigned in this patch; the compatibility ranking path remains, but readiness and inventory syncing now align with the current Stage 4 gate contract without reintroducing removed Stage 3/common-ground behavior. PR: local Codex patch, link pending.
+- Issue 6: Fixed locally for no-Clerk E2E by allowing `/sessions/:id/state` to auto-accept a ready pending invitation only when `E2E_AUTH_BYPASS=true`, making direct invitee session URLs deterministic in local gold runs. PR: local Codex patch, link pending.
+- Issue 7: Fixed locally by handling the actual `partner.ready_to_rank` realtime event and deriving Eve's already-ready waiting state from DB/cache gates instead of showing `Ready to Rank` again. PR: local Codex patch, link pending.
+- Issue 8: Same fix as Issue 4: obvious superseded proposal rows are removed during Stage 4 capture before inserting refined replacements. PR: local Codex patch, link pending.
+- Issue 9: Same fix as Issue 3: the ready-but-waiting state now hides freeform input unless ranking opens or the strategy inventory changes. PR: local Codex patch, link pending.

--- a/mobile/src/config/waitingStatusConfig.ts
+++ b/mobile/src/config/waitingStatusConfig.ts
@@ -281,6 +281,17 @@ export const WAITING_STATUS_CONFIG: Record<NonNullable<WaitingStatusState>, Wait
     showKeepChattingAction: false,
   },
 
+  // Stage 4: User is ready to rank, waiting for partner readiness
+  'strategy-readiness-pending': {
+    showBanner: true,
+    hideInput: true,
+    showInnerThoughts: false,
+    isActionRequired: false,
+    showSpinner: false,
+    showKeepChattingAction: false,
+    bannerText: (p) => `${p} is getting ready to rank the ideas.`,
+  },
+
   // Stage 4: All agreements confirmed by me, waiting for partner
   'agreement-pending': {
     showBanner: true,

--- a/mobile/src/hooks/__tests__/useStages.test.ts
+++ b/mobile/src/hooks/__tests__/useStages.test.ts
@@ -24,6 +24,7 @@ import {
   useConsentShareNeeds,
   useStrategies,
   useProposeStrategy,
+  useMarkReadyToRank,
   useSubmitRankings,
   useStrategiesReveal,
   useAgreements,
@@ -640,6 +641,55 @@ describe('useStages', () => {
     });
 
     describe('useSubmitRankings hook', () => {
+      it('optimistically marks current user ready to rank in cache', async () => {
+        mockPost.mockResolvedValueOnce({
+          ready: true,
+          readyAt: '2026-05-05T00:00:00.000Z',
+          partnerReady: false,
+          canStartRanking: false,
+        });
+
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        queryClient.setQueryData(stageKeys.strategies(sessionId), {
+          strategies: [],
+          phase: StrategyPhase.COLLECTING,
+          aiSuggestionsAvailable: false,
+          myReadyToRank: false,
+          partnerReadyToRank: false,
+        });
+        queryClient.setQueryData(stageKeys.progress(sessionId), {
+          sessionId,
+          myProgress: {
+            stage: Stage.STRATEGIC_REPAIR,
+            status: StageStatus.IN_PROGRESS,
+            startedAt: '2026-05-05T00:00:00.000Z',
+            completedAt: null,
+            gatesSatisfied: null,
+          },
+          partnerProgress: {
+            stage: Stage.STRATEGIC_REPAIR,
+            status: StageStatus.IN_PROGRESS,
+            gatesSatisfied: null,
+          },
+          canAdvance: false,
+        });
+        const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+          return React.createElement(QueryClientProvider, { client: queryClient }, children);
+        };
+
+        const { result } = renderHook(() => useMarkReadyToRank(), { wrapper });
+
+        await act(async () => {
+          await result.current.mutateAsync({ sessionId });
+        });
+
+        expect(mockPost).toHaveBeenCalledWith(`/sessions/${sessionId}/strategies/ready`);
+        expect(queryClient.getQueryData<any>(stageKeys.strategies(sessionId))?.myReadyToRank).toBe(true);
+        expect(
+          queryClient.getQueryData<any>(stageKeys.progress(sessionId))?.myProgress.gatesSatisfied.readyToRank
+        ).toBe(true);
+      });
+
       it('submits strategy rankings', async () => {
         mockPost.mockResolvedValueOnce({
           submitted: true,

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -119,6 +119,10 @@ export interface UseChatUIStateProps {
 
   // Stage 4: Strategies
   strategyPhase: StrategyPhase | string;
+  strategyReadiness?: {
+    myReadyToRank?: boolean;
+    partnerReadyToRank?: boolean;
+  };
   overlappingStrategiesCount: number;
 
   // Stage 4: Agreements
@@ -214,6 +218,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     commonGroundAllConfirmedByBoth,
     hasConfirmedCommonGroundLocal,
     strategyPhase,
+    strategyReadiness,
     overlappingStrategiesCount,
     agreements,
   } = props;
@@ -249,6 +254,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
       allConfirmedByBoth: commonGroundAllConfirmedByBoth,
     },
     strategyPhase,
+    strategyReadiness,
     overlappingStrategies: { count: overlappingStrategiesCount },
     agreements,
 
@@ -314,6 +320,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     commonGroundAllConfirmedByBoth,
     hasConfirmedCommonGroundLocal,
     strategyPhase,
+    strategyReadiness,
     overlappingStrategiesCount,
     agreements,
     sessionStatus,

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -67,6 +67,7 @@ import {
   SaveValidationFeedbackDraftResponse,
   RefineValidationFeedbackRequest,
   RefineValidationFeedbackResponse,
+  StrategyPhase,
 } from '@meet-without-fear/shared';
 
 // Import query keys from centralized file to avoid circular dependencies
@@ -1654,7 +1655,15 @@ export function useRequestStrategySuggestions(
  */
 export function useMarkReadyToRank(
   options?: Omit<
-    UseMutationOptions<MarkReadyResponse, ApiClientError, { sessionId: string }>,
+    UseMutationOptions<
+      MarkReadyResponse,
+      ApiClientError,
+      { sessionId: string },
+      {
+        previousStrategies: GetStrategiesResponse | undefined;
+        previousProgress: GetProgressResponse | undefined;
+      }
+    >,
     'mutationFn'
   >
 ) {
@@ -1664,9 +1673,79 @@ export function useMarkReadyToRank(
     mutationFn: async ({ sessionId }) => {
       return post<MarkReadyResponse>(`/sessions/${sessionId}/strategies/ready`);
     },
-    onSuccess: (_, { sessionId }) => {
-      queryClient.invalidateQueries({ queryKey: stageKeys.strategies(sessionId) });
-      queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+    onMutate: async ({ sessionId }) => {
+      await queryClient.cancelQueries({ queryKey: stageKeys.strategies(sessionId) });
+      await queryClient.cancelQueries({ queryKey: stageKeys.progress(sessionId) });
+
+      const previousStrategies = queryClient.getQueryData<GetStrategiesResponse>(
+        stageKeys.strategies(sessionId)
+      );
+      const previousProgress = queryClient.getQueryData<GetProgressResponse>(
+        stageKeys.progress(sessionId)
+      );
+      const readyAt = new Date().toISOString();
+
+      queryClient.setQueryData<GetStrategiesResponse>(
+        stageKeys.strategies(sessionId),
+        (old) => old
+          ? { ...old, myReadyToRank: true }
+          : old
+      );
+      queryClient.setQueryData<any>(
+        stageKeys.progress(sessionId),
+        (old: any) => old
+          ? {
+              ...old,
+              myProgress: {
+                ...old.myProgress,
+                gatesSatisfied: {
+                  ...((old.myProgress as { gatesSatisfied?: Record<string, unknown> }).gatesSatisfied ?? {}),
+                  readyToRank: true,
+                  readyAt,
+                },
+              },
+            }
+          : old
+      );
+
+      return { previousStrategies, previousProgress };
+    },
+    onSuccess: (data, { sessionId }) => {
+      queryClient.setQueryData<GetStrategiesResponse>(
+        stageKeys.strategies(sessionId),
+        (old) => old
+          ? {
+              ...old,
+              myReadyToRank: true,
+              partnerReadyToRank: data.partnerReady,
+              phase: data.canStartRanking ? StrategyPhase.RANKING : old.phase,
+            }
+          : old
+      );
+      queryClient.setQueryData<any>(
+        stageKeys.progress(sessionId),
+        (old: any) => old
+          ? {
+              ...old,
+              myProgress: {
+                ...old.myProgress,
+                gatesSatisfied: {
+                  ...((old.myProgress as { gatesSatisfied?: Record<string, unknown> }).gatesSatisfied ?? {}),
+                  readyToRank: true,
+                  readyAt: data.readyAt ?? new Date().toISOString(),
+                },
+              },
+            }
+          : old
+      );
+    },
+    onError: (_error, { sessionId }, context) => {
+      if (context?.previousStrategies) {
+        queryClient.setQueryData(stageKeys.strategies(sessionId), context.previousStrategies);
+      }
+      if (context?.previousProgress) {
+        queryClient.setQueryData(stageKeys.progress(sessionId), context.previousProgress);
+      }
     },
     ...options,
   });

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -80,6 +80,12 @@ import {
 // Re-export for backwards compatibility
 export { stageKeys };
 
+type ProgressCacheWithGates = GetProgressResponse & {
+  myProgress: GetProgressResponse['myProgress'] & {
+    gatesSatisfied?: Record<string, unknown> | null;
+  };
+};
+
 // ============================================================================
 // Progress Hook
 // ============================================================================
@@ -1661,7 +1667,7 @@ export function useMarkReadyToRank(
       { sessionId: string },
       {
         previousStrategies: GetStrategiesResponse | undefined;
-        previousProgress: GetProgressResponse | undefined;
+        previousProgress: ProgressCacheWithGates | undefined;
       }
     >,
     'mutationFn'
@@ -1680,7 +1686,7 @@ export function useMarkReadyToRank(
       const previousStrategies = queryClient.getQueryData<GetStrategiesResponse>(
         stageKeys.strategies(sessionId)
       );
-      const previousProgress = queryClient.getQueryData<GetProgressResponse>(
+      const previousProgress = queryClient.getQueryData<ProgressCacheWithGates>(
         stageKeys.progress(sessionId)
       );
       const readyAt = new Date().toISOString();
@@ -1691,15 +1697,15 @@ export function useMarkReadyToRank(
           ? { ...old, myReadyToRank: true }
           : old
       );
-      queryClient.setQueryData<any>(
+      queryClient.setQueryData<ProgressCacheWithGates>(
         stageKeys.progress(sessionId),
-        (old: any) => old
+        (old) => old
           ? {
               ...old,
               myProgress: {
                 ...old.myProgress,
                 gatesSatisfied: {
-                  ...((old.myProgress as { gatesSatisfied?: Record<string, unknown> }).gatesSatisfied ?? {}),
+                  ...(old.myProgress.gatesSatisfied ?? {}),
                   readyToRank: true,
                   readyAt,
                 },
@@ -1722,15 +1728,15 @@ export function useMarkReadyToRank(
             }
           : old
       );
-      queryClient.setQueryData<any>(
+      queryClient.setQueryData<ProgressCacheWithGates>(
         stageKeys.progress(sessionId),
-        (old: any) => old
+        (old) => old
           ? {
               ...old,
               myProgress: {
                 ...old.myProgress,
                 gatesSatisfied: {
-                  ...((old.myProgress as { gatesSatisfied?: Record<string, unknown> }).gatesSatisfied ?? {}),
+                  ...(old.myProgress.gatesSatisfied ?? {}),
                   readyToRank: true,
                   readyAt: data.readyAt ?? new Date().toISOString(),
                 },

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -358,7 +358,7 @@ export function useUnifiedSession(
       }
       // Invalidate strategies cache when AI extracts new strategies (Stage 4)
       if (sessionId && metadata.proposedStrategies && metadata.proposedStrategies.length > 0) {
-        queryClient.invalidateQueries({ queryKey: stageKeys.strategies(sessionId) });
+        queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
       }
       // Invalidate needs cache when AI captures reviewable needs (Stage 3)
       if (sessionId && metadata.proposedNeeds && metadata.proposedNeeds.length > 0) {
@@ -550,6 +550,9 @@ export function useUnifiedSession(
   // Strategy phase
   const strategyPhase = strategyData?.phase ?? StrategyPhase.COLLECTING;
   const strategies = useMemo(() => strategyData?.strategies ?? [], [strategyData?.strategies]);
+  const myReadyToRank =
+    strategyData?.myReadyToRank === true ||
+    (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.readyToRank === true;
   const overlappingStrategies = useMemo(() => revealData?.overlap ?? [], [revealData?.overlap]);
   const agreements = useMemo(() => agreementsData?.agreements ?? [], [agreementsData?.agreements]);
 
@@ -702,7 +705,7 @@ export function useUnifiedSession(
     // Stage 4: Strategic Repair cards
     if (currentStage === Stage.STRATEGIC_REPAIR) {
       // Strategy pool preview (hide after session is resolved)
-      if (strategyPhase === StrategyPhase.COLLECTING && session?.status !== SessionStatus.RESOLVED) {
+      if (strategyPhase === StrategyPhase.COLLECTING && !myReadyToRank && session?.status !== SessionStatus.RESOLVED) {
         cards.push({
           id: 'strategy-pool-preview',
           type: 'strategy-pool-preview',
@@ -766,6 +769,7 @@ export function useUnifiedSession(
     commonGroundComplete,
     strategyPhase,
     strategies,
+    myReadyToRank,
     overlappingStrategies,
     agreements,
     partnerName,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -371,6 +371,7 @@ export function UnifiedSessionScreen({
     commonGround,
     commonGroundData,
     commonGroundComplete,
+    strategyData,
     strategyPhase,
     strategies,
     revealData,
@@ -803,19 +804,41 @@ export function UnifiedSessionScreen({
       // Stage 4: Strategic Repair Events
       // -----------------------------------------------------------------------
 
+      if (eventName === 'session.strategies_updated') {
+        console.log('[UnifiedSessionScreen] Strategies updated');
+        queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
+      }
+
       if (eventName === 'partner.ranking_submitted') {
         // Partner submitted their strategy rankings
         console.log('[UnifiedSessionScreen] Partner submitted rankings');
-        queryClient.invalidateQueries({ queryKey: stageKeys.strategies(sessionId) });
-        queryClient.invalidateQueries({ queryKey: stageKeys.strategiesReveal(sessionId) });
-        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+        queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
+        queryClient.refetchQueries({ queryKey: stageKeys.strategiesReveal(sessionId) });
+        queryClient.refetchQueries({ queryKey: stageKeys.progress(sessionId) });
       }
 
-      if (eventName === 'partner.marked_ready') {
+      if (eventName === 'partner.ready_to_rank' || eventName === 'partner.marked_ready') {
         // Partner marked ready to rank
         console.log('[UnifiedSessionScreen] Partner marked ready to rank');
-        queryClient.invalidateQueries({ queryKey: stageKeys.strategies(sessionId) });
-        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+        queryClient.setQueryData(stageKeys.strategies(sessionId), (old: any) => old
+          ? { ...old, partnerReadyToRank: true }
+          : old
+        );
+        queryClient.setQueryData(stageKeys.progress(sessionId), (old: any) => {
+          if (!old?.partnerProgress) return old;
+          return {
+            ...old,
+            partnerProgress: {
+              ...old.partnerProgress,
+              gatesSatisfied: {
+                ...(old.partnerProgress.gatesSatisfied ?? {}),
+                readyToRank: true,
+              },
+            },
+          };
+        });
+        queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
+        queryClient.refetchQueries({ queryKey: stageKeys.progress(sessionId) });
       }
 
       if (eventName === 'agreement.proposed') {
@@ -1235,6 +1258,12 @@ export function UnifiedSessionScreen({
     commonGroundAllConfirmedByBoth: commonGroundComplete,
     hasConfirmedCommonGroundLocal: completedActions.has('validated-needs'),
     strategyPhase,
+    strategyReadiness: {
+      myReadyToRank: strategyData?.myReadyToRank === true ||
+        (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.readyToRank === true,
+      partnerReadyToRank: strategyData?.partnerReadyToRank === true ||
+        ((partnerProgress as { gatesSatisfied?: Record<string, unknown> } | undefined)?.gatesSatisfied)?.readyToRank === true,
+    },
     overlappingStrategiesCount: overlappingStrategies?.length ?? 0,
     agreements: agreements?.map(a => ({
       agreedByMe: a.agreedByMe,

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -67,6 +67,22 @@ describe('Onboarding State (isInOnboardingUnsigned)', () => {
   });
 });
 
+describe('Stage 4 Strategy Readiness', () => {
+  it('hides input while the user is ready to rank and waiting for partner', () => {
+    const inputs = createInputs({
+      myStage: Stage.STRATEGIC_REPAIR,
+      myProgress: { stage: Stage.STRATEGIC_REPAIR },
+      strategyPhase: 'COLLECTING',
+      strategyReadiness: { myReadyToRank: true, partnerReadyToRank: false },
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.waitingStatus).toBe('strategy-readiness-pending');
+    expect(result.shouldHideInput).toBe(true);
+    expect(result.panels.showWaitingBanner).toBe(true);
+  });
+});
+
 // ============================================================================
 // Panel Priority Tests
 // ============================================================================

--- a/mobile/src/utils/__tests__/getWaitingStatus.test.ts
+++ b/mobile/src/utils/__tests__/getWaitingStatus.test.ts
@@ -329,6 +329,17 @@ describe('Priority 5: Stage 3 (Needs)', () => {
 // ============================================================================
 
 describe('Priority 6: Stage 4 (Strategies)', () => {
+  it('returns strategy-readiness-pending when user is ready and partner is not', () => {
+    const inputs = createDefaultInputs({
+      myStage: Stage.STRATEGIC_REPAIR,
+      strategyPhase: StrategyPhase.COLLECTING,
+      strategyReadiness: { myReadyToRank: true, partnerReadyToRank: false },
+      overlappingStrategies: { count: 0 },
+    });
+
+    expect(computeWaitingStatus(inputs)).toBe('strategy-readiness-pending');
+  });
+
   it('returns ranking-pending when in REVEALING phase with no overlap', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.STRATEGIC_REPAIR,

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -118,6 +118,12 @@ export interface ChatUIStateInputs extends WaitingStatusInputs {
   commonGroundAllConfirmedByMe: boolean;
   commonGroundAllConfirmedByBoth: boolean;
   hasConfirmedCommonGroundLocal: boolean;
+
+  // Stage 4: Strategy readiness
+  strategyReadiness?: {
+    myReadyToRank?: boolean;
+    partnerReadyToRank?: boolean;
+  };
 }
 
 /**
@@ -714,6 +720,7 @@ export function createDefaultChatUIStateInputs(): ChatUIStateInputs {
     needs: { allConfirmed: false },
     commonGround: { count: 0 },
     strategyPhase: 'COLLECTING',
+    strategyReadiness: undefined,
     overlappingStrategies: { count: 0 },
     agreements: undefined,
 

--- a/mobile/src/utils/getWaitingStatus.ts
+++ b/mobile/src/utils/getWaitingStatus.ts
@@ -27,6 +27,7 @@ export type WaitingStatusState =
   | 'common-ground-pending' // Stage 3: Waiting for partner to confirm common ground
   | 'partner-validating-needs' // Stage 3: User validated revealed needs, waiting for partner
   | 'ranking-pending' // Stage 4: Waiting for partner to submit ranking
+  | 'strategy-readiness-pending' // Stage 4: User is ready to rank, waiting for partner readiness
   | 'partner-signed' // Partner has signed compact (transient)
   | 'partner-completed-witness' // Partner completed witness stage (transient)
   | 'partner-shared-empathy' // Partner shared their empathy attempt (transient)
@@ -96,6 +97,10 @@ export interface WaitingStatusInputs {
 
   // Stage 4: Strategy phase and overlap
   strategyPhase: StrategyPhase | string;
+  strategyReadiness?: {
+    myReadyToRank?: boolean;
+    partnerReadyToRank?: boolean;
+  };
   overlappingStrategies: {
     count: number;
   };
@@ -136,6 +141,7 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
     needs,
     commonGround,
     strategyPhase,
+    strategyReadiness,
     overlappingStrategies,
   } = inputs;
 
@@ -285,6 +291,15 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
   }
 
   // --- Priority 6: Stage 4 (Strategies) ---
+
+  if (
+    myStage === Stage.STRATEGIC_REPAIR &&
+    strategyPhase === StrategyPhase.COLLECTING &&
+    strategyReadiness?.myReadyToRank &&
+    !strategyReadiness?.partnerReadyToRank
+  ) {
+    return 'strategy-readiness-pending';
+  }
 
   if (strategyPhase === StrategyPhase.REVEALING && overlappingStrategies.count === 0) {
     return 'ranking-pending';

--- a/shared/src/dto/realtime.ts
+++ b/shared/src/dto/realtime.ts
@@ -96,6 +96,7 @@ export type SessionEventType =
   | 'session.common_ground_ready' // Legacy alias for side-by-side needs reveal readiness
   | 'partner.common_ground_confirmed' // Legacy alias for needs validation
   // Stage 4: Strategic Repair events
+  | 'session.strategies_updated'
   | 'partner.ranking_submitted'
   | 'partner.ready_to_rank'
   | 'partner.consent_granted'

--- a/shared/src/dto/strategy.ts
+++ b/shared/src/dto/strategy.ts
@@ -38,6 +38,8 @@ export interface GetStrategiesResponse {
   strategies: StrategyDTO[];
   aiSuggestionsAvailable: boolean;
   phase: StrategyPhase;
+  myReadyToRank?: boolean;
+  partnerReadyToRank?: boolean;
 }
 
 export interface ProposeStrategyRequest {
@@ -72,6 +74,7 @@ export interface RequestSuggestionsResponse {
 
 export interface MarkReadyResponse {
   ready: boolean;
+  readyAt?: string;
   partnerReady: boolean;
   canStartRanking: boolean;
 }


### PR DESCRIPTION
## Summary
- sync Stage 4 strategy inventory through a new session.strategies_updated realtime event
- make Ready to Rank cache-first with optimistic progress/strategy updates and an already-ready waiting state
- add E2E-only pending invitation auto-accept for direct local invitee session URLs
- collapse obvious superseded strategy proposal drafts during Stage 4 capture
- add fix notes to the Adam/Eve Stage 4 live-run report

## Tests
- npm run check
- npm -w backend test -- src/utils/__tests__/strategy-dedupe.test.ts src/routes/__tests__/stage4.test.ts --runInBand
- npm -w mobile test -- src/utils/__tests__/getWaitingStatus.test.ts src/utils/__tests__/chatUIState.test.ts src/hooks/__tests__/useStages.test.ts --runInBand --forceExit
- npm run test (fails in existing mobile baseline: EmotionalBarometer label expectations, ChatInterface/axios stream setup, Sentry ESM transform/navigation, StrategicRepairScreen axios stream setup; backend and shared full suites pass)
