### PR TITLE
docs: rerun incremental docs audit

### DIFF
--- a/docs/backend/api/stage-0.md
+++ b/docs/backend/api/stage-0.md
@@ -137,9 +137,8 @@ To advance from Stage 0 to Stage 1:
 | Gate | Requirement |
 |------|-------------|
 | `compactSigned` | User has signed the compact |
-| `partnerCompactSigned` | Partner has signed the compact |
 
-**Both** users must sign before **either** can advance.
+The generic stage-advance gate checks the caller's own `compactSigned` key. The compact status response still reports whether the partner has signed so the UI can show the right waiting state. The session creator can advance from Stage 0 to Stage 1 while the session is still `INVITED`; when both parties sign and the session is still `CREATED` / `INVITED`, signing self-heals the session to `ACTIVE`.
 
 ---
 

--- a/docs/backend/api/stage-4.md
+++ b/docs/backend/api/stage-4.md
@@ -41,12 +41,14 @@ interface GetStrategiesResponse {
   strategies: StrategyDTO[];
   aiSuggestionsAvailable: boolean;
   phase: StrategyPhase;
+  myReadyToRank?: boolean;
+  partnerReadyToRank?: boolean;
 }
 
 interface StrategyDTO {
   id: string;
   description: string;
-  needsAddressed: string[];      // Which common ground needs
+  needsAddressed: string[];      // Which confirmed Stage 3 needs
   duration: string | null;       // e.g., "1 week"
   measureOfSuccess: string | null;
   // Note: NO source attribution
@@ -90,8 +92,10 @@ enum StrategyPhase {
         "measureOfSuccess": "Did we use it? Did it help?"
       }
     ],
-    "aiSuggestionsAvailable": true,
-    "phase": "COLLECTING"
+    "aiSuggestionsAvailable": false,
+    "phase": "COLLECTING",
+    "myReadyToRank": false,
+    "partnerReadyToRank": false
   }
 }
 ```
@@ -125,8 +129,13 @@ interface ProposeStrategyRequest {
 
 ```typescript
 interface ProposeStrategyResponse {
-  strategy: StrategyDTO;
-  totalStrategies: number;
+  strategy: {
+    id: string;
+    description: string;
+    duration: string | null;
+    measureOfSuccess: string | null;
+  };
+  createdAt: string;
 }
 ```
 
@@ -173,7 +182,7 @@ interface RequestSuggestionsResponse {
 ### Source Constraints
 
 AI suggestions are designed to be generated from:
-- Common ground needs (Shared Vessel)
+- Confirmed Stage 3 needs (Shared Vessel)
 - Global Micro-Experiments Library (anonymized)
 
 **Never** from user memory (Retrieval Contract enforced).
@@ -260,15 +269,18 @@ GET /api/v1/sessions/:id/strategies/overlap
 
 ```typescript
 interface RevealOverlapResponse {
-  overlap: StrategyDTO[];
-  phase: StrategyPhase; // Should be REVEALING or later
+  overlap: Array<Pick<StrategyDTO, 'id' | 'description' | 'needsAddressed' | 'duration'>> | null;
+  waitingForPartner: boolean;
+  agreementCandidates: Array<Pick<StrategyDTO, 'id' | 'description' | 'duration'>> | null;
 }
 ```
 
 ### Behavior
 
-- Phase is computed from the `(callerReady, partnerReady, callerRanked, partnerRanked)` combination: `COLLECTING` → `RANKING` → `REVEALING`.
-- If no overlap exists once both sides have ranked, the response is `{ overlap: [], phase: 'REVEALING' }`; there is no separate `NEGOTIATING` phase.
+- Until both users have ranked, the response is `{ overlap: null, waitingForPartner: true, agreementCandidates: null }`.
+- Once both users have ranked, `overlap` contains strategies that appear in both users' top three.
+- If no top-three overlap exists, `overlap` is `[]` and `agreementCandidates` falls back to each user's top-ranked strategy so the UI can keep the conversation moving.
+- Non-active sessions return empty data with `waitingForPartner: false`.
 
 ---
 
@@ -376,15 +388,17 @@ Each session is capped at **two `Agreement` rows**. `createAgreement` returns `V
 
 ## Stage 4 Gate Requirements
 
-Advancement to `RESOLVED` uses these caller-side gates (set on `StageProgress.gatesSatisfied`):
+Stage 4 uses these caller-side gate markers on `StageProgress.gatesSatisfied`:
 
 | Gate | Requirement |
 |------|-------------|
 | `readyToRank` | Caller posted `/strategies/ready` |
 | `rankingSubmitted` | Caller posted `/strategies/rank` |
-| `agreementConfirmed` | Caller confirmed at least one agreement (partner too, for session to resolve) |
+| `agreementCreated` | Required by the generic `/stages/advance` gate table, but Stage 4 normally resolves through agreement confirmation rather than manual advancement |
 
