### PR TITLE
docs: rerun incremental docs audit

### DIFF
--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -3,7 +3,7 @@ title: External Integrations
 sidebar_position: 6
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-05-01
+updated: 2026-05-05
 status: living
 ---
 # External Integrations
@@ -90,8 +90,9 @@ status: living
   - SDK: `mixpanel-react-native` (mobile/native), `mixpanel-browser` (mobile/Expo web build)
   - Auth: `EXPO_PUBLIC_MIXPANEL_TOKEN` (environment variable, public token)
   - Tracking: Session events, user actions, completion milestones
+  - PII posture: Users are identified only by pseudonymous Clerk user ID. `setUserProperties` sends only `last_login_at`; real name and email are never sent to Mixpanel.
   - Files:
-    - Mobile (native): `mobile/src/services/mixpanel.ts`, `mobile/src/services/analytics.ts`
+    - Mobile (native): `mobile/src/services/mixpanel.ts`, `mobile/src/services/analytics.ts`, `mobile/src/components/MixpanelInitializer.tsx`
     - Mobile (Expo web build): `mobile/src/services/mixpanel.web.ts` (platform override using `mixpanel-browser`)
     - Website: Google Analytics via Next.js
 
@@ -152,6 +153,11 @@ status: living
 - Winston structured logger (`backend/src/lib/logger.ts`) with JSON output in production, pretty-print in development
 - Automatic request context injection: turnId, sessionId, userId, requestId
 - Sentry transport: error-level logs forwarded to Sentry via custom SentryTransport
+- Mobile Sentry: initialized in `mobile/app/_layout.tsx`
+  - `sendDefaultPii: false` — prevents automatic PII capture
+  - `beforeSend` hook: strips PII keys from event extras and breadcrumbs before transmission
+  - `beforeBreadcrumb` hook: filters PII from breadcrumbs in real-time
+  - `tracesSampleRate: 0.2` (20% performance trace sampling)
 - LLM telemetry: `llm-telemetry.ts` tracks token usage, cost, duration per turn
 - Brain Activity: Stored in `BrainActivity` table for audit and cost analysis (brain service)
 - TurnTrace: Request-scoped logging via AsyncLocalStorage captures `turnId` for correlating logs


### PR DESCRIPTION
## Changes
- Add: Mixpanel PII posture note — users identified by pseudonymous Clerk ID only, `setUserProperties` sends `last_login_at` only (no name/email)
- Add: Mobile Sentry PII scrubbing config — `beforeSend`, `beforeBreadcrumb`, `sendDefaultPii: false`, `tracesSampleRate: 0.2`
- Fix: `updated` date bumped to 2026-05-05 in `integrations.md`

## Provenance
- **Channel:** cron / nightly audit
- **Requested by:** audit-docs bot
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs skill, incremental stage

## Docs updated
- `docs/architecture/integrations.md` — Mixpanel PII posture + Mobile Sentry config (PRs #332 and #333 shipped these changes; docs were silent)