### PR TITLE
[codex] Fix Adam/Eve Stage 4 strategy ranking gates

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -112,7 +112,7 @@ const PLANNER_LINE_PREFIXES = [
 
 export function scrubVisibleAIText(text: string): { text: string; scrubbed: boolean } {
   const before = text;
-  const cleaned = cleanVisibleAIText(text
+  const plannerScrubbed = text
     .split(/\r?\n/)
     .filter((line) => {
       const trimmed = line.trim().toLowerCase();
@@ -120,7 +120,8 @@ export function scrubVisibleAIText(text: string): { text: string; scrubbed: bool
     })
     .join('\n')
     .replace(/\bI should\b/gi, '')
-    .replace(/\bso both lists should be available\b/gi, ''));
+    .replace(/\bso both lists should be available\b/gi, '');
+  const cleaned = cleanVisibleAIText(plannerScrubbed);
 
   return { text: cleaned, scrubbed: cleaned !== before };
 }

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -40,6 +40,7 @@ import { CONTEXT_WINDOW, trimConversationHistory } from '../utils/token-budget';
 import { estimateContextSizes, finalizeTurnMetrics, recordContextSizes } from '../services/llm-telemetry';
 import { captureProposedNeedsForUser } from '../services/needs';
 import { filterNewStrategiesAgainstExisting } from '../utils/strategy-dedupe';
+import { cleanVisibleAIText } from '../utils/visible-text';
 
 // ============================================================================
 // Helpers
@@ -111,7 +112,7 @@ const PLANNER_LINE_PREFIXES = [
 
 export function scrubVisibleAIText(text: string): { text: string; scrubbed: boolean } {
   const before = text;
-  const cleaned = text
+  const cleaned = cleanVisibleAIText(text
     .split(/\r?\n/)
     .filter((line) => {
       const trimmed = line.trim().toLowerCase();
@@ -119,7 +120,7 @@ export function scrubVisibleAIText(text: string): { text: string; scrubbed: bool
     })
     .join('\n')
     .replace(/\bI should\b/gi, '')
-    .replace(/\bso both lists should be available\b/gi, '');
+    .replace(/\bso both lists should be available\b/gi, ''));
 
   return { text: cleaned, scrubbed: cleaned !== before };
 }

--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -43,6 +43,7 @@ import { publishSessionEvent } from '../services/realtime';
 import { updateContext } from '../lib/request-context';
 import { routeModel, scoreAmbiguity } from '../services/model-router';
 import { transition } from '../services/empathy-state-machine';
+import { cleanVisibleAIText } from '../utils/visible-text';
 
 // ============================================================================
 // Types
@@ -855,7 +856,7 @@ Respond in JSON format:
         try {
           const parsed = extractJsonFromResponse(aiResponse) as Record<string, unknown>;
           transitionContent = typeof parsed.response === 'string'
-            ? parsed.response
+            ? cleanVisibleAIText(parsed.response)
             : bothShared
               ? `Thank you for sharing your attempt. Now you can read ${partnerName || 'your partner'}'s empathy statement and mark whether it feels accurate.`
               : `You've done something difficult — thank you for staying with it. You've completed your part for now. We'll notify you when ${partnerName || 'your partner'} has completed their side. Then you'll each see the other's attempt to understand.`;
@@ -1644,7 +1645,7 @@ Respond in JSON format:
         try {
           const parsed = extractJsonFromResponse(aiResponse) as Record<string, unknown>;
           if (typeof parsed.response === 'string') {
-            content = parsed.response;
+            content = cleanVisibleAIText(parsed.response);
           }
         } catch (e) {
           logger.warn('Failed to parse transition AI response', e);
@@ -2122,7 +2123,7 @@ Respond in JSON format:
         try {
           const parsed = extractJsonFromResponse(aiResponse) as Record<string, unknown>;
           transitionContent = typeof parsed.response === 'string'
-            ? parsed.response
+            ? cleanVisibleAIText(parsed.response)
             : `You're showing real understanding here. We'll send this through a separate privacy-protected review to check whether your updated perspective is ready to share.`;
         } catch {
           transitionContent = `You're showing real understanding here. We'll send this through a separate privacy-protected review to check whether your updated perspective is ready to share.`;

--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -77,6 +77,25 @@ function shuffleArray<T>(array: T[]): T[] {
   return shuffled;
 }
 
+type StrategyProposalForVisibility = {
+  id: string;
+  description: string;
+  needsAddressed: string[];
+  duration: string | null;
+  measureOfSuccess: string | null;
+  createdByUserId: string | null;
+};
+
+function toStrategyDTO(strategy: StrategyProposalForVisibility) {
+  return {
+    id: strategy.id,
+    description: strategy.description,
+    needsAddressed: strategy.needsAddressed,
+    duration: strategy.duration,
+    measureOfSuccess: strategy.measureOfSuccess,
+  };
+}
+
 // Create agreement request schema locally
 const createAgreementRequestSchema = z.object({
   strategyId: z.string().optional(),
@@ -132,7 +151,8 @@ export async function getStrategies(req: Request, res: Response): Promise<void> 
       return;
     }
 
-    // Get strategies without exposing createdBy
+    // Get creator attribution for server-side visibility checks, but strip it
+    // before returning the anonymous pool to clients.
     const strategies = await prisma.strategyProposal.findMany({
       where: { sessionId },
       select: {
@@ -141,9 +161,9 @@ export async function getStrategies(req: Request, res: Response): Promise<void> 
         needsAddressed: true,
         duration: true,
         measureOfSuccess: true,
-        // Note: createdByUserId NOT selected - anonymous pool
+        createdByUserId: true,
       },
-    });
+    }) as StrategyProposalForVisibility[];
 
     // Compute actual phase from DB state
     const allProgress = await prisma.stageProgress.findMany({
@@ -167,20 +187,31 @@ export async function getStrategies(req: Request, res: Response): Promise<void> 
 
     const bothRanked = rankings.length >= 2;
     const myRanked = rankings.some((r) => r.userId === user.id);
+    const myProposalCount = strategies.filter((s) => s.createdByUserId === user.id).length;
+    const rankingOpenForUser = allReadyToRank && myProposalCount > 0;
 
     let phase: StrategyPhase;
     if (bothRanked) {
       phase = StrategyPhase.REVEALING;
     } else if (myRanked) {
       phase = StrategyPhase.REVEALING;
-    } else if (allReadyToRank) {
+    } else if (rankingOpenForUser) {
       phase = StrategyPhase.RANKING;
     } else {
       phase = StrategyPhase.COLLECTING;
     }
 
+    const fullPoolVisible = rankingOpenForUser || myRanked || bothRanked;
+    const visibleStrategies = fullPoolVisible
+      ? strategies
+      : strategies.filter((s) => s.createdByUserId === user.id);
+    const canRank = phase === StrategyPhase.RANKING && !myRanked && strategies.length > 0;
+    const canMarkReadyToRank = phase === StrategyPhase.COLLECTING &&
+      myGates?.readyToRank !== true &&
+      myProposalCount > 0;
+
     // Shuffle to avoid order bias
-    const shuffled = shuffleArray(strategies);
+    const shuffled = shuffleArray(visibleStrategies.map(toStrategyDTO));
 
     successResponse(res, {
       strategies: shuffled,
@@ -188,6 +219,9 @@ export async function getStrategies(req: Request, res: Response): Promise<void> 
       aiSuggestionsAvailable: false,
       myReadyToRank: myGates?.readyToRank === true,
       partnerReadyToRank: partnerGates?.readyToRank === true,
+      canMarkReadyToRank,
+      canRank,
+      rankableStrategyCount: fullPoolVisible ? strategies.length : visibleStrategies.length,
     });
   } catch (error) {
     logger.error('[getStrategies] Error:', error);
@@ -329,6 +363,10 @@ export async function submitRanking(req: Request, res: Response): Promise<void> 
     }
 
     const { rankedIds } = parseResult.data;
+    if (new Set(rankedIds).size !== rankedIds.length) {
+      errorResponse(res, 'VALIDATION_ERROR', 'Ranked strategy IDs must be unique', 400);
+      return;
+    }
 
     // Check session exists and user has access
     const session = await prisma.session.findFirst({
@@ -372,6 +410,37 @@ export async function submitRanking(req: Request, res: Response): Promise<void> 
         `Cannot submit ranking: you are in stage ${currentStage}, but stage 4 is required`,
         400
       );
+      return;
+    }
+
+    const allProgress = await prisma.stageProgress.findMany({
+      where: { sessionId, stage: 4 },
+    });
+    const allReadyToRank = allProgress.length >= 2 &&
+      allProgress.every((p) => {
+        const gates = p.gatesSatisfied as Record<string, unknown> | null;
+        return gates?.readyToRank === true;
+      });
+    if (!allReadyToRank) {
+      errorResponse(res, 'VALIDATION_ERROR', 'Strategies are not ready to rank yet', 400);
+      return;
+    }
+
+    const myProposalCount = await prisma.strategyProposal.count({
+      where: { sessionId, createdByUserId: user.id },
+    });
+    if (myProposalCount === 0) {
+      errorResponse(res, 'VALIDATION_ERROR', 'Add at least one strategy before ranking', 400);
+      return;
+    }
+
+    const rankableStrategies = await prisma.strategyProposal.findMany({
+      where: { sessionId },
+      select: { id: true },
+    });
+    const rankableIds = new Set(rankableStrategies.map((strategy) => strategy.id));
+    if (rankedIds.some((id) => !rankableIds.has(id))) {
+      errorResponse(res, 'VALIDATION_ERROR', 'Ranked strategy IDs must belong to this session', 400);
       return;
     }
 
@@ -1025,6 +1094,14 @@ export async function markReady(req: Request, res: Response): Promise<void> {
         `Cannot mark ready: you are in stage ${currentStage}, but stage 4 is required`,
         400
       );
+      return;
+    }
+
+    const myProposalCount = await prisma.strategyProposal.count({
+      where: { sessionId, createdByUserId: user.id },
+    });
+    if (myProposalCount === 0) {
+      errorResponse(res, 'VALIDATION_ERROR', 'Add at least one strategy before marking ready to rank', 400);
       return;
     }
 

--- a/backend/src/routes/__tests__/stage4.test.ts
+++ b/backend/src/routes/__tests__/stage4.test.ts
@@ -27,6 +27,7 @@ import {
   getStrategies,
   proposeStrategy,
   submitRanking,
+  markReady,
   getOverlap,
   createAgreement,
   confirmAgreement,
@@ -117,7 +118,7 @@ describe('Stage 4 API', () => {
           needsAddressed: ['connection'],
           duration: '2 weeks',
           measureOfSuccess: 'Feel more connected',
-          // Note: createdByUserId is NOT returned due to Prisma select
+          createdByUserId: mockUser.id,
         },
         {
           id: mockStrategyIds[1],
@@ -125,7 +126,7 @@ describe('Stage 4 API', () => {
           needsAddressed: ['recognition'],
           duration: '1 week',
           measureOfSuccess: null,
-          // Note: createdByUserId is NOT returned due to Prisma select
+          createdByUserId: mockUser.id,
         },
       ]);
 
@@ -155,7 +156,7 @@ describe('Stage 4 API', () => {
         expect(strategy).not.toHaveProperty('createdByUserId');
       });
 
-      // Verify Prisma was called with select that excludes createdByUserId
+      // Verify Prisma can use createdByUserId for server-side visibility without exposing it
       expect(prisma.strategyProposal.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           select: expect.objectContaining({
@@ -164,12 +165,50 @@ describe('Stage 4 API', () => {
             needsAddressed: true,
             duration: true,
             measureOfSuccess: true,
+            createdByUserId: true,
           }),
         })
       );
-      // Verify createdByUserId is NOT in the select
-      const findManyCall = (prisma.strategyProposal.findMany as jest.Mock).mock.calls[0][0];
-      expect(findManyCall.select.createdByUserId).toBeUndefined();
+    });
+
+    it('does not return partner-only strategies while current user is still collecting', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.stageProgress.findMany as jest.Mock).mockResolvedValue([
+        { userId: mockUser.id, stage: 4, gatesSatisfied: null },
+        { userId: mockPartnerId, stage: 4, gatesSatisfied: { readyToRank: true } },
+      ]);
+      (prisma.strategyProposal.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: mockStrategyIds[0],
+          description: 'Partner-only idea',
+          needsAddressed: [],
+          duration: null,
+          measureOfSuccess: null,
+          createdByUserId: mockPartnerId,
+        },
+      ]);
+      (prisma.strategyRanking.findMany as jest.Mock).mockResolvedValue([]);
+
+      await getStrategies(req as Request, res as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            phase: 'COLLECTING',
+            strategies: [],
+            canMarkReadyToRank: false,
+            canRank: false,
+          }),
+        })
+      );
     });
 
     it('returns revealing phase for a user who already submitted ranking while partner has not', async () => {
@@ -397,6 +436,14 @@ describe('Stage 4 API', () => {
         status: 'IN_PROGRESS',
         gatesSatisfied: {},
       });
+      (prisma.stageProgress.findMany as jest.Mock).mockResolvedValue([
+        { userId: mockUser.id, stage: 4, gatesSatisfied: { readyToRank: true } },
+        { userId: mockPartnerId, stage: 4, gatesSatisfied: { readyToRank: true } },
+      ]);
+      (prisma.strategyProposal.findMany as jest.Mock).mockResolvedValue(
+        rankedIds.map((id) => ({ id }))
+      );
+      (prisma.strategyProposal.count as jest.Mock).mockResolvedValue(1);
       (prisma.strategyRanking.upsert as jest.Mock).mockResolvedValue({
         id: 'clranking0001',
         rankedIds,
@@ -445,6 +492,14 @@ describe('Stage 4 API', () => {
         status: 'IN_PROGRESS',
         gatesSatisfied: {},
       });
+      (prisma.stageProgress.findMany as jest.Mock).mockResolvedValue([
+        { userId: mockUser.id, stage: 4, gatesSatisfied: { readyToRank: true } },
+        { userId: mockPartnerId, stage: 4, gatesSatisfied: { readyToRank: true } },
+      ]);
+      (prisma.strategyProposal.findMany as jest.Mock).mockResolvedValue(
+        rankedIds.map((id) => ({ id }))
+      );
+      (prisma.strategyProposal.count as jest.Mock).mockResolvedValue(1);
       (prisma.strategyRanking.upsert as jest.Mock).mockResolvedValue({
         id: 'clranking0001',
         rankedIds,
@@ -491,6 +546,35 @@ describe('Stage 4 API', () => {
           error: expect.objectContaining({ code: 'VALIDATION_ERROR' }),
         })
       );
+    });
+  });
+
+  describe('POST /sessions/:id/strategies/ready (markReady)', () => {
+    it('rejects readiness when current user has not contributed strategies', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue({
+        stage: 4,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: {},
+      });
+      (prisma.strategyProposal.count as jest.Mock).mockResolvedValue(0);
+
+      await markReady(req as Request, res as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ code: 'VALIDATION_ERROR' }),
+        })
+      );
+      expect(prisma.stageProgress.update).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/services/needs.ts
+++ b/backend/src/services/needs.ts
@@ -10,6 +10,7 @@
 import { resetBedrockClient } from '../lib/bedrock';
 import { prisma } from '../lib/prisma';
 import { NeedCategory, type CapturedNeedInput } from '@meet-without-fear/shared';
