### PR TITLE
[codex] Clean up Stage 3 needs reveal drift

### DIFF
--- a/docs/backend/api/gate-mapping.md
+++ b/docs/backend/api/gate-mapping.md
@@ -31,8 +31,8 @@ Canonical mapping from gate keys to the endpoints/payloads that set them. Used b
 | Gate | Endpoint | Payload trigger |
 |------|----------|-----------------|
 | `needsConfirmed` | `POST /sessions/:id/needs/confirm` | Caller confirms needs |
-| `partnerNeedsConfirmed` | Derived | Partner confirms needs |
-| `commonGroundConfirmed` | `POST /sessions/:id/common-ground/confirm` | Both confirm common ground |
+| `needsShared` | `POST /sessions/:id/needs/consent` | Caller consents to share confirmed needs |
+| `needsValidated` | `POST /sessions/:id/needs/validate` | Caller validates the side-by-side needs reveal |
 
 ## Stage 4
 | Gate | Endpoint | Payload trigger |

--- a/docs/backend/api/index.md
+++ b/docs/backend/api/index.md
@@ -130,13 +130,14 @@ User-driven self-reflection on what truly matters; AI facilitates needs clarity,
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET`  | `/sessions/:id/needs` | Get synthesized needs |
+| `GET`  | `/sessions/:id/needs` | Get stored captured needs; does not trigger extraction |
+| `POST` | `/sessions/:id/needs/capture` | Persist AI-suggested needs for user review |
 | `POST` | `/sessions/:id/needs` | Add a custom need |
 | `POST` | `/sessions/:id/needs/confirm` | Confirm/adjust needs |
 | `POST` | `/sessions/:id/needs/consent` | Consent to share needs |
-| `GET`  | `/sessions/:id/needs/comparison` | Compare confirmed needs across partners |
-| `GET`  | `/sessions/:id/common-ground` | Get common ground |
-| `POST` | `/sessions/:id/common-ground/confirm` | Confirm common ground |
+| `GET`  | `/sessions/:id/needs/comparison` | Reveal confirmed needs side by side |
+| `GET`  | `/sessions/:id/needs/reveal` | Alias for the side-by-side needs reveal |
+| `POST` | `/sessions/:id/needs/validate` | Validate the side-by-side needs reveal |
 
 ### [Stage 4: Strategic Repair](./stage-4.md)
 Collaborative strategy and agreement.

--- a/docs/backend/api/stage-3.md
+++ b/docs/backend/api/stage-3.md
@@ -3,7 +3,7 @@ title: "Stage 3 API: What Matters"
 sidebar_position: 10
 description: Endpoints for identifying needs, confirming them, and validating revealed needs with a partner.
 slug: /backend/api/stage-3
-updated: "2026-05-03"
+updated: "2026-05-05"
 ---
 # Stage 3 API: What Matters
 
@@ -21,9 +21,9 @@ Key concepts:
 
 ---
 
-## Get Captured Needs
+## Get Stored Captured Needs
 
-Get the current user's captured needs.
+Get the current user's stored captured needs. This is a read-only endpoint; it never starts automatic extraction or background synthesis.
 
 ```
 GET /api/v1/sessions/:id/needs
@@ -34,7 +34,7 @@ GET /api/v1/sessions/:id/needs
 ```typescript
 interface GetNeedsResponse {
   needs: IdentifiedNeedDTO[];
-  extracting: boolean;         // Always false — extraction is not triggered on-demand
+  extracting: boolean;          // Deprecated compatibility field; always false
   synthesizedAt: string | null; // null when no needs exist
   isDirty: boolean;
 }
@@ -99,7 +99,7 @@ enum NeedCategory {
 
 ### Behavior
 
-`GET /needs` is a direct read — it returns the stored `IdentifiedNeed` rows for the caller without triggering AI extraction. Needs are created only through explicit capture or user add/edit actions after Stage 3 conversation. `extracting` is always `false`; `synthesizedAt` is `null` when no needs exist.
+`GET /needs` is a direct read — it returns the stored `IdentifiedNeed` rows for the caller without triggering AI extraction. Needs are created only through explicit capture or user add/edit actions after Stage 3 conversation. `extracting` is retained only as a deprecated compatibility field and is always `false`; `synthesizedAt` is `null` when no needs exist.
 
 Validation: each need has evidence 1-5 items; `aiConfidence` 0-1. The response includes both `need` and `description` fields carrying the same string (`description` is a compatibility alias).
 
@@ -107,7 +107,7 @@ Validation: each need has evidence 1-5 items; `aiConfidence` 0-1. The response i
 
 ## Capture Needs from AI Summary
 
-Bulk-create needs from an AI-generated summary card. This is the primary way needs are created in Stage 3 — the AI surfaces a summary card mid-conversation, and the client calls this endpoint to persist the proposed needs for user review.
+Bulk-create needs from an AI-suggested summary card. This is the primary way needs are created in Stage 3 — the AI facilitates needs clarity during conversation, then the client calls this endpoint to persist the proposed needs for user review.
 
 ```
 POST /api/v1/sessions/:id/needs/capture
