### PR TITLE
fix(shared): align ProposeStrategyResponse DTO with stage4 controller (#353)

### DIFF
--- a/shared/src/dto/strategy.ts
+++ b/shared/src/dto/strategy.ts
@@ -50,8 +50,13 @@ export interface ProposeStrategyRequest {
 }
 
 export interface ProposeStrategyResponse {
-  strategy: StrategyDTO;
-  totalStrategies: number;
+  strategy: {
+    id: string;
+    description: string;
+    duration: string | null;
+    measureOfSuccess: string | null;
+  };
+  createdAt: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Aligns `ProposeStrategyResponse` in shared DTO with actual stage4 controller response
- Removes stale `totalStrategies` field, adds `createdAt` field
- Updates `strategy` field type to match the subset returned by the controller

Closes #353

## Test plan
- [ ] `npm run check` passes
- [ ] `npm run test` passes
- [ ] Mobile types align with actual API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)