+import { cleanVisibleAIText } from '../utils/visible-text';
 
 // ============================================================================
 // Types
@@ -81,9 +82,9 @@ export async function captureProposedNeedsForUser(
       await tx.identifiedNeed.create({
         data: {
           vesselId: vessel.id,
-          need: item.description || item.need,
+          need: cleanVisibleAIText(item.description || item.need),
           category: item.category,
-          evidence,
+          evidence: evidence.map(cleanVisibleAIText).filter(Boolean),
           aiConfidence: 0.85,
           confirmed: false,
         },

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -19,6 +19,7 @@ import {
 } from '../stage-prompts';
 import type { ContextBundle } from '../context-assembler';
 import { extractJsonFromResponse } from '../../utils/json-extractor';
+import { cleanVisibleAIText } from '../../utils/visible-text';
 import type {
   ReconcilerResult,
   ShareOfferMessage,
@@ -468,6 +469,8 @@ Respond in JSON:
     // Return null to signal failure - let caller handle the error state
     return null;
   }
+  response.suggestedContent = cleanVisibleAIText(response.suggestedContent);
+  response.reason = cleanVisibleAIText(response.reason);
   logger.info('Share suggestion generated', { preview: response.suggestedContent.substring(0, 50), reason: response.reason });
 
   // Use provided DB record or fall back to retry loop
@@ -773,6 +776,7 @@ export async function respondToShareSuggestion(
   } else {
     sharedContent = shareOffer.suggestedContent || '';
   }
+  sharedContent = cleanVisibleAIText(sharedContent);
 
   // Error if suggestedContent was somehow empty - this is a data integrity issue
   if (!sharedContent.trim()) {
@@ -1197,7 +1201,11 @@ Respond in JSON:
     return null;
   }
 
-  logger.debug('Generated feelings-focused suggestion', { preview: suggestionResult.suggestedContent.substring(0, 50) });
+  const offerMessage = cleanVisibleAIText(offerResult.message);
+  const suggestedContent = cleanVisibleAIText(suggestionResult.suggestedContent);
+  const suggestedReason = cleanVisibleAIText(suggestionResult.reason);
+
+  logger.debug('Generated feelings-focused suggestion', { preview: suggestedContent.substring(0, 50) });
 
   // Create or update share offer record with the crafted suggestion
   await prisma.reconcilerShareOffer.upsert({
@@ -1206,22 +1214,22 @@ Respond in JSON:
       resultId: result.id,
       userId: subjectId,
       status: 'OFFERED',
-      offerMessage: offerResult.message,
-      suggestedContent: suggestionResult.suggestedContent,
-      suggestedReason: suggestionResult.reason,
+      offerMessage,
+      suggestedContent,
+      suggestedReason,
     },
     update: {
       status: 'OFFERED',
-      offerMessage: offerResult.message,
-      suggestedContent: suggestionResult.suggestedContent,
-      suggestedReason: suggestionResult.reason,
+      offerMessage,
+      suggestedContent,
+      suggestedReason,
     },
   });
 
   return {
-    offerMessage: offerResult.message,
-    suggestedContent: suggestionResult.suggestedContent,
-    suggestedReason: suggestionResult.reason,
+    offerMessage,
+    suggestedContent,
+    suggestedReason,
     gapDescription: result.mostImportantGap || result.gapSummary,
   };
 }

--- a/backend/src/utils/__tests__/visible-text.test.ts
+++ b/backend/src/utils/__tests__/visible-text.test.ts
@@ -14,8 +14,14 @@ describe('cleanVisibleAIText', () => {
   });
 
   it('preserves intentional inline quotes and emphasis', () => {
-    expect(cleanVisibleAIText('I said "I need room" and I feel *really* stuck.')).toBe(
-      'I said "I need room" and I feel *really* stuck.'
+    expect(cleanVisibleAIText('I said "I need room" and I feel **really** stuck.')).toBe(
+      'I said "I need room" and I feel **really** stuck.'
+    );
+  });
+
+  it('removes full-string emphasis wrappers', () => {
+    expect(cleanVisibleAIText('**I need room to be scared**')).toBe(
+      'I need room to be scared'
     );
   });
 });

