### PR TITLE
Refine Stage 2 user-facing language around separate privacy review

### DIFF
--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -2093,7 +2093,7 @@ export async function resubmitEmpathy(
 
 Generate a brief, warm acknowledgment message (2-3 sentences) for ${userName} that:
 1. Acknowledges the effort to refine their understanding
-2. Notes that we will check whether their updated statement is ready to share
+2. Notes that a separate privacy-protected review will check whether their updated statement is ready to share
 3. Encourages them that this iterative process helps build deeper understanding
 
 Use human process language. Do not mention internal systems or implementation details.
@@ -2123,12 +2123,12 @@ Respond in JSON format:
           const parsed = extractJsonFromResponse(aiResponse) as Record<string, unknown>;
           transitionContent = typeof parsed.response === 'string'
             ? parsed.response
-            : `You're showing real understanding here. We'll check whether your updated perspective is ready to share.`;
+            : `You're showing real understanding here. We'll send this through a separate privacy-protected review to check whether your updated perspective is ready to share.`;
         } catch {
-          transitionContent = `You're showing real understanding here. We'll check whether your updated perspective is ready to share.`;
+          transitionContent = `You're showing real understanding here. We'll send this through a separate privacy-protected review to check whether your updated perspective is ready to share.`;
         }
       } else {
-        transitionContent = `You're showing real understanding here. We'll check whether your updated perspective is ready to share.`;
+        transitionContent = `You're showing real understanding here. We'll send this through a separate privacy-protected review to check whether your updated perspective is ready to share.`;
       }
 
       // Save the transition message to the database
@@ -2178,7 +2178,7 @@ Respond in JSON format:
 
     successResponse(res, {
       status: 'ANALYZING',
-      message: 'We are checking whether your updated understanding is ready to share...',
+      message: 'We are sending this through a separate privacy-protected review to check whether your updated understanding is ready to share...',
       empathyMessage: {
         id: newMessage.id,
         content: newMessage.content,

--- a/mobile/src/components/ShareTopicDrawer.tsx
+++ b/mobile/src/components/ShareTopicDrawer.tsx
@@ -1,7 +1,7 @@
 /**
  * ShareTopicDrawer Component
  *
- * A full-screen drawer that displays the reconciler's topic suggestion
+ * A full-screen drawer that displays a privacy-protected review suggestion
  * for the subject to share additional context with their partner.
  *
  * This is Phase 1 of the two-phase share flow:
@@ -29,11 +29,11 @@ import { colors } from '@/theme';
 export interface ShareTopicDrawerProps {
   /** Whether the drawer is visible */
   visible: boolean;
-  /** Reconciler action type - affects language and styling */
+  /** Review action type - affects language and styling */
   action: 'OFFER_SHARING' | 'OFFER_OPTIONAL';
   /** Partner's name */
   partnerName: string;
-  /** The reconciler's suggested focus topic */
+  /** The suggested focus topic from the separate review */
   suggestedShareFocus: string;
   /** Callback when "Yes, help me share" is tapped */
   onAccept: () => void;
@@ -123,8 +123,9 @@ export function ShareTopicDrawer({
 
             {/* Intro text */}
             <Text style={styles.intro}>
-              There may be context that would help {partnerName} understand
-              this more accurately. You can choose whether you want help{' '}
+              A separate privacy-protected review suggested there may be
+              something important {partnerName} still needs understood. You
+              can choose whether you want help{' '}
               <Text style={[styles.actionText, { color: actionTextColor }]}>
                 {actionSuffix}
               </Text>


### PR DESCRIPTION
### Motivation
- Replace implementation/technical phrasing like "internal reconciler" with simple, trust-forward language that reassures users their private chat stays private while explaining a separate review step.
- Keep user-facing copy human and process-oriented so it doesn't imply one user's AI read the other's private conversation.

### Description
- Update Stage 2 resubmission prompt and fallback strings in `backend/src/controllers/stage2.ts` to refer to a `separate privacy-protected review` and to avoid implementation wording in the generated acknowledgment and API response.
- Change the success response message in `resubmitEmpathy` to: `We are sending this through a separate privacy-protected review to check whether your updated understanding is ready to share...`.
- Update `mobile/src/components/ShareTopicDrawer.tsx` copy and comments to describe the suggestion as coming from a "privacy-protected review" and adjust prop/comments to match the new framing.

### Testing
- Attempted to run the targeted backend test with `npm --workspace=backend test -- stage2-copy.test.ts`, which failed in this environment because `jest` is not available (`sh: 1: jest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f980f5ba648330a1d54347c58d8ee5)