@@ -138,6 +138,28 @@ interface CaptureNeedsResponse {
 ```
 
 Validation: `needs` array required and non-empty; each item must have `need`, `description`, and a valid `category`. Captured needs are created with `confirmed: false` (user must confirm via `POST /needs/confirm` before consenting to share).
+
+### Example Response
+
+```json
+{
+  "success": true,
+  "data": {
+    "needs": [
+      {
+        "id": "need_003",
+        "need": "To feel heard",
+        "category": "CONNECTION",
+        "description": "I want my concern to be understood before we solve it.",
+        "evidence": ["I keep repeating myself because I do not think it landed."],
+        "confirmed": false,
+        "aiConfidence": 0.82
+      }
+    ],
+    "capturedAt": "2026-05-05T18:00:00Z"
+  }
+}
+```
 
 ---
 
@@ -283,7 +305,7 @@ POST /api/v1/sessions/:id/needs/validate
 
 ```typescript
 interface ValidateNeedsRequest {
-  validated: boolean;  // Defaults to true if omitted
+  validated?: boolean;  // Defaults to true if omitted
 }
 ```
 
@@ -300,12 +322,28 @@ interface ValidateNeedsResponse {
 
 ### Side Effects
 
+Calling this endpoint with `validated !== false` sets the caller's `needsValidated` gate.
+
 When both partners validate (`canAdvance === true`):
 1. Both partners' Stage-3 status transitions to `COMPLETED`
 2. Both partners' Stage-4 progress records are created (`IN_PROGRESS`)
 3. A transition message is published to both users
 
 Pre-conditions: both partners must have consented to share needs (`needsShared` gate) before calling this endpoint. The `hasPartnerSharedNeeds` check is enforced server-side.
+
+### Example Response
+
+```json
+{
+  "success": true,
+  "data": {
+    "validated": true,
+    "validatedAt": "2026-05-05T18:05:00Z",
+    "partnerValidated": false,
+    "canAdvance": false
+  }
+}
+```
 
 ---
 

--- a/docs/backend/prompts/stage-3-needs.md
+++ b/docs/backend/prompts/stage-3-needs.md
@@ -1,7 +1,7 @@
 ---
 title: "Stage 3: What Matters Prompt"
 sidebar_position: 12
-description: Guiding users to validate synthesized needs and discover common ground.
+description: Guiding users through user-driven needs identification, confirmation, reveal, noticing, and validation.
 slug: /backend/prompts/stage-3-needs
 model: sonnet
 temperature: 0.6
@@ -9,31 +9,46 @@ max_tokens: 800
 ---
 # Stage 3: What Matters Prompt
 
-Guiding users to validate synthesized needs and discover common ground.
+Guiding users through user-driven needs identification, confirmation, reveal, noticing, and validation.
 
 ## Context
 
 - User completed Stage 2 (perspective stretch)
-- AI has synthesized needs from Stage 1-2 content
-- Goal: Validate needs and find common ground with partner
+- AI retains Stage 1-2 context for continuity, but does not present pre-extracted needs
+- Goal: Help the user identify what matters, confirm their own needs, consent to reveal, notice both lists side by side, emotionally process the reveal, and validate whether the revealed needs are accurate enough for Stage 4
+
+## Modes
+
+Stage 3 prompt behavior depends on the user's current phase:
+
+| Mode | When Active | AI Task |
+|------|-------------|---------|
+| `EXPLORING` | User has not confirmed their needs list | Ask what matters, redirect from blame to self-reference, offer needs language as suggestion |
+| `CONFIRMING` | AI believes the list may be ready | Ask the user to confirm, edit, remove, or add needs before anything is shared |
+| `AWAITING_CONSENT` | User confirmed their own list | Ask for explicit consent to reveal the confirmed needs to their partner |
+| `WAITING_FOR_PARTNER` | Current user is complete but partner is not | Hold the user's needs private and set expectation without disclosing partner data |
+| `REVEALED_NOTICE` | Both users consented and side-by-side needs are available | Ask an open noticing prompt, conceptually "What do you notice?" |
+| `POST_REVEAL_PROCESSING` | User is reacting to the reveal | Help name feelings, surprise, relief, grief, skepticism, or resonance without interpreting the overlap for them |
+| `VALIDATING` | User has had space to process | Ask whether both revealed lists feel valid enough to carry into Stage 4 |
 
 ## System Prompt
 
 ```
-You are Meet Without Fear, a Process Guardian in the What Matters stage. Your role is to help {{user_name}} understand and validate the needs that have emerged from their sharing.
+You are Meet Without Fear, a Process Guardian in the What Matters stage. Your role is to help {{user_name}} articulate what matters to them in their own words, confirm that list, consent before it is shared, and then process the mutual reveal.
 
 CRITICAL RULES:
-- Present needs as observations, not diagnoses
-- Let user adjust or reject any need identification
-- Never tell them what they should need
-- Celebrate common ground without minimizing differences
-- Keep focus on universal human needs, not positions
+- Keep Stage 3 user-driven; the user discovers what matters, the AI guides
+- Offer needs language as suggestion, not correction
+- Ask before treating any need as confirmed
+- Never tell the user what they should need
+- Keep focus on universal human needs, not positions or strategies
+- After reveal, ask what the user notices instead of explaining what the lists mean
 
 CRITICAL - NO HALLUCINATION:
-- Use the user's own words when describing their needs
+- Use the user's own words when reflecting possible needs
 - NEVER add context or specifics they did not provide
-- If a need identification feels uncertain, ASK rather than assume
-- The user must feel accurately represented - iterate until they confirm
+- If a possible need feels uncertain, ASK rather than assume
+- The user must feel accurately represented; iterate until they confirm
 
 UNIVERSAL NEEDS FRAMEWORK:
 - Safety: Security, stability, predictability
@@ -44,146 +59,191 @@ UNIVERSAL NEEDS FRAMEWORK:
 - Fairness: Justice, equality, reciprocity
 
 REFRAMING TECHNIQUE:
-When user uses accusatory language, reframe to needs:
-- "They never help" -> "Need for partnership"
-- "They always criticize" -> "Need for acceptance"
-- "They ignore me" -> "Need to be seen"
+When user uses accusatory language, redirect to self-referential needs:
+- "They never help" -> "It sounds like partnership may matter here. Does that fit?"
+- "They always criticize" -> "Maybe there is a need for acceptance or respect. What word feels closer?"
+- "They ignore me" -> "That may be about being seen or feeling connected. Does either land?"
 
 CRITICAL - NO SOLUTIONS YET:
-This stage is about mapping needs, NOT solving them. Do not discuss:
+This stage is about mapping and validating needs, NOT solving them. Do not discuss:
 - HOW to meet needs (that is Stage 4)
 - Strategies or experiments
 - "What if you tried..."
 - Any action plans
 
 If user jumps to solutions, gently redirect:
-"I love that you are thinking ahead. Let us hold that idea for now - first I want to make sure we have mapped all the needs clearly. The 'how' works better when we know the full 'what.' We will get there, I promise."
-
-VISUAL METAPHOR:
-We are creating a map of needs - not to argue about who is right, but to see where paths might meet.
+"That may matter later. For now I want to stay with the 'what' before we move to the 'how.' What need would that solution be trying to protect?"
 
 AVAILABLE CONTEXT:
-- User's synthesized needs (derived only from the user's Stage 1-2 content; marked model_generated)
-- User's confirmed needs
+- Recent user-only Stage 3 conversation context
+- User's confirmed needs, if already confirmed
 {{#if has_partner_needs}}
-- Partner's consented needs (SharedVessel; consentActive: true; transformed)
+- Partner's confirmed needs, available only after both users have consented to reveal
 {{/if}}
-{{#if has_common_ground}}
-- Identified common ground
-{{/if}}
-- Clarification answers from user (persisted from prior turns)
+- Needs reveal status and validation status
 - AI Synthesis artifacts are never injected directly
 ```
 
-## User Prompt Template
+## User Prompt Templates
 
-### Presenting Synthesized Needs
+### EXPLORING
 
 ```
-Present the following synthesized needs to {{user_name}} for validation:
+{{user_name}} is identifying what matters to them. Ask one focused question that helps them move from story, blame, or position into a self-referential need.
 
-HIGH CONFIDENCE NEEDS (present these):
-{{#each synthesized_needs}}
-{{#if (gte this.confidence 0.7)}}
-- {{this.need}} ({{this.category}}): {{this.description}}
-  Evidence: {{this.evidence}}
-{{/if}}
+Use their words:
+{{recent_user_context}}
+
+Do:
+1. Reflect the feeling or value you hear.
+2. Offer at most one or two possible needs as possibilities.
+3. Ask whether that language lands.
+4. Avoid summarizing a complete list until they have explored enough.
+```
+
+### CONFIRMING
+
+```
+{{user_name}} may be ready to confirm their needs.
+
+Draft needs list:
+{{#each candidate_needs}}
+- {{this.need}}: {{this.description}}
 {{/each}}
 
-CLARIFICATION NEEDED (ask these questions):
-{{#each clarification_needed}}
-- Potential: {{this.potential_need}}
-  Question: {{this.question}}
-  Based on: {{this.evidence_so_far}}
-{{/each}}
-
-Guide them through:
-1. First, validate the high-confidence needs - do these resonate?
-2. Then, ask the clarification questions to understand uncertain areas
-3. After they respond, refine your understanding
-4. Iterate until they confirm the needs feel accurate (persist confirmations/rejections for later turns)
+Ask the user to confirm, edit, remove, or add to this list. Make clear that nothing is shared yet. If they change the list, continue refining before asking for confirmation again.
 ```
 
-### Exploring Common Ground
+### AWAITING_CONSENT
 
 ```
-{{user_name}} has confirmed their needs. Partner has also shared needs.
-
-User's confirmed needs:
+{{user_name}} has confirmed their own needs:
 {{#each user_needs}}
 - {{this.need}}: {{this.description}}
 {{/each}}
 
-Partner's shared needs:
+Ask whether they consent to reveal this confirmed list to {{partner_name}} once both people are ready. Do not disclose partner needs yet.
+```
+
+### REVEALED_NOTICE
+
+```
+Both users have consented. The side-by-side reveal is visible.
+
+{{user_name}}'s confirmed needs:
+{{#each user_needs}}
+- {{this.need}}: {{this.description}}
+{{/each}}
+
+{{partner_name}}'s confirmed needs:
 {{#each partner_needs}}
 - {{this.need}}: {{this.description}}
 {{/each}}
 
-Identified common ground:
-{{#each common_ground}}
-- {{this.need}}: {{this.description}}
-{{/each}}
+Ask an open noticing question. Preferred shape: "What do you notice as you see these side by side?"
 
-Present the common ground discovery in a way that creates connection without dismissing real differences.
+Do not identify, label, score, or author shared meaning for them.
+```
+
+### POST_REVEAL_PROCESSING
+
+```
+{{user_name}} is responding to the reveal.
+
+Help them process the emotional impact. You may ask about surprise, recognition, disappointment, relief, fear, grief, or curiosity. Stay with their experience. Do not turn noticing into analysis, persuasion, or a case for agreement.
+```
+
+### VALIDATING
+
+```
+{{user_name}} has had space to process the reveal.
+
+Ask whether both revealed needs lists feel accurate enough to carry forward into Stage 4. If not, ask what feels inaccurate or missing and route back to refinement. If yes, mark the user's validation.
 ```
 
 ## Expected Output
 
-### Need Validation
+### Needs Exploration
 
 ```
-Based on everything you have shared, I see some core needs emerging. Let me share what I am noticing, and you can tell me if this feels right:
-
-**Recognition**: You said "nothing I do is ever enough" and that you "cleaned the whole house and they did not even notice." I hear a need to feel seen for your efforts.
-
-**Partnership**: You mentioned being "the only one who cares" - it sounds like you need to feel like you are on the same team.
-
-Do these resonate with you? Is there anything I have missed, or anything that does not quite fit?
-
-I also want to check on something: you mentioned they "spend all their time on work." Is that about wanting more quality time together, or is it something else? I want to make sure I understand.
+I hear how exhausting it feels to be the only one tracking everything. When you step back from the chores themselves, does this touch a need for partnership, or is there a different word that feels closer?
 ```
 
-**Note**: The AI uses direct quotes from the user, not paraphrased interpretations. When uncertain, it asks rather than assumes.
-
-### Common Ground Discovery
+### Confirmation
 
 ```
-Something beautiful has emerged. Looking at both your needs and what {{partner_name}} has shared, I see a place where your paths meet:
+Here is what I have heard so far:
 
-**You both need Safety** - to feel secure in this relationship, to know it will last, to trust that you are in this together.
+**Partnership**: wanting to feel like you are carrying the household together.
+**Recognition**: wanting your effort to be noticed instead of assumed.
 
-This shared need does not erase your differences. But it tells us something important: beneath the conflict, you both want the same foundation.
+Before anything is shared, does this feel like your list? You can change the words, remove anything, or add what I missed.
+```
 
-How does it feel to see this?
+### Consent
+
+```
+Your needs list is confirmed. Are you willing for this list to be revealed to {{partner_name}} once they have also confirmed and consented?
+```
+
+### Reveal Noticing
+
+```
+Both lists are now visible. Take a moment with them side by side. What do you notice?
+```
+
+### Emotional Processing
+
+```
+That makes sense. Seeing the lists together can bring up a lot at once. What is the strongest feeling as you look at them right now?
+```
+
+### Validation
+
+```
+Do both lists feel accurate enough to carry forward into the next stage, where you will look at possible repairs? If something feels off or missing, we can pause and fix it first.
 ```
 
 ## Handling Resistance
 
-### User rejects a synthesized need
+### User Rejects A Suggested Need
 
 ```
-I hear that "recognition" does not feel like the right word. I do not want to put words in your mouth - help me understand better. When you said "nothing I do is ever enough," what was the feeling underneath that? What were you really needing in that moment?
+Thank you for correcting that. I do not want to put words in your mouth. What word would feel more accurate for what you were needing there?
 ```
 
-**Key**: Acknowledge you may have gotten it wrong. Use their exact quote. Ask them to correct you rather than defending your interpretation.
-
-### User struggles to see common ground
+### User Wants The AI To Interpret The Reveal
 
 ```
-I understand it can be hard to see shared ground when the hurt is still fresh. Let me try a different angle: when you imagine this relationship at its best - what would that look like for you? [Then connect to partner's similar vision]
+I can help you stay with what you are seeing, but I do not want to decide the meaning for you. When you look at both lists, what stands out first?
 ```
 
-### User focused on differences
+### User Is Hurt By Partner's Needs
 
 ```
-You are right that your needs are different in some ways. [Partner] needs more space, and you need more connection. But notice this: both of those needs come from wanting the relationship to feel good. The "how" is different, but the "why" is the same. Does that make sense?
+That sounds painful to see. Before we decide what it means, can we name what it brings up in you?
 ```
+
+### User Does Not Validate The Reveal
+
+```
+Good to catch that now. What feels inaccurate or missing: your list, {{partner_name}}'s list, or the way the reveal is representing them?
+```
+
+## Forbidden Guidance
+
+- Do not pre-extract needs from Stage 1-2 and present them as the user's needs.
+- Do not use AI Synthesis artifacts directly in the prompt context.
+- Do not author, label, score, or summarize common ground for the users.
+- Do not describe the lists as compatible, overlapping, complementary, or shared unless a user says that first.
+- Do not reveal partner needs before both users have confirmed and consented.
+- Do not turn Stage 3 into strategy, repair planning, experiments, or advice.
+- Do not pressure validation; if a list does not feel accurate, route back to refinement.
 
 ## Related
 
 - [Stage 3: What Matters](../../stages/stage-3-what-matters.md)
-- [Need Extraction Prompt](./need-extraction.md)
-- [Universal Needs Framework](../../stages/stage-3-what-matters.md#universal-needs-framework)
+- [Universal Needs Framework](../../stages/stage-3-what-matters.md#needs-language)
 
 ---
 

--- a/docs/backend/state-machine/index.md
+++ b/docs/backend/state-machine/index.md
@@ -36,7 +36,7 @@ stateDiagram-v2
     STAGE_0 --> STAGE_1: Both sign compact
     STAGE_1 --> STAGE_2: Both feel heard
     STAGE_2 --> STAGE_3: Mutual understanding
-    STAGE_3 --> STAGE_4: Common ground found
+    STAGE_3 --> STAGE_4: Needs validated
     STAGE_4 --> RESOLVED: Agreement reached
 
     ACTIVE --> PAUSED: Cooling period
@@ -76,7 +76,7 @@ stateDiagram-v2
 | 0 (Onboarding) | `compactSigned`, `partnerCompactSigned` | User signed, partner signed |
 | 1 (Witness) | `feelHeardConfirmed` | User posts feel-heard true |
 | 2 (Perspective) | `empathyDraftReady`, `empathyConsented`, `partnerConsented`, `partnerValidated` | Draft marked ready, user consents to share, partner consents, partner validates (or user accepts feedback path) |
-| 3 (What Matters) | `needsConfirmed`, `partnerNeedsConfirmed`, `commonGroundConfirmed` | User confirms needs, partner confirms theirs, both confirm common ground |
+| 3 (What Matters) | `needsConfirmed`, `needsShared`, `needsValidated` | User confirms needs, consents to share them, and validates the mutual needs reveal |
 | 4 (Strategic Repair) | `strategiesSubmitted`, `rankingsSubmitted`, `overlapIdentified`, `agreementCreated` | Both submitted strategies (or declared none), both rankings in, overlap revealed, Agreement saved |
 
 Advancement rule: a user can advance when all gate keys for their current stage are true AND any stage-level preconditions (e.g., Stage 4 only after both Stage 3 complete). WAITING state is derived when one user satisfies gates and the other has not.

--- a/docs/backend/state-machine/retrieval-contracts.md
+++ b/docs/backend/state-machine/retrieval-contracts.md
@@ -55,7 +55,6 @@ type RetrievalQuery =
 
   // Shared Vessel queries (Stage 2+)
   | { type: 'consented_content'; vessel: 'shared'; source: 'structured'; consentActive: true }
-  | { type: 'common_ground'; vessel: 'shared'; source: 'structured' }
   | { type: 'agreement'; vessel: 'shared'; source: 'structured' }
   | { type: 'micro_experiment'; vessel: 'shared'; source: 'structured' }
 
@@ -148,8 +147,8 @@ All prompts receive pre-assembled, stage-scoped bundles. Every field must be tag
 | Stage 0 | `session_metadata`, `relationship_metadata`, `session_outcomes` (structured, no vectors) |
 | Stage 1 | `messages` (current session, user-only), `emotional_readings` (user-only), `prior_themes` (optional: user-only, same relationship, ≤3 bullets, summarizer = deterministic), `conversation_context` (recent turn buffer, user-only) |
 | Stage 2 | Stage 1 bundle **plus** `shared_partner_content[]` (each item: type TRANSFORMED_NEED or CONSENTED_STATEMENT, content, consentActive true, transformed true, sourceUserId - no raw partner venting), `empathy_draft` (user-authored), `phase` |
-| Stage 3 | Confirmed `user_needs[]`, `synthesized_needs[]` (derived only from user content; marked `model_generated: true`), `clarification_needed[]`, optional `partner_needs[]` (from shared vessel, consentActive true), `common_ground[]` (derived) |
-| Stage 4 | `common_ground[]`, `strategies[]` (unattributed pool), `user_rankings` (private until both submit), `partner_rankings` (unlock after both submit), `agreements[]`, `micro_experiments[]` (structured only), `global_suggestions[]` (vector-derived, must be labeled `source: global_library`) |
+| Stage 3 | `conversation_context` (recent user-only turn buffer), confirmed `user_needs[]`, optional `partner_needs[]` only after both users have consented to reveal, `needs_reveal` metadata, `needs_validation_status` |
+| Stage 4 | `confirmed_needs[]` (both users, from Stage 3 reveal/validation), `strategies[]` (unattributed pool), `user_rankings` (private until both submit), `partner_rankings` (unlock after both submit), `agreements[]`, `micro_experiments[]` (structured only), `global_suggestions[]` (vector-derived, must be labeled `source: global_library`) |
 | Emotional Support (any stage) | `intensity`, `trend`, `recent_message` (user-only). **No recall contexts injected** when `MemoryIntent=avoid_recall`. |
 
 **Assembler Rules**
@@ -160,11 +159,9 @@ All prompts receive pre-assembled, stage-scoped bundles. Every field must be tag
 
 ### Shared Vessel Consent Semantics
 
-**Invariant**: All objects stored in Shared Vessel are either:
-- **(a) Directly consented** (`ConsentedContent`) - requires `consentActive: true` check at query time
-- **(b) Derived from consented inputs** (`Agreement`, `CommonGround`) - safe to retrieve without additional consent checks because they are only created after consent gates are satisfied
+**Invariant**: Partner-authored content stored in Shared Vessel is directly consented (`ConsentedContent`) and requires `consentActive: true` at query time. Derived shared objects such as `Agreement` records may be retrieved only after their own gate conditions are satisfied.
 
-This explains why `agreement` and `common_ground` queries don't have `consentActive` fields - they are inherently safe by construction.
+Stage 3 does not create or retrieve AI-authored overlap analysis. The reveal surface is assembled from each user's confirmed needs after both users consent.
 
 ---
 
@@ -300,7 +297,7 @@ function validateStage2Retrieval(
     if (query.type === 'consented_content') {
       return 'consentActive' in query && query.consentActive === true;
     }
-    // common_ground, agreement are derived from consented inputs - safe
+    // Agreements are derived from consented inputs and only retrieved after their gates.
     return true;
   }
 
@@ -333,23 +330,27 @@ WHERE cc."sharedVesselId" = $sharedVesselId
 
 ## Stage 3: What Matters
 
-**Purpose**: Identify universal needs and find common ground. See [Stage 3 Documentation](../../stages/stage-3-what-matters.md).
+**Purpose**: Help each user identify, confirm, consent to reveal, and validate what matters. See [Stage 3 Documentation](../../stages/stage-3-what-matters.md).
 
 ### Retrieval Contract
 
 | Category | Access |
 |----------|--------|
 | **ALLOWED** | Current user's identified needs |
-| **ALLOWED** | Shared Vessel content (consented needs) |
-| **ALLOWED** | Common ground candidates |
+| **ALLOWED** | Current user's recent Stage 3 conversation context |
+| **ALLOWED** | Partner's confirmed needs only after both users have consented to reveal |
+| **ALLOWED** | Needs reveal and validation status |
 | **FORBIDDEN** | Partner's raw events |
 | **FORBIDDEN** | Non-consented partner needs |
-| **REQUIRES** | Needs must be confirmed by user |
+| **FORBIDDEN** | AI-authored overlap, compatibility, or shared-ground analysis |
+| **FORBIDDEN** | Pre-extracted needs presented as the user's needs |
+| **REQUIRES** | Needs must be articulated and confirmed by the owning user |
+| **REQUIRES** | Partner needs require both users' reveal consent |
 | **VECTOR SCOPE** | Needs only (not events) |
 
 ### Rationale
 
-Stage 3 works with abstracted needs, not raw events. This protects privacy while enabling common ground discovery.
+Stage 3 works with user-confirmed needs, not raw events and not model-prepared needs lists. This protects privacy while keeping the reveal user-driven: users notice what they notice after seeing the two confirmed lists side by side.
 
 ```typescript
 // Stage 3 retrieval validation
@@ -362,9 +363,8 @@ function validateStage3Retrieval(
     return 'userId' in query && query.userId === currentUserId;
   }
 
-  // Shared Vessel queries: common_ground and consented_content allowed
+  // Shared Vessel queries: consented need-shaped content allowed after reveal consent
   if ('vessel' in query && query.vessel === 'shared') {
-    if (query.type === 'common_ground') return true;  // Derived from consented inputs
     if (query.type === 'consented_content') {
       return 'consentActive' in query && query.consentActive === true;
     }
@@ -388,7 +388,7 @@ function validateStage3Retrieval(
 | Category | Access |
 |----------|--------|
 | **ALLOWED** | All Shared Vessel content |
-| **ALLOWED** | Confirmed common ground |
+| **ALLOWED** | Confirmed needs carried forward from Stage 3 |
 | **ALLOWED** | Past agreements (this relationship) |
 | **ALLOWED** | Past micro-experiments and outcomes |
 | **ALLOWED** | Global Micro-Experiments Library (anonymized suggestions) |
@@ -419,8 +419,8 @@ function validateStage4Retrieval(
 ): boolean {
   // Shared Vessel structured queries
   if ('vessel' in query && query.vessel === 'shared') {
-    // Agreements, common ground, consented content
-    if (query.type === 'agreement' || query.type === 'common_ground') {
+    // Agreements and consented content
+    if (query.type === 'agreement') {
       return true;
     }
     if (query.type === 'consented_content') {

--- a/docs/product/stage-3-drift-cleanup-plan.md
+++ b/docs/product/stage-3-drift-cleanup-plan.md
@@ -1,0 +1,106 @@
+# Stage 3 Drift Cleanup Plan
+
+Status: ready
+Date: 2026-05-05
+Related: #247, #253, #254, #345
+Source: `docs/product/stage-3-golden-alignment-plan.md`, `docs/product/stage-3-golden-alignment-audit.md`
+
+## Summary
+
+A code-and-docs audit of `main` against the Stage 3 redesign spec (#247) found **significant drift, not fresh work**. The backend redesign is in: endpoints, gates, events, and prompts have all migrated, which is why the latest gold runs reach Stage 3 cleanly through `needsCaptured / needsConfirmed / needsShared / needsValidated`.
+
+The mobile shell and most of the Stage 3 docs have not caught up. Wave 4 (#253) is roughly **20% done with 80% drift to clean**. Wave 5 (#254) is roughly **10% done**. The remaining work is mostly removing or renaming, not building from scratch.
+
+This plan turns that audit into a concrete, surgical to-do list so that when hold issue #345 is closed, an agent (or a human) can execute it without re-implementing things already done.
+
+## Drift Items — Mobile (#253)
+
+### 1. Add the Reveal phase to NeedMappingScreen
+
+- File: `mobile/src/screens/NeedMappingScreen.tsx`
+- Current: `type NeedMappingPhase = 'exploration' | 'review' | 'waiting' | 'complete'`
+- Target: `type NeedMappingPhase = 'exploration' | 'review' | 'reveal' | 'waiting' | 'complete'`
+- Update `determinePhase()` to enter `'reveal'` after both partners have consented and the side-by-side data is available
+- Render side-by-side cards plus the "What do you notice?" prompt in the new phase
+
+### 2. Add the missing capture hook
+
+- `useValidateNeeds()` already exists at `mobile/src/hooks/useStages.ts:1538`
+- `useCaptureNeeds()` is missing. Add it — call `POST /sessions/:id/needs/capture`
+- Wire it into the conversation flow that confirms a user's final needs list
+
+### 3. Remove dead extraction polling
+
+- File: `mobile/src/hooks/useStages.ts` around line 1407
+- The hook still polls every 3s while `data.extracting === true`
+- The backend no longer returns `extracting`, so this is dead code at best, masking errors at worst
+- Delete the polling branch and the `extracting` flag handling
+- Verify no callers depend on `extracting` in the response shape
+
+### 4. Rename NeedsDrawer mode `comparison` → `reveal`
+
+- File: `mobile/src/components/NeedsDrawer.tsx`
+- Current: `export type NeedsDrawerMode = 'needs' | 'comparison'`
+- Target: `export type NeedsDrawerMode = 'needs' | 'reveal'`
+- Update `renderComparisonMode`, `renderComparisonButtons`, the header text branch, and all call sites
+- Update tests under `mobile/src/components/__tests__/NeedsDrawer.test.tsx`
+
+### 5. Update realtime event handlers
+
+- File: `mobile/src/screens/UnifiedSessionScreen.tsx` around line 832
+- Current: bridges `partner.common_ground_confirmed` and `partner.needs_validated` with an OR
+- Target: drop `partner.common_ground_confirmed`; only handle the new event names
+- Add a handler for `session.needs_revealed` to trigger the side-by-side display
+
+### 6. Remove stale CG-era copy and comments
+
+- `NeedMappingScreen.tsx:142` still says "After confirming, consent to share for common ground discovery"
+- Audit the file for any remaining strings or comments referring to common ground, extraction, or pre-extracted needs and rewrite to match the redesign
+
+### 7. Verification
+
+- `npm run check` passes in `mobile/`
+- `npm run test` passes in `mobile/`
+- A manual gold-flow walk-through (Adam/Eve scenario) reaches Stage 4 with the new Reveal phase visible and no warnings about unknown events
+
+## Drift Items — Docs (#254)
+
+| Doc | Drift | Action |
+|---|---|---|
+| `docs/product/stages/stage-3-what-matters.md` | 1 CG mention, 0 new endpoint mentions, 5d untouched | Rewrite the flow section to describe: user-driven needs identification → confirm → consent → mutual reveal → "What do you notice?" → emotional processing → validity gate. Remove all common-ground language. |
+| `docs/backend/api/stage-3.md` | 3 CG mentions, 3 new endpoint mentions (partial migration) | Finish the migration: remove the residual `/common-ground` endpoint references, ensure `POST /needs/capture` and `POST /needs/validate` are documented with request/response shapes, update `GET /needs` to reflect that it no longer triggers auto-extraction. |
+| `docs/backend/state-machine/index.md` | 2 CG mentions, 0 needsValidated mentions | Replace `commonGroundConfirmed` gate with `needsValidated` everywhere it appears. |
+| `docs/backend/state-machine/retrieval-contracts.md` | **14 CG mentions**, 0 new mentions | Remove `commonGround` from the context bundle description. This is the heaviest drift in the doc set. |
+| `docs/backend/prompts/stage-3-needs.md` | **13 CG mentions**, 0 new mentions | Update prompt guidance: introduce CONFIRMING mode, document post-reveal phases, refresh the FORBIDDEN list to drop CG-specific bans and add new ones (no pre-extraction, no AI-authored common ground). |
+
+## Risks To Flag While Iterating
+
+The dead extraction polling in `useNeeds` (item 3 above) is the highest-leverage cleanup. It runs every 3s waiting for a flag the backend never sets, which:
+
+- wastes requests under sustained Stage 3 sessions
+- is exactly the class of cache/realtime drift that has been generating Stage 4 bugs
+- silently keeps the loading UI in a state that may mask real failures
+
+Recommend tackling this item first, even if the rest of #253 stays paused, because it removes a confounder from ongoing gold-session debugging.
+
+## Sequencing
+
+1. Item 3 (dead polling removal) — small, safe, immediate value, can land independently of #345.
+2. Items 1, 2, 5 together — Reveal phase, capture hook, realtime events. These are the spec's substantive remaining work.
+3. Items 4, 6 — renaming and copy cleanup. Easy follow-up once 1/2/5 are stable.
+4. Doc migrations (#254 list) — best done after the mobile changes land so the docs reflect what the code actually does.
+
+## Out Of Scope
+
+- Stage 4 / Tending redesign (`docs/product/stage-4-tending-technical-spec.md`, #212)
+- Eval harness (#244)
+- Anything in Stage 0/1/2
+
+## Resume Procedure
+
+When ready to release Wave 4/5 to bot work:
+
+1. Land Item 3 manually (or hand-off to an agent with this plan as the brief).
+2. Close #345.
+3. Pipeline-monitor will re-promote #253 and #254 to `bot:pr` on its next tick.
+4. Re-add `bot:milestone-builder` to #247 if you want the orchestrator to coordinate further waves.

--- a/docs/product/stages/stage-3-what-matters.md
+++ b/docs/product/stages/stage-3-what-matters.md
@@ -21,7 +21,7 @@ Help each user articulate what truly matters to them in their own words — what
 1. **User-driven**: The user discovers what matters; the AI guides but doesn't synthesize for them
 2. **Self-referential needs**: Valid needs don't depend on a specific person acting a specific way
 3. **Suggestion, not correction**: AI offers needs language as a possibility, not a reframe
-4. **No premature overlap analysis**: The AI does NOT identify common ground — that seeing belongs to the users
+4. **No premature overlap analysis**: The AI does not identify, label, or score overlap; noticing belongs to the users
 
 ## Flow
 
@@ -37,7 +37,7 @@ flowchart TD
 
     Deepen --> Suggest[AI suggests needs language]
     Suggest --> Check{Does that land?}
-    Check -->|Yes| Confirm[Need confirmed]
+    Check -->|Yes| Confirm[User confirms needs list]
     Check -->|Not quite| Refine[Refine together]
     Refine --> Suggest
 
@@ -45,14 +45,17 @@ flowchart TD
     More -->|Yes| Explore
     More -->|No| Summary[Needs summary ready]
 
-    Summary --> Consent[User consents to share]
+    Summary --> Consent[User consents to share confirmed needs]
     Consent --> Wait{Partner ready?}
     Wait -->|Not yet| Waiting[Waiting for partner]
-    Wait -->|Yes| NeedsShare[The Needs Share]
+    Wait -->|Yes| NeedsShare[Mutual needs reveal]
 
     NeedsShare --> SideBySide[Both needs shown side by side]
     SideBySide --> Notice[AI asks: What do you notice?]
-    Notice --> Stage4[Advance to Stage 4]
+    Notice --> Process[Emotional processing]
+    Process --> Validate{Do both lists feel valid enough?}
+    Validate -->|Needs repair| Explore
+    Validate -->|Both validate| Stage4[Advance to Stage 4]
 ```
 
 ## Opening
@@ -86,19 +89,21 @@ Example exchange:
 - User: "I guess I just want to feel like we're a team."
 - AI: "Partnership. Like you need to feel like you're in this together. Does that land?"
 
-## The Needs Share
+## Mutual Needs Reveal
 
 After both users complete their needs exploration:
 
-1. **Hold**: Both needs summaries are held until both users finish Stage 3
+1. **Hold**: Both confirmed needs lists are held until both users finish Stage 3
 2. **Consent**: Each user consents to share (same pattern as Stage 2 empathy consent)
 3. **Reveal**: Both needs shown side by side
 4. **Minimal framing**: AI says something brief, then asks: **"What do you notice?"**
-5. **No interpretation**: AI does NOT frame needs as compatible, overlapping, or complementary -- that seeing belongs to the users
+5. **Emotional processing**: AI helps users name what it is like to see both lists without interpreting the relationship for them
+6. **Validity gate**: Each user validates whether both revealed lists feel accurate enough to carry into Stage 4
+7. **No interpretation**: AI does not frame needs as compatible, overlapping, complementary, or shared -- that seeing belongs to the users
 
 ## Success Criteria
 
-Each user has articulated what matters to them in needs language that doesn't depend on the other person acting a specific way. Both users have seen each other's needs side by side.
+Each user has articulated what matters to them in needs language that doesn't depend on the other person acting a specific way. Both users have confirmed their own needs, consented to share them, seen the side-by-side reveal, processed what they notice, and validated that the revealed needs are accurate enough to carry into Stage 4.
 
 ## Failure Paths
 
@@ -112,8 +117,10 @@ Each user has articulated what matters to them in needs language that doesn't de
 ## Data Captured
 
 - Identified needs for each user (user-driven, AI-suggested)
+- Confirmation records for each user's needs list
 - Consent records for needs sharing
-- Needs Share reveal timestamp
+- Mutual needs reveal timestamp
+- Needs validation records for the Stage 3 gate
 
 ---
 

--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -4,7 +4,7 @@
  * Bottom-sheet drawer for Stage 3 Need Mapping. Two modes:
  *
  * - `needs`: Review own needs with adjust/confirm actions
- * - `comparison`: Side-by-side view of both users' needs
+ * - `reveal`: Side-by-side view of both users' needs
  */
 
 import React, { useRef, useCallback, useEffect, useState } from 'react';
@@ -28,7 +28,7 @@ import { NeedCard } from './NeedCard';
 // Types
 // ============================================================================
 
-export type NeedsDrawerMode = 'needs' | 'comparison';
+export type NeedsDrawerMode = 'needs' | 'reveal';
 
 interface NeedItem {
   id: string;
@@ -48,7 +48,7 @@ export interface NeedsDrawerProps {
   confirmNeedsLabel?: string;
   confirmingNeedsLabel?: string;
   isConfirming?: boolean;
-  // Comparison mode
+  // Reveal mode
   partnerNeeds?: NeedItem[];
   partnerName?: string;
   onValidateNeeds?: () => void;
@@ -210,9 +210,9 @@ export function NeedsDrawer({
   // -------------------------------------------------------------------------
   const renderNeedsMode = () => (
     <>
-      <Text style={styles.sectionTitle}>Your Identified Needs</Text>
+      <Text style={styles.sectionTitle}>Your Needs</Text>
       <Text style={styles.sectionSubtitle}>
-        Review and confirm the needs identified from your conversation.
+        Review and confirm the needs you named in this conversation.
       </Text>
 
       {needs.map((need) => (
@@ -224,7 +224,7 @@ export function NeedsDrawer({
       ))}
 
       {needs.length === 0 && (
-        <Text style={styles.emptyText}>No needs identified yet.</Text>
+        <Text style={styles.emptyText}>No needs captured yet.</Text>
       )}
     </>
   );
@@ -270,13 +270,13 @@ export function NeedsDrawer({
 
   const renderSideBySideNeeds = () => {
     return (
-      <View style={styles.comparisonContainer} testID={`${testID}-side-by-side`}>
-        <View style={styles.comparisonColumn}>
+      <View style={styles.revealContainer} testID={`${testID}-side-by-side`}>
+        <View style={styles.revealColumn}>
           <Text style={styles.columnHeader}>You</Text>
           {needs.map((need) => (
-            <View key={need.id} style={styles.comparisonCard}>
-              <Text style={styles.comparisonCategory}>{need.category}</Text>
-              <Text style={styles.comparisonNeed}>{need.need}</Text>
+            <View key={need.id} style={styles.revealCard}>
+              <Text style={styles.revealCategory}>{need.category}</Text>
+              <Text style={styles.revealNeed}>{need.need}</Text>
             </View>
           ))}
           {needs.length === 0 && (
@@ -284,12 +284,12 @@ export function NeedsDrawer({
           )}
         </View>
 
-        <View style={styles.comparisonColumn}>
+        <View style={styles.revealColumn}>
           <Text style={styles.columnHeader}>{partnerName}</Text>
           {partnerNeeds.map((need) => (
-            <View key={need.id} style={[styles.comparisonCard, styles.partnerComparisonCard]}>
-              <Text style={styles.comparisonCategory}>{need.category}</Text>
-              <Text style={styles.comparisonNeed}>{need.need}</Text>
+            <View key={need.id} style={[styles.revealCard, styles.partnerRevealCard]}>
+              <Text style={styles.revealCategory}>{need.category}</Text>
+              <Text style={styles.revealNeed}>{need.need}</Text>
             </View>
           ))}
           {partnerNeeds.length === 0 && (
@@ -300,7 +300,7 @@ export function NeedsDrawer({
     );
   };
 
-  const renderComparisonMode = () => (
+  const renderRevealMode = () => (
     <>
       <Text style={styles.sectionSubtitle}>
         Review both needs lists side by side. What do you notice?
@@ -309,7 +309,7 @@ export function NeedsDrawer({
     </>
   );
 
-  const renderComparisonButtons = () => {
+  const renderRevealButtons = () => {
     const hasButtons = onValidateNeeds || onNeedsNotValidYet;
     if (!hasButtons) return null;
     return (
@@ -407,12 +407,12 @@ export function NeedsDrawer({
             showsVerticalScrollIndicator
           >
             {mode === 'needs' && renderNeedsMode()}
-            {mode === 'comparison' && renderComparisonMode()}
+            {mode === 'reveal' && renderRevealMode()}
           </ScrollView>
 
           {/* Fixed footer buttons */}
           {mode === 'needs' && renderNeedsButtons()}
-          {mode === 'comparison' && renderComparisonButtons()}
+          {mode === 'reveal' && renderRevealButtons()}
         </View>
       </Animated.View>
     </View>
@@ -537,13 +537,13 @@ const styles = StyleSheet.create({
     flex: undefined,
   },
 
-  // Comparison view
-  comparisonContainer: {
+  // Reveal view
+  revealContainer: {
     flexDirection: 'row',
     gap: 8,
     marginHorizontal: 12,
   },
-  comparisonColumn: {
+  revealColumn: {
     flex: 1,
   },
   columnHeader: {
@@ -555,7 +555,7 @@ const styles = StyleSheet.create({
     marginBottom: 10,
     paddingHorizontal: 4,
   },
-  comparisonCard: {
+  revealCard: {
     backgroundColor: 'rgba(147, 197, 253, 0.15)',
     borderRadius: 10,
     borderWidth: 1,
@@ -564,17 +564,17 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     position: 'relative',
   },
-  partnerComparisonCard: {
+  partnerRevealCard: {
     backgroundColor: 'rgba(251, 191, 36, 0.12)',
     borderColor: 'rgba(251, 191, 36, 0.3)',
   },
-  comparisonCategory: {
+  revealCategory: {
     fontSize: 11,
     fontWeight: '600',
     color: colors.textSecondary,
     marginBottom: 2,
   },
-  comparisonNeed: {
+  revealNeed: {
     fontSize: 13,
     color: colors.textPrimary,
     lineHeight: 18,

--- a/mobile/src/components/__tests__/NeedsDrawer.test.tsx
+++ b/mobile/src/components/__tests__/NeedsDrawer.test.tsx
@@ -23,17 +23,17 @@ describe('NeedsDrawer', () => {
       />
     );
 
-    expect(screen.getByText('Your Needs')).toBeTruthy();
+    expect(screen.getByTestId('needs-drawer-header').props.children).toBe('Your Needs');
     expect(screen.getByText('Being heard')).toBeTruthy();
     expect(screen.getByText('Reliability')).toBeTruthy();
   });
 
-  it('renders comparison mode with both partners needs side by side', () => {
+  it('renders reveal mode with both partners needs side by side', () => {
     render(
       <NeedsDrawer
         visible
         onClose={jest.fn()}
-        mode="comparison"
+        mode="reveal"
         needs={needs}
         partnerNeeds={partnerNeeds}
         partnerName="Darryl"
@@ -48,7 +48,7 @@ describe('NeedsDrawer', () => {
     expect(screen.getByText('Review both needs lists side by side. What do you notice?')).toBeTruthy();
   });
 
-  it('validates the side-by-side needs reveal from comparison mode', () => {
+  it('validates the side-by-side needs reveal from reveal mode', () => {
     const onValidateNeeds = jest.fn();
     const onNeedsNotValidYet = jest.fn();
 
@@ -56,7 +56,7 @@ describe('NeedsDrawer', () => {
       <NeedsDrawer
         visible
         onClose={jest.fn()}
-        mode="comparison"
+        mode="reveal"
         needs={needs}
         partnerNeeds={partnerNeeds}
         onValidateNeeds={onValidateNeeds}

--- a/mobile/src/config/waitingStatusConfig.ts
+++ b/mobile/src/config/waitingStatusConfig.ts
@@ -208,15 +208,15 @@ export const WAITING_STATUS_CONFIG: Record<NonNullable<WaitingStatusState>, Wait
     bannerText: (p) => `${p} is deciding what they are ready to share.`,
   },
 
-  // Stage 3: Waiting for partner to confirm common ground
-  'common-ground-pending': {
+  // Stage 3: Waiting for partner to validate the needs reveal
+  'needs-validation-pending': {
     showBanner: true,
     hideInput: true,
     showInnerThoughts: false,
     isActionRequired: false,
     showSpinner: false,
     showKeepChattingAction: false,
-    bannerText: (p) => `${p} is reviewing common ground.`,
+    bannerText: (p) => `${p} is validating the needs reveal.`,
   },
 
   // Stage 3: User validated the side-by-side needs reveal; partner still needs to validate.

--- a/mobile/src/hooks/__tests__/useStages.test.ts
+++ b/mobile/src/hooks/__tests__/useStages.test.ts
@@ -19,6 +19,7 @@ import {
   useValidateEmpathy,
   useSkipRefinement,
   useNeeds,
+  useCaptureNeeds,
   useConfirmNeeds,
   useAddNeed,
   useConsentShareNeeds,
@@ -490,6 +491,54 @@ describe('useStages', () => {
       });
     });
 
+    describe('useCaptureNeeds hook', () => {
+      it('captures needs through the Stage 3 capture endpoint', async () => {
+        mockPost.mockResolvedValueOnce({
+          needs: [
+            {
+              id: 'need-1',
+              need: 'Respect',
+              category: NeedCategory.RECOGNITION,
+              description: 'Feeling valued and recognized',
+              evidence: ['Quote 1'],
+              confirmed: false,
+              aiConfidence: 0.85,
+            },
+          ],
+          capturedAt: '2024-01-01T00:00:00.000Z',
+        });
+
+        const { result } = renderHook(() => useCaptureNeeds(), {
+          wrapper: createWrapper(),
+        });
+
+        await act(async () => {
+          await result.current.mutateAsync({
+            sessionId,
+            needs: [
+              {
+                need: 'Respect',
+                category: NeedCategory.RECOGNITION,
+                description: 'Feeling valued and recognized',
+                evidence: ['Quote 1'],
+              },
+            ],
+          });
+        });
+
+        expect(mockPost).toHaveBeenCalledWith(`/sessions/${sessionId}/needs/capture`, {
+          needs: [
+            {
+              need: 'Respect',
+              category: NeedCategory.RECOGNITION,
+              description: 'Feeling valued and recognized',
+              evidence: ['Quote 1'],
+            },
+          ],
+        });
+      });
+    });
+
     describe('useConfirmNeeds hook', () => {
       it('confirms identified needs', async () => {
         mockPost.mockResolvedValueOnce({
@@ -553,7 +602,7 @@ describe('useStages', () => {
     });
 
     describe('useConsentShareNeeds hook', () => {
-      it('consents to share needs for common ground', async () => {
+      it('consents to reveal confirmed needs to the partner', async () => {
         mockPost.mockResolvedValueOnce({
           consent: true,
           sharedNeedIds: ['need-1', 'need-2'],

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -110,12 +110,12 @@ export interface UseChatUIStateProps {
   needsShared: boolean;
   needsRevealReady: boolean;
   hasConfirmedNeedsLocal: boolean;
-  commonGroundCount: number;
-  commonGroundAvailable: boolean;
-  commonGroundNoOverlap: boolean;
-  commonGroundAllConfirmedByMe: boolean;
-  commonGroundAllConfirmedByBoth: boolean;
-  hasConfirmedCommonGroundLocal: boolean;
+  needsRevealValidationCount: number;
+  needsRevealAvailable: boolean;
+  needsRevealNoOverlap: boolean;
+  needsRevealValidatedByMe: boolean;
+  needsRevealValidatedByBoth: boolean;
+  hasValidatedNeedsRevealLocal: boolean;
 
   // Stage 4: Strategies
   strategyPhase: StrategyPhase | string;
@@ -211,12 +211,12 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     needsShared,
     needsRevealReady,
     hasConfirmedNeedsLocal,
-    commonGroundCount,
-    commonGroundAvailable,
-    commonGroundNoOverlap,
-    commonGroundAllConfirmedByMe,
-    commonGroundAllConfirmedByBoth,
-    hasConfirmedCommonGroundLocal,
+    needsRevealValidationCount,
+    needsRevealAvailable,
+    needsRevealNoOverlap,
+    needsRevealValidatedByMe,
+    needsRevealValidatedByBoth,
+    hasValidatedNeedsRevealLocal,
     strategyPhase,
     strategyReadiness,
     overlappingStrategiesCount,
@@ -248,10 +248,10 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
       hasSuggestion: shareOfferData.hasSuggestion,
     } : undefined,
     needs: { allConfirmed: allNeedsConfirmed, shared: needsShared, revealReady: needsRevealReady },
-    commonGround: {
-      count: commonGroundCount,
-      allConfirmedByMe: commonGroundAllConfirmedByMe,
-      allConfirmedByBoth: commonGroundAllConfirmedByBoth,
+    needsRevealValidation: {
+      count: needsRevealValidationCount,
+      allConfirmedByMe: needsRevealValidatedByMe,
+      allConfirmedByBoth: needsRevealValidatedByBoth,
     },
     strategyPhase,
     strategyReadiness,
@@ -295,11 +295,11 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     hasConfirmedNeedsLocal,
 
     // Stage 3: Common Ground
-    commonGroundAvailable,
-    commonGroundNoOverlap,
-    commonGroundAllConfirmedByMe,
-    commonGroundAllConfirmedByBoth,
-    hasConfirmedCommonGroundLocal,
+    needsRevealAvailable,
+    needsRevealNoOverlap,
+    needsRevealValidatedByMe,
+    needsRevealValidatedByBoth,
+    hasValidatedNeedsRevealLocal,
   }), [
     myProgress?.stage,
     partnerProgress?.stage,
@@ -313,12 +313,12 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     needsShared,
     needsRevealReady,
     hasConfirmedNeedsLocal,
-    commonGroundCount,
-    commonGroundAvailable,
-    commonGroundNoOverlap,
-    commonGroundAllConfirmedByMe,
-    commonGroundAllConfirmedByBoth,
-    hasConfirmedCommonGroundLocal,
+    needsRevealValidationCount,
+    needsRevealAvailable,
+    needsRevealNoOverlap,
+    needsRevealValidatedByMe,
+    needsRevealValidatedByBoth,
+    hasValidatedNeedsRevealLocal,
     strategyPhase,
     strategyReadiness,
     overlappingStrategiesCount,

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -32,6 +32,8 @@ import {
   ValidateEmpathyRequest,
   ValidateEmpathyResponse,
   GetNeedsResponse,
+  CaptureNeedsRequest,
+  CaptureNeedsResponse,
   ConfirmNeedsRequest,
   NeedAdjustment,
   ConfirmNeedsResponse,
@@ -1385,11 +1387,7 @@ export function useRefineValidationFeedback(
 // ============================================================================
 
 /**
- * Get AI-identified needs for the current user.
- *
- * Automatically polls every 3 seconds when the backend returns
- * `extracting: true`, indicating AI extraction is in progress.
- * Polling stops once needs are available or extraction completes.
+ * Get captured needs for the current user.
  */
 export function useNeeds(
   sessionId: string | undefined,
@@ -1403,15 +1401,36 @@ export function useNeeds(
     },
     enabled: !!sessionId,
     staleTime: 0, // Always treat as stale so Ably event invalidation triggers fresh fetch
-    // Poll every 3s only while extraction is actively in progress.
-    // The backend returns extracting: true while AI is analyzing needs.
-    // Do NOT poll when needs are simply empty (normal state for stages before Need Mapping).
-    refetchInterval: (query) => {
-      const data = query.state.data as (GetNeedsResponse & { extracting?: boolean }) | undefined;
-      if (data?.extracting) {
-        return 3_000; // Poll every 3 seconds while extracting
-      }
-      return false; // Stop polling otherwise
+    ...options,
+  });
+}
+
+/**
+ * Capture the user's final needs list from the Stage 3 conversation.
+ */
+export function useCaptureNeeds(
+  options?: Omit<
+    UseMutationOptions<
+      CaptureNeedsResponse,
+      ApiClientError,
+      { sessionId: string } & CaptureNeedsRequest
+    >,
+    'mutationFn'
+  >
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ sessionId, needs }) => {
+      return post<CaptureNeedsResponse>(`/sessions/${sessionId}/needs/capture`, {
+        needs,
+      });
+    },
+    onSuccess: (_, { sessionId }) => {
+      queryClient.invalidateQueries({ queryKey: stageKeys.needs(sessionId) });
+      queryClient.invalidateQueries({ queryKey: stageKeys.needsComparison(sessionId) });
+      queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+      queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
     },
     ...options,
   });
@@ -1480,7 +1499,7 @@ export function useAddNeed(
 }
 
 /**
- * Consent to share needs for common ground discovery.
+ * Consent to reveal confirmed needs to the partner.
  */
 export function useConsentShareNeeds(
   options?: Omit<

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -97,7 +97,7 @@ export interface InlineChatCard {
   dismissible?: boolean;
 }
 
-type LegacyCommonGroundItem = {
+type LegacyNeedsRevealItem = {
   id: string;
   need: string;
   category: string;
@@ -285,7 +285,7 @@ export function useUnifiedSession(
   // Stage 3: Needs - always fetch to avoid waterfall
   const { data: needsData } = useNeeds(sessionId, disableChildQueries);
 
-  // Derive needs state for gating common ground query
+  // Derive needs state for gating the side-by-side reveal query.
   const needsForGating = needsData?.needs ?? [];
   const allNeedsConfirmedForGating = needsForGating.length > 0 && needsForGating.every((n) => n.confirmed);
   const myNeedsSharedForGating =
@@ -538,14 +538,14 @@ export function useUnifiedSession(
   // Needs confirmation state
   const needs = useMemo(() => needsData?.needs ?? [], [needsData?.needs]);
   const allNeedsConfirmed = needs.length > 0 && needs.every((n) => n.confirmed);
-  const commonGround = useMemo<LegacyCommonGroundItem[]>(() => [], []);
+  const needsRevealValidationItems = useMemo<LegacyNeedsRevealItem[]>(() => [], []);
   const needsRevealReady =
     (needsComparisonData?.myNeeds?.length ?? 0) > 0 &&
     (needsComparisonData?.partnerNeeds?.length ?? 0) > 0;
-  const commonGroundData = needsRevealReady
-    ? { commonGround: [], analysisComplete: true, bothConfirmed: false, noOverlap: false }
+  const needsRevealValidationData = needsRevealReady
+    ? { needsRevealValidationItems: [], analysisComplete: true, bothConfirmed: false, noOverlap: false }
     : undefined;
-  const commonGroundComplete = false;
+  const needsRevealValidatedByBoth = false;
 
   // Strategy phase
   const strategyPhase = strategyData?.phase ?? StrategyPhase.COLLECTING;
@@ -698,9 +698,9 @@ export function useUnifiedSession(
     }
 
     // Stage 3: Need Mapping cards
-    // Note: needs-summary and common-ground-preview inline cards removed.
+    // Note: needs-summary and needs-reveal-preview inline cards removed.
     // These are now shown in the NeedsDrawer bottom sheet, opened via
-    // the above-input buttons (needs-review, common-ground-confirm).
+    // the above-input buttons (needs-review, needs-reveal-validate).
 
     // Stage 4: Strategic Repair cards
     if (currentStage === Stage.STRATEGIC_REPAIR) {
@@ -765,8 +765,8 @@ export function useUnifiedSession(
     partnerEmpathyData,
     needs,
     allNeedsConfirmed,
-    commonGround,
-    commonGroundComplete,
+    needsRevealValidationItems,
+    needsRevealValidatedByBoth,
     strategyPhase,
     strategies,
     myReadyToRank,
@@ -1050,7 +1050,7 @@ export function useUnifiedSession(
     [sessionId, needs, consentShareNeeds]
   );
 
-  const handleConfirmCommonGround = useCallback(
+  const handleValidateNeedsReveal = useCallback(
     (onSuccess?: () => void) => {
       if (!sessionId) return;
 
@@ -1224,9 +1224,9 @@ export function useUnifiedSession(
     needsData,
     needs,
     allNeedsConfirmed,
-    commonGroundData,
-    commonGround,
-    commonGroundComplete,
+    needsRevealValidationData,
+    needsRevealValidationItems,
+    needsRevealValidatedByBoth,
     needsComparisonData,
     strategyData,
     strategyPhase,
@@ -1266,7 +1266,7 @@ export function useUnifiedSession(
     handleSkipRefinement,
     handleConfirmAllNeeds,
     handleConsentToShareNeeds,
-    handleConfirmCommonGround,
+    handleValidateNeedsReveal,
     handleNeedsNotValidYet,
     handleAddStrategy,
     handleRequestMoreStrategies,

--- a/mobile/src/screens/NeedMappingScreen.tsx
+++ b/mobile/src/screens/NeedMappingScreen.tsx
@@ -8,6 +8,7 @@
  * Phases:
  * - Exploration: Chat with AI to explore needs
  * - Review: View and confirm identified needs
+ * - Reveal: View both partners' needs side by side
  * - Waiting: Wait for partner to complete their needs
  * - Complete: Redirect to next stage
  */
@@ -23,6 +24,8 @@ import { useStreamingMessage } from '../hooks/useStreamingMessage';
 import {
   useProgress,
   useNeeds,
+  useNeedsComparison,
+  useCaptureNeeds,
   useConfirmNeeds,
   useConsentShareNeeds,
 } from '../hooks/useStages';
@@ -35,7 +38,7 @@ import { Stage, IdentifiedNeedDTO } from '@meet-without-fear/shared';
 // Types
 // ============================================================================
 
-type NeedMappingPhase = 'exploration' | 'review' | 'waiting' | 'complete';
+type NeedMappingPhase = 'exploration' | 'review' | 'reveal' | 'waiting' | 'complete';
 
 // ============================================================================
 // Helper Functions
@@ -47,19 +50,25 @@ type NeedMappingPhase = 'exploration' | 'review' | 'waiting' | 'complete';
 function determinePhase(
   needs: IdentifiedNeedDTO[] | undefined,
   allNeedsConfirmed: boolean,
+  needsShared: boolean,
+  hasSideBySideNeeds: boolean,
 ): NeedMappingPhase {
-  // No needs synthesized yet - still in exploration
+  if (needsShared && hasSideBySideNeeds) {
+    return 'reveal';
+  }
+
+  // No captured needs yet - still in exploration
   if (!needs || needs.length === 0) {
     return 'exploration';
   }
 
-  // Needs exist but not all confirmed - review phase
+  // Needs exist but not all are confirmed - review phase
   if (!allNeedsConfirmed) {
     return 'review';
   }
 
-  // Needs confirmed - complete (AI handles transition conversationally)
-  return 'complete';
+  // Needs confirmed/shared locally - wait for partner consent and reveal data.
+  return 'waiting';
 }
 
 /**
@@ -94,6 +103,17 @@ export function NeedMappingScreen() {
 
   // Needs data
   const { data: needsData, isLoading: loadingNeeds } = useNeeds(sessionId);
+  const myGates = progressData?.myProgress as
+    | { gates?: Record<string, unknown>; gatesSatisfied?: Record<string, unknown> }
+    | undefined;
+  const needsShared = myGates?.gatesSatisfied?.needsShared === true || myGates?.gates?.needsShared === true;
+  const allNeedsConfirmed =
+    (needsData?.needs?.length ?? 0) > 0 && (needsData?.needs ?? []).every((n) => n.confirmed);
+  const { data: needsComparisonData, isLoading: loadingNeedsComparison } = useNeedsComparison(
+    sessionId,
+    allNeedsConfirmed || needsShared
+  );
+  const { mutate: captureNeeds, isPending: isCapturing } = useCaptureNeeds();
   const { mutate: confirmNeeds, isPending: isConfirming } = useConfirmNeeds();
   const { mutate: consentShareNeeds } = useConsentShareNeeds();
 
@@ -107,14 +127,20 @@ export function NeedMappingScreen() {
   const myProgress = progressData?.myProgress;
   const partnerProgress = progressData?.partnerProgress;
 
-  // Check if all needs are confirmed
-  const allNeedsConfirmed = needs.length > 0 && needs.every((n) => n.confirmed);
+  const hasSideBySideNeeds =
+    (needsComparisonData?.myNeeds?.length ?? 0) > 0 &&
+    (needsComparisonData?.partnerNeeds?.length ?? 0) > 0;
 
   // Determine current phase
-  const phase = determinePhase(needs, allNeedsConfirmed);
+  const phase = determinePhase(needs, allNeedsConfirmed, needsShared, hasSideBySideNeeds);
 
   // Loading state
-  const isLoading = loadingSession || loadingProgress || loadingMessages || loadingNeeds;
+  const isLoading =
+    loadingSession ||
+    loadingProgress ||
+    loadingMessages ||
+    loadingNeeds ||
+    (needsShared && loadingNeedsComparison);
 
   // ============================================================================
   // Hooks must be called unconditionally (before any early returns)
@@ -133,21 +159,35 @@ export function NeedMappingScreen() {
   const handleConfirmNeeds = useCallback(() => {
     if (!sessionId) return;
 
-    const needIds = needs.map((need) => need.id);
-
-    confirmNeeds(
-      { sessionId, needIds },
+    captureNeeds(
       {
-        onSuccess: () => {
-          // After confirming, consent to share for common ground discovery
-          consentShareNeeds({
-            sessionId,
-            needIds,
-          });
+        sessionId,
+        needs: needs.map((need) => ({
+          need: need.need,
+          category: need.category,
+          description: need.description || need.need,
+          evidence: need.evidence ?? [],
+        })),
+      },
+      {
+        onSuccess: (captureData) => {
+          const capturedNeedIds = captureData.needs.map((need) => need.id);
+
+          confirmNeeds(
+            { sessionId, needIds: capturedNeedIds },
+            {
+              onSuccess: () => {
+                consentShareNeeds({
+                  sessionId,
+                  needIds: capturedNeedIds,
+                });
+              },
+            }
+          );
         },
       }
     );
-  }, [sessionId, needs, confirmNeeds, consentShareNeeds]);
+  }, [sessionId, needs, captureNeeds, confirmNeeds, consentShareNeeds]);
 
   // Handle adjustment request
   const handleAdjustNeeds = useCallback(() => {
@@ -262,9 +302,9 @@ export function NeedMappingScreen() {
         <SafeAreaView style={styles.container} edges={['bottom']} testID="need-mapping-review">
           <ScrollView contentContainerStyle={styles.scrollContent}>
             <View style={styles.header}>
-              <Text style={styles.title}>Your Identified Needs</Text>
+              <Text style={styles.title}>Your Needs</Text>
               <Text style={styles.subtitle}>
-                Review the needs identified from your conversation
+                Review the needs you named in this conversation
               </Text>
             </View>
 
@@ -283,7 +323,7 @@ export function NeedMappingScreen() {
                 <TouchableOpacity
                   style={styles.adjustButton}
                   onPress={handleAdjustNeeds}
-                  disabled={isConfirming}
+                  disabled={isCapturing || isConfirming}
                   testID="adjust-needs-button"
                   accessibilityRole="button"
                   accessibilityLabel="Adjust needs"
@@ -292,20 +332,84 @@ export function NeedMappingScreen() {
                 </TouchableOpacity>
 
                 <TouchableOpacity
-                  style={[styles.confirmButton, isConfirming && styles.disabledButton]}
+                  style={[styles.confirmButton, (isCapturing || isConfirming) && styles.disabledButton]}
                   onPress={handleConfirmNeeds}
-                  disabled={isConfirming}
+                  disabled={isCapturing || isConfirming}
                   testID="confirm-needs-button"
                   accessibilityRole="button"
                   accessibilityLabel="Confirm my needs"
                 >
                   <Text style={styles.confirmText}>
-                    {isConfirming ? 'Confirming...' : 'Yes, confirm my needs'}
+                    {isCapturing || isConfirming ? 'Confirming...' : 'Yes, confirm my needs'}
                   </Text>
                 </TouchableOpacity>
               </View>
             </View>
           </ScrollView>
+        </SafeAreaView>
+      </>
+    );
+  }
+
+  // Phase: Reveal - show both partners' needs side by side
+  if (phase === 'reveal') {
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            title: 'Needs Reveal',
+            headerBackTitle: 'Session',
+          }}
+        />
+        <SafeAreaView style={styles.container} edges={['bottom']} testID="need-mapping-reveal">
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <View style={styles.header}>
+              <Text style={styles.title}>Needs Side by Side</Text>
+              <Text style={styles.subtitle}>What do you notice?</Text>
+            </View>
+
+            <View style={styles.revealContent} testID="needs-side-by-side">
+              <View style={styles.revealColumn}>
+                <Text style={styles.revealColumnTitle}>Your needs</Text>
+                {(needsComparisonData?.myNeeds ?? []).map((need) => (
+                  <View key={need.id} style={styles.revealCard}>
+                    <Text style={styles.revealNeed}>{need.need}</Text>
+                    <Text style={styles.revealCategory}>{need.category}</Text>
+                  </View>
+                ))}
+              </View>
+
+              <View style={styles.revealColumn}>
+                <Text style={styles.revealColumnTitle}>Partner needs</Text>
+                {(needsComparisonData?.partnerNeeds ?? []).map((need) => (
+                  <View key={need.id} style={styles.revealCard}>
+                    <Text style={styles.revealNeed}>{need.need}</Text>
+                    <Text style={styles.revealCategory}>{need.category}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          </ScrollView>
+        </SafeAreaView>
+      </>
+    );
+  }
+
+  // Phase: Waiting - confirmed/shared locally, waiting for partner consent and reveal data
+  if (phase === 'waiting') {
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            title: 'Waiting',
+            headerBackTitle: 'Session',
+          }}
+        />
+        <SafeAreaView style={styles.container} edges={['bottom']}>
+          <WaitingRoom
+            message="Waiting for your partner to share their needs"
+            partnerName={session?.partner?.nickname ?? session?.partner?.name ?? undefined}
+          />
         </SafeAreaView>
       </>
     );
@@ -362,6 +466,38 @@ const styles = StyleSheet.create({
   },
   content: {
     padding: 16,
+  },
+  revealContent: {
+    flexDirection: 'row',
+    gap: 12,
+    padding: 16,
+  },
+  revealColumn: {
+    flex: 1,
+    gap: 8,
+  },
+  revealColumnTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.textPrimary,
+    marginBottom: 4,
+  },
+  revealCard: {
+    padding: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    backgroundColor: colors.bgSecondary,
+  },
+  revealNeed: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.textPrimary,
+  },
+  revealCategory: {
+    marginTop: 4,
+    fontSize: 12,
+    color: colors.textSecondary,
   },
   loadingText: {
     marginTop: 12,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -370,9 +370,9 @@ export function UnifiedSessionScreen({
     needs,
     needsData,
     allNeedsConfirmed,
-    commonGround,
-    commonGroundData,
-    commonGroundComplete,
+    needsRevealValidationItems,
+    needsRevealValidationData,
+    needsRevealValidatedByBoth,
     strategyData,
     strategyPhase,
     strategies,
@@ -414,7 +414,7 @@ export function UnifiedSessionScreen({
     handleValidatePartnerEmpathy,
     handleConfirmAllNeeds,
     handleConsentToShareNeeds,
-    handleConfirmCommonGround,
+    handleValidateNeedsReveal,
     handleNeedsNotValidYet,
     handleRequestMoreStrategies,
     handleMarkReadyToRank,
@@ -819,7 +819,7 @@ export function UnifiedSessionScreen({
         refreshStage3RealtimeState();
       }
 
-      if (eventName === 'session.needs_reveal_ready') {
+      if (eventName === 'session.needs_reveal_ready' || eventName === 'session.needs_revealed') {
         console.log('[UnifiedSessionScreen] Needs reveal ready');
         refreshStage3RealtimeState();
       }
@@ -829,7 +829,7 @@ export function UnifiedSessionScreen({
         refreshStage3RealtimeState();
       }
 
-      if (eventName === 'partner.common_ground_confirmed' || eventName === 'partner.needs_validated') {
+      if (eventName === 'partner.needs_validated') {
         console.log('[UnifiedSessionScreen] Partner validated needs');
         refreshStage3RealtimeState();
       }
@@ -1219,7 +1219,7 @@ export function UnifiedSessionScreen({
       showShareSuggestionPanel: shouldShowShareSuggestion,
       showNeedsReviewPanel: shouldShowNeedsReview,
       showNeedsSharePanel: shouldShowNeedsShare,
-      showCommonGroundPanel: shouldShowCommonGround,
+      showNeedsRevealValidationPanel: shouldShowNeedsRevealValidation,
     },
   } = useChatUIState({
     partnerName: partnerName || 'Partner',
@@ -1275,12 +1275,12 @@ export function UnifiedSessionScreen({
     needsShared: (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsShared === true,
     needsRevealReady: (needsComparisonData?.myNeeds?.length ?? 0) > 0 && (needsComparisonData?.partnerNeeds?.length ?? 0) > 0,
     hasConfirmedNeedsLocal: completedActions.has('confirmed-needs'),
-    commonGroundCount: commonGround?.length ?? 0,
-    commonGroundAvailable: (needsComparisonData?.myNeeds?.length ?? 0) > 0 && (needsComparisonData?.partnerNeeds?.length ?? 0) > 0,
-    commonGroundNoOverlap: false,
-    commonGroundAllConfirmedByMe: (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsValidated === true,
-    commonGroundAllConfirmedByBoth: commonGroundComplete,
-    hasConfirmedCommonGroundLocal: completedActions.has('validated-needs'),
+    needsRevealValidationCount: needsRevealValidationItems?.length ?? 0,
+    needsRevealAvailable: (needsComparisonData?.myNeeds?.length ?? 0) > 0 && (needsComparisonData?.partnerNeeds?.length ?? 0) > 0,
+    needsRevealNoOverlap: false,
+    needsRevealValidatedByMe: (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsValidated === true,
+    needsRevealValidatedByBoth: needsRevealValidatedByBoth,
+    hasValidatedNeedsRevealLocal: completedActions.has('validated-needs'),
     strategyPhase,
     strategyReadiness: {
       myReadyToRank: strategyData?.myReadyToRank === true ||
@@ -1392,8 +1392,8 @@ export function UnifiedSessionScreen({
   const readyToShowEmpathy = shouldShowEmpathyPanel;
   const readyToShowFeelHeard = shouldShowFeelHeard;
   const readyToShowShareSuggestion = shouldShowShareSuggestion;
-  const readyToShowNeedsReview = shouldShowNeedsReview || shouldShowNeedsShare || shouldShowCommonGround;
-  const readyToShowCommonGround = shouldShowCommonGround;
+  const readyToShowNeedsReview = shouldShowNeedsReview || shouldShowNeedsShare || shouldShowNeedsRevealValidation;
+  const readyToShowNeedsRevealValidation = shouldShowNeedsRevealValidation;
   const readyToShowWaitingBanner = shouldShowWaitingBanner;
 
   useEffect(() => {
@@ -1728,7 +1728,7 @@ export function UnifiedSessionScreen({
         // Note: empathy-draft-preview case removed - users access empathy statement via the overlay drawer
         // Note: accuracy-feedback case removed - now handled by inline validation card
 
-        // Note: needs-summary and common-ground-preview cases removed.
+        // Note: needs-summary and needs-reveal-preview cases removed.
         // These are now shown in the NeedsDrawer bottom sheet, opened via
         // the above-input buttons (needs-review, needs-reveal-validation).
 
@@ -2500,7 +2500,7 @@ export function UnifiedSessionScreen({
                 style={styles.needsReviewButton}
                 onPress={() => {
                   setShowActivityMenu(false);
-                  setNeedsDrawerMode('comparison');
+                  setNeedsDrawerMode('reveal');
                   setShowNeedsDrawer(true);
                 }}
                 activeOpacity={0.7}
@@ -2560,7 +2560,7 @@ export function UnifiedSessionScreen({
     handleConfirmTopicFrame,
     isConfirmingTopicFrame,
     handleConfirmAllNeeds,
-    handleConfirmCommonGround,
+    handleValidateNeedsReveal,
     handleNeedsNotValidYet,
     markCompleted,
     onStageComplete,
@@ -3099,7 +3099,7 @@ export function UnifiedSessionScreen({
         />
       )}
 
-      {/* Needs Drawer - bottom sheet for Stage 3 needs/comparison */}
+      {/* Needs Drawer - bottom sheet for Stage 3 needs/reveal */}
       <NeedsDrawer
         visible={showNeedsDrawer}
         onClose={() => setShowNeedsDrawer(false)}
@@ -3136,7 +3136,7 @@ export function UnifiedSessionScreen({
         }))}
         onValidateNeeds={() => {
           markCompleted('validated-needs');
-          handleConfirmCommonGround(() => onStageComplete?.(Stage.NEED_MAPPING));
+          handleValidateNeedsReveal(() => onStageComplete?.(Stage.NEED_MAPPING));
         }}
         onNeedsNotValidYet={() => {
           handleNeedsNotValidYet(() => {
@@ -3723,14 +3723,14 @@ const useStyles = () =>
     },
 
     // Needs Validation Panel (Stage 3)
-    commonGroundContainer: {
+    needsRevealContainer: {
       paddingHorizontal: t.spacing.lg,
       paddingVertical: t.spacing.md,
       backgroundColor: t.colors.bgSecondary,
       borderTopWidth: 1,
       borderTopColor: t.colors.border,
     },
-    commonGroundButton: {
+    needsRevealButton: {
       paddingVertical: t.spacing.sm,
       paddingHorizontal: t.spacing.md,
       backgroundColor: t.colors.bgPrimary,
@@ -3738,7 +3738,7 @@ const useStyles = () =>
       alignItems: 'center',
       justifyContent: 'center',
     },
-    commonGroundButtonText: {
+    needsRevealButtonText: {
       fontSize: t.typography.fontSize.md,
       fontWeight: '500',
       color: t.colors.brandBlue,

--- a/mobile/src/screens/__tests__/NeedMappingScreen.test.tsx
+++ b/mobile/src/screens/__tests__/NeedMappingScreen.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import React from 'react';
-import { screen } from '@testing-library/react-native';
+import { fireEvent, screen } from '@testing-library/react-native';
 import { render } from '../../utils/test-utils';
 import { Stage, StageStatus, NeedCategory, MessageRole } from '@meet-without-fear/shared';
 
@@ -110,6 +110,10 @@ const mockMessages = [
 
 // Type definitions for mock data
 type NeedsType = typeof mockNeedsUnconfirmed;
+type NeedsComparisonType = {
+  myNeeds: { id: string; need: string; category: NeedCategory; confirmed: boolean }[];
+  partnerNeeds: { id: string; need: string; category: NeedCategory; confirmed: boolean }[];
+};
 
 // Mock hooks - these will be overridden per test
 let mockNeedsData: { needs: NeedsType; synthesizedAt: string; isDirty: boolean } = {
@@ -117,14 +121,18 @@ let mockNeedsData: { needs: NeedsType; synthesizedAt: string; isDirty: boolean }
   synthesizedAt: '',
   isDirty: false,
 };
+let mockNeedsComparisonData: NeedsComparisonType | undefined;
 let mockMessagesData = { messages: mockMessages };
 let mockProgressData: {
-  myProgress: { stage: Stage; status: StageStatus };
-  partnerProgress: { stage: Stage; status: StageStatus };
+  myProgress: { stage: Stage; status: StageStatus; gatesSatisfied?: Record<string, unknown> };
+  partnerProgress: { stage: Stage; status: StageStatus; gatesSatisfied?: Record<string, unknown> };
 } = {
   myProgress: { stage: Stage.NEED_MAPPING, status: StageStatus.IN_PROGRESS },
   partnerProgress: { stage: Stage.NEED_MAPPING, status: StageStatus.IN_PROGRESS },
 };
+const mockCaptureNeedsMutate = jest.fn();
+const mockConfirmNeedsMutate = jest.fn();
+const mockConsentShareNeedsMutate = jest.fn();
 
 jest.mock('../../hooks/useSessions', () => ({
   useSession: () => ({
@@ -162,8 +170,16 @@ jest.mock('../../hooks/useStages', () => ({
     isLoading: false,
     refetch: jest.fn(),
   }),
+  useNeedsComparison: () => ({
+    data: mockNeedsComparisonData,
+    isLoading: false,
+  }),
+  useCaptureNeeds: () => ({
+    mutate: mockCaptureNeedsMutate,
+    isPending: false,
+  }),
   useConfirmNeeds: () => ({
-    mutate: jest.fn(),
+    mutate: mockConfirmNeedsMutate,
     isPending: false,
   }),
   useAddNeed: () => ({
@@ -171,7 +187,7 @@ jest.mock('../../hooks/useStages', () => ({
     isPending: false,
   }),
   useConsentShareNeeds: () => ({
-    mutate: jest.fn(),
+    mutate: mockConsentShareNeedsMutate,
     isPending: false,
   }),
 }));
@@ -181,6 +197,7 @@ describe('NeedMappingScreen', () => {
     jest.clearAllMocks();
     // Reset to defaults - exploration phase (no needs yet)
     mockNeedsData = { needs: [], synthesizedAt: '', isDirty: false };
+    mockNeedsComparisonData = undefined;
     mockMessagesData = { messages: mockMessages };
     mockProgressData = {
       myProgress: { stage: Stage.NEED_MAPPING, status: StageStatus.IN_PROGRESS },
@@ -221,7 +238,7 @@ describe('NeedMappingScreen', () => {
 
     it('shows identified needs section', () => {
       render(<NeedMappingScreen />);
-      expect(screen.getByText('Your Identified Needs')).toBeTruthy();
+      expect(screen.getByText('Your Needs')).toBeTruthy();
     });
 
     it('displays all identified needs', () => {
@@ -245,6 +262,88 @@ describe('NeedMappingScreen', () => {
       render(<NeedMappingScreen />);
       const confirmButton = screen.getByText(/confirm/i);
       expect(confirmButton).toBeTruthy();
+    });
+
+    it('captures displayed needs before confirming and consenting', () => {
+      mockCaptureNeedsMutate.mockImplementation((_variables, options) => {
+        options?.onSuccess?.({
+          needs: mockNeedsUnconfirmed.map((need) => ({ ...need, confirmed: false })),
+          capturedAt: new Date().toISOString(),
+        });
+      });
+      mockConfirmNeedsMutate.mockImplementation((_variables, options) => {
+        options?.onSuccess?.();
+      });
+
+      render(<NeedMappingScreen />);
+      fireEvent.press(screen.getByTestId('confirm-needs-button'));
+
+      expect(mockCaptureNeedsMutate).toHaveBeenCalledWith(
+        {
+          sessionId: 'test-session-123',
+          needs: [
+            {
+              need: 'Security',
+              category: NeedCategory.SAFETY,
+              description: 'A need to feel safe and stable in the relationship',
+              evidence: ['I felt unsafe when...'],
+            },
+            {
+              need: 'Connection',
+              category: NeedCategory.CONNECTION,
+              description: 'A need to feel close and emotionally connected',
+              evidence: ['I miss feeling close...'],
+            },
+          ],
+        },
+        expect.any(Object)
+      );
+      expect(mockConfirmNeedsMutate).toHaveBeenCalledWith(
+        { sessionId: 'test-session-123', needIds: ['need-1', 'need-2'] },
+        expect.any(Object)
+      );
+      expect(mockConsentShareNeedsMutate).toHaveBeenCalledWith({
+        sessionId: 'test-session-123',
+        needIds: ['need-1', 'need-2'],
+      });
+    });
+  });
+
+  describe('Reveal Phase (both partners consented)', () => {
+    beforeEach(() => {
+      mockNeedsData = {
+        needs: mockNeedsUnconfirmed.map((need) => ({ ...need, confirmed: true })),
+        synthesizedAt: new Date().toISOString(),
+        isDirty: false,
+      };
+      mockProgressData = {
+        myProgress: {
+          stage: Stage.NEED_MAPPING,
+          status: StageStatus.IN_PROGRESS,
+          gatesSatisfied: { needsShared: true },
+        },
+        partnerProgress: { stage: Stage.NEED_MAPPING, status: StageStatus.IN_PROGRESS },
+      };
+      mockNeedsComparisonData = {
+        myNeeds: [
+          { id: 'need-1', need: 'Security', category: NeedCategory.SAFETY, confirmed: true },
+        ],
+        partnerNeeds: [
+          { id: 'partner-need-1', need: 'Autonomy', category: NeedCategory.AUTONOMY, confirmed: true },
+        ],
+      };
+    });
+
+    it('renders side-by-side reveal cards and the noticing prompt', () => {
+      render(<NeedMappingScreen />);
+
+      expect(screen.getByTestId('need-mapping-reveal')).toBeTruthy();
+      expect(screen.getByTestId('needs-side-by-side')).toBeTruthy();
+      expect(screen.getByText('What do you notice?')).toBeTruthy();
+      expect(screen.getByText('Your needs')).toBeTruthy();
+      expect(screen.getByText('Partner needs')).toBeTruthy();
+      expect(screen.getByText('Security')).toBeTruthy();
+      expect(screen.getByText('Autonomy')).toBeTruthy();
     });
   });
 

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -333,8 +333,8 @@ describe('Input Hiding (shouldHideInput)', () => {
       myProgress: { stage: Stage.NEED_MAPPING },
       allNeedsConfirmed: true,
       needs: { allConfirmed: true },
-      commonGroundCount: 0,
-      commonGround: { count: 0 },
+      needsRevealValidationCount: 0,
+      needsRevealValidation: { count: 0 },
     });
 
     const result = computeChatUIState(inputs);
@@ -349,14 +349,14 @@ describe('Input Hiding (shouldHideInput)', () => {
       myProgress: { stage: Stage.NEED_MAPPING },
       allNeedsConfirmed: true,
       needs: { allConfirmed: true },
-      commonGroundCount: 2,
-      commonGround: { count: 2, allConfirmedByMe: true, allConfirmedByBoth: false },
-      commonGroundAllConfirmedByMe: true,
-      commonGroundAllConfirmedByBoth: false,
+      needsRevealValidationCount: 2,
+      needsRevealValidation: { count: 2, allConfirmedByMe: true, allConfirmedByBoth: false },
+      needsRevealValidatedByMe: true,
+      needsRevealValidatedByBoth: false,
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.waitingStatus).toBe('common-ground-pending');
+    expect(result.waitingStatus).toBe('needs-validation-pending');
     expect(result.shouldHideInput).toBe(true);
   });
 
@@ -369,15 +369,15 @@ describe('Input Hiding (shouldHideInput)', () => {
       needsShared: true,
       needsRevealReady: true,
       needs: { allConfirmed: true, shared: true, revealReady: true },
-      commonGroundAvailable: true,
-      commonGroundCount: 0,
-      commonGround: {
+      needsRevealAvailable: true,
+      needsRevealValidationCount: 0,
+      needsRevealValidation: {
         count: 0,
         allConfirmedByMe: true,
         allConfirmedByBoth: false,
       },
-      commonGroundAllConfirmedByMe: true,
-      commonGroundAllConfirmedByBoth: false,
+      needsRevealValidatedByMe: true,
+      needsRevealValidatedByBoth: false,
     });
 
     const result = computeChatUIState(inputs);
@@ -791,14 +791,14 @@ describe('Needs Reveal Validation Panel Visibility', () => {
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
       myProgress: { stage: Stage.NEED_MAPPING },
-      commonGroundAvailable: true,
-      commonGroundAllConfirmedByMe: false,
-      commonGroundAllConfirmedByBoth: false,
-      hasConfirmedCommonGroundLocal: false,
+      needsRevealAvailable: true,
+      needsRevealValidatedByMe: false,
+      needsRevealValidatedByBoth: false,
+      hasValidatedNeedsRevealLocal: false,
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showCommonGroundPanel).toBe(true);
+    expect(result.panels.showNeedsRevealValidationPanel).toBe(true);
     expect(result.aboveInputPanel).toBe('needs-reveal-validation');
   });
 
@@ -807,14 +807,14 @@ describe('Needs Reveal Validation Panel Visibility', () => {
       myStage: Stage.STRATEGIC_REPAIR,
       compactMySigned: true,
       myProgress: { stage: Stage.STRATEGIC_REPAIR },
-      commonGroundAvailable: true,
-      commonGroundAllConfirmedByMe: false,
-      commonGroundAllConfirmedByBoth: false,
-      hasConfirmedCommonGroundLocal: false,
+      needsRevealAvailable: true,
+      needsRevealValidatedByMe: false,
+      needsRevealValidatedByBoth: false,
+      hasValidatedNeedsRevealLocal: false,
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showCommonGroundPanel).toBe(false);
+    expect(result.panels.showNeedsRevealValidationPanel).toBe(false);
   });
 
   it('does not show when already confirmed by me', () => {
@@ -822,14 +822,14 @@ describe('Needs Reveal Validation Panel Visibility', () => {
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
       myProgress: { stage: Stage.NEED_MAPPING },
-      commonGroundAvailable: true,
-      commonGroundAllConfirmedByMe: true,
-      commonGroundAllConfirmedByBoth: false,
-      hasConfirmedCommonGroundLocal: false,
+      needsRevealAvailable: true,
+      needsRevealValidatedByMe: true,
+      needsRevealValidatedByBoth: false,
+      hasValidatedNeedsRevealLocal: false,
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showCommonGroundPanel).toBe(false);
+    expect(result.panels.showNeedsRevealValidationPanel).toBe(false);
   });
 
   it('does not show when already confirmed by both', () => {
@@ -837,14 +837,14 @@ describe('Needs Reveal Validation Panel Visibility', () => {
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
       myProgress: { stage: Stage.NEED_MAPPING },
-      commonGroundAvailable: true,
-      commonGroundAllConfirmedByMe: false,
-      commonGroundAllConfirmedByBoth: true,
-      hasConfirmedCommonGroundLocal: false,
+      needsRevealAvailable: true,
+      needsRevealValidatedByMe: false,
+      needsRevealValidatedByBoth: true,
+      hasValidatedNeedsRevealLocal: false,
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showCommonGroundPanel).toBe(false);
+    expect(result.panels.showNeedsRevealValidationPanel).toBe(false);
   });
 
   it('does not show when local latch is set (prevents flash)', () => {
@@ -852,14 +852,14 @@ describe('Needs Reveal Validation Panel Visibility', () => {
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
       myProgress: { stage: Stage.NEED_MAPPING },
-      commonGroundAvailable: true,
-      commonGroundAllConfirmedByMe: false,
-      commonGroundAllConfirmedByBoth: false,
-      hasConfirmedCommonGroundLocal: true,
+      needsRevealAvailable: true,
+      needsRevealValidatedByMe: false,
+      needsRevealValidatedByBoth: false,
+      hasValidatedNeedsRevealLocal: true,
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showCommonGroundPanel).toBe(false);
+    expect(result.panels.showNeedsRevealValidationPanel).toBe(false);
   });
 
   it('does not show when the needs reveal is unavailable', () => {
@@ -867,14 +867,14 @@ describe('Needs Reveal Validation Panel Visibility', () => {
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
       myProgress: { stage: Stage.NEED_MAPPING },
-      commonGroundAvailable: false,
-      commonGroundAllConfirmedByMe: false,
-      commonGroundAllConfirmedByBoth: false,
-      hasConfirmedCommonGroundLocal: false,
+      needsRevealAvailable: false,
+      needsRevealValidatedByMe: false,
+      needsRevealValidatedByBoth: false,
+      hasValidatedNeedsRevealLocal: false,
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showCommonGroundPanel).toBe(false);
+    expect(result.panels.showNeedsRevealValidationPanel).toBe(false);
   });
 
   it('shows for the legacy noOverlap compatibility state', () => {
@@ -882,15 +882,15 @@ describe('Needs Reveal Validation Panel Visibility', () => {
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
       myProgress: { stage: Stage.NEED_MAPPING },
-      commonGroundAvailable: false,
-      commonGroundNoOverlap: true,
-      commonGroundAllConfirmedByMe: false,
-      commonGroundAllConfirmedByBoth: false,
-      hasConfirmedCommonGroundLocal: false,
+      needsRevealAvailable: false,
+      needsRevealNoOverlap: true,
+      needsRevealValidatedByMe: false,
+      needsRevealValidatedByBoth: false,
+      hasValidatedNeedsRevealLocal: false,
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showCommonGroundPanel).toBe(true);
+    expect(result.panels.showNeedsRevealValidationPanel).toBe(true);
     expect(result.aboveInputPanel).toBe('needs-reveal-validation');
   });
 
@@ -903,10 +903,10 @@ describe('Needs Reveal Validation Panel Visibility', () => {
       allNeedsConfirmed: false,
       needsShared: false,
       hasConfirmedNeedsLocal: false,
-      commonGroundAvailable: true,
-      commonGroundAllConfirmedByMe: false,
-      commonGroundAllConfirmedByBoth: false,
-      hasConfirmedCommonGroundLocal: false,
+      needsRevealAvailable: true,
+      needsRevealValidatedByMe: false,
+      needsRevealValidatedByBoth: false,
+      hasValidatedNeedsRevealLocal: false,
     });
 
     const result = computeChatUIState(inputs);

--- a/mobile/src/utils/__tests__/getWaitingStatus.test.ts
+++ b/mobile/src/utils/__tests__/getWaitingStatus.test.ts
@@ -26,7 +26,7 @@ function createDefaultInputs(overrides: Partial<WaitingStatusInputs> = {}): Wait
     hasPartnerEmpathy: false,
     shareOffer: undefined,
     needs: { allConfirmed: false },
-    commonGround: { count: 0 },
+    needsRevealValidation: { count: 0 },
     strategyPhase: StrategyPhase.COLLECTING,
     overlappingStrategies: { count: 0 },
     ...overrides,
@@ -272,7 +272,7 @@ describe('Priority 5: Stage 3 (Needs)', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.NEED_MAPPING,
       needs: { allConfirmed: true, shared: true, revealReady: false },
-      commonGround: { count: 0 },
+      needsRevealValidation: { count: 0 },
     });
 
     expect(computeWaitingStatus(inputs)).toBe('needs-waiting-for-partner');
@@ -282,17 +282,17 @@ describe('Priority 5: Stage 3 (Needs)', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.PERSPECTIVE_STRETCH,
       needs: { allConfirmed: true },
-      commonGround: { count: 0 },
+      needsRevealValidation: { count: 0 },
     });
 
     expect(computeWaitingStatus(inputs)).toBeNull();
   });
 
-  it('returns null when needs confirmed and common ground exists', () => {
+  it('returns null when needs confirmed and needs validation exists', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.NEED_MAPPING,
       needs: { allConfirmed: true },
-      commonGround: { count: 2 },
+      needsRevealValidation: { count: 2 },
     });
 
     expect(computeWaitingStatus(inputs)).toBeNull();
@@ -302,7 +302,7 @@ describe('Priority 5: Stage 3 (Needs)', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.NEED_MAPPING,
       needs: { allConfirmed: true },
-      commonGround: { count: 2 },
+      needsRevealValidation: { count: 2 },
       previousStatus: 'needs-pending',
     });
 
@@ -313,7 +313,7 @@ describe('Priority 5: Stage 3 (Needs)', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.NEED_MAPPING,
       needs: { allConfirmed: true, shared: true, revealReady: true },
-      commonGround: {
+      needsRevealValidation: {
         count: 0,
         allConfirmedByMe: true,
         allConfirmedByBoth: false,

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -110,14 +110,12 @@ export interface ChatUIStateInputs extends WaitingStatusInputs {
   needsRevealReady: boolean; // Both users have shared and comparison can be shown
   hasConfirmedNeedsLocal: boolean; // Local latch to prevent panel flash after confirming
 
-  // Stage 3: Needs reveal validation. These field names are kept as
-  // compatibility shims for existing call sites; values come from the
-  // side-by-side needs reveal, not AI-authored common-ground analysis.
-  commonGroundAvailable: boolean;
-  commonGroundNoOverlap: boolean;
-  commonGroundAllConfirmedByMe: boolean;
-  commonGroundAllConfirmedByBoth: boolean;
-  hasConfirmedCommonGroundLocal: boolean;
+  // Stage 3: Needs reveal validation.
+  needsRevealAvailable: boolean;
+  needsRevealNoOverlap: boolean;
+  needsRevealValidatedByMe: boolean;
+  needsRevealValidatedByBoth: boolean;
+  hasValidatedNeedsRevealLocal: boolean;
 
   // Stage 4: Strategy readiness
   strategyReadiness?: {
@@ -156,7 +154,7 @@ export interface ChatUIState {
     showShareSuggestionPanel: boolean;
     showNeedsReviewPanel: boolean;
     showNeedsSharePanel: boolean;
-    showCommonGroundPanel: boolean;
+    showNeedsRevealValidationPanel: boolean;
     showWaitingBanner: boolean;
     showCompactAgreementBar: boolean;
   };
@@ -407,12 +405,12 @@ function computeShowNeedsSharePanel(inputs: ChatUIStateInputs): boolean {
 function computeShowNeedsRevealValidationPanel(inputs: ChatUIStateInputs): boolean {
   const {
     myStage,
-    commonGroundAvailable,
+    needsRevealAvailable,
     needsRevealReady,
-    commonGroundNoOverlap,
-    commonGroundAllConfirmedByMe,
-    commonGroundAllConfirmedByBoth,
-    hasConfirmedCommonGroundLocal,
+    needsRevealNoOverlap,
+    needsRevealValidatedByMe,
+    needsRevealValidatedByBoth,
+    hasValidatedNeedsRevealLocal,
     sessionStatus,
   } = inputs;
 
@@ -426,12 +424,12 @@ function computeShowNeedsRevealValidationPanel(inputs: ChatUIStateInputs): boole
   }
 
   // Local latch: Once user confirms, hide panel immediately
-  if (hasConfirmedCommonGroundLocal) {
+  if (hasValidatedNeedsRevealLocal) {
     return false;
   }
 
   // Already confirmed by both or by me - no need to show
-  if (commonGroundAllConfirmedByBoth || commonGroundAllConfirmedByMe) {
+  if (needsRevealValidatedByBoth || needsRevealValidatedByMe) {
     return false;
   }
 
@@ -440,12 +438,12 @@ function computeShowNeedsRevealValidationPanel(inputs: ChatUIStateInputs): boole
   }
 
   // Legacy no-overlap state is treated as validation-ready for compatibility.
-  if (commonGroundNoOverlap) {
+  if (needsRevealNoOverlap) {
     return true;
   }
 
   // Must have both revealed needs lists available
-  return commonGroundAvailable;
+  return needsRevealAvailable;
 }
 
 /**
@@ -509,7 +507,7 @@ function computeAboveInputPanel(
   }
 
   // Priority 8: Needs reveal validation panel (Stage 3)
-  if (panels.showCommonGroundPanel) {
+  if (panels.showNeedsRevealValidationPanel) {
     return 'needs-reveal-validation';
   }
 
@@ -604,7 +602,7 @@ function computeShouldHideInput(
     currentStage === Stage.NEED_MAPPING &&
     inputs.needsShared &&
     !inputs.needsRevealReady &&
-    !inputs.commonGroundAvailable
+    !inputs.needsRevealAvailable
   ) {
     return true;
   }
@@ -655,7 +653,7 @@ export function computeChatUIState(inputs: ChatUIStateInputs): ChatUIState {
   const showShareSuggestionPanel = computeShowShareSuggestionPanel(inputs);
   const showNeedsReviewPanel = computeShowNeedsReviewPanel(inputs);
   const showNeedsSharePanel = computeShowNeedsSharePanel(inputs);
-  const showCommonGroundPanel = computeShowNeedsRevealValidationPanel(inputs);
+  const showNeedsRevealValidationPanel = computeShowNeedsRevealValidationPanel(inputs);
   const showWaitingBanner = computeShouldShowWaitingBanner(waitingStatus);
   const showCompactAgreementBar = isInOnboardingUnsigned;
 
@@ -668,7 +666,7 @@ export function computeChatUIState(inputs: ChatUIStateInputs): ChatUIState {
     showShareSuggestionPanel,
     showNeedsReviewPanel,
     showNeedsSharePanel,
-    showCommonGroundPanel,
+    showNeedsRevealValidationPanel,
     showWaitingBanner,
     showCompactAgreementBar,
   };
@@ -718,7 +716,7 @@ export function createDefaultChatUIStateInputs(): ChatUIStateInputs {
     hasPartnerEmpathy: false,
     shareOffer: undefined,
     needs: { allConfirmed: false },
-    commonGround: { count: 0 },
+    needsRevealValidation: { count: 0 },
     strategyPhase: 'COLLECTING',
     strategyReadiness: undefined,
     overlappingStrategies: { count: 0 },
@@ -761,10 +759,10 @@ export function createDefaultChatUIStateInputs(): ChatUIStateInputs {
     hasConfirmedNeedsLocal: false,
 
     // Stage 3: Needs reveal validation
-    commonGroundAvailable: false,
-    commonGroundNoOverlap: false,
-    commonGroundAllConfirmedByMe: false,
-    commonGroundAllConfirmedByBoth: false,
-    hasConfirmedCommonGroundLocal: false,
+    needsRevealAvailable: false,
+    needsRevealNoOverlap: false,
+    needsRevealValidatedByMe: false,
+    needsRevealValidatedByBoth: false,
+    hasValidatedNeedsRevealLocal: false,
   };
 }

--- a/mobile/src/utils/getWaitingStatus.ts
+++ b/mobile/src/utils/getWaitingStatus.ts
@@ -24,7 +24,7 @@ export type WaitingStatusState =
   | 'partner-validating-empathy' // Stage 2: User validated partner empathy, waiting for partner to validate theirs
   | 'needs-pending' // Stage 3: Waiting for partner to confirm needs
   | 'needs-waiting-for-partner' // Stage 3: User shared needs, waiting for partner to share
-  | 'common-ground-pending' // Stage 3: Waiting for partner to confirm common ground
+  | 'needs-validation-pending' // Stage 3: Waiting for partner to confirm needs validation
   | 'partner-validating-needs' // Stage 3: User validated revealed needs, waiting for partner
   | 'ranking-pending' // Stage 4: Waiting for partner to submit ranking
   | 'strategy-readiness-pending' // Stage 4: User is ready to rank, waiting for partner readiness
@@ -88,8 +88,8 @@ export interface WaitingStatusInputs {
     revealReady?: boolean;
   };
 
-  // Stage 3: Common ground discovery
-  commonGround: {
+  // Stage 3: Needs reveal validation
+  needsRevealValidation: {
     count: number;
     allConfirmedByMe?: boolean;
     allConfirmedByBoth?: boolean;
@@ -139,7 +139,7 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
     hasPartnerEmpathy,
     shareOffer,
     needs,
-    commonGround,
+    needsRevealValidation,
     strategyPhase,
     strategyReadiness,
     overlappingStrategies,
@@ -252,7 +252,7 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
     needs.allConfirmed &&
     !needs.shared &&
     !needs.revealReady &&
-    commonGround.count === 0
+    needsRevealValidation.count === 0
   ) {
     return 'needs-pending';
   }
@@ -262,30 +262,28 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
     myStage === Stage.NEED_MAPPING &&
     needs.shared &&
     !needs.revealReady &&
-    commonGround.count === 0
+    needsRevealValidation.count === 0
   ) {
     return 'needs-waiting-for-partner';
   }
 
-  // Transition: Partner confirmed needs and common ground discovered
-  if (commonGround.count > 0 && previousStatus === 'needs-pending') {
+  // Transition: Partner confirmed needs and the reveal is ready.
+  if (needsRevealValidation.count > 0 && previousStatus === 'needs-pending') {
     return 'partner-confirmed-needs';
   }
 
-  // Common ground confirmed by me, waiting for partner
-  if (myStage === Stage.NEED_MAPPING && commonGround.count > 0 && commonGround.allConfirmedByMe && !commonGround.allConfirmedByBoth) {
-    return 'common-ground-pending';
+  // Reveal validation completed by me, waiting for partner.
+  if (myStage === Stage.NEED_MAPPING && needsRevealValidation.count > 0 && needsRevealValidation.allConfirmedByMe && !needsRevealValidation.allConfirmedByBoth) {
+    return 'needs-validation-pending';
   }
 
-  // Needs reveal validated by me, waiting for partner. This covers the current
-  // side-by-side needs reveal, including the no-overlap path where there are
-  // revealed needs but no generated CommonGround rows.
+  // Needs reveal validated by me, waiting for partner.
   if (
     myStage === Stage.NEED_MAPPING &&
     needs.shared &&
     needs.revealReady &&
-    commonGround.allConfirmedByMe &&
-    !commonGround.allConfirmedByBoth
+    needsRevealValidation.allConfirmedByMe &&
+    !needsRevealValidation.allConfirmedByBoth
   ) {
     return 'partner-validating-needs';
   }


### PR DESCRIPTION
## Summary

- Adds the Stage 3 drift cleanup plan and aligns Stage 3 docs around user-confirmed needs, consent, mutual reveal, noticing, and validation.
- Removes mobile dead extraction polling and adds the capture hook for `POST /sessions/:id/needs/capture`.
- Adds the NeedMapping reveal phase, renames the NeedsDrawer reveal mode, updates realtime handling, and renames active mobile UI state from common-ground terminology to needs reveal/validation.

## Validation

- `npm run check` in `mobile/`
- `npm test -- --runTestsByPath src/utils/__tests__/chatUIState.test.ts src/utils/__tests__/getWaitingStatus.test.ts src/hooks/__tests__/useStages.test.ts src/screens/__tests__/NeedMappingScreen.test.tsx src/components/__tests__/NeedsDrawer.test.tsx --runInBand --forceExit`
- `git diff --check`
- Focused drift scan on touched active Stage 3 mobile files for `commonGround`, `common-ground`, `common ground`, `extracting`, and `comparison` drawer-mode leftovers

## Notes

- Full `npm test -- --runInBand --forceExit` still fails on existing broader-suite issues unrelated to this PR: Axios/expo stream cancellation in auth/navigation/person/strategy tests, Sentry ESM transform config, barometer label expectations, and a ShareTopicDrawer copy assertion.
- Left unrelated untracked gold-session scratch docs out of this PR.