--- a/backend/src/utils/__tests__/visible-text.test.ts
+++ b/backend/src/utils/__tests__/visible-text.test.ts
@@ -1,0 +1,21 @@
+import { cleanVisibleAIText } from '../visible-text';
+
+describe('cleanVisibleAIText', () => {
+  it('removes leading markdown separators, emphasis, and quote wrappers', () => {
+    expect(cleanVisibleAIText('"--- **When you are ready, we will shift.**"')).toBe(
+      'When you are ready, we will shift.'
+    );
+  });
+
+  it('removes escaped full-string quote wrappers', () => {
+    expect(cleanVisibleAIText('\\"I need emotional presence from Adam.\\"')).toBe(
+      'I need emotional presence from Adam.'
+    );
+  });
+
+  it('preserves intentional inline quotes and emphasis', () => {
+    expect(cleanVisibleAIText('I said "I need room" and I feel *really* stuck.')).toBe(
+      'I said "I need room" and I feel *really* stuck.'
+    );
+  });
+});

--- a/backend/src/utils/micro-tag-parser.ts
+++ b/backend/src/utils/micro-tag-parser.ts
@@ -12,6 +12,7 @@
 import { extractJsonFromResponse } from './json-extractor';
 import { logger } from '../lib/logger';
 import { NeedCategory, type CapturedNeedInput } from '@meet-without-fear/shared';
