### PR TITLE
Fix Stage 4 no-agreement framing

### DIFF
--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -793,7 +793,7 @@ FOUR MODES:
 - REDIRECTING: User is framing things in terms of the other person. Gently bring the focus back to the user — help them name what feels important or missing for them when that happens.
 - SUGGESTING: User is exploring but hasn't landed on needs language. Offer a need as a suggestion, not a correction — propose a word and check whether it resonates. Let them accept, reject, or refine.
 - DEEPENING: User has named something that matters. Help them explore what that need looks like in practice — what changes when it's met, what it means day-to-day.
-- CONFIRMING: User has articulated what feels like their core needs. Present a clean summary of what they've named so far and ask if it captures what matters. Format as a simple list they can review. No hardcoded threshold for when to enter this mode — use your judgment based on conversational signals that they've landed.
+- CONFIRMING: User has articulated what feels like their core needs. Present a clean summary of what they've named so far and tell them it is ready for review in the app. Format as a simple list they can review. Do not ask a direct chat question like "Does that capture it?" when the app's next interaction is the review/confirm button. No hardcoded threshold for when to enter this mode — use your judgment based on conversational signals that they've landed.
 
 UNIVERSAL NEEDS FRAMEWORK (internal lens — don't teach this explicitly):
 Safety, Connection, Autonomy, Recognition, Meaning, Fairness. Most positions map to one or two of these.
@@ -813,7 +813,7 @@ FORBIDDEN in Stage 3:
 No-hallucination guard: Use the user's exact words when reflecting needs. Never add context, feelings, or details they didn't provide.
 
 NEEDS CAPTURE:
-When ${context.userName} has clearly landed on their own needs and you present a clean summary for review, set NeedsReady:Y and include the hidden <needs> block. In visible text, say you have captured a draft of what matters to them for their review. Do not say anything about sharing, partner readiness, or side-by-side reveal.
+When ${context.userName} has clearly landed on their own needs and you present a clean summary for review, set NeedsReady:Y and include the hidden <needs> block. In visible text, say you have captured a draft of what matters to them for their review and that they can use the review button to confirm or adjust it. Do not ask "Does that capture it?" or invite an inline chat answer unless you are also keeping the chat interaction open. Do not say anything about sharing, partner readiness, or side-by-side reveal.
 
 Length: default 1–3 sentences. Go longer only if they explicitly ask for help or detail.
 ${LATERAL_PROBING_GUIDANCE}
@@ -898,7 +898,9 @@ When a proposal is vague, help sharpen it by asking about ONE missing criterion 
 FOLLOW-UP CHECK-IN (REQUIRED):
 Every experiment MUST include a follow-up check-in. Before wrapping up, ask when they want to check back in: "When should we check in on how this went?" This is not optional — a strategy without a follow-up is incomplete.
 
-UNLABELED POOL PRINCIPLE: Both partners propose strategies independently. When presented together, strategies are shown without attribution to avoid defensiveness.
+UNLABELED POOL PRINCIPLE: Both partners propose strategies independently. When presented together, strategies are shown without author labels to avoid defensiveness. Do not promise full anonymity: some safe, specific strategies may naturally name roles or responsibilities.
+
+ROLE-SPECIFIC STRATEGIES: Prefer neutral wording when it stays safe and clear. If a strategy must name a role or person to preserve accountability or safety, name the role plainly and do not describe the pool as anonymous.
 
 SELF-IDENTIFICATION: If the user says "I proposed the check-in idea," acknowledge their ownership warmly without confirming or denying which strategies came from whom to the partner.
 

--- a/mobile/src/components/ChatIndicator.tsx
+++ b/mobile/src/components/ChatIndicator.tsx
@@ -113,14 +113,14 @@ export function ChatIndicator({ type, timestamp, testID, onPress, metadata }: Ch
       case 'needs-identified':
         return 'Needs identified';
       case 'common-ground-found':
-        return 'Common ground found';
+        return 'Needs overlap ready to review';
       // Stage 4: Strategic Repair
       case 'strategies-ready':
         return 'Strategies ready';
       case 'overlap-revealed':
         return 'Overlap revealed';
       case 'agreement-reached':
-        return 'Agreement reached ✓';
+        return 'Next step confirmed ✓';
       // Semantic indicator types
       case 'empathy-validated':
         const validatorName = metadata?.partnerName || 'Partner';

--- a/mobile/src/components/OverlapReveal.tsx
+++ b/mobile/src/components/OverlapReveal.tsx
@@ -26,9 +26,9 @@ interface OverlapRevealProps {
   uniqueToMe: Strategy[];
   /** Strategies only the partner selected */
   uniqueToPartner: Strategy[];
-  /** Callback when user wants to create an agreement from a matched strategy */
+  /** Callback when user wants to use a matched strategy as a next step */
   onCreateAgreement?: (strategy: { id: string; description: string }) => void;
-  /** Whether to disable the Create Agreement button (max agreements reached) */
+  /** Whether to disable the next-step button (max agreements reached) */
   disableCreate?: boolean;
 }
 
@@ -42,7 +42,7 @@ interface OverlapRevealProps {
  * Key features:
  * - Highlights shared choices (overlap)
  * - Shows unique selections without judgment
- * - Provides positive messaging for common ground
+ * - Frames overlap as a possible protocol, not a settled agreement
  * - Handles no-overlap case gracefully
  */
 export function OverlapReveal({
@@ -58,13 +58,13 @@ export function OverlapReveal({
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       <View style={styles.header}>
-        <Text style={styles.title}>Your Shared Priorities</Text>
-        <Text style={styles.subtitle}>Common ground found!</Text>
+        <Text style={styles.title}>Possible Shared Steps</Text>
+        <Text style={styles.subtitle}>Both of you marked these as worth discussing.</Text>
       </View>
 
       {hasOverlap && (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>You Both Chose</Text>
+          <Text style={styles.sectionTitle}>Both Marked Worth Discussing</Text>
           {overlapping.map((strategy) => (
             <View key={strategy.id}>
               <StrategyCard strategy={strategy} isOverlap />
@@ -74,15 +74,15 @@ export function OverlapReveal({
                     style={[styles.createAgreementButton, disableCreate && styles.createAgreementButtonDisabled]}
                     onPress={() => !disableCreate && onCreateAgreement({ id: strategy.id, description: strategy.description })}
                     accessibilityRole="button"
-                    accessibilityLabel={`Create agreement from strategy: ${strategy.description}`}
+                    accessibilityLabel={`Use as next step: ${strategy.description}`}
                     accessibilityState={{ disabled: disableCreate }}
                     testID="create-agreement-button"
                     disabled={disableCreate}
                   >
-                    <Text style={[styles.createAgreementText, disableCreate && styles.createAgreementTextDisabled]}>Create Agreement</Text>
+                    <Text style={[styles.createAgreementText, disableCreate && styles.createAgreementTextDisabled]}>Use as Next Step</Text>
                   </TouchableOpacity>
                   {disableCreate && (
-                    <Text style={styles.maxAgreementsText}>You can create up to 2 agreements per session.</Text>
+                    <Text style={styles.maxAgreementsText}>You can choose up to 2 next steps per session.</Text>
                   )}
                 </>
               )}
@@ -93,7 +93,7 @@ export function OverlapReveal({
 
       {hasUnique && (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Only One of You Chose</Text>
+          <Text style={styles.sectionTitle}>Different Preferences</Text>
           {[...uniqueToMe, ...uniqueToPartner].map((strategy) => (
             <StrategyCard key={strategy.id} strategy={strategy} />
           ))}
@@ -103,8 +103,8 @@ export function OverlapReveal({
       {!hasOverlap && (
         <View style={styles.noOverlap}>
           <Text style={styles.noOverlapText}>
-            No direct overlap yet - but that is okay! Let us explore your
-            different preferences.
+            No direct overlap yet. Return to chat to decide whether there is a smaller step,
+            an individual commitment, or no shared next step for now.
           </Text>
         </View>
       )}

--- a/mobile/src/components/SessionCompletionScreen.tsx
+++ b/mobile/src/components/SessionCompletionScreen.tsx
@@ -56,7 +56,7 @@ export function SessionCompletionScreen({
         <Text style={styles.icon}>🤝</Text>
         <Text style={styles.headline}>A Path Forward</Text>
         <Text style={styles.subheading}>
-          You and {partnerName} reached an agreement together
+          You and {partnerName} identified a limited next step. This does not have to mean everything is resolved.
         </Text>
       </View>
 
@@ -64,7 +64,7 @@ export function SessionCompletionScreen({
       {agreements.length > 0 && (
         <View style={styles.agreementsSection}>
           <Text style={styles.sectionTitle}>
-            {agreements.length === 1 ? 'Your Agreement' : 'Your Agreements'}
+            {agreements.length === 1 ? 'Your Next Step' : 'Your Next Steps'}
           </Text>
           {agreements.map((agreement) => (
             <AgreementSummaryCard

--- a/mobile/src/components/StrategyPool.tsx
+++ b/mobile/src/components/StrategyPool.tsx
@@ -1,7 +1,7 @@
 /**
  * StrategyPool Component
  *
- * Displays the pool of strategies without attribution.
+ * Displays the pool of strategies without author labels.
  * Users can request more AI-generated ideas or proceed to ranking.
  */
 
@@ -37,7 +37,7 @@ interface StrategyPoolProps {
 // ============================================================================
 
 /**
- * StrategyPool displays all available strategies without attribution.
+ * StrategyPool displays all available strategies without author labels.
  *
  * Key features:
  * - Shows strategies unlabeled (no source indication)
@@ -58,7 +58,7 @@ export function StrategyPool({
           <View style={styles.headerText}>
             <Text style={styles.title}>Here is what we have come up with</Text>
             <Text style={styles.subtitle}>
-              Strategies are shown without attribution - focus on the ideas
+              Strategies are grouped by idea. Some may name roles when safety or accountability needs that clarity.
             </Text>
           </View>
           {onClose && (

--- a/mobile/src/components/__tests__/OverlapReveal.test.tsx
+++ b/mobile/src/components/__tests__/OverlapReveal.test.tsx
@@ -1,7 +1,7 @@
 /**
  * OverlapReveal Component Tests
  *
- * Tests for the overlap reveal component that shows shared priorities.
+ * Tests for the overlap reveal component that shows possible shared steps.
  */
 
 import React from 'react';
@@ -58,10 +58,10 @@ describe('OverlapReveal', () => {
       />
     );
 
-    expect(screen.getByText(/you both chose/i)).toBeTruthy();
+    expect(screen.getByText(/both marked worth discussing/i)).toBeTruthy();
   });
 
-  it('shows shared priorities header', () => {
+  it('shows possible shared steps header', () => {
     render(
       <OverlapReveal
         overlapping={overlappingStrategies}
@@ -70,7 +70,7 @@ describe('OverlapReveal', () => {
       />
     );
 
-    expect(screen.getByText(/shared priorities/i)).toBeTruthy();
+    expect(screen.getByText(/possible shared steps/i)).toBeTruthy();
   });
 
   it('renders overlapping strategies', () => {
@@ -99,7 +99,7 @@ describe('OverlapReveal', () => {
       />
     );
 
-    expect(screen.getByText(/only one of you chose/i)).toBeTruthy();
+    expect(screen.getByText(/different preferences/i)).toBeTruthy();
     expect(
       screen.getByText('Practice active listening exercises')
     ).toBeTruthy();
@@ -118,10 +118,10 @@ describe('OverlapReveal', () => {
     );
 
     expect(screen.getByText(/no direct overlap/i)).toBeTruthy();
-    expect(screen.getByText(/that is okay/i)).toBeTruthy();
+    expect(screen.getByText(/no shared next step/i)).toBeTruthy();
   });
 
-  it('shows positive messaging for common ground', () => {
+  it('frames overlap as worth discussing rather than an agreement', () => {
     render(
       <OverlapReveal
         overlapping={overlappingStrategies}
@@ -130,7 +130,7 @@ describe('OverlapReveal', () => {
       />
     );
 
-    expect(screen.getByText(/common ground found/i)).toBeTruthy();
+    expect(screen.getAllByText(/worth discussing/i).length).toBeGreaterThan(0);
   });
 
   it('does not show unique section when no unique choices', () => {
@@ -142,6 +142,6 @@ describe('OverlapReveal', () => {
       />
     );
 
-    expect(screen.queryByText(/only one of you chose/i)).toBeNull();
+    expect(screen.queryByText(/different preferences/i)).toBeNull();
   });
 });

--- a/mobile/src/components/__tests__/StrategyPool.test.tsx
+++ b/mobile/src/components/__tests__/StrategyPool.test.tsx
@@ -1,7 +1,7 @@
 /**
  * StrategyPool Component Tests
  *
- * Tests for the strategy pool component that displays unlabeled strategies.
+ * Tests for the strategy pool component that displays strategies without author labels.
  */
 
 import React from 'react';
@@ -49,7 +49,7 @@ describe('StrategyPool', () => {
     jest.clearAllMocks();
   });
 
-  it('shows strategy pool without attribution', () => {
+  it('shows strategy pool without author attribution', () => {
     render(<StrategyPool {...defaultProps} />);
 
     // Verify strategies shown without "You suggested" or "Partner suggested"
@@ -71,11 +71,11 @@ describe('StrategyPool', () => {
     ).toBeTruthy();
   });
 
-  it('displays header text explaining unlabeled strategies', () => {
+  it('displays header text explaining role-specific clarity', () => {
     render(<StrategyPool {...defaultProps} />);
 
     expect(
-      screen.getByText(/strategies are shown without attribution/i)
+      screen.getByText(/some may name roles/i)
     ).toBeTruthy();
   });
 

--- a/mobile/src/config/waitingStatusConfig.ts
+++ b/mobile/src/config/waitingStatusConfig.ts
@@ -60,7 +60,7 @@ export const WAITING_STATUS_CONFIG: Record<NonNullable<WaitingStatusState>, Wait
     isActionRequired: false,
     showSpinner: false,
     showKeepChattingAction: true,
-    bannerText: (p) => `${p} is still reflecting.`,
+    bannerText: (p) => `${p} is still sharing their side.`,
   },
 
   // Stage 2: Waiting for partner to share their empathy perspective

--- a/mobile/src/screens/StrategicRepairScreen.tsx
+++ b/mobile/src/screens/StrategicRepairScreen.tsx
@@ -3,7 +3,7 @@
  *
  * Stage 4 - Strategic Repair
  * Implements the strategy pool, ranking, overlap reveal, and agreement flow.
- * Strategies are shown without attribution to focus on the ideas themselves.
+ * Strategies are shown without author labels to focus on the ideas themselves.
  */
 
 import { useState } from 'react';
@@ -692,7 +692,7 @@ export function StrategicRepairScreen() {
     return (
       <SafeAreaView style={styles.container} edges={['bottom']}>
         <WaitingRoom
-          message="Creating your agreement based on shared priorities..."
+          message="Preparing the next-step review..."
           partnerName={session?.partner?.nickname ?? session?.partner?.name ?? undefined}
         />
       </SafeAreaView>

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -250,16 +250,22 @@ function InviteeTopicIntroCard({
 
 function NeedsIdentifiedChatCard({
   needs,
-  confirmed,
+  status,
   onReview,
 }: {
   needs: Array<{ id: string; need: string; category: string }>;
-  confirmed: boolean;
+  status: 'ready' | 'confirmed' | 'shared';
   onReview: () => void;
 }) {
   const styles = useStyles();
   const visibleNeeds = needs.slice(0, 3);
   const extraCount = Math.max(0, needs.length - visibleNeeds.length);
+  const statusLabel = status === 'shared'
+    ? 'Shared'
+    : status === 'confirmed'
+      ? 'Confirmed'
+      : 'Ready to review';
+  const actionLabel = status === 'ready' ? 'Review and confirm' : 'Open review';
 
   return (
     <TouchableOpacity
@@ -270,9 +276,7 @@ function NeedsIdentifiedChatCard({
     >
       <View style={styles.needsSummaryHeader}>
         <Text style={styles.needsSummaryEyebrow}>WHAT MATTERS</Text>
-        <Text style={styles.needsSummaryStatus}>
-          {confirmed ? 'Confirmed' : 'Ready to review'}
-        </Text>
+        <Text style={styles.needsSummaryStatus}>{statusLabel}</Text>
       </View>
       <Text style={styles.needsSummaryTitle}>Your needs so far</Text>
       <View style={styles.needsSummaryList}>
@@ -286,9 +290,7 @@ function NeedsIdentifiedChatCard({
           <Text style={styles.needsSummaryMore}>+{extraCount} more</Text>
         ) : null}
       </View>
-      <Text style={styles.needsSummaryAction}>
-        {confirmed ? 'Open review' : 'Review and confirm'}
-      </Text>
+      <Text style={styles.needsSummaryAction}>{actionLabel}</Text>
     </TouchableOpacity>
   );
 }
@@ -467,6 +469,25 @@ export function UnifiedSessionScreen({
       queryClient.refetchQueries({ queryKey: messageKeys.infinite(sessionId) });
     }
   }, [queryClient, sessionId]);
+
+  useEffect(() => {
+    const latestMessage = messages[messages.length - 1];
+    if (
+      !latestMessage ||
+      latestMessage.role !== MessageRole.USER ||
+      isSending ||
+      session?.status === SessionStatus.RESOLVED
+    ) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      queryClient.refetchQueries({ queryKey: messageKeys.infinite(sessionId) });
+      queryClient.refetchQueries({ queryKey: messageKeys.list(sessionId) });
+    }, 2500);
+
+    return () => clearTimeout(timeout);
+  }, [messages, isSending, queryClient, sessionId, session?.status]);
 
   // User-level events (memory suggestions are now sent to specific user, not session)
   useUserSessionUpdates({
@@ -1745,7 +1766,7 @@ export function UnifiedSessionScreen({
         case 'overlap-preview':
           return (
             <View style={styles.inlineCard} key={card.id}>
-              <Text style={styles.cardTitle}>You Both Chose</Text>
+              <Text style={styles.cardTitle}>Possible Shared Step</Text>
               <Text style={styles.overlapDescription}>
                 {(card.props.topOverlap as { description: string })?.description}
               </Text>
@@ -1963,7 +1984,13 @@ export function UnifiedSessionScreen({
   const needsReviewCards = useMemo((): ChatCustomCardItem[] => {
     if (currentStage !== Stage.NEED_MAPPING) return [];
     if (!needsData?.synthesizedAt || !needs || needs.length === 0) return [];
-    if ((myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsShared === true) return [];
+    const gates = myProgress?.gatesSatisfied as Record<string, unknown> | undefined;
+    let needsStatus: 'ready' | 'confirmed' | 'shared' = 'ready';
+    if (gates?.needsShared === true) {
+      needsStatus = 'shared';
+    } else if (allNeedsConfirmed) {
+      needsStatus = 'confirmed';
+    }
 
     return [{
       type: 'custom-card',
@@ -1977,7 +2004,7 @@ export function UnifiedSessionScreen({
             need: need.need,
             category: String(need.category),
           }))}
-          confirmed={allNeedsConfirmed}
+          status={needsStatus}
           onReview={() => {
             setNeedsDrawerMode('needs');
             setShowNeedsDrawer(true);
@@ -2610,7 +2637,7 @@ export function UnifiedSessionScreen({
           connectionStatus={connectionStatus}
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
           onBackPress={onNavigateBack}
-          stageName="Resolved"
+          stageName="Closed"
           testID="session-chat-header"
         />
         <SessionCompletionScreen

--- a/mobile/src/screens/__tests__/StrategicRepairScreen.test.tsx
+++ b/mobile/src/screens/__tests__/StrategicRepairScreen.test.tsx
@@ -301,7 +301,7 @@ describe('StrategicRepairScreen', () => {
     it('reveals overlap after both rank', () => {
       render(<StrategicRepairScreen />);
 
-      expect(screen.getByText(/you both chose/i)).toBeTruthy();
+      expect(screen.getByText(/both marked worth discussing/i)).toBeTruthy();
     });
 
     it('shows shared strategies', () => {
@@ -315,7 +315,7 @@ describe('StrategicRepairScreen', () => {
     it('shows positive messaging for common ground', () => {
       render(<StrategicRepairScreen />);
 
-      expect(screen.getByText(/shared priorities/i)).toBeTruthy();
+      expect(screen.getByText(/possible shared steps/i)).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Summary
- soften Stage 4 ranking/reveal and completion copy so limited protocols are not framed as full resolution
- align Stage 3 needs-summary prompt and shared-needs card rendering with the CTA flow
- clarify strategy attribution copy and Stage 1 waiting copy, plus add a fallback message refetch after user turns

## Verification
- npm --workspace mobile test -- OverlapReveal StrategyPool getWaitingStatus --runInBand
- npm --workspace mobile test -- OverlapReveal --runInBand
- npm --workspace backend test -- stage-prompts --runInBand
- npm --workspace mobile run check
- npm --workspace backend run check
- npm --workspace mobile run lint -- --quiet
- git diff --check

## Notes
- StrategicRepairScreen.test.tsx still hits the existing Expo/axios Jest import error before running: Cannot cancel a stream that already has a reader.
- Backend repo-wide lint still has pre-existing parser/prettier errors outside this patch.