-Session resolves once both partners have at least one `AGREED` agreement (see Resolve Session side effect above).
+`readyToRank` and `rankingSubmitted` are actively set by the Stage 4 controller. Agreement confirmation updates `Agreement` rows and may resolve the session directly; it does not currently set a StageProgress `agreementConfirmed` gate.
+
+Session resolves when every `Agreement` row in the session is fully signed by both partners. If two agreements exist and only one is agreed, the session remains active until the other is also agreed.
 
 ---
 
@@ -402,10 +416,10 @@ flowchart TD
     Rank --> BothRanked{Both ranked?}
     BothRanked -->|No| Wait[Wait for partner]
     BothRanked -->|Yes| Reveal[Reveal overlap]
-    Reveal --> HasOverlap{Overlap exists?}
+    Reveal --> HasOverlap{Top-three overlap exists?}
     HasOverlap -->|Yes| Discuss[Discuss overlapping options]
-    HasOverlap -->|No| Negotiate[Explore differences]
-    Negotiate --> MoreIdeas
+    HasOverlap -->|No| Candidates[Show each user's top choice as agreement candidates]
+    Candidates --> MoreIdeas
     Discuss --> Agree[Create agreement]
     Agree --> PartnerConfirm{Partner confirms?}
     PartnerConfirm -->|No| Modify[Modify and re-propose]
@@ -422,7 +436,7 @@ In Stage 4, the API enforces these retrieval rules:
 | Allowed | Forbidden |
 |---------|-----------|
 | All Shared Vessel content | User Vessel raw content |
-| Confirmed common ground | Vector search on user memory |
+| Confirmed Stage 3 needs | Vector search on user memory |
 | Past agreements | Any retrieval for decision-making |
 | Global Library (vector) | - |
 

--- a/docs/backend/prompts/stage-4-repair.md
+++ b/docs/backend/prompts/stage-4-repair.md
@@ -13,21 +13,22 @@ Guiding collaborative strategy creation and agreement.
 
 ## Context
 
-- Both users completed Stage 3 (common ground confirmed)
+- Both users completed Stage 3 needs confirmation, reveal, and validation
 - Goal: Create small, reversible micro-experiments
 - Key design: Strategies are presented without attribution
 
 ## System Prompt
 
 ```
-You are Meet Without Fear, a Process Guardian in the Strategic Repair stage. Your role is to help both parties design small, reversible experiments that address their shared needs.
+You are Meet Without Fear in Strategic Repair. Your role is to help the current user design small, testable micro-experiments that honor the needs surfaced earlier.
 
 CRITICAL RULES:
-- Invite BOTH users to propose strategies
+- Invite each user to propose strategies independently
 - Present all strategies WITHOUT attribution (no "yours" vs "theirs")
 - Help refine proposals to be specific, time-bounded, and reversible
-- Celebrate overlap without pressuring agreement
+- Treat all proposals as good-faith attempts without pressuring agreement
 - Focus on experiments, not permanent commitments
+- Every experiment needs a follow-up check-in before it is complete
 
 FOUNDATIONAL TRUTH (share with users when helpful):
 Experiments sometimes fail. That is okay - we learn and try something else. What would fracture this connection is not a failed experiment - it is losing sight of the good in each other. You have both done the hard work to see that good. Whatever you try, that foundation remains.
@@ -61,11 +62,11 @@ Example user message: "The weekly date night was my idea, and I think Alex shoul
 Example response: "Its great that you feel connected to that idea. What matters now is whether it resonates with both of you. Lets see if your partner finds it meaningful too - regardless of where it came from."
 
 AVAILABLE CONTEXT:
-- Confirmed common ground
+- Confirmed Stage 3 needs
 - All proposed strategies (without attribution)
 - User's private ranking (after submission)
 - Partner's ranking (only after both submit)
-- Global Library suggestions (must be labeled `source: global_library`)
+- Global Library suggestions are allowed by the retrieval contract, but the current `/strategies/suggest` controller is a placeholder and returns no suggestions
 - AI Synthesis artifacts are not injected; only structured session records
 ```
 
@@ -76,9 +77,9 @@ AVAILABLE CONTEXT:
 ```
 {{user_name}} is entering the strategy creation phase.
 
-Common ground: {{common_ground}}
+Confirmed needs: {{confirmed_needs}}
 
-Invite them to propose a small experiment that addresses one of the shared needs. Help them make it specific and time-bounded.
+Invite them to propose a small experiment that honors one of the needs surfaced earlier. Help them make it specific, time-bounded, reversible, and observable.
 ```
 
 ### Presenting Strategy Pool
@@ -108,7 +109,7 @@ Overlap (both ranked highly):
 No direct overlap was found. Present this gently and explore paths forward.
 {{/if}}
 
-Present this discovery in a way that celebrates common ground or gently explores differences.
+Present this discovery in a way that acknowledges any overlap or gently explores differences.
 ```
 
 ## Expected Output
@@ -116,7 +117,7 @@ Present this discovery in a way that celebrates common ground or gently explores
 ### Inviting Strategy
 
 ```
-Now that you have both identified this shared need for {{common_ground}}, let us think about a small experiment you could try.
+Now that you have named what matters, let us think about a small experiment you could try.
 
 What is one small thing - something specific and time-limited - that you think might help? It does not have to be perfect. Just something small you would be willing to try.
 

--- a/docs/backend/state-machine/index.md
+++ b/docs/backend/state-machine/index.md
@@ -73,11 +73,11 @@ stateDiagram-v2
 
 | Stage | Gate Keys | Satisfied When |
 |-------|-----------|----------------|
-| 0 (Onboarding) | `compactSigned`, `partnerCompactSigned` | User signed, partner signed |
+| 0 (Onboarding) | `compactSigned` | User signs the compact. Partner signing is reported in compact status, but the generic advancement gate checks the caller's own key. |
 | 1 (Witness) | `feelHeardConfirmed` | User posts feel-heard true |
-| 2 (Perspective) | `empathyDraftReady`, `empathyConsented`, `partnerConsented`, `partnerValidated` | Draft marked ready, user consents to share, partner consents, partner validates (or user accepts feedback path) |
+| 2 (Perspective) | `empathyValidated` | Caller validates the partner's empathy attempt, or explicitly accepts the remaining differences via the skip-refinement path |
 | 3 (What Matters) | `needsConfirmed`, `needsShared`, `needsValidated` | User confirms needs, consents to share them, and validates the mutual needs reveal |
-| 4 (Strategic Repair) | `strategiesSubmitted`, `rankingsSubmitted`, `overlapIdentified`, `agreementCreated` | Both submitted strategies (or declared none), both rankings in, overlap revealed, Agreement saved |
+| 4 (Strategic Repair) | `rankingSubmitted`, `agreementCreated` | Generic advancement checks for a submitted ranking and agreement-created marker. The Stage 4 controller also sets `readyToRank`; agreement confirmation can resolve the session directly. |
 
 Advancement rule: a user can advance when all gate keys for their current stage are true AND any stage-level preconditions (e.g., Stage 4 only after both Stage 3 complete). WAITING state is derived when one user satisfies gates and the other has not.
 

--- a/docs/product/stages/stage-4-strategic-repair.md
+++ b/docs/product/stages/stage-4-strategic-repair.md
@@ -20,7 +20,7 @@ Move from understanding to action by designing small, reversible experiments tha
 - Collect and combine suggestions from both parties
 - Present all strategies as **unlabeled options** (no attribution to source)
 - Allow users to select from the combined pool
-- Offer to generate additional AI suggestions if desired
+- Offer to generate additional AI suggestions if desired (product target; the current backend endpoint is still a placeholder)
 - Document agreed-upon micro-experiments
 
 ## Key Design: Collaborative Strategy Generation
@@ -57,7 +57,7 @@ flowchart TD
     Collect --> Present[Present unlabeled strategy pool]
     Present --> Question[Happy with options or want more?]
 
-    Question -->|Want more| Generate[AI generates additional ideas]
+    Question -->|Want more| Generate[AI suggestions endpoint - placeholder today]
     Generate --> Present
 
     Question -->|Happy| PrivateRank[Each privately ranks top choices]
@@ -69,7 +69,7 @@ flowchart TD
     Overlap -->|No| Explore[Explore differences]
     Explore --> MoreOptions{Want more options?}
     MoreOptions -->|Yes| Generate
-    MoreOptions -->|No| Negotiate[Work toward common ground]
+    MoreOptions -->|No| Negotiate[Explore differences honestly]
     Negotiate --> Discuss
 
     Discuss --> Document[Document micro-experiment]
@@ -114,7 +114,7 @@ flowchart TB
 
 ## When No Overlap Exists
 
-If private rankings reveal no overlap, the AI facilitates finding common ground:
+If private rankings reveal no overlap, the backend returns each user's top-ranked strategy as agreement candidates so the UI can keep the conversation moving:
 
 ```mermaid
 flowchart TD
@@ -145,7 +145,7 @@ flowchart TB
             Status[Building your path forward]
         end
 
-        subgraph Foundation[Common Ground Foundation]
+        subgraph Foundation[Needs Foundation]
             Title1[Building on shared needs]
             SharedNeed[You both need: Recognition]
         end
@@ -201,7 +201,7 @@ flowchart TB
         subgraph Header[Header]
             Logo[Meet Without Fear]
             Stage[Stage 4: Strategic Repair]
-            Status[Common ground found]
+            Status[Shared priorities found]
         end
 
         subgraph Overlap[You Both Chose]
@@ -220,7 +220,7 @@ flowchart TB
 - Strategy options are presented without labels indicating who suggested them
 - All buttons use soft, neutral colors (no "yours" vs "theirs" styling)
 - Ranking is private until both submit
-- Overlap is revealed together, celebrating common ground
+- Overlap is revealed together without implying agreement where none exists
 
 ## Success Criteria
 


### PR DESCRIPTION
## Summary
- reran the incremental docs audit against current main after #351 landed
- updated Stage 0/Stage 4 API docs to match current controller behavior
- aligned Stage 4 prompt/product docs and state-machine gate docs with current code

## Verification
- git diff --check

Supersedes #329.