+import { cleanVisibleAIText } from './visible-text';
 
 export interface ParsedMicroTagResponse {
   /** The user-facing response text (all tags stripped) */
@@ -58,13 +59,16 @@ function parseNeedsBlock(rawNeeds: string | null): CapturedNeedInput[] {
     return items.flatMap((item): CapturedNeedInput[] => {
       if (!item || typeof item !== 'object') return [];
       const candidate = item as Record<string, unknown>;
-      const need = typeof candidate.need === 'string' ? candidate.need.trim() : '';
+      const need = typeof candidate.need === 'string' ? cleanVisibleAIText(candidate.need) : '';
       const description = typeof candidate.description === 'string'
-        ? candidate.description.trim()
+        ? cleanVisibleAIText(candidate.description)
         : need;
       const category = candidate.category;
       const evidence = Array.isArray(candidate.evidence)
-        ? candidate.evidence.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+        ? candidate.evidence
+            .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+            .map(cleanVisibleAIText)
+            .filter(Boolean)
         : [];
 
       if (!need || !description || !isNeedCategory(category)) return [];
@@ -128,7 +132,7 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
   const strategyRegex = /ProposedStrategy:\s*(.+)/gi;
   let strategyMatch: RegExpExecArray | null;
   while ((strategyMatch = strategyRegex.exec(thinking)) !== null) {
-    const strategy = strategyMatch[1].trim();
+    const strategy = cleanVisibleAIText(strategyMatch[1]);
     if (strategy.length > 0) {
       proposedStrategies.push(strategy);
     }
@@ -137,9 +141,9 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
   const needRegex = /ProposedNeed:\s*([^|]+)\|([^|]+)\|(.+)/gi;
   let needMatch: RegExpExecArray | null;
   while ((needMatch = needRegex.exec(thinking)) !== null) {
-    const need = needMatch[1].trim();
+    const need = cleanVisibleAIText(needMatch[1]);
     const category = needMatch[2].trim();
-    const description = needMatch[3].trim();
+    const description = cleanVisibleAIText(needMatch[3]);
     if (need && isNeedCategory(category) && description) {
       proposedNeeds.push({ need, category, description, evidence: [] });
     }

--- a/backend/src/utils/visible-text.ts
+++ b/backend/src/utils/visible-text.ts
@@ -23,9 +23,13 @@ export function cleanVisibleAIText(text: string): string {
       })
       .join('\n')
       .replace(/^---+\s*/, '')
-      .replace(/\*\*([^*\n][\s\S]*?[^*\n])\*\*/g, '$1')
-      .replace(/__([^_\n][\s\S]*?[^_\n])__/g, '$1')
       .trim();
+
+    const emphasisMatch = cleaned.match(/^\*\*([\s\S]*?)\*\*$/) ??
+      cleaned.match(/^__([\s\S]*?)__$/);
+    if (emphasisMatch) {
+      cleaned = emphasisMatch[1].trim();
+    }
 
     const quoteMatch = cleaned.match(/^["“”']([\s\S]*?)["“”']$/);
     if (quoteMatch) {

--- a/backend/src/utils/visible-text.ts
+++ b/backend/src/utils/visible-text.ts
@@ -1,0 +1,38 @@
+/**
+ * Cleanup for AI-generated text before it is shown or persisted.
+ *
+ * This is intentionally narrow: it removes serialization and markdown artifacts
+ * that the prompt format can leak, without rewriting normal prose.
+ */
+export function cleanVisibleAIText(text: string): string {
+  let cleaned = text
+    .replace(/\\"/g, '"')
+    .replace(/\r\n/g, '\n')
+    .trim();
+
+  for (let i = 0; i < 4; i += 1) {
+    const before = cleaned;
+    cleaned = cleaned
+      .split('\n')
+      .filter((line, index) => {
+        const trimmed = line.trim();
+        if (index === 0 && /^(?:---+|```(?:json|markdown)?|~~~)$/.test(trimmed)) {
+          return false;
+        }
+        return !/^(?:```|~~~)$/.test(trimmed);
+      })
+      .join('\n')
+      .replace(/^---+\s*/, '')
+      .replace(/\*\*([^*\n][\s\S]*?[^*\n])\*\*/g, '$1')
+      .replace(/__([^_\n][\s\S]*?[^_\n])__/g, '$1')
+      .trim();
+
+    const quoteMatch = cleaned.match(/^["“”']([\s\S]*?)["“”']$/);
+    if (quoteMatch) {
+      cleaned = quoteMatch[1].trim();
+    }
+    if (cleaned === before) break;
+  }
+
+  return cleaned;
+}

--- a/docs/backend/api/stage-4.md
+++ b/docs/backend/api/stage-4.md
@@ -14,7 +14,8 @@ Stage 4 is **sequential** (unlike stages 1-3 which are parallel). Both users mus
 
 Key design:
 - Both users propose strategies independently
-- Strategies are presented as an **unlabeled pool**
+- During collection, each user only sees their own proposed strategies
+- The shared pool is presented as **unlabeled options** only after both users are ready and the current user has contributed at least one strategy
 - Users **privately rank** their preferences
 - Overlap is revealed together
 
@@ -28,11 +29,13 @@ Key design:
 
 ## Get Strategy Pool
 
-Get all proposed strategies (unlabeled).
+Get the strategies currently visible to the caller.
 
 ```
 GET /api/v1/sessions/:id/strategies
 ```
+
+During `COLLECTING`, the response only includes strategies created by the caller. Partner-origin strategies remain hidden so one side cannot be asked to rank a partner-only pool. After both users mark ready and the caller has contributed at least one strategy, the endpoint returns the full shared pool as unlabeled options.
 
 ### Response
 
@@ -43,6 +46,9 @@ interface GetStrategiesResponse {
   phase: StrategyPhase;
   myReadyToRank?: boolean;
   partnerReadyToRank?: boolean;
+  canMarkReadyToRank?: boolean;
+  canRank?: boolean;
+  rankableStrategyCount?: number;
 }
 
 interface StrategyDTO {
@@ -95,12 +101,15 @@ enum StrategyPhase {
     "aiSuggestionsAvailable": false,
     "phase": "COLLECTING",
     "myReadyToRank": false,
-    "partnerReadyToRank": false
+    "partnerReadyToRank": false,
+    "canMarkReadyToRank": true,
+    "canRank": false,
+    "rankableStrategyCount": 3
   }
 }
 ```
 
-**Privacy note**: Strategies are never attributed to their source. Both parties see the same unlabeled list.
+**Privacy note**: Strategies are never attributed to their source. During collection, partner-created strategies are not returned to the caller. Once ranking opens for the caller, both parties see the same unlabeled shared list.
 
 Validation: description required (1-800 chars), needsAddressed max 3 entries, duration/measureOfSuccess optional. Allow duplicates; UI may dedupe.
 
@@ -195,7 +204,7 @@ Validation: count 1-5; focusNeeds max 3 entries.
 
 ## Mark Ready to Rank
 
-Indicate readiness to move to ranking phase.
+Indicate that the caller is done adding ideas and ready to move toward ranking.
 
 ```
 POST /api/v1/sessions/:id/strategies/ready
@@ -206,10 +215,19 @@ POST /api/v1/sessions/:id/strategies/ready
 ```typescript
 interface MarkReadyResponse {
   ready: boolean;
+  readyAt?: string;
   partnerReady: boolean;
   canStartRanking: boolean;
 }
 ```
+
+### Preconditions
+
+- Session must be active.
+- Caller must be in Stage 4.
+- Caller must have contributed at least one `StrategyProposal` in this session.
+
+If the caller has no strategies, the endpoint returns `VALIDATION_ERROR` (400) and does not set `readyToRank`.
 
 ### Side Effects
 
@@ -253,7 +271,16 @@ interface SubmitRankingResponse {
 
 Rankings are **completely private** until both submit. Neither party can see the other's choices during ranking.
 
-Validation: IDs must exist in session, no duplicates, overwrite allowed (last write wins). Gate link: sets `rankingSubmitted` on the caller's `StageProgress.gatesSatisfied`.
+### Preconditions and Validation
+
+- Session must be active.
+- Caller must be in Stage 4.
+- Both users must have `readyToRank`.
+- Caller must have contributed at least one strategy.
+- `rankedIds` must be unique.
+- Every ranked ID must belong to the session's rankable strategy pool.
+
+Overwrite is allowed (last write wins). Gate link: sets `rankingSubmitted` on the caller's `StageProgress.gatesSatisfied`.
 
 ---
 
@@ -392,8 +419,8 @@ Stage 4 uses these caller-side gate markers on `StageProgress.gatesSatisfied`:
 
 | Gate | Requirement |
 |------|-------------|
-| `readyToRank` | Caller posted `/strategies/ready` |
-| `rankingSubmitted` | Caller posted `/strategies/rank` |
+| `readyToRank` | Caller posted `/strategies/ready` after contributing at least one strategy |
+| `rankingSubmitted` | Caller posted `/strategies/rank` after both users were ready and the caller had contributed at least one strategy |
 | `agreementCreated` | Required by the generic `/stages/advance` gate table, but Stage 4 normally resolves through agreement confirmation rather than manual advancement |
 
 `readyToRank` and `rankingSubmitted` are actively set by the Stage 4 controller. Agreement confirmation updates `Agreement` rows and may resolve the session directly; it does not currently set a StageProgress `agreementConfirmed` gate.
@@ -407,12 +434,15 @@ Session resolves when every `Agreement` row in the session is fully signed by bo
 ```mermaid
 flowchart TD
     Enter[Enter Stage 4] --> Collect[Both propose strategies]
-    Collect --> Pool[Strategies in unlabeled pool]
-    Pool --> MoreIdeas{Want more ideas?}
+    Collect --> LocalPool[Each user sees only their own ideas]
+    LocalPool --> MoreIdeas{Want more ideas?}
     MoreIdeas -->|Yes| AISuggest[AI generates suggestions]
-    AISuggest --> Pool
-    MoreIdeas -->|No| Ready[Both mark ready]
-    Ready --> Rank[Private ranking]
+    AISuggest --> LocalPool
+    MoreIdeas -->|No| Done[Each marks done adding ideas]
+    Done --> Ready{Both ready and each contributed?}
+    Ready -->|No| WaitReady[Wait for partner readiness or contribution]
+    Ready -->|Yes| SharedPool[Show full unlabeled shared pool]
+    SharedPool --> Rank[Private ranking]
     Rank --> BothRanked{Both ranked?}
     BothRanked -->|No| Wait[Wait for partner]
     BothRanked -->|Yes| Reveal[Reveal overlap]

--- a/docs/product/stages/stage-4-strategic-repair.md
+++ b/docs/product/stages/stage-4-strategic-repair.md
@@ -18,7 +18,8 @@ Move from understanding to action by designing small, reversible experiments tha
 - Invite **both users** to propose their own strategies
 - Help refine proposals to be small, reversible, and time-bounded
 - Collect and combine suggestions from both parties
-- Present all strategies as **unlabeled options** (no attribution to source)
+- During collection, keep each person's proposed strategies visible only to that person
+- Present all strategies as **unlabeled options** only once both users are ready to rank and each has contributed
 - Allow users to select from the combined pool
 - Offer to generate additional AI suggestions if desired (product target; the current backend endpoint is still a placeholder)
 - Document agreed-upon micro-experiments
@@ -28,14 +29,16 @@ Move from understanding to action by designing small, reversible experiments tha
 Unlike traditional negotiation where one person proposes and the other reacts, Stage 4 invites **both parties to contribute strategies independently**. The AI then:
 
 1. Collects strategies from both users
-2. Presents them as a single unlabeled pool (no attribution to source)
-3. Asks: "Here is what we have come up with so far. Are you happy with these options, or would you like me to try and generate a few more to explore?"
-4. Each person **privately ranks their top choices**
-5. AI reveals where selections overlap
+2. Shows each user only their own ideas while collection is still in progress
+3. Lets each user mark "Done Adding Ideas" after they have contributed at least one strategy
+4. Presents the combined list as a single unlabeled pool once both users are ready
+5. Each person **privately ranks their top choices**
+6. AI reveals where selections overlap
 
 This approach:
 - Removes defensiveness that comes with accepting another's proposal
 - Creates joint ownership of solutions
+- Prevents one person from being asked to rank a partner-only set of ideas
 - Avoids win/lose dynamics
 - Encourages creativity when users can build on unlabeled ideas
 - Private ranking removes pressure of visible negotiation
@@ -51,16 +54,19 @@ flowchart TD
 
     InviteB[Invite User B strategy] --> RefineB[AI helps refine]
 
-    RefineA --> Collect[Collect all strategies]
+    RefineA --> Collect[Collect each user's strategies]
     RefineB --> Collect
 
-    Collect --> Present[Present unlabeled strategy pool]
-    Present --> Question[Happy with options or want more?]
+    Collect --> LocalReview[Show each user their own saved ideas]
+    LocalReview --> Question[Done adding ideas or want more?]
 
     Question -->|Want more| Generate[AI suggestions endpoint - placeholder today]
-    Generate --> Present
+    Generate --> LocalReview
 
-    Question -->|Happy| PrivateRank[Each privately ranks top choices]
+    Question -->|Done| Ready{Both ready and each contributed?}
+    Ready -->|No| WaitReady[Wait for partner readiness or contribution]
+    Ready -->|Yes| Present[Present combined unlabeled strategy pool]
+    Present --> PrivateRank[Each privately ranks top choices]
     PrivateRank --> WaitBoth[Wait for both to rank]
     WaitBoth --> Reveal[AI reveals overlap]
     Reveal --> Overlap{Any overlap?}
@@ -166,6 +172,10 @@ flowchart TB
     end
 ```
 
+### Collection View
+
+Before the shared pool opens, the user sees only ideas created from their side of the Stage 4 conversation. The primary action is **Done Adding Ideas**, not **Ready to Rank**. This marks the caller's readiness gate and waits for the partner if the combined pool is not ready yet.
+
 ### Private Ranking View
 
 ```mermaid
@@ -217,7 +227,8 @@ flowchart TB
 ```
 
 **Key visual elements:**
-- Strategy options are presented without labels indicating who suggested them
+- During collection, users see only their own saved ideas
+- Once ranking is available, strategy options are presented without labels indicating who suggested them
 - All buttons use soft, neutral colors (no "yours" vs "theirs" styling)
 - Ranking is private until both submit
 - Overlap is revealed together without implying agreement where none exists

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -122,6 +122,8 @@ export interface UseChatUIStateProps {
   strategyReadiness?: {
     myReadyToRank?: boolean;
     partnerReadyToRank?: boolean;
+    canMarkReadyToRank?: boolean;
+    canRank?: boolean;
   };
   overlappingStrategiesCount: number;
 

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -1744,6 +1744,8 @@ export function useMarkReadyToRank(
               myReadyToRank: true,
               partnerReadyToRank: data.partnerReady,
               phase: data.canStartRanking ? StrategyPhase.RANKING : old.phase,
+              canMarkReadyToRank: false,
+              canRank: data.canStartRanking,
             }
           : old
       );
@@ -1763,6 +1765,9 @@ export function useMarkReadyToRank(
             }
           : old
       );
+      queryClient.invalidateQueries({ queryKey: stageKeys.strategies(sessionId) });
+      queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+      queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
     },
     onError: (_error, { sessionId }, context) => {
       if (context?.previousStrategies) {

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -575,6 +575,8 @@ export function useUnifiedSession(
   const myReadyToRank =
     strategyData?.myReadyToRank === true ||
     (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.readyToRank === true;
+  const canMarkReadyToRank = strategyData?.canMarkReadyToRank === true;
+  const canRankStrategies = strategyData?.canRank === true;
   const overlappingStrategies = useMemo(() => revealData?.overlap ?? [], [revealData?.overlap]);
   const agreements = useMemo(() => agreementsData?.agreements ?? [], [agreementsData?.agreements]);
 
@@ -734,6 +736,8 @@ export function useUnifiedSession(
           position: 'end',
           props: {
             strategyCount: strategies.length,
+            canMarkReadyToRank,
+            canRank: canRankStrategies,
             // Note: StrategyDTO doesn't expose source to keep strategies unlabeled
             userContributedCount: 0,
           },
@@ -792,6 +796,8 @@ export function useUnifiedSession(
     strategyPhase,
     strategies,
     myReadyToRank,
+    canMarkReadyToRank,
+    canRankStrategies,
     overlappingStrategies,
     agreements,
     partnerName,
@@ -1253,6 +1259,8 @@ export function useUnifiedSession(
     strategyData,
     strategyPhase,
     strategies,
+    canMarkReadyToRank,
+    canRankStrategies,
     revealData,
     overlappingStrategies,
     agreementsData,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1295,6 +1295,8 @@ export function UnifiedSessionScreen({
         (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.readyToRank === true,
       partnerReadyToRank: strategyData?.partnerReadyToRank === true ||
         ((partnerProgress as { gatesSatisfied?: Record<string, unknown> } | undefined)?.gatesSatisfied)?.readyToRank === true,
+      canMarkReadyToRank: strategyData?.canMarkReadyToRank === true,
+      canRank: strategyData?.canRank === true,
     },
     overlappingStrategiesCount: overlappingStrategies?.length ?? 0,
     agreements: agreements?.map(a => ({
@@ -1742,16 +1744,21 @@ export function UnifiedSessionScreen({
 
         case 'strategy-pool-preview': {
           const stratCount = card.props.strategyCount as number;
+          const canMarkReadyToRank = card.props.canMarkReadyToRank === true;
+          const canRank = card.props.canRank === true;
+          const showPoolActions = stratCount > 0 && canRank;
           return (
             <View style={styles.inlineCard} key={card.id}>
               <Text style={styles.cardTitle}>Ideas So Far</Text>
               <Text style={styles.cardSubtitle}>
                 {stratCount === 0
                   ? 'Strategies are being gathered from your conversation...'
-                  : `${stratCount} ${stratCount === 1 ? 'strategy' : 'strategies'} ready to review`}
+                  : canRank
+                    ? `${stratCount} ${stratCount === 1 ? 'strategy' : 'strategies'} ready to review`
+                    : `${stratCount} ${stratCount === 1 ? 'strategy' : 'strategies'} saved from your side`}
               </Text>
               <View style={styles.strategyPreviewButtons}>
-                {stratCount > 0 && (
+                {showPoolActions && (
                   <TouchableOpacity
                     style={styles.secondaryButton}
                     onPress={() => openOverlay('strategy-pool')}
@@ -1759,13 +1766,22 @@ export function UnifiedSessionScreen({
                     <Text style={styles.secondaryButtonText}>View All</Text>
                   </TouchableOpacity>
                 )}
-                <TouchableOpacity
-                  style={[styles.primaryButton, stratCount === 0 && { opacity: 0.5 }]}
-                  onPress={handleMarkReadyToRank}
-                  disabled={stratCount === 0}
-                >
-                  <Text style={styles.primaryButtonText}>Ready to Rank</Text>
-                </TouchableOpacity>
+                {canMarkReadyToRank && (
+                  <TouchableOpacity
+                    style={styles.primaryButton}
+                    onPress={handleMarkReadyToRank}
+                  >
+                    <Text style={styles.primaryButtonText}>Done Adding Ideas</Text>
+                  </TouchableOpacity>
+                )}
+                {showPoolActions && (
+                  <TouchableOpacity
+                    style={styles.primaryButton}
+                    onPress={() => openOverlay('strategy-ranking')}
+                  >
+                    <Text style={styles.primaryButtonText}>Ready to Rank</Text>
+                  </TouchableOpacity>
+                )}
               </View>
             </View>
           );
@@ -2108,6 +2124,7 @@ export function UnifiedSessionScreen({
         );
 
       case 'strategy-pool':
+        if (strategyData?.canRank !== true) return null;
         return (
           <View style={styles.overlayContainer}>
             <StrategyPool
@@ -2128,6 +2145,7 @@ export function UnifiedSessionScreen({
         );
 
       case 'strategy-ranking':
+        if (strategyData?.canRank !== true) return null;
         return (
           <View style={styles.overlayContainer}>
             <StrategyRanking
@@ -2731,7 +2749,11 @@ export function UnifiedSessionScreen({
   // -------------------------------------------------------------------------
   // Strategy Ranking Phase - Full Screen Overlay
   // -------------------------------------------------------------------------
-  if (currentStage === Stage.STRATEGIC_REPAIR && strategyPhase === StrategyPhase.RANKING) {
+  if (
+    currentStage === Stage.STRATEGIC_REPAIR &&
+    strategyPhase === StrategyPhase.RANKING &&
+    strategyData?.canRank === true
+  ) {
     return (
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
         <SessionChatHeader

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -121,6 +121,8 @@ export interface ChatUIStateInputs extends WaitingStatusInputs {
   strategyReadiness?: {
     myReadyToRank?: boolean;
     partnerReadyToRank?: boolean;
+    canMarkReadyToRank?: boolean;
+    canRank?: boolean;
   };
 }
 

--- a/mobile/src/utils/getWaitingStatus.ts
+++ b/mobile/src/utils/getWaitingStatus.ts
@@ -100,6 +100,8 @@ export interface WaitingStatusInputs {
   strategyReadiness?: {
     myReadyToRank?: boolean;
     partnerReadyToRank?: boolean;
+    canMarkReadyToRank?: boolean;
+    canRank?: boolean;
   };
   overlappingStrategies: {
     count: number;

--- a/shared/src/dto/strategy.ts
+++ b/shared/src/dto/strategy.ts
@@ -40,6 +40,9 @@ export interface GetStrategiesResponse {
   phase: StrategyPhase;
   myReadyToRank?: boolean;
   partnerReadyToRank?: boolean;
+  canMarkReadyToRank?: boolean;
+  canRank?: boolean;
+  rankableStrategyCount?: number;
 }
 
 export interface ProposeStrategyRequest {


### PR DESCRIPTION
## Summary

Fixes the Adam-side Stage 4 regression from `docs/product/adam-eve-gold-session-stage4-adam-side-report-2026-05-05.md` by making strategy visibility and ranking server-gated per user.

- Hide partner-only strategies from the current user during Stage 4 collection; the backend now uses `createdByUserId` internally but still strips attribution from the public DTO.
- Require current-user strategy contribution before `readyToRank`, and require both readiness gates plus a current-user contribution before ranking submissions are accepted.
- Add explicit `canMarkReadyToRank`, `canRank`, and `rankableStrategyCount` fields so mobile does not infer rankability from `strategies.length`.
- Replace the early `Ready to Rank` CTA with `Done Adding Ideas` during collection, and gate strategy pool/ranking overlays on `canRank`.
- Normalize generated display text at backend boundaries to remove markdown separators, full-string quote wrappers, and escaped quote artifacts before persistence/rendering.

## Evaluation Against The Report

- Issue 1, Adam sees Eve-only strategies: addressed. `GET /strategies` returns only current-user proposals until this user is eligible for the shared ranking phase, so Eve-only proposals are no longer presented to Adam as a shared pool.
- Issue 2, Ready to Rank appears clickable too early: addressed. Mobile no longer shows the ranking affordance from strategy count alone, and backend rejects readiness/ranking calls that do not satisfy the contribution/readiness gates.
- Issue 3, realtime/manual refresh: partially addressed. Stage 4 readiness mutations now invalidate strategy/progress/session state more aggressively; the broader Stage 1/3 message reconciliation issue remains outside this focused fix.
- Issue 4, raw markdown/escaped quotes: addressed for new generated text at backend persistence/stream boundaries, including transitions, needs, share suggestions, and shared context. Existing dirty DB rows are not migrated.
- Issue 5, ambiguous gate/wait UI: partially addressed for the Stage 4 controls called out in the report. Wider stale chat input behavior in Stage 1/3 remains separate.

## Validation

- `npm --workspace backend test -- --runTestsByPath src/routes/__tests__/stage4.test.ts src/utils/__tests__/visible-text.test.ts --runInBand`
- `npm --workspace backend run check`
- `npm --workspace mobile run check`
- `git diff --check`

cc @slam-paws
