### PR TITLE
Fix Stage 4 post-action state refresh

### DIFF
--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -166,9 +166,12 @@ export async function getStrategies(req: Request, res: Response): Promise<void> 
     const partnerGates = partnerProgress?.gatesSatisfied as Record<string, unknown> | null;
 
     const bothRanked = rankings.length >= 2;
+    const myRanked = rankings.some((r) => r.userId === user.id);
 
     let phase: StrategyPhase;
     if (bothRanked) {
+      phase = StrategyPhase.REVEALING;
+    } else if (myRanked) {
       phase = StrategyPhase.REVEALING;
     } else if (allReadyToRank) {
       phase = StrategyPhase.RANKING;
@@ -411,6 +414,11 @@ export async function submitRanking(req: Request, res: Response): Promise<void> 
     }
 
     successResponse(res, {
+      submitted: true,
+      submittedAt: new Date().toISOString(),
+      partnerSubmitted: partnerRanked,
+      awaitingReveal: canReveal,
+      // Legacy aliases kept for older clients.
       ranked: true,
       rankedAt: new Date().toISOString(),
       partnerRanked,
@@ -684,7 +692,12 @@ export async function createAgreement(req: Request, res: Response): Promise<void
           id: agreement.id,
           description: agreement.description,
           type: agreement.type,
+          duration: null,
+          measureOfSuccess: null,
           status: agreement.status,
+          agreedByMe: true,
+          agreedByPartner: false,
+          agreedAt: agreement.agreedAt?.toISOString() ?? null,
           followUpDate: agreement.followUpDate?.toISOString() ?? null,
         },
         awaitingPartnerConfirmation: true,

--- a/backend/src/routes/__tests__/stage4.test.ts
+++ b/backend/src/routes/__tests__/stage4.test.ts
@@ -172,6 +172,46 @@ describe('Stage 4 API', () => {
       expect(findManyCall.select.createdByUserId).toBeUndefined();
     });
 
+    it('returns revealing phase for a user who already submitted ranking while partner has not', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.stageProgress.findMany as jest.Mock).mockResolvedValue([
+        { userId: mockUser.id, stage: 4, gatesSatisfied: { readyToRank: true, rankingSubmitted: true } },
+        { userId: mockPartnerId, stage: 4, gatesSatisfied: { readyToRank: true } },
+      ]);
+      (prisma.strategyProposal.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: mockStrategyIds[0],
+          description: 'Weekly check-in',
+          needsAddressed: ['connection'],
+          duration: '2 weeks',
+          measureOfSuccess: 'Feel more connected',
+        },
+      ]);
+      (prisma.strategyRanking.findMany as jest.Mock).mockResolvedValue([
+        { sessionId: mockSessionId, userId: mockUser.id, rankedIds: [mockStrategyIds[0]] },
+      ]);
+
+      await getStrategies(req as Request, res as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            phase: 'REVEALING',
+            myReadyToRank: true,
+            partnerReadyToRank: true,
+          }),
+        })
+      );
+    });
+
     it('requires authentication', async () => {
       const req = createMockRequest({
         params: { id: mockSessionId },

--- a/docs/product/adam-eve-gold-session-stage4-followup-issues-2026-05-05.md
+++ b/docs/product/adam-eve-gold-session-stage4-followup-issues-2026-05-05.md
@@ -1,0 +1,353 @@
+# Adam/Eve Gold Session Stage 4 Follow-Up Issues - 2026-05-05
+
+Scenario: Adam/Eve successful-resolution benchmark  
+Session ID: `cmos1tow4000epxzhjg829ef0`  
+App: local E2E/no-Clerk web bundle on `http://localhost:8082`
+
+This report captures a second Adam/Eve Stage 4 local E2E gold-session playthrough after the earlier `cmoru5afm000bpxj2e3coa3ij` Stage 4 report. Evidence came from both side scratch logs, Eve-side browser inspection, and local Prisma DB checks.
+
+## Adam Side: Invitor
+
+Role: Adam, session creator/invitor  
+Browser URL: `http://localhost:8082/session/cmos1tow4000epxzhjg829ef0?e2e-user-id=cmorpyyqi0002pxnt18abhy7t&e2e-user-email=adam@e2e.test`  
+Partner: Eve, invitation acceptor
+
+### Summary
+
+Adam's side completed Stages 0 through 3 without the previous Stage 3 reveal blocker. Adam reviewed the side-by-side needs, validated them, entered Stage 4, and proposed a concrete reversible experiment: Eve names a small new thing she wants to try, Adam asks curious questions for ten minutes before reacting, they choose a low-cost reversible version, and they check in Sunday at 7pm.
+
+Adam then reached the strategy pool, marked readiness, ranked three choices, saw overlap on the shared pause-phrase strategy, and clicked `Create Agreement`. The backend created the proposed agreement and marked Adam's side agreed, but Adam's UI stayed on the overlap card with `Create Agreement` still visible. At handoff, Adam had no legitimate further action unless the stale UI was bypassed or Eve confirmed the agreement.
+
+### Adam-Side Findings From Scratch Log
+
+#### Stage 4 Strategy Gathering Status May Not Expose The Next Action
+
+Type: UI / state-machine  
+Severity: Medium
+
+What happened:
+Adam saw `Ideas So Far`, `Strategies are being gathered from your conversation...`, and `Ready to Rank` before a clear actionable ranking control was available. Typing a readiness-style message moved the flow into strategy drafting.
+
+Evidence:
+- Adam DOM showed `Ready to Rank` as visible text but no accessible ranking drawer opened at that point.
+- After Adam typed that he was ready to look at strategies, the AI prompted him for a concrete low-risk experiment.
+- Eve later reproduced the same ambiguous `Strategies are being gathered...` state from the other side.
+
+Expected:
+Stage 4 should clearly distinguish waiting for strategy generation, asking the user to add strategy ideas, and offering an enabled ranking/review action.
+
+Likely fix locations:
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/components/StrategyPool.tsx`
+
+#### Strategy Pool Contains Near-Duplicate Ideas
+
+Type: UI / eval coverage  
+Severity: Medium
+
+What happened:
+Adam's strategy pool contained multiple near-duplicate variants of the same experiment, including overlapping versions of the curious-questions evening, low-cost reversible activity, and follow-up check-in.
+
+Expected:
+Ranking should present meaningfully distinct strategies or consolidate related variants into one coherent proposal with steps.
+
+Likely fix locations:
+- Stage 4 strategy extraction/deduplication
+- `backend/src/controllers/stage4.ts`
+- `mobile/src/components/StrategyPool.tsx`
+
+#### Agreement Creation Persists But UI Stays On Create Button
+
+Type: UI / state-machine  
+Severity: High
+
+What happened:
+Adam clicked `Create Agreement` from the overlap reveal. DB created agreement `cmos3af3000h0pxzhu0n8r90f`, but Adam's UI still showed `Create Agreement` after reload.
+
+Evidence:
+- Agreement description: `Create a pause phrase both can use when either starts shutting down, so the conversation can resume later`.
+- DB state: `status: PROPOSED`, `agreedByA: true`, `agreedByB: false`.
+- Adam UI remained on the overlap card rather than showing a proposed-agreement or waiting state.
+
+Expected:
+After agreement creation, Adam should see that the agreement was proposed and is awaiting Eve, and the create CTA should be replaced or disabled.
+
+Likely fix locations:
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/components/OverlapReveal.tsx`
+- `backend/src/controllers/stage4.ts`
+
+## Eve Side: Invitation Acceptor
+
+Role: Eve, invitation acceptor  
+Browser URL: `http://localhost:8082/session/cmos1tow4000epxzhjg829ef0?e2e-user-id=cmorpyysd0003pxntibmkhf9p&e2e-user-email=eve@e2e.test`  
+Partner: Adam, session creator/invitor
+
+### Summary
+
+Eve completed the full flow through Stage 4 agreement proposal. Qualitatively, the run was strong: Stage 2 helped Eve move from reading Adam's silence as rejection toward understanding it as panic/fear, without erasing the cost to her. Stage 3 captured Eve's core needs around aliveness, becoming, autonomy from managing Adam's fear, emotional presence, open future, and loving without containment. Stage 4 produced gold-aligned strategies: a reversible day trip/class, Adam naming excitement and fear, a pause phrase for shutdown, and a follow-up check-in.
+
+The main failures were not prompt quality; they were realtime/cache and action-state failures. Eve repeatedly saw stale UI after the DB had advanced: Stage 3 wait copy after both users reached Stage 4, a grey strategy-gathering panel while strategies already existed, a ranking screen after her ranking had been submitted, and `Create Agreement` after the agreement had already been created.
+
+### Comparison Against Previous Gold-Run Notes
+
+Previous notes reviewed:
+- `docs/product/adam-eve-gold-session-issues.md`
+- `docs/product/adam-eve-gold-session-stage4-issues-2026-05-05.md`
+- `docs/product/james-catherine-gold-session-bug-handoff-2026-05-04.md`
+- `docs/product/gold-flow-next-session-plan.md`
+- `docs/product/stage-4-tending-technical-spec.md`
+
+Fixed or improved:
+- Stage 3 reveal/validation worked through UI for both sides in this run.
+- Both users reached Stage 4 and submitted rankings.
+- The side-by-side needs reveal stayed needs-oriented and did not present AI-authored common ground as product truth.
+- Stage 4 found a plausible shared strategy overlap instead of blocking before ranking.
+- No cross-user private prompt leak was observed from Eve's side.
+
+Still open or newly reproduced:
+- Stage 2 can still show completion/validation copy before the partner has actually finished refining.
+- Current action state remains stale after backend transitions.
+- Stage 4 strategy inventory can show zero/gathering while DB rows already exist.
+- Stage 4 proposal pool includes near-duplicates.
+- Stage 4 lacks the needs-coverage inventory called for in `stage-4-tending-technical-spec.md`.
+- Agreement creation does not update the proposing user's UI.
+
+### Current DB State At Stop
+
+Checked from local Prisma against `SESSION_ID=cmos1tow4000epxzhjg829ef0`.
+
+Session:
+- `status: ACTIVE`
+- Members:
+  - Adam: `cmorpyyqi0002pxnt18abhy7t`, `adam@e2e.test`
+  - Eve: `cmorpyysd0003pxntibmkhf9p`, `eve@e2e.test`
+
+Stage progress:
+- Adam Stage 0-3: `COMPLETED`
+- Adam Stage 4: `IN_PROGRESS`, gates include `readyToRank: true`, `rankingSubmitted: true`
+- Eve Stage 0-3: `COMPLETED`
+- Eve Stage 4: `IN_PROGRESS`, gates include `readyToRank: true`, `rankingSubmitted: true`
+
+Needs:
+- Adam confirmed needs around stability not making him small/wrong, reassurance that Eve values what they built, steadiness for emotional risk, and change inside commitment.
+- Eve confirmed needs around aliveness/becoming, wanting without managing Adam's fear, Adam staying engaged during growth/change conversations, an open future, and loving without becoming smaller.
+
+Strategy state:
+- 9 `StrategyProposal` rows existed.
+- Both users submitted `StrategyRanking` rows.
+- Shared overlap selected the pause-phrase strategy.
+
+Agreement state:
+- Agreement `cmos3af3000h0pxzhu0n8r90f`
+- Description: `Create a pause phrase both can use when either starts shutting down, so the conversation can resume later`
+- Type: `MICRO_EXPERIMENT`
+- Status: `PROPOSED`
+- `agreedByA: true`
+- `agreedByB: false`
+
+### Issue 1: Previously Visible AI Messages Reanimated After Eve Shared Empathy
+
+Type: UI animation / chat rendering  
+Severity: Medium  
+Status: fixed locally during run
+
+What happened:
+After Eve shared empathy, multiple previously visible AI messages replayed their typewriter animation one at a time.
+
+Evidence:
+- User observed the behavior live immediately after Eve shared empathy.
+- Code inspection showed already-rendered AI items could later be promoted into the animation queue after button-only actions because only typed `USER` messages were treated as a response boundary.
+
+Expected:
+Once a chat item has rendered visibly, it should never typewrite again for that session, even after refetches, status changes, or share/reconciler updates.
+
+Likely fix locations:
+- Patched `mobile/src/components/ChatInterface.tsx`
+- Added regression coverage in `mobile/src/components/__tests__/ChatInterface.test.tsx`
+
+### Issue 2: Missing Typing Indicator After Button-Only Empathy Actions
+
+Type: UI loading state  
+Severity: Medium  
+Status: fixed locally during run
+
+What happened:
+After Eve shared empathy, there was a pause before the AI follow-up arrived and no three-dot typing indicator appeared.
+
+Evidence:
+- User observed missing dots live.
+- Code inspection showed `ChatInterface` derives dots from the last `USER` message, but empathy share/resubmit are button-only actions.
+- First share also waits on `saveDraftAsync` before the consent mutation starts, and resubmit had no pending flag wired into chat loading.
+
+Expected:
+Button-only actions that trigger AI follow-up should show the same typing indicator until the AI response or transition message is inserted.
+
+Likely fix locations:
+- Patched `mobile/src/hooks/useUnifiedSession.ts`
+- Patched `mobile/src/screens/UnifiedSessionScreen.tsx`
+
+### Issue 3: Eve Saw Completion Copy Before Adam Was Done Refining
+
+Type: UI / backend state / waiting-state  
+Severity: Medium
+
+What happened:
+After Eve shared her empathy statement, Eve saw completion-style copy: `Both of you have now put in the vulnerable work of trying to understand each other's perspective. Next, you'll each read what the other person wrote...` The UI later settled into a wait state saying Adam was deciding whether to share more context.
+
+Evidence:
+- Eve browser showed the completion/validation copy before later showing the Adam wait copy.
+- DB inspection during the run showed Adam's empathy attempt was still `REFINING`.
+- Eve Stage 2 was still `IN_PROGRESS`.
+- Adam-side recent messages showed Adam was still responding to Eve's shared context.
+
+Expected:
+Eve should see wait copy that matches the live gate until both empathy attempts are actually ready for validation. The product should not imply both users have finished the mutual understanding work while one partner is still refining.
+
+Impact:
+This can make the Stage 2 validation/reveal sequence feel out of order and undermines trust in whether the current visible instruction is live state or stale history.
+
+Likely fix locations:
+- `backend/src/controllers/stage2.ts`
+- `backend/src/services/reconciler/sharing.ts`
+- `mobile/src/utils/getWaitingStatus.ts`
+- `mobile/src/config/waitingStatusConfig.ts`
+
+### Issue 4: Eve Saw Stage 3 Waiting Copy After Both Users Advanced To Stage 4
+
+Type: realtime / cache / waiting-state  
+Severity: High
+
+What happened:
+Eve's main screen continued to say `Adam is reviewing the needs you both shared.` after DB showed both users had completed Stage 3 and both had Stage 4 `IN_PROGRESS` rows. The header showed `New activity available`; clicking `Open exchange history` refreshed the visible state into Stage 4.
+
+Evidence:
+- DB showed Adam and Eve Stage 3 `COMPLETED` with `needsValidated: true`.
+- DB showed both users Stage 4 `IN_PROGRESS`.
+- Stage 4 transition messages existed at `2026-05-05T03:42:22Z`.
+- Eve DOM still showed the stale Stage 3 wait copy until the activity control was opened.
+
+Expected:
+The main waiting state should consume the same realtime/session update that raised `New activity available` and automatically replace Stage 3 wait copy with the correct Stage 4 state.
+
+Likely fix locations:
+- `mobile/src/hooks/useRealtime.ts`
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `mobile/src/utils/getWaitingStatus.ts`
+- `mobile/src/config/waitingStatusConfig.ts`
+
+### Issue 5: Stage 4 Strategy Panel Looked Blocked Until Eve Chatted Again
+
+Type: UI / realtime / cache / backend state  
+Severity: High
+
+What happened:
+Eve's Stage 4 screen showed a greyed `Ideas So Far` panel with `Strategies are being gathered from your conversation...`, while also showing `Ready to Rank` and an open chat box. It was unclear whether Eve should wait, chat more, or rank. After Eve sent one more strategy message, the panel updated to `9 strategies ready to review` and `View All`.
+
+Evidence:
+- Before Eve's extra chat, DB already had 7 `StrategyProposal` rows.
+- After Eve chatted about a reversible day trip/class and pause phrase, DB had 9 strategies and the strategy pool rendered.
+- This means the prior `Strategies are being gathered...` copy was stale or misleading, not an accurate empty-state.
+
+Expected:
+If strategies exist, Stage 4 should show the available count and review CTA immediately. If more chat is required, the copy should explicitly ask for more strategy ideas.
+
+Likely fix locations:
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `backend/src/controllers/stage4.ts`
+- strategy proposal realtime/cache invalidation
+
+### Issue 6: Ranking Submit Succeeded In DB But Eve Still Saw Active Submit
+
+Type: UI / realtime / cache / backend state  
+Severity: High
+
+What happened:
+Eve selected three ranking choices and submitted. DB recorded her `StrategyRanking` row and set Eve Stage 4 gates to `rankingSubmitted: true`, but the browser remained on `Rank Your Top Choices` with `Submit my ranking` still active after multiple checks.
+
+Evidence:
+- DB showed Eve ranking with three ranked IDs and `submittedAt: 2026-05-05T03:48:12.282Z`.
+- Eve Stage 4 gates included `readyToRank: true`, `rankingSubmitted: true`, and `rankingSubmittedAt`.
+- DOM still showed the active submit button.
+
+Expected:
+After ranking submit succeeds, Eve should transition to a submitted/waiting state until Adam submits, or to overlap reveal if Adam has already submitted.
+
+Likely fix locations:
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- ranking mutation success handling and `stageKeys.progress(sessionId)` invalidation
+
+### Issue 7: Agreement Creation Succeeded In DB But Eve Still Saw Create Agreement
+
+Type: UI / realtime / cache / backend state  
+Severity: High
+
+What happened:
+After both users submitted rankings, Eve saw shared overlap on the pause phrase and clicked `Create Agreement`. DB created the agreement and marked Eve's side agreed, but Eve's UI stayed on the same `Create Agreement` button.
+
+Evidence:
+- Agreement `cmos3af3000h0pxzhu0n8r90f` exists.
+- `status: PROPOSED`
+- `agreedByA: true`
+- `agreedByB: false`
+- Eve DOM still showed active `Create Agreement`.
+
+Expected:
+After successful agreement creation, Eve should see that the agreement was proposed and is awaiting Adam, or a clear pending/confirmation state. The create CTA should not remain available for the same strategy.
+
+Likely fix locations:
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- `backend/src/controllers/stage4.ts`
+- agreement query invalidation and `agreement.proposed` event handling
+
+### Gold Standard Alignment Review
+
+| Stage | Expected gold beat | Live evidence | Rating | Notes / fix |
+| --- | --- | --- | --- | --- |
+| Stage 1 Eve | Eve is heard as slowly disappearing and grieving aliveness, not simply dissatisfied or leaving. | Eve named feeling trapped/lonely and missing the early version where she felt alive with Adam; the AI reflected sadness and not wanting to leave prematurely. | Pass | Keep. |
+| Stage 2 Eve | Eve moves from "he is choosing comfort over me" toward seeing Adam's fear and stability as care/protection, without erasing her cost. | Eve reframed Adam's silence as panic/fear and said she could hold more tenderness while still needing him to stay present. | Pass | Keep. |
+| Stage 3 Eve | Eve's needs include room to grow, wanting without apology, Adam staying present, and small real experiments. | Confirmed needs included aliveness/becoming, wanting without managing Adam's fear, emotional presence, open future, and loving without containment. | Pass | Keep. |
+| Stage 3 reveal | The flow shows compatibility and tension without flattening the issue into "travel more" or "be content." | Side-by-side reveal showed Adam's steadiness/reassurance needs and Eve's aliveness/open-future needs without AI-authored common ground. | Pass | Keep. |
+| Stage 4 | Strategies preserve both stability and aliveness. | Strategy pool included reversible exploration, Adam naming excitement/fear, a pause phrase, and a check-in. | Pass | Qualitative strategy direction was good despite UI state bugs. |
+| Stage 4 | The AI checks whether strategies cover Adam's safety/pacing and Eve's growth/aliveness. | Current legacy ranking path found overlap but did not show an explicit needs-coverage audit. | Partial | Align with `stage-4-tending-technical-spec.md` proposal inventory / coverage audit. |
+| Closure | The pair can move toward shared experiments without pretending the deeper tension is permanently solved. | A micro-experiment agreement was proposed around the pause phrase, but final mutual confirmation was blocked by stale UI. | Partial | Agreement confirmation UI/state needs fixing. |
+| Tending | Follow-up checks whether experiments helped both stability and aliveness, not just whether tasks were done. | Adam proposed a Sunday 7pm check-in and Eve ranked a check-in option; persisted Tending was not reached. | Partial | Tending persistence remains future Stage 4 work. |
+
+### Gold Alignment Notes
+
+Worked well:
+- Eve's qualitative arc preserved both her longing and love for Adam.
+- Adam's needs were not treated as resistance; Eve could recognize fear and stability as meaningful.
+- Stage 3 needs were universal and user-confirmed, not narrow demands.
+- Stage 4 strategy content was strongly aligned with the Adam/Eve benchmark.
+- The final overlap on a pause phrase is a credible small shared experiment.
+
+Risks:
+- Realtime/cache bugs make successful actions look failed.
+- The user may repeat actions, type unnecessary extra chat, or distrust the flow.
+- Strategy duplicates can turn a relationally good plan into a mechanical ranking exercise.
+- Current Stage 4 still lacks the planned coverage inventory and clearer shared/individual closure model.
+
+## Fix Notes / Follow-Up Targets
+
+Most urgent engineering cluster:
+- Stage 4 query invalidation and realtime handling for strategy creation, readiness, ranking submission, overlap, and agreement creation.
+- Submitted/pending UI states for the current user after mutations succeed.
+- Agreement proposal rendering for both proposer and partner.
+- Deduplication or lifecycle status for superseded strategy proposals.
+
+Already patched locally during the Eve-side investigation:
+- Prevent already-seen AI chat items from replaying typewriter animation.
+- Show typing indicator for button-only empathy share/resubmit work.
+
+Suggested next report/check:
+- Have the Adam-side Codex verify whether Adam can see Eve's final agreement state after Eve-side confirmation is fixed or manually refreshed.

--- a/docs/product/gold-session-scratch/2026-05-04-cmos1tow4000epxzhjg829ef0-adam.md
+++ b/docs/product/gold-session-scratch/2026-05-04-cmos1tow4000epxzhjg829ef0-adam.md
@@ -1,0 +1,113 @@
+# Gold Session Scratch Log
+
+Date: 2026-05-04
+Session ID: `cmos1tow4000epxzhjg829ef0`
+Assigned side: Adam
+Scenario: Adam/Eve
+Browser URL: `http://localhost:8082/session/cmos1tow4000epxzhjg829ef0?e2e-user-id=cmorpyyqi0002pxnt18abhy7t&e2e-user-email=adam@e2e.test`
+
+## Timeline
+
+- Created no-Clerk Adam/Eve E2E session and opened Adam's assigned URL.
+- Adam completed Getting Started, shared the invitation topic, completed Your Story, and marked himself heard.
+- Adam completed Walking in Their Shoes and shared his empathy draft.
+- Stopped at the partner gate: Adam's UI says Eve is still reflecting.
+- Resumed after Eve shared additional context. Adam processed Eve's grief/aliveness context, shared optional context back to Eve, then revisited and resubmitted his refined understanding of Eve.
+- DB check after resubmission: Adam's empathy attempt is `READY` with `revisionCount: 1`; Eve's empathy attempt remains `REFINING`. Stopped again at the Eve refinement gate.
+- Resumed after Eve completed refinement. Adam validated Eve's understanding with "Yes, mostly," advanced to What Matters Most, confirmed and shared his needs.
+- Stopped at the Stage 3 partner gate: Adam's UI says Eve is deciding what they are ready to share.
+- Resumed when `Review needs together` appeared. Adam reviewed side-by-side needs, validated them, advanced to What Comes Next, and proposed a concrete low-risk experiment with a Sunday 7pm follow-up.
+- Stopped at the Stage 4 partner gate: Adam's UI says Eve is also designing experiments and Adam will see the combined strategy list once Eve is ready.
+- Resumed when Adam showed `7 strategies ready to review`. Opened `View All`, saw the strategy pool, clicked `These look good - rank my choices`, and Adam moved to a partner wait state: `Eve is getting ready to rank the ideas.`
+- Resumed when delayed ranking UI appeared. Adam selected three strategies and submitted ranking; overlap revealed that both chose the pause phrase strategy. Clicked `Create Agreement`.
+- DB showed the agreement was created (`PROPOSED`, `agreedByA: true`, `agreedByB: false`) but Adam's UI remained on the overlap card with `Create Agreement` still visible, even after reload.
+- Final Adam-side DB check: both Adam and Eve rankings are submitted; agreement `cmos3af3000h0pxzhu0n8r90f` remains `PROPOSED` with `agreedByA: true`, `agreedByB: false`. Adam has no legitimate further action unless the stale UI is bypassed or Eve confirms the agreement.
+
+## Findings
+
+### Stage 2 Adam perspective stretch reached Eve's aliveness need
+
+- Stage: Walking in Their Shoes
+- Type: gold alignment
+- Status: confirmed
+- Expected beat: Adam moves from "nothing will satisfy her" toward seeing Eve as feeling stuck, disappearing, needing aliveness, motion, and a future not only about preservation.
+- Live evidence: Adam named that Eve may feel stuck, disappearing, and folded smaller to fit a life that works for him; his shared draft said she needs him to see her motion/discovery needs as real rather than threatening.
+- Rating: Pass
+
+### Stage 2B Adam refinement incorporated Eve's grief context
+
+- Stage: Walking in Their Shoes / informed empathy refinement
+- Type: gold alignment
+- Status: confirmed
+- Expected beat: After Eve clarifies she is grieving the loss of feeling alive with Adam, Adam should revise from "she wants more than I can give" toward "she misses dreaming with me."
+- Live evidence: Adam said Eve's wanting change may mean she misses feeling alive with him, not away from him; the resubmitted draft incorporated that she is grieving the loss of aliveness and that Adam's fear made dreaming together feel unsafe.
+- DB evidence: Adam empathy attempt status became `READY`, `revisionCount: 1`; Eve's attempt stayed `REFINING`, so Adam was legitimately blocked on Eve.
+- Rating: Pass
+
+### Stage 3 Adam needs preserve stability without freezing change
+
+- Stage: What Matters Most
+- Type: gold alignment
+- Status: confirmed
+- Expected beat: Adam clarifies safety/stability as a need while opening space for Eve's aliveness rather than insisting nothing change.
+- Live evidence: Adam named recognition that wanting stability does not make him small or wrong, reassurance that Eve values what they built, safety that makes emotional risk possible, and change inside commitment.
+- Rating: Pass
+
+### Stage 4 Adam proposes reversible aliveness experiment
+
+- Stage: What Comes Next
+- Type: gold alignment
+- Status: confirmed
+- Expected beat: Adam should support a concrete experiment that preserves his need for steadiness while giving Eve real space for aliveness and dreaming.
+- Live evidence: Adam proposed one evening where Eve names one small new thing she wants to try, Adam asks curious questions for ten minutes before reacting/problem-solving, they choose a low-cost reversible version, and they check in Sunday at 7pm about staying connected.
+- Rating: Pass
+
+### Stage 4 strategy gathering status may not expose the next action
+
+- Stage: What Comes Next
+- Type: UI / state-machine
+- Status: suspected
+- What happened: Adam previously sat on `Ideas So Far / Strategies are being gathered from your conversation... / Ready to Rank` for an extended period with no clickable ranking control exposed in the DOM snapshot. Typing a message into chat moved Adam into strategy drafting. User reports Eve is now stuck on the same `Ideas So Far / Strategies are being gathered from your conversation...` state.
+- Evidence: Adam DOM showed `Ready to Rank` as visible status text but no accessible button or drawer opened when clicked; after Adam typed readiness in chat, MWF prompted for a concrete experiment. Current user report says Eve is stuck on the same gathering copy.
+- Expected: Once strategies are ready, the UI should expose a clear actionable CTA or automatically prompt the user for the next strategy-drafting/ranking step. If the system is still gathering, the copy should not show `Ready to Rank`.
+- Likely fix: Investigate Stage 4 strategy readiness gating and UI CTA rendering around the `Ideas So Far`, `Ready to Rank`, and strategy drawer states in mobile stage/session components.
+
+### Strategy pool contains near-duplicate ideas
+
+- Stage: What Comes Next
+- Type: UI / eval coverage
+- Status: suspected
+- What happened: Adam's strategy pool listed seven strategies, but most were near-duplicate fragments or variants of the same Adam-authored experiment.
+- Evidence: The pool included multiple variants of "one evening this week Eve names one small new thing; Adam asks curious questions for 10 minutes," multiple versions of choosing a low-cost reversible idea, and multiple follow-up/check-in variants.
+- Expected: Ranking should present meaningfully distinct strategies or consolidate variants into one coherent strategy with steps.
+- Likely fix: Investigate Stage 4 strategy extraction/deduplication before presenting the pool and before ranking.
+
+### Ranking UI appears after unclear wait
+
+- Stage: What Comes Next
+- Type: UI
+- Status: suspected
+- What happened: After Adam clicked `These look good - rank my choices`, the UI showed a partner wait state (`Eve is getting ready to rank the ideas`) before eventually changing to the ranking UI.
+- Evidence: User observed that the ranking UI finally appeared after the wait; previous Adam state did not explain that a delayed transition to ranking was pending.
+- Expected: The wait copy should make it clear whether Adam is waiting for Eve, waiting for ranking setup, or will be taken to ranking automatically once both sides are ready.
+- Likely fix: Clarify Stage 4 wait-state copy and/or show progress toward ranking readiness.
+
+### Agreement creation persists but UI stays on create button
+
+- Stage: What Comes Next
+- Type: UI / state-machine
+- Status: confirmed
+- What happened: Adam clicked `Create Agreement` from the overlap reveal. The UI did not visibly advance after multiple clicks and still showed `Create Agreement`; after reload it still showed the same create button.
+- Evidence: DB contains agreement `cmos3af3000h0pxzhu0n8r90f` for shared vessel `cmos1towe000mpxzh2jtwjopk`, proposal `cmos37w0g00gppxzh15muq5wh`, description `Create a pause phrase both can use when either starts shutting down, so the conversation can resume later`, status `PROPOSED`, `agreedByA: true`, `agreedByB: false`. UI continued to show the overlap reveal and `Create Agreement` instead of an agreement preview or waiting state.
+- Expected: After agreement creation succeeds, Adam should see a proposed agreement card or a clear wait state indicating Eve needs to review/confirm the agreement. The create button should not remain available for the same strategy.
+- Likely fix: Investigate `useCreateAgreement` success handling, `agreements` query invalidation/refetch, and overlap reveal state in `mobile/src/hooks/useUnifiedSession.ts` and `mobile/src/components/OverlapReveal.tsx`.
+
+### Adam handoff state for Eve-side report
+
+- Stage: What Comes Next
+- Type: backend state / handoff
+- Status: confirmed
+- What happened: Adam completed ranking and created the shared pause-phrase agreement. Backend state is now waiting for Eve to confirm that agreement.
+- Evidence: `StrategyRanking` rows exist for both Adam (`cmorpyyqi0002pxnt18abhy7t`) and Eve (`cmorpyysd0003pxntibmkhf9p`). Agreement `cmos3af3000h0pxzhu0n8r90f` is `PROPOSED`, `agreedByA: true`, `agreedByB: false`.
+- Expected: Eve side should show the proposed agreement for confirmation; Adam side should show a waiting state, but currently shows stale `Create Agreement`.
+- Likely fix: Eve-side session should continue by reviewing/confirming the proposed agreement; product investigation should focus on why Adam's agreement state did not render after creation.

--- a/docs/product/gold-session-scratch/2026-05-05-cmoru5afm000bpxj2e3coa3ij-adam.md
+++ b/docs/product/gold-session-scratch/2026-05-05-cmoru5afm000bpxj2e3coa3ij-adam.md
@@ -1,0 +1,45 @@
+# Gold Session Scratch Log
+
+Date: 2026-05-05
+Session ID: `cmoru5afm000bpxj2e3coa3ij`
+Assigned side: Adam
+Scenario: Adam/Eve
+Browser URL: `http://localhost:8082/session/cmoru5afm000bpxj2e3coa3ij?e2e-user-id=cmorpyyqi0002pxnt18abhy7t&e2e-user-email=adam@e2e.test`
+
+## Timeline
+
+- Adam/Eve local E2E run reached Stage 4 / `What Comes Next`.
+- Both users completed Stage 3 needs gates.
+- Eve reached Stage 4 `readyToRank: true`; Adam remained Stage 4 `IN_PROGRESS` with no `readyToRank`.
+
+## Findings
+
+### Stage 4 strategy card appears inert and contradicts backend state
+
+- Stage: What Comes Next
+- Type: UI / backend state / realtime
+- Status: confirmed
+- What happened: Adam saw `Ideas So Far`, `Strategies are being gathered from your conversation...`, and `Ready to Rank`. The UI looked actionable but did not advance Adam or set `readyToRank`.
+- Evidence: Browser text showed the strategy card and `Ready to Rank`; DB had six `StrategyProposal` rows; Eve Stage 4 gates included `readyToRank: true`; Adam Stage 4 gates were `null`; no `StrategyRanking` rows existed.
+- Expected: If strategies exist, Adam should see the strategy pool or a nonzero strategy count and an enabled readiness action. If strategies are still generating, `Ready to Rank` should not appear as an actionable control.
+- Likely fix: `mobile/src/hooks/useUnifiedSession.ts`, `mobile/src/screens/UnifiedSessionScreen.tsx`, `mobile/src/hooks/useStages.ts`, `backend/src/controllers/stage4.ts`, strategy proposal realtime/cache invalidation.
+
+### Confirmed needs are shown as plain chat text instead of consistent structured UI
+
+- Stage: What Comes Next / historical What Matters Most content
+- Type: UI / gold alignment
+- Status: confirmed
+- What happened: Adam’s confirmed needs appeared in old chat text as a markdown-style list with `Does that capture what matters most to you?`, while the app previously used polished structured needs review/reveal UI. The old text remained visually prominent near the current Stage 4 state.
+- Evidence: Browser text showed `Here's what I'm hearing you say matters most to you:` followed by bullet-style needs and the old confirmation prompt. The current stage header was already `What Comes Next`.
+- Expected: Confirmed needs should be represented as a structured artifact/card/drawer once Stage 3 is complete. Chat can contain historical reflection, but it should not compete with the current Stage 4 action or look like a live needs-review prompt.
+- Likely fix: `mobile/src/screens/UnifiedSessionScreen.tsx`, `mobile/src/components/ChatInterface.tsx`, needs card/drawer rendering, current-action panel/history separation.
+
+### Stage 4 is blocked before gold-standard strategy evaluation can complete
+
+- Stage: What Comes Next
+- Type: gold alignment / UI / backend state
+- Status: blocked
+- Expected beat: Adam/Eve Stage 4 should shape small experiments that preserve both Adam's stability/safety and Eve's aliveness/growth, then check whether strategies cover both sets of needs.
+- Live evidence: DB contained strategy proposals that looked directionally gold-aligned, including low-stakes exploration, a pause phrase, and a one-month check-in. Adam could not mark ready to rank because the UI behaved as though strategies were still being gathered.
+- Rating: Blocked
+- Likely fix: Fix Stage 4 strategy query/cache and readiness CTA before evaluating ranking, coverage audit, agreement, or Tending behavior.

--- a/docs/product/gold-session-scratch/2026-05-05-cmos1tow4000epxzhjg829ef0-Eve.md
+++ b/docs/product/gold-session-scratch/2026-05-05-cmos1tow4000epxzhjg829ef0-Eve.md
@@ -1,0 +1,94 @@
+# Gold Session Scratch Log
+
+Date: 2026-05-05
+Session ID: `cmos1tow4000epxzhjg829ef0`
+Assigned side: Eve
+Scenario: Adam/Eve
+Browser URL: `http://localhost:8082/session/cmos1tow4000epxzhjg829ef0?e2e-user-id=cmorpyysd0003pxntibmkhf9p&e2e-user-email=eve@e2e.test`
+
+## Timeline
+
+- Accepted Adam's pending invitation `cmos1tow8000gpxzhma84d3hn` as Eve through the local E2E API. DB/API reported session status changed from `INVITED` to `ACTIVE` and members are Adam/Eve.
+- Eve completed Stage 1, clicked `I feel heard`, completed Stage 2 perspective stretch, shared extra context with Adam, and shared her empathy statement. Eve is now blocked on Adam.
+- After Adam shared context, Eve reflected on his silence as panic/fear rather than indifference, revised and resubmitted her empathy statement, then validated Adam's understanding with `Yes, mostly`. Eve is now waiting on Adam to review what she shared.
+- Eve entered Stage 3, named and confirmed needs around aliveness/becoming, autonomy from managing Adam's fear, emotional presence, an open future, and loving without containment. Eve shared her needs, reviewed Adam's shared needs side by side, validated Adam's needs, and is now waiting on Adam to review the shared needs.
+
+## Findings
+
+### Eve saw completion copy before Adam was done refining
+
+- Stage: Walking in Their Shoes
+- Type: UI / backend state
+- Status: confirmed
+- What happened: After Eve shared her empathy statement, Eve saw: "Both of you have now put in the vulnerable work of trying to understand each other's perspective. Next, you'll each read what the other person wrote..." The UI then settled into "Adam is deciding whether to share more context."
+- Evidence: DB query showed Adam's `EmpathyAttempt.status` was `REFINING`, Eve's Stage 2 remained `IN_PROGRESS`, and the latest Adam-side messages showed Adam responding to Eve's shared context. Eve's browser displayed the completion copy before later displaying the Adam-wait copy.
+- Expected: Eve should see wait copy that matches the live gate, e.g. Adam is still finishing/refining, until both empathy attempts are actually ready for validation.
+- Likely fix: Stage 2 post-share transition copy/status handling in `backend/src/controllers/stage2.ts`, `backend/src/services/reconciler/sharing.ts`, and waiting-copy mapping in `mobile/src/utils/getWaitingStatus.ts` / `mobile/src/config/waitingStatusConfig.ts`.
+
+### Previously visible AI messages replayed typewriter after Eve shared empathy
+
+- Stage: Walking in Their Shoes
+- Type: UI
+- Status: resolved during run
+- What happened: After Eve shared her empathy statement, several previously visible AI chat messages replayed their typewriter animation one at a time.
+- Evidence: User observed the behavior live in the in-app browser immediately after the empathy share action. Code inspection showed `ChatInterface` could later promote already rendered AI messages into the animation queue after button-only actions because only typed `USER` messages were treated as a response boundary.
+- Expected: Once a chat item has rendered visibly, it should never typewrite again for that session, even after message refetches, status changes, or Stage 2 share/reconciler updates.
+- Likely fix: Patched `mobile/src/components/ChatInterface.tsx` to keep a session-scoped seen-animation set and mark rendered non-user items as seen when they do not receive the current animation turn. Added a regression test in `mobile/src/components/__tests__/ChatInterface.test.tsx`.
+
+### Stage 2 Adam context helped Eve refine without collapsing her boundary
+
+- Stage: Walking in Their Shoes
+- Type: gold alignment
+- Status: confirmed
+- Expected beat: Eve softens from reading Adam's silence as rejection/indifference toward understanding his fear, while still maintaining that his fear cannot determine both of their future.
+- Live evidence: Eve named Adam's silence as "panic" and said she could see him with more tenderness, while preserving "I still need him to stay with me when the conversation gets scary." The revised share text included both compassion for his fear and the impact of leaving her alone with the future.
+- Rating: Pass
+
+### Missing typing indicator after empathy share button action
+
+- Stage: Walking in Their Shoes
+- Type: UI
+- Status: resolved during run
+- What happened: After Eve shared empathy, there was a pause before the AI follow-up arrived and the chat did not show the three-dot typing indicator.
+- Evidence: User observed the missing dots live after empathy share. Code inspection showed `ChatInterface` derives dots from the last `USER` message, but empathy share/resubmit are button-only actions. The first-share path also waits on `saveDraftAsync` before the consent mutation starts, and resubmit had no pending flag wired into chat loading.
+- Expected: Button-only actions that trigger AI follow-up should show the same three-dot indicator until the AI response or transition message is inserted.
+- Likely fix: Patched `mobile/src/hooks/useUnifiedSession.ts` to expose `isSavingEmpathyDraft` and `isResubmittingEmpathy`; patched `mobile/src/screens/UnifiedSessionScreen.tsx` to pass those flags, along with `isSharingEmpathy`, into `ChatInterface.isLoading`.
+
+### Stage 3 Eve needs remained user-articulated and not AI-authored common ground
+
+- Stage: What Matters Most
+- Type: gold alignment
+- Status: confirmed
+- Expected beat: Eve identifies her own needs before reveal; side-by-side reveal shows both users' needs without presenting AI-authored common ground as product truth.
+- Live evidence: Eve named aliveness, an open future, emotional presence, autonomy from managing Adam's fear, and loving without containment. The needs drawer listed Eve's needs and Adam's needs side by side; Eve validated Adam's needs after review. No common-ground claim was shown before validation.
+- Rating: Pass
+
+### Eve waiting state stayed on Stage 3 after both users advanced to Stage 4
+
+- Stage: What Matters Most / What Comes Next
+- Type: realtime / cache / waiting-state
+- Status: confirmed
+- What happened: Eve's main session screen continued to say `Adam is reviewing the needs you both shared.` even after the DB showed both users had completed Stage 3 and both had Stage 4 `IN_PROGRESS` rows. The header showed `New activity available`; clicking `Open exchange history` refreshed the visible state into Stage 4 (`Ideas So Far`, `Strategies are being gathered from your conversation...`, `Ready to Rank`).
+- Evidence: Browser URL was `cmos1tow4000epxzhjg829ef0`; DOM before re-check showed the stale Stage 3 wait copy. DB showed Adam Stage 3 `COMPLETED` with `needsValidated: true`, Eve Stage 3 `COMPLETED` with `needsValidated: true`, and both users Stage 4 `IN_PROGRESS`, with Stage 4 transition messages at `2026-05-05T03:42:22Z`. After clicking the new-activity control, the Stage 3 wait copy disappeared and Stage 4 UI rendered.
+- Expected: Eve's main waiting state should consume the same realtime/session-state update that raised `New activity available` and automatically replace Stage 3 wait copy with the correct Stage 4 state. If Eve is waiting in Stage 4, the copy should describe Adam's Stage 4 readiness/ranking blocker, not Stage 3 needs review.
+- Likely fix: Realtime handlers and query invalidation around Stage 3 completion / Stage 4 creation in `mobile/src/hooks/useRealtime.ts`, `mobile/src/hooks/useUnifiedSession.ts`, `mobile/src/hooks/useStages.ts`, and `mobile/src/screens/UnifiedSessionScreen.tsx`; waiting-copy selection in `mobile/src/utils/getWaitingStatus.ts` / `mobile/src/config/waitingStatusConfig.ts`.
+
+### Stage 4 strategy panel looked blocked until Eve chatted again, then ranking submit stayed stale
+
+- Stage: What Comes Next
+- Type: UI / realtime / cache / backend state
+- Status: confirmed
+- What happened: Eve's Stage 4 screen showed a greyed `Ideas So Far` panel with `Strategies are being gathered from your conversation...`, while also showing `Ready to Rank` and an open chat box. This made it unclear whether Eve should wait, chat more, or rank. After Eve sent one more strategy message, the panel updated to `9 strategies ready to review` and `View All`, and ranking became reachable. After Eve selected three choices and submitted, the DB recorded the ranking but the UI stayed on `Rank Your Top Choices` with `Submit my ranking` still active.
+- Evidence: Before Eve's extra chat, DB already had 7 `StrategyProposal` rows for the session, so `Strategies are being gathered...` was stale/misleading. After Eve chatted about a reversible day trip/class and pause phrase, DB had 9 strategies and the strategy pool rendered. After Eve submitted rankings, DB had a `StrategyRanking` row for Eve and Eve Stage 4 gates included `readyToRank: true`, `rankingSubmitted: true`, and `rankingSubmittedAt`, but the DOM still showed the active submit button after multiple re-checks.
+- Expected: If strategies exist, Stage 4 should show the available count and review CTA immediately instead of a grey gathering placeholder. If more chat is required, the copy should explicitly ask for more strategy ideas. After ranking submit succeeds, the ranking screen should transition to a submitted/waiting-for-Adam state and should not leave an active submit button.
+- Likely fix: Stage 4 strategy query/cache invalidation and submitted-state rendering in `mobile/src/hooks/useUnifiedSession.ts`, `mobile/src/hooks/useStages.ts`, `mobile/src/screens/UnifiedSessionScreen.tsx`, and `backend/src/controllers/stage4.ts`; verify realtime events for strategy proposal creation and ranking submission update `stageKeys.progress(sessionId)` and any strategy-list/ranking queries.
+
+### Agreement creation succeeded in DB but Eve still saw Create Agreement
+
+- Stage: What Comes Next
+- Type: UI / realtime / cache / backend state
+- Status: confirmed
+- What happened: After both users submitted rankings, Eve saw `Your Shared Priorities` with common ground on the pause phrase and clicked `Create Agreement`. The backend created a proposed agreement and marked Eve's side agreed, but the UI stayed on the same `Create Agreement` button with no submitted/pending state.
+- Evidence: DB showed agreement `cmos3af3000h0pxzhu0n8r90f` for `Create a pause phrase both can use when either starts shutting down, so the conversation can resume later`, status `PROPOSED`, `agreedByA: true`, `agreedByB: false`. Browser DOM still showed the active `Create Agreement` button after a re-check.
+- Expected: After successful create/propose, Eve should see that the agreement was proposed and is awaiting Adam, or a confirmation/pending state. The create CTA should be disabled/replaced so Eve cannot believe nothing happened or duplicate the proposal.
+- Likely fix: Agreement mutation success handling and shared-priority/agreement query invalidation in `mobile/src/hooks/useStages.ts`, `mobile/src/screens/UnifiedSessionScreen.tsx`, and `backend/src/controllers/stage4.ts`; ensure `agreement.proposed` / session state events refresh agreement cards for the proposing user as well as the partner.

--- a/docs/product/gold-session-scratch/2026-05-05-cmos4fj6j000npx6a4w5cllw4-adam.md
+++ b/docs/product/gold-session-scratch/2026-05-05-cmos4fj6j000npx6a4w5cllw4-adam.md
@@ -1,0 +1,49 @@
+# Gold Session Scratch Log
+
+Date: 2026-05-05
+Session ID: `cmos4fj6j000npx6a4w5cllw4`
+Assigned side: Adam
+Scenario: Adam/Eve Stage 4 refresh check
+Browser URL: `http://localhost:8082/session/cmos4fj6j000npx6a4w5cllw4?e2e-user-id=cmos4fj65000gpx6aqq04yi42&e2e-user-email=adam-stage4-refresh%40e2e.test`
+
+## Timeline
+
+- Seeded a fresh Adam/Eve E2E session at `NEED_MAPPING_COMPLETE` so both users begin in Stage 4. This run is scoped to post-action Stage 4 cache/UI behavior after the three commits.
+- Added three deterministic strategy rows through the local E2E API. After Adam reload, the Stage 4 panel showed `3 strategies ready to review`, not the zero-strategy gathering copy.
+- Eve was marked ready first, then Adam marked ready through the UI and reached `Rank Your Top Choices`.
+- Adam submitted ranking through the UI. Initial check showed the backend persisted `rankingSubmitted: true`, but `GET /strategies` still returned `phase: RANKING` for Adam while Eve had not ranked, so Adam's UI reloaded back to active ranking. Patched backend phase derivation during this run.
+- After patch, Adam's `GET /strategies` returned `phase: REVEALING` while Eve still returned `phase: RANKING`; Adam UI showed `Waiting for your partner to submit their ranking` with no active submit button.
+- Eve ranking was submitted through the local E2E API. Adam reload showed `Your Shared Priorities` with overlap and `Create Agreement` actions.
+- Adam clicked `Create Agreement` for the pause-phrase strategy. UI changed to `You've proposed the agreement. Waiting for Eve to confirm.` with no `Create Agreement` button.
+- Eve confirmed the proposed agreement through the local E2E API. Adam reload showed the resolved completion screen and the agreed pause-phrase agreement.
+
+## Findings
+
+### Submitted ranking still returned active ranking phase
+
+- Stage: What Comes Next / Stage 4
+- Type: backend state / UI state
+- Status: confirmed, fixed during run
+- What happened: Adam submitted ranking successfully and DB progress showed `rankingSubmitted: true`, but the strategies endpoint still returned `phase: RANKING` because Eve had not ranked yet. Adam's UI reloaded back to the active ranking submit screen.
+- Evidence: `GET /progress` for Adam had `gatesSatisfied.rankingSubmitted: true`; `GET /strategies` returned `phase: RANKING` before the patch.
+- Expected: The submitting user should move to a waiting/reveal state while the unranked partner still sees active ranking.
+- Fix: `backend/src/controllers/stage4.ts` now returns `REVEALING` for the current user when their ranking exists, even if the partner has not ranked. Added coverage in `backend/src/routes/__tests__/stage4.test.ts`.
+
+### Agreement proposal state no longer leaves Create Agreement visible
+
+- Stage: What Comes Next / Stage 4
+- Type: UI / cache state
+- Status: confirmed fixed
+- What happened: After Adam clicked `Create Agreement`, the UI switched to a waiting state: `You've proposed the agreement. Waiting for Eve to confirm.`
+- Evidence: Agreement API returned `status: PROPOSED`, `agreedByMe: true`, `agreedByPartner: false`; Adam DOM no longer contained `Create Agreement`.
+- Expected: Proposer sees proposed/waiting state, not another create action.
+- Likely fix: Existing Stage 4 cache/action-state commit plus backend DTO shape worked as intended for agreement proposal.
+
+### Partner confirmation resolves session cleanly
+
+- Stage: What Comes Next / Stage 4
+- Type: UI / backend state
+- Status: confirmed
+- What happened: Eve confirmed the agreement through the local E2E API. Adam reload showed the resolved completion screen with the agreed pause-phrase experiment.
+- Evidence: Confirm API returned `status: AGREED`, `agreedByMe: true`, `agreedByPartner: true`, `sessionCanResolve: true`; Adam DOM showed `Resolved`, `A Path Forward`, and the agreement text.
+- Expected: Both users confirming the proposed agreement resolves the session and shows completion.

--- a/mobile/src/components/ChatInput.tsx
+++ b/mobile/src/components/ChatInput.tsx
@@ -116,7 +116,7 @@ export function ChatInput({
         </TouchableOpacity>
       )}
       <TouchableOpacity
-        testID={canSend ? 'send-button' : undefined}
+        testID="send-button"
         style={[styles.sendButton, !canSend && styles.sendButtonDisabled]}
         onPress={handleSend}
         disabled={!canSend}

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -174,6 +174,23 @@ const DEFAULT_EMPTY_TITLE = 'Start the Conversation';
 const DEFAULT_EMPTY_MESSAGE =
   "Share what's on your mind. I'm here to listen and help you work through it.";
 
+const seenAnimatedItemIdsByScope = new Map<string, Set<string>>();
+let localAnimationScopeCounter = 0;
+
+function createLocalAnimationScope(): string {
+  localAnimationScopeCounter += 1;
+  return `__local_chat_animation_scope_${localAnimationScopeCounter}`;
+}
+
+function getSeenAnimatedItemIds(scope: string): Set<string> {
+  let ids = seenAnimatedItemIdsByScope.get(scope);
+  if (!ids) {
+    ids = new Set<string>();
+    seenAnimatedItemIdsByScope.set(scope, ids);
+  }
+  return ids;
+}
+
 export function ChatInterface({
   sessionId,
   messages,
@@ -213,6 +230,18 @@ export function ChatInterface({
 }: ChatInterfaceProps) {
   const styles = useStyles();
   const flatListRef = useRef<FlatList<ChatListItem>>(null);
+  const localAnimationScopeRef = useRef<string | null>(null);
+  if (localAnimationScopeRef.current === null) {
+    localAnimationScopeRef.current = createLocalAnimationScope();
+  }
+  const animationScope = sessionId || localAnimationScopeRef.current;
+  const animationScopeRef = useRef(animationScope);
+  const seenAnimatedItemIdsRef = useRef(getSeenAnimatedItemIds(animationScope));
+
+  if (animationScopeRef.current !== animationScope) {
+    animationScopeRef.current = animationScope;
+    seenAnimatedItemIdsRef.current = getSeenAnimatedItemIds(animationScope);
+  }
 
   // ---------------------------------------------------------------------------
   // Cache-First Architecture: Derive "waiting for AI" from last message role
@@ -245,6 +274,11 @@ export function ChatInterface({
 
   // Track items that have completed animation during this mount.
   const animatedItemIdsRef = useRef<Set<string>>(new Set());
+
+  const markItemAnimationSeen = useCallback((itemId: string) => {
+    animatedItemIdsRef.current.add(itemId);
+    seenAnimatedItemIdsRef.current.add(itemId);
+  }, []);
 
   // STABLE SORT: Ensure order never flip-flops if timestamps are identical
   const listItems = useMemo((): ChatListItem[] => {
@@ -369,14 +403,20 @@ export function ChatInterface({
   if (isInitialLoadRef.current && messages.length > 0) {
     const shouldSkip = skipInitialHistory && messages.length === 1;
     if (!shouldSkip) {
-      messages.forEach(m => mountSnapshotIdsRef.current.add(m.id));
+      messages.forEach((m) => {
+        mountSnapshotIdsRef.current.add(m.id);
+        seenAnimatedItemIdsRef.current.add(m.id);
+      });
     }
     isInitialLoadRef.current = false;
   }
 
   // Add pagination messages to snapshot (they're history, not new)
   if (isLoadingHistoryRef.current && messages.length > 0) {
-    messages.forEach(m => mountSnapshotIdsRef.current.add(m.id));
+    messages.forEach((m) => {
+      mountSnapshotIdsRef.current.add(m.id);
+      seenAnimatedItemIdsRef.current.add(m.id);
+    });
   }
 
   // Detect when custom empty state is removed (e.g., compact was signed)
@@ -416,6 +456,7 @@ export function ChatInterface({
   const shouldAnimateItem = useCallback((item: ChatListItem, index: number) => {
     if (isIndicator(item) || isValidationCard(item) || isCustomEmptyState(item)) return false;
     if (animatedItemIdsRef.current.has(item.id)) return false;
+    if (seenAnimatedItemIdsRef.current.has(item.id)) return false;
     if (isAtOrBeforeSeenBoundary(item, index)) return false;
 
     if (isCustomCard(item)) {
@@ -497,6 +538,30 @@ export function ChatInterface({
     return null;
   }, [listItems, animatingItemId, shouldAnimateItem]);
 
+  // Once a non-user chat item renders in full, it should never be eligible for
+  // a later typewriter pass. This prevents refetches/status changes after
+  // button-only actions from replaying older visible messages one by one.
+  useEffect(() => {
+    listItems.forEach((item, index) => {
+      if (isIndicator(item) || isValidationCard(item) || isCustomEmptyState(item)) return;
+      if (item.id === nextAnimatableMessageId || item.id === animatingItemId) return;
+
+      if (isCustomCard(item)) {
+        if (item.animate === true && !shouldAnimateItem(item, index)) {
+          markItemAnimationSeen(item.id);
+        }
+        return;
+      }
+
+      const message = item as ChatMessage;
+      if (message.role === MessageRole.USER) return;
+      if (message.id.startsWith('optimistic-')) return;
+      if (!shouldAnimateItem(message, index)) {
+        markItemAnimationSeen(message.id);
+      }
+    });
+  }, [listItems, nextAnimatableMessageId, animatingItemId, shouldAnimateItem, markItemAnimationSeen]);
+
   // Notify parent when typewriter state changes
   useEffect(() => {
     const isAnimating = animatingItemId !== null;
@@ -557,7 +622,7 @@ export function ChatInterface({
           {item.render({
             skipAnimation: !shouldAnimate || !isNextAnimatable,
             onAnimationComplete: shouldAnimate && isNextAnimatable ? () => {
-              animatedItemIdsRef.current.add(item.id);
+              markItemAnimationSeen(item.id);
               setAnimatingItemId(null);
               onTypewriterComplete?.();
             } : undefined,
@@ -595,7 +660,7 @@ export function ChatInterface({
           message={bubbleMessage}
           onAnimationStart={isNextAnimatable ? () => setAnimatingItemId(message.id) : undefined}
           onAnimationComplete={(isNextAnimatable || isCurrentlyAnimating) ? () => {
-            animatedItemIdsRef.current.add(message.id);
+            markItemAnimationSeen(message.id);
             setAnimatingItemId(null);
             onTypewriterComplete?.();
           } : undefined}
@@ -606,7 +671,7 @@ export function ChatInterface({
         {renderMessageExtra?.(message)}
       </>
     );
-  }, [listItems, shouldAnimateItem, nextAnimatableMessageId, animatingItemId, onTypewriterComplete, isSpeaking, currentId, handleSpeakerPress, customEmptyState, styles, partnerName, renderMessageExtra, onValidateAccurate, onValidateNotQuite]);
+  }, [listItems, shouldAnimateItem, nextAnimatableMessageId, animatingItemId, onTypewriterComplete, isSpeaking, currentId, handleSpeakerPress, customEmptyState, styles, partnerName, renderMessageExtra, onValidateAccurate, onValidateNotQuite, markItemAnimationSeen]);
 
   const keyExtractor = useCallback((item: ChatListItem) => item.id, []);
 

--- a/mobile/src/components/__tests__/ChatInterface.test.tsx
+++ b/mobile/src/components/__tests__/ChatInterface.test.tsx
@@ -23,6 +23,30 @@ jest.mock('../SpeakerButton', () => {
   };
 });
 
+jest.mock('../../hooks/useSpeech', () => ({
+  useSpeech: () => ({
+    isSpeaking: false,
+    currentId: null,
+    toggle: jest.fn(),
+  }),
+  useAutoSpeech: () => ({
+    isAutoSpeechEnabled: false,
+  }),
+}));
+
+jest.mock('../TypewriterText', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    TypewriterText: ({ text, onComplete }: { text: string; onComplete?: () => void }) => {
+      React.useEffect(() => {
+        onComplete?.();
+      }, [onComplete]);
+      return <Text testID="typewriter-text">{text}</Text>;
+    },
+  };
+});
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -177,6 +201,72 @@ describe('ChatInterface', () => {
       render(<ChatInterface messages={[]} onSendMessage={mockOnSendMessage} isLoading={false} />);
 
       expect(screen.queryByTestId('typing-indicator')).toBeNull();
+    });
+  });
+
+  describe('Typewriter Animation', () => {
+    it('does not replay already rendered AI messages after message updates', async () => {
+      const baseTime = new Date('2026-05-05T03:00:00.000Z').getTime();
+      const userMessage = createMockMessage({
+        id: 'user-1',
+        role: MessageRole.USER,
+        content: 'I replied',
+        timestamp: new Date(baseTime).toISOString(),
+      });
+      const firstAIMessage = createMockMessage({
+        id: 'ai-1',
+        role: MessageRole.AI,
+        content: 'First AI response',
+        timestamp: new Date(baseTime + 1000).toISOString(),
+      });
+      const secondAIMessage = createMockMessage({
+        id: 'ai-2',
+        role: MessageRole.AI,
+        content: 'Second AI response',
+        timestamp: new Date(baseTime + 2000).toISOString(),
+      });
+      const thirdAIMessage = createMockMessage({
+        id: 'ai-3',
+        role: MessageRole.AI,
+        content: 'Third AI response',
+        timestamp: new Date(baseTime + 3000).toISOString(),
+      });
+
+      const { rerender } = render(
+        <ChatInterface
+          sessionId="animation-regression-session"
+          messages={[userMessage]}
+          onSendMessage={mockOnSendMessage}
+          skipInitialHistory
+        />
+      );
+
+      rerender(
+        <ChatInterface
+          sessionId="animation-regression-session"
+          messages={[userMessage, firstAIMessage, secondAIMessage]}
+          onSendMessage={mockOnSendMessage}
+          skipInitialHistory
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.queryAllByTestId('typewriter-text').length).toBeLessThanOrEqual(1);
+      });
+
+      rerender(
+        <ChatInterface
+          sessionId="animation-regression-session"
+          messages={[userMessage, firstAIMessage, secondAIMessage, thirdAIMessage]}
+          onSendMessage={mockOnSendMessage}
+          skipInitialHistory
+        />
+      );
+
+      await waitFor(() => {
+        const animatedTexts = screen.queryAllByTestId('typewriter-text').map((node) => node.props.children);
+        expect(animatedTexts).not.toContain('Second AI response');
+      });
     });
   });
 

--- a/mobile/src/hooks/__tests__/useStages.test.ts
+++ b/mobile/src/hooks/__tests__/useStages.test.ts
@@ -711,6 +711,57 @@ describe('useStages', () => {
           rankedIds: ['strategy-1', 'strategy-2', 'strategy-3'],
         });
       });
+
+      it('moves the local strategy cache out of active ranking immediately', async () => {
+        mockPost.mockResolvedValueOnce({
+          ranked: true,
+          rankedAt: '2026-05-05T00:00:00.000Z',
+          partnerRanked: false,
+          canReveal: false,
+        });
+
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        queryClient.setQueryData(stageKeys.strategies(sessionId), {
+          strategies: [],
+          phase: StrategyPhase.RANKING,
+          aiSuggestionsAvailable: false,
+          myReadyToRank: true,
+          partnerReadyToRank: true,
+        });
+        queryClient.setQueryData(stageKeys.progress(sessionId), {
+          sessionId,
+          myProgress: {
+            stage: Stage.STRATEGIC_REPAIR,
+            status: StageStatus.IN_PROGRESS,
+            startedAt: '2026-05-05T00:00:00.000Z',
+            completedAt: null,
+            gatesSatisfied: { readyToRank: true },
+          },
+          partnerProgress: {
+            stage: Stage.STRATEGIC_REPAIR,
+            status: StageStatus.IN_PROGRESS,
+            gatesSatisfied: { readyToRank: true },
+          },
+          canAdvance: false,
+        });
+        const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+          React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+        const { result } = renderHook(() => useSubmitRankings(), { wrapper });
+
+        await act(async () => {
+          await result.current.mutateAsync({
+            sessionId,
+            rankedIds: ['strategy-1', 'strategy-2'],
+          });
+        });
+
+        expect(queryClient.getQueryData<any>(stageKeys.strategies(sessionId))?.phase)
+          .toBe(StrategyPhase.REVEALING);
+        expect(
+          queryClient.getQueryData<any>(stageKeys.progress(sessionId))?.myProgress.gatesSatisfied.rankingSubmitted
+        ).toBe(true);
+      });
     });
 
     describe('useStrategiesReveal hook', () => {
@@ -784,7 +835,7 @@ describe('useStages', () => {
             status: 'PROPOSED',
             duration: null,
             measureOfSuccess: null,
-            agreedByMe: false,
+            agreedByMe: true,
             agreedByPartner: false,
             agreedAt: null,
             followUpDate: null,
@@ -810,6 +861,49 @@ describe('useStages', () => {
           description: 'We agree to weekly check-ins on Sundays',
           type: AgreementType.COMMITMENT,
         });
+      });
+
+      it('adds the created agreement to cache and leaves reveal state', async () => {
+        mockPost.mockResolvedValueOnce({
+          agreement: {
+            id: 'agreement-1',
+            description: 'We agree to weekly check-ins on Sundays',
+            type: AgreementType.COMMITMENT,
+            status: 'PROPOSED',
+            duration: null,
+            measureOfSuccess: null,
+            agreedByMe: true,
+            agreedByPartner: false,
+            agreedAt: null,
+            followUpDate: null,
+          },
+          awaitingPartnerConfirmation: true,
+        });
+
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        queryClient.setQueryData(stageKeys.strategies(sessionId), {
+          strategies: [],
+          phase: StrategyPhase.REVEALING,
+          aiSuggestionsAvailable: false,
+        });
+        const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+          React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+        const { result } = renderHook(() => useCreateAgreement(), { wrapper });
+
+        await act(async () => {
+          await result.current.mutateAsync({
+            sessionId,
+            strategyId: 'strategy-1',
+            description: 'We agree to weekly check-ins on Sundays',
+            type: AgreementType.COMMITMENT,
+          });
+        });
+
+        expect(queryClient.getQueryData<any>(stageKeys.agreements(sessionId))?.agreements)
+          .toHaveLength(1);
+        expect(queryClient.getQueryData<any>(stageKeys.strategies(sessionId))?.phase)
+          .toBe(StrategyPhase.NEGOTIATING);
       });
     });
 

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -1765,7 +1765,11 @@ export function useSubmitRankings(
     UseMutationOptions<
       SubmitRankingResponse,
       ApiClientError,
-      { sessionId: string; rankedIds: string[] }
+      { sessionId: string; rankedIds: string[] },
+      {
+        previousStrategies: GetStrategiesResponse | undefined;
+        previousProgress: ProgressCacheWithGates | undefined;
+      }
     >,
     'mutationFn'
   >
@@ -1778,12 +1782,65 @@ export function useSubmitRankings(
         rankedIds,
       });
     },
-    onSuccess: (_, { sessionId }) => {
-      queryClient.invalidateQueries({ queryKey: stageKeys.strategies(sessionId) });
-      queryClient.invalidateQueries({
-        queryKey: stageKeys.strategiesReveal(sessionId),
-      });
-      queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+    onMutate: async ({ sessionId }) => {
+      await queryClient.cancelQueries({ queryKey: stageKeys.strategies(sessionId) });
+      await queryClient.cancelQueries({ queryKey: stageKeys.progress(sessionId) });
+
+      const previousStrategies = queryClient.getQueryData<GetStrategiesResponse>(
+        stageKeys.strategies(sessionId)
+      );
+      const previousProgress = queryClient.getQueryData<ProgressCacheWithGates>(
+        stageKeys.progress(sessionId)
+      );
+      const submittedAt = new Date().toISOString();
+
+      queryClient.setQueryData<GetStrategiesResponse>(
+        stageKeys.strategies(sessionId),
+        (old) => old
+          ? { ...old, phase: StrategyPhase.REVEALING }
+          : old
+      );
+      queryClient.setQueryData<ProgressCacheWithGates>(
+        stageKeys.progress(sessionId),
+        (old) => old
+          ? {
+              ...old,
+              myProgress: {
+                ...old.myProgress,
+                gatesSatisfied: {
+                  ...(old.myProgress.gatesSatisfied ?? {}),
+                  rankingSubmitted: true,
+                  rankingSubmittedAt: submittedAt,
+                },
+              },
+            }
+          : old
+      );
+
+      return { previousStrategies, previousProgress };
+    },
+    onSuccess: (data, { sessionId }) => {
+      const canReveal =
+        (data as SubmitRankingResponse & { canReveal?: boolean }).canReveal ??
+        (data as SubmitRankingResponse & { awaitingReveal?: boolean }).awaitingReveal ??
+        false;
+      queryClient.setQueryData<GetStrategiesResponse>(
+        stageKeys.strategies(sessionId),
+        (old) => old
+          ? { ...old, phase: canReveal ? StrategyPhase.REVEALING : old.phase }
+          : old
+      );
+      queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
+      queryClient.refetchQueries({ queryKey: stageKeys.strategiesReveal(sessionId) });
+      queryClient.refetchQueries({ queryKey: stageKeys.progress(sessionId) });
+    },
+    onError: (_error, { sessionId }, context) => {
+      if (context?.previousStrategies) {
+        queryClient.setQueryData(stageKeys.strategies(sessionId), context.previousStrategies);
+      }
+      if (context?.previousProgress) {
+        queryClient.setQueryData(stageKeys.progress(sessionId), context.previousProgress);
+      }
     },
     ...options,
   });
@@ -1806,7 +1863,7 @@ export function useStrategiesReveal(
       return get<RevealOverlapResponse>(`/sessions/${sessionId}/strategies/overlap`);
     },
     enabled: !!sessionId,
-    staleTime: 30_000,
+    staleTime: 0,
     ...options,
   });
 }
@@ -1832,7 +1889,7 @@ export function useAgreements(
       return get<{ agreements: AgreementDTO[] }>(`/sessions/${sessionId}/agreements`);
     },
     enabled: !!sessionId,
-    staleTime: 30_000,
+    staleTime: 0,
     ...options,
   });
 }
@@ -1859,8 +1916,23 @@ export function useCreateAgreement(
         request
       );
     },
-    onSuccess: (_, { sessionId }) => {
-      queryClient.invalidateQueries({ queryKey: stageKeys.agreements(sessionId) });
+    onSuccess: (data, { sessionId }) => {
+      queryClient.setQueryData<{ agreements: AgreementDTO[] }>(
+        stageKeys.agreements(sessionId),
+        (old) => {
+          const existing = old?.agreements ?? [];
+          const withoutDuplicate = existing.filter((a) => a.id !== data.agreement.id);
+          return { agreements: [...withoutDuplicate, data.agreement] };
+        }
+      );
+      queryClient.setQueryData<GetStrategiesResponse>(
+        stageKeys.strategies(sessionId),
+        (old) => old
+          ? { ...old, phase: StrategyPhase.NEGOTIATING }
+          : old
+      );
+      queryClient.refetchQueries({ queryKey: stageKeys.agreements(sessionId) });
+      queryClient.refetchQueries({ queryKey: stageKeys.progress(sessionId) });
     },
     ...options,
   });

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -314,7 +314,7 @@ export function useUnifiedSession(
   const { mutate: signCompact, isPending: isSigningCompact } = useSignCompact();
   const { mutate: confirmInvitationMessage, isPending: isConfirmingInvitation } = useConfirmInvitationMessage();
   const { mutate: advanceStage } = useAdvanceStage();
-  const { mutate: saveDraft, mutateAsync: saveDraftAsync } = useSaveEmpathyDraft();
+  const { mutate: saveDraft, mutateAsync: saveDraftAsync, isPending: isSavingEmpathyDraft } = useSaveEmpathyDraft();
   const { mutate: consentToShare, isPending: isSharingEmpathy } = useConsentToShareEmpathy({
     onError: (error) => {
       console.error('[useConsentToShareEmpathy] Mutation error', error);
@@ -324,7 +324,7 @@ export function useUnifiedSession(
     },
   });
   const { mutate: validateEmpathy } = useValidateEmpathy();
-  const { mutate: resubmitEmpathy } = useResubmitEmpathy();
+  const { mutate: resubmitEmpathy, isPending: isResubmittingEmpathy } = useResubmitEmpathy();
   const { mutate: skipRefinement } = useSkipRefinement();
   const { mutate: confirmNeeds, isPending: isConfirmingNeeds } = useConfirmNeeds();
   const { mutate: consentShareNeeds } = useConsentShareNeeds();
@@ -1238,7 +1238,9 @@ export function useUnifiedSession(
     empathyStatusData,
     shareOfferData,
     isGenerating,
+    isSavingEmpathyDraft,
     isSharingEmpathy,
+    isResubmittingEmpathy,
     isProposing,
     isConfirmingNeeds,
 

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -719,7 +719,7 @@ export function useUnifiedSession(
       }
 
       // Overlap preview after ranking (hide after session is resolved)
-      if (strategyPhase === StrategyPhase.REVEALING && overlappingStrategies.length > 0 && session?.status !== SessionStatus.RESOLVED) {
+      if (strategyPhase === StrategyPhase.REVEALING && overlappingStrategies.length > 0 && agreements.length === 0 && session?.status !== SessionStatus.RESOLVED) {
         cards.push({
           id: 'overlap-preview',
           type: 'overlap-preview',

--- a/mobile/src/screens/StrategicRepairScreen.tsx
+++ b/mobile/src/screens/StrategicRepairScreen.tsx
@@ -512,6 +512,53 @@ export function StrategicRepairScreen() {
     }
   };
 
+  const agreements = agreementsData?.agreements || [];
+  const unconfirmedAgreement = agreements.find((a) => !a.agreedByMe);
+  const waitingForPartnerAgreement =
+    agreements.length > 0 &&
+    agreements.every((a) => a.agreedByMe) &&
+    agreements.some((a) => !a.agreedByPartner);
+
+  if (unconfirmedAgreement) {
+    return (
+      <SafeAreaView style={styles.container} edges={['bottom']}>
+        <ScrollView style={styles.scrollContainer}>
+          <AgreementCard
+            agreement={{
+              experiment: unconfirmedAgreement.description,
+              duration: unconfirmedAgreement.duration || 'To be determined',
+              successMeasure:
+                unconfirmedAgreement.measureOfSuccess || 'To be defined together',
+              checkInDate: unconfirmedAgreement.followUpDate || followUpDate?.toISOString() || undefined,
+            }}
+            confirmedByMe={unconfirmedAgreement.agreedByMe}
+            confirmedByPartner={unconfirmedAgreement.agreedByPartner}
+            partnerName={session?.partner?.nickname ?? session?.partner?.name ?? undefined}
+            onConfirm={handleConfirmAgreement}
+          />
+
+          {!unconfirmedAgreement.followUpDate && (
+            <FollowUpScheduler
+              onSchedule={setFollowUpDate}
+              initialDate={followUpDate || undefined}
+            />
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
+
+  if (waitingForPartnerAgreement) {
+    return (
+      <SafeAreaView style={styles.container} edges={['bottom']}>
+        <WaitingRoom
+          message="You've proposed the agreement. Waiting for your partner to confirm."
+          partnerName={session?.partner?.nickname ?? session?.partner?.name ?? undefined}
+        />
+      </SafeAreaView>
+    );
+  }
+
   // Phase: Collecting strategies
   if (phase === StrategyPhase.COLLECTING) {
     return (
@@ -548,10 +595,14 @@ export function StrategicRepairScreen() {
     );
   }
 
+  const waitingForRankingReveal = !revealData ||
+    (revealData as { waitingForPartner?: boolean; overlap?: unknown[] | null }).waitingForPartner === true ||
+    (revealData as { overlap?: unknown[] | null }).overlap === null;
+
   // Phase: Waiting for partner to rank
   // Note: This is typically handled by polling the phase, but we can show
   // a waiting state if we detect the user has submitted but phase hasn't changed
-  if (phase === StrategyPhase.REVEALING && !revealData) {
+  if (phase === StrategyPhase.REVEALING && waitingForRankingReveal) {
     return (
       <SafeAreaView style={styles.container} edges={['bottom']}>
         <WaitingRoom
@@ -608,7 +659,7 @@ export function StrategicRepairScreen() {
     phase === StrategyPhase.NEGOTIATING ||
     phase === StrategyPhase.AGREED
   ) {
-    const agreement = agreementsData?.agreements?.[0];
+    const agreement = agreements[0];
 
     if (agreement) {
       return (

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -378,7 +378,9 @@ export function UnifiedSessionScreen({
     overlappingStrategies,
     agreements,
     isGenerating,
+    isSavingEmpathyDraft,
     isSharingEmpathy,
+    isResubmittingEmpathy,
     isConfirmingNeeds,
 
     // Memory suggestion
@@ -2737,8 +2739,16 @@ export function UnifiedSessionScreen({
           // Cache-First: Ghost dots are derived from last message role in ChatInterface
           // isSending is still needed for brief moment during API call before optimistic message appears
           // isFetchingInitialMessage shows dots while fetching first AI message
-          // isConfirmingFeelHeard, isSharingEmpathy, and isConfirmingInvitation show dots during those API calls
-          isLoading={isFetchingInitialMessage || isConfirmingFeelHeard || isSharingEmpathy || isConfirmingInvitation}
+          // Button-only actions do not add a USER message, so pass their pending state
+          // explicitly to keep ghost dots visible until the AI follow-up is inserted.
+          isLoading={
+            isFetchingInitialMessage ||
+            isConfirmingFeelHeard ||
+            isSavingEmpathyDraft ||
+            isSharingEmpathy ||
+            isResubmittingEmpathy ||
+            isConfirmingInvitation
+          }
           // isInputDisabled prevents sending while API call is in progress
           isInputDisabled={isSending}
           showEmotionSlider={!isInOnboardingUnsigned}

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -59,7 +59,7 @@ import { usePendingActions } from '../hooks/usePendingActions';
 import { useNeedsComparison } from '../hooks/useStages';
 import { deriveIndicators, SessionIndicatorData } from '../utils/chatListSelector';
 import { canInsertRealtimeMessageForCurrentUser, isRealtimePayloadAddressedToCurrentUser } from '../utils/realtimePrivacy';
-import { getStage2RealtimeInvalidationQueryKeys, getStage3RealtimeInvalidationQueryKeys } from '../utils/realtimeInvalidation';
+import { getStage2RealtimeInvalidationQueryKeys, getStage3RealtimeInvalidationQueryKeys, getStage4RealtimeInvalidationQueryKeys } from '../utils/realtimeInvalidation';
 import { useToast } from '../contexts/ToastContext';
 import { createStyles } from '../theme/styled';
 import { WaitingBanner } from '../components/WaitingBanner';
@@ -457,6 +457,17 @@ export function UnifiedSessionScreen({
     }
   }, [queryClient, sessionId]);
 
+  const refreshStage4RealtimeState = useCallback((options?: { refetchMessages?: boolean }) => {
+    for (const queryKey of getStage4RealtimeInvalidationQueryKeys(sessionId)) {
+      queryClient.invalidateQueries({ queryKey });
+    }
+    queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
+    queryClient.refetchQueries({ queryKey: stageKeys.agreements(sessionId) });
+    if (options?.refetchMessages) {
+      queryClient.refetchQueries({ queryKey: messageKeys.infinite(sessionId) });
+    }
+  }, [queryClient, sessionId]);
+
   // User-level events (memory suggestions are now sent to specific user, not session)
   useUserSessionUpdates({
     disableRefetch: true,
@@ -808,15 +819,13 @@ export function UnifiedSessionScreen({
 
       if (eventName === 'session.strategies_updated') {
         console.log('[UnifiedSessionScreen] Strategies updated');
-        queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
+        refreshStage4RealtimeState();
       }
 
       if (eventName === 'partner.ranking_submitted') {
         // Partner submitted their strategy rankings
         console.log('[UnifiedSessionScreen] Partner submitted rankings');
-        queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
-        queryClient.refetchQueries({ queryKey: stageKeys.strategiesReveal(sessionId) });
-        queryClient.refetchQueries({ queryKey: stageKeys.progress(sessionId) });
+        refreshStage4RealtimeState();
       }
 
       if (eventName === 'partner.ready_to_rank' || eventName === 'partner.marked_ready') {
@@ -839,33 +848,25 @@ export function UnifiedSessionScreen({
             },
           };
         });
-        queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
-        queryClient.refetchQueries({ queryKey: stageKeys.progress(sessionId) });
+        refreshStage4RealtimeState();
       }
 
       if (eventName === 'agreement.proposed') {
         // Partner proposed an agreement
         console.log('[UnifiedSessionScreen] Agreement proposed');
-        queryClient.invalidateQueries({ queryKey: stageKeys.agreements(sessionId) });
-        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+        refreshStage4RealtimeState();
       }
 
       if (eventName === 'agreement.confirmed') {
         // Partner confirmed an agreement
         console.log('[UnifiedSessionScreen] Agreement confirmed');
-        queryClient.invalidateQueries({ queryKey: stageKeys.agreements(sessionId) });
-        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
-        queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
+        refreshStage4RealtimeState();
       }
 
       if (eventName === 'session.resolved') {
         // Session has been resolved
         console.log('[UnifiedSessionScreen] Session resolved');
-        queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
-        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
-        queryClient.invalidateQueries({ queryKey: stageKeys.pendingActions(sessionId) });
-        queryClient.invalidateQueries({ queryKey: notificationKeys.badgeCount() });
-        queryClient.invalidateQueries({ queryKey: stageKeys.agreements(sessionId) });
+        refreshStage4RealtimeState();
       }
     },
     // Fire-and-forget pattern: AI responses arrive via Ably
@@ -2629,6 +2630,70 @@ export function UnifiedSessionScreen({
   }
 
   // -------------------------------------------------------------------------
+  // Agreement Confirmation / Waiting - Full Screen Overlay
+  // -------------------------------------------------------------------------
+  if (currentStage === Stage.STRATEGIC_REPAIR && agreements.length > 0) {
+    const unconfirmedAgreement = agreements.find((a) => !a.agreedByMe);
+    const waitingForPartner = agreements.every((a) => a.agreedByMe) &&
+      agreements.some((a) => !a.agreedByPartner);
+
+    if (unconfirmedAgreement) {
+      return (
+        <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+          <SessionChatHeader
+            partnerName={partnerName}
+            partnerOnline={partnerOnline}
+            connectionStatus={connectionStatus}
+            briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
+            onBackPress={onNavigateBack}
+            stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
+            testID="session-chat-header"
+          />
+          <AgreementCard
+            agreement={{
+              experiment: unconfirmedAgreement.description,
+              duration: unconfirmedAgreement.duration || 'To be determined',
+              successMeasure: unconfirmedAgreement.measureOfSuccess || 'To be defined together',
+              checkInDate: unconfirmedAgreement.followUpDate || undefined,
+            }}
+            confirmedByMe={unconfirmedAgreement.agreedByMe}
+            confirmedByPartner={unconfirmedAgreement.agreedByPartner}
+            partnerName={partnerName}
+            onConfirm={() => {
+              handleConfirmAgreement(unconfirmedAgreement.id, (response: ConfirmAgreementResponse) => {
+                if (response.sessionCanResolve) {
+                  trackSessionResolved(sessionId, 'agreement');
+                  handleResolveSession(() => onStageComplete?.(Stage.STRATEGIC_REPAIR));
+                }
+              });
+            }}
+          />
+        </SafeAreaView>
+      );
+    }
+
+    if (waitingForPartner) {
+      return (
+        <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+          <SessionChatHeader
+            partnerName={partnerName}
+            partnerOnline={partnerOnline}
+            connectionStatus={connectionStatus}
+            briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
+            onBackPress={onNavigateBack}
+            stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
+            testID="session-chat-header"
+          />
+          <WaitingRoom
+            message={`You've proposed the agreement. Waiting for ${partnerName || 'your partner'} to confirm.`}
+            partnerName={partnerName || undefined}
+          />
+        </SafeAreaView>
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // Strategy Ranking Phase - Full Screen Overlay
   // -------------------------------------------------------------------------
   if (currentStage === Stage.STRATEGIC_REPAIR && strategyPhase === StrategyPhase.RANKING) {
@@ -2659,6 +2724,10 @@ export function UnifiedSessionScreen({
   // Strategy Revealing Phase - Full Screen Overlay
   // -------------------------------------------------------------------------
   if (currentStage === Stage.STRATEGIC_REPAIR && strategyPhase === StrategyPhase.REVEALING) {
+    const waitingForRankingReveal = !revealData ||
+      (revealData as { waitingForPartner?: boolean; overlap?: unknown[] | null }).waitingForPartner === true ||
+      (revealData as { overlap?: unknown[] | null }).overlap === null;
+
     return (
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
         <SessionChatHeader
@@ -2670,7 +2739,7 @@ export function UnifiedSessionScreen({
           stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
           testID="session-chat-header"
         />
-        {!revealData ? (
+        {waitingForRankingReveal ? (
           <WaitingRoom
             message="Waiting for your partner to submit their ranking"
             partnerName={partnerName || undefined}

--- a/mobile/src/utils/__tests__/realtimeInvalidation.test.ts
+++ b/mobile/src/utils/__tests__/realtimeInvalidation.test.ts
@@ -2,6 +2,7 @@ import { messageKeys, notificationKeys, sessionKeys, stageKeys } from '../../hoo
 import {
   getStage2RealtimeInvalidationQueryKeys,
   getStage3RealtimeInvalidationQueryKeys,
+  getStage4RealtimeInvalidationQueryKeys,
 } from '../realtimeInvalidation';
 
 describe('realtime invalidation key sets', () => {
@@ -24,6 +25,19 @@ describe('realtime invalidation key sets', () => {
     expect(getStage3RealtimeInvalidationQueryKeys(sessionId)).toEqual([
       stageKeys.needs(sessionId),
       stageKeys.needsComparison(sessionId),
+      stageKeys.progress(sessionId),
+      sessionKeys.state(sessionId),
+      messageKeys.infinite(sessionId),
+      stageKeys.pendingActions(sessionId),
+      notificationKeys.badgeCount(),
+    ]);
+  });
+
+  it('covers Stage 4 strategy, agreement, progress, session, and message caches', () => {
+    expect(getStage4RealtimeInvalidationQueryKeys(sessionId)).toEqual([
+      stageKeys.strategies(sessionId),
+      stageKeys.strategiesReveal(sessionId),
+      stageKeys.agreements(sessionId),
       stageKeys.progress(sessionId),
       sessionKeys.state(sessionId),
       messageKeys.infinite(sessionId),

--- a/mobile/src/utils/realtimeInvalidation.ts
+++ b/mobile/src/utils/realtimeInvalidation.ts
@@ -24,3 +24,16 @@ export function getStage3RealtimeInvalidationQueryKeys(sessionId: string) {
     notificationKeys.badgeCount(),
   ];
 }
+
+export function getStage4RealtimeInvalidationQueryKeys(sessionId: string) {
+  return [
+    stageKeys.strategies(sessionId),
+    stageKeys.strategiesReveal(sessionId),
+    stageKeys.agreements(sessionId),
+    stageKeys.progress(sessionId),
+    sessionKeys.state(sessionId),
+    messageKeys.infinite(sessionId),
+    stageKeys.pendingActions(sessionId),
+    notificationKeys.badgeCount(),
+  ];
+}


### PR DESCRIPTION
## Summary
- add Stage 4 realtime/cache invalidation coverage for strategies, reveal, agreements, progress, session state, messages, and badges
- update ranking/agreement mutations and backend DTOs so post-submit and post-proposal UI leaves stale active action states
- preserve chat animation/loading fixes and add gold-session scratch evidence for the Stage 4 follow-up and smoke run

## Validation
- npm --workspace mobile test -- useStages.test.ts realtimeInvalidation.test.ts --runInBand --forceExit
- npm --workspace backend test -- stage4.test.ts --runInBand
- npm --workspace mobile run check
- npm --workspace backend run check
- fresh Adam/Eve Stage 4 smoke run: `cmos4fj6j000npx6a4w5cllw4`

## Notes
The smoke run found and fixed one extra backend phase issue: after the current user submitted rankings, `GET /strategies` still returned `RANKING` until the partner ranked. The endpoint now returns `REVEALING` for the already-ranked user while the unranked partner remains in `RANKING`.
