### PR TITLE
[codex] Fix persisted message refresh and chat gating

### DIFF
--- a/mobile/src/config/waitingStatusConfig.ts
+++ b/mobile/src/config/waitingStatusConfig.ts
@@ -295,7 +295,7 @@ export const WAITING_STATUS_CONFIG: Record<NonNullable<WaitingStatusState>, Wait
   // Stage 4: All agreements confirmed by me, waiting for partner
   'agreement-pending': {
     showBanner: true,
-    hideInput: false,
+    hideInput: true,
     showInnerThoughts: false,
     isActionRequired: false,
     showSpinner: false,

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -18,6 +18,7 @@ import {
   CapturedNeedInput,
 } from '@meet-without-fear/shared';
 import { messageKeys, sessionKeys, stageKeys, timelineKeys } from './queryKeys';
+import { getPersistedMessageRefreshQueryKeys } from '../utils/realtimeInvalidation';
 
 // ============================================================================
 // Types
@@ -155,6 +156,7 @@ export function useStreamingMessage(
   // Ref for 15-second fallback timer to handle stuck connections
   const fallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const FALLBACK_TIMEOUT = 15000; // 15 seconds
+  const reconciliationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   /**
    * Add a message to the cache
@@ -369,8 +371,10 @@ export function useStreamingMessage(
 
   const invalidateAfterSuccessfulStream = useCallback(
     (sessionId: string, stage?: Stage) => {
+      queryClient.invalidateQueries({ queryKey: messageKeys.list(sessionId) });
       queryClient.invalidateQueries({ queryKey: messageKeys.infinite(sessionId) });
       queryClient.invalidateQueries({ queryKey: timelineKeys.infinite(sessionId) });
+      queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
       if (stage === Stage.PERSPECTIVE_STRETCH) {
         queryClient.invalidateQueries({ queryKey: stageKeys.empathyStatus(sessionId) });
       }
@@ -380,6 +384,28 @@ export function useStreamingMessage(
         queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
         queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
       }
+    },
+    [queryClient]
+  );
+
+  const reconcilePersistedMessages = useCallback(
+    (sessionId: string) => {
+      if (reconciliationTimerRef.current) {
+        clearTimeout(reconciliationTimerRef.current);
+        reconciliationTimerRef.current = null;
+      }
+
+      for (const queryKey of getPersistedMessageRefreshQueryKeys(sessionId)) {
+        queryClient.invalidateQueries({ queryKey });
+        queryClient.refetchQueries({ queryKey });
+      }
+
+      reconciliationTimerRef.current = setTimeout(() => {
+        for (const queryKey of getPersistedMessageRefreshQueryKeys(sessionId)) {
+          queryClient.refetchQueries({ queryKey });
+        }
+        reconciliationTimerRef.current = null;
+      }, 1200);
     },
     [queryClient]
   );
@@ -745,6 +771,7 @@ export function useStreamingMessage(
               if (data.metadata) {
                 handleMetadata(sessionId, data.metadata);
               }
+              reconcilePersistedMessages(sessionId);
 
               // If text_complete wasn't received (fallback), handle completion here
               if (!textCompleteReceivedRef.current) {
@@ -789,6 +816,10 @@ export function useStreamingMessage(
             clearTimeout(fallbackTimerRef.current);
             fallbackTimerRef.current = null;
           }
+          if (reconciliationTimerRef.current) {
+            clearTimeout(reconciliationTimerRef.current);
+            reconciliationTimerRef.current = null;
+          }
 
           // Clear any pending throttled update
           if (pendingUpdateRef.current) {
@@ -812,6 +843,10 @@ export function useStreamingMessage(
         });
 
       } catch (error) {
+        if (reconciliationTimerRef.current) {
+          clearTimeout(reconciliationTimerRef.current);
+          reconciliationTimerRef.current = null;
+        }
         console.error('[useStreamingMessage] Error:', error);
         cleanupFailedStream(sessionId, currentStage);
         setErrorMessage((error as Error).message || 'Failed to send message');
@@ -819,7 +854,7 @@ export function useStreamingMessage(
         onError?.(error as Error);
       }
     },
-    [addMessageToCache, updateMessageInCache, cleanupFailedStream, handleMetadata, invalidateAfterSuccessfulStream, queryClient, onComplete, onError]
+    [addMessageToCache, updateMessageInCache, cleanupFailedStream, handleMetadata, invalidateAfterSuccessfulStream, reconcilePersistedMessages, queryClient, onComplete, onError]
   );
 
   /**
@@ -830,6 +865,10 @@ export function useStreamingMessage(
     if (fallbackTimerRef.current) {
       clearTimeout(fallbackTimerRef.current);
       fallbackTimerRef.current = null;
+    }
+    if (reconciliationTimerRef.current) {
+      clearTimeout(reconciliationTimerRef.current);
+      reconciliationTimerRef.current = null;
     }
 
     // Clear any pending throttled update

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -59,7 +59,12 @@ import { usePendingActions } from '../hooks/usePendingActions';
 import { useNeedsComparison } from '../hooks/useStages';
 import { deriveIndicators, SessionIndicatorData } from '../utils/chatListSelector';
 import { canInsertRealtimeMessageForCurrentUser, isRealtimePayloadAddressedToCurrentUser } from '../utils/realtimePrivacy';
-import { getStage2RealtimeInvalidationQueryKeys, getStage3RealtimeInvalidationQueryKeys, getStage4RealtimeInvalidationQueryKeys } from '../utils/realtimeInvalidation';
+import {
+  getPersistedMessageRefreshQueryKeys,
+  getStage2RealtimeInvalidationQueryKeys,
+  getStage3RealtimeInvalidationQueryKeys,
+  getStage4RealtimeInvalidationQueryKeys,
+} from '../utils/realtimeInvalidation';
 import { useToast } from '../contexts/ToastContext';
 import { createStyles } from '../theme/styled';
 import { WaitingBanner } from '../components/WaitingBanner';
@@ -449,23 +454,29 @@ export function UnifiedSessionScreen({
   // AI message handler for fire-and-forget pattern
   const { addAIMessage, handleAIMessageError } = useAIMessageHandler();
 
+  const refetchPersistedMessages = useCallback(() => {
+    for (const queryKey of getPersistedMessageRefreshQueryKeys(sessionId)) {
+      queryClient.refetchQueries({ queryKey });
+    }
+  }, [queryClient, sessionId]);
+
   const refreshStage2RealtimeState = useCallback((options?: { refetchMessages?: boolean }) => {
     for (const queryKey of getStage2RealtimeInvalidationQueryKeys(sessionId)) {
       queryClient.invalidateQueries({ queryKey });
     }
     if (options?.refetchMessages) {
-      queryClient.refetchQueries({ queryKey: messageKeys.infinite(sessionId) });
+      refetchPersistedMessages();
     }
-  }, [queryClient, sessionId]);
+  }, [queryClient, refetchPersistedMessages, sessionId]);
 
   const refreshStage3RealtimeState = useCallback((options?: { refetchMessages?: boolean }) => {
     for (const queryKey of getStage3RealtimeInvalidationQueryKeys(sessionId)) {
       queryClient.invalidateQueries({ queryKey });
     }
     if (options?.refetchMessages) {
-      queryClient.refetchQueries({ queryKey: messageKeys.infinite(sessionId) });
+      refetchPersistedMessages();
     }
-  }, [queryClient, sessionId]);
+  }, [queryClient, refetchPersistedMessages, sessionId]);
 
   const refreshStage4RealtimeState = useCallback((options?: { refetchMessages?: boolean }) => {
     for (const queryKey of getStage4RealtimeInvalidationQueryKeys(sessionId)) {
@@ -474,9 +485,9 @@ export function UnifiedSessionScreen({
     queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
     queryClient.refetchQueries({ queryKey: stageKeys.agreements(sessionId) });
     if (options?.refetchMessages) {
-      queryClient.refetchQueries({ queryKey: messageKeys.infinite(sessionId) });
+      refetchPersistedMessages();
     }
-  }, [queryClient, sessionId]);
+  }, [queryClient, refetchPersistedMessages, sessionId]);
 
   useEffect(() => {
     const latestMessage = messages[messages.length - 1];
@@ -812,34 +823,34 @@ export function UnifiedSessionScreen({
       if (eventName === 'session.needs_extracted') {
         // My own needs have been extracted by the backend
         console.log('[UnifiedSessionScreen] Needs extracted, refreshing cache');
-        refreshStage3RealtimeState();
+        refreshStage3RealtimeState({ refetchMessages: true });
       }
 
       if (eventName === 'partner.needs_confirmed') {
         // Partner confirmed their identified needs
         console.log('[UnifiedSessionScreen] Partner confirmed needs');
-        refreshStage3RealtimeState();
+        refreshStage3RealtimeState({ refetchMessages: true });
       }
 
       if (eventName === 'partner.needs_shared') {
         // Partner consented to share their needs
         console.log('[UnifiedSessionScreen] Partner shared needs');
-        refreshStage3RealtimeState();
+        refreshStage3RealtimeState({ refetchMessages: true });
       }
 
       if (eventName === 'session.needs_reveal_ready' || eventName === 'session.needs_revealed') {
         console.log('[UnifiedSessionScreen] Needs reveal ready');
-        refreshStage3RealtimeState();
+        refreshStage3RealtimeState({ refetchMessages: true });
       }
 
       if (eventName === 'session.common_ground_ready') {
         console.log('[UnifiedSessionScreen] Common ground ready');
-        refreshStage3RealtimeState();
+        refreshStage3RealtimeState({ refetchMessages: true });
       }
 
       if (eventName === 'partner.needs_validated') {
         console.log('[UnifiedSessionScreen] Partner validated needs');
-        refreshStage3RealtimeState();
+        refreshStage3RealtimeState({ refetchMessages: true });
       }
 
       // -----------------------------------------------------------------------
@@ -1150,7 +1161,9 @@ export function UnifiedSessionScreen({
         // React Query's focusManager also triggers stale refetches, but this
         // ensures immediate refresh even within the 30s staleTime window.
         queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
-        queryClient.invalidateQueries({ queryKey: messageKeys.infinite(sessionId) });
+        for (const queryKey of getPersistedMessageRefreshQueryKeys(sessionId)) {
+          queryClient.invalidateQueries({ queryKey });
+        }
       }
     });
     return () => subscription.remove();
@@ -2934,8 +2947,7 @@ export function UnifiedSessionScreen({
           ) : undefined}
           hideInput={
             // Use derived hideInput logic from useChatUIState
-            // Never hide when empathy review panel is showing (user still needs to interact)
-            !shouldShowEmpathyPanel && derivedShouldHideInput
+            derivedShouldHideInput
           }
           validationCards={validationCards}
           onValidateAccurate={handleValidationAccurate}

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -288,16 +288,46 @@ describe('Input Hiding (shouldHideInput)', () => {
     expect(result.shouldHideInput).toBe(true);
   });
 
-  it('shows input when awaiting-context-share (user can still chat)', () => {
+  it('hides input when awaiting-context-share panel owns the next action', () => {
     const inputs = createInputs({
       myStage: Stage.PERSPECTIVE_STRETCH,
       compactMySigned: true,
       myProgress: { stage: Stage.PERSPECTIVE_STRETCH },
       shareOffer: { hasSuggestion: true },
+      hasShareSuggestion: true,
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.shouldHideInput).toBe(false);
+    expect(result.aboveInputPanel).toBe('share-suggestion');
+    expect(result.shouldHideInput).toBe(true);
+  });
+
+  it('hides input while the empathy review panel owns the next action', () => {
+    const inputs = createInputs({
+      myStage: Stage.PERSPECTIVE_STRETCH,
+      compactMySigned: true,
+      myProgress: { stage: Stage.PERSPECTIVE_STRETCH },
+      hasEmpathyContent: true,
+      empathyAlreadyConsented: false,
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.aboveInputPanel).toBe('empathy-statement');
+    expect(result.shouldHideInput).toBe(true);
+  });
+
+  it('hides input while the feel-heard panel owns the next action', () => {
+    const inputs = createInputs({
+      myStage: Stage.WITNESS,
+      compactMySigned: true,
+      myProgress: { stage: Stage.WITNESS },
+      showFeelHeardConfirmation: true,
+      feelHeardConfirmedAt: null,
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.aboveInputPanel).toBe('feel-heard');
+    expect(result.shouldHideInput).toBe(true);
   });
 
   it('hides input while empathy review is running', () => {
@@ -382,6 +412,40 @@ describe('Input Hiding (shouldHideInput)', () => {
 
     const result = computeChatUIState(inputs);
     expect(result.waitingStatus).toBe('partner-validating-needs');
+    expect(result.shouldHideInput).toBe(true);
+  });
+
+  it('hides input while the needs reveal validation panel owns the next action', () => {
+    const inputs = createInputs({
+      myStage: Stage.NEED_MAPPING,
+      compactMySigned: true,
+      myProgress: { stage: Stage.NEED_MAPPING },
+      allNeedsConfirmed: true,
+      needsShared: true,
+      needsRevealReady: true,
+      needs: { allConfirmed: true, shared: true, revealReady: true },
+      needsRevealAvailable: true,
+      needsRevealValidationCount: 2,
+      needsRevealValidation: { count: 2, allConfirmedByMe: false, allConfirmedByBoth: false },
+      needsRevealValidatedByMe: false,
+      needsRevealValidatedByBoth: false,
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.aboveInputPanel).toBe('needs-reveal-validation');
+    expect(result.shouldHideInput).toBe(true);
+  });
+
+  it('hides input while Stage 4 agreement review owns the next action', () => {
+    const inputs = createInputs({
+      myStage: Stage.STRATEGIC_REPAIR,
+      compactMySigned: true,
+      myProgress: { stage: Stage.STRATEGIC_REPAIR },
+      strategyPhase: 'NEGOTIATING',
+      agreements: [{ agreedByMe: false, agreedByPartner: true }],
+    });
+
+    const result = computeChatUIState(inputs);
     expect(result.shouldHideInput).toBe(true);
   });
 

--- a/mobile/src/utils/__tests__/getWaitingStatus.test.ts
+++ b/mobile/src/utils/__tests__/getWaitingStatus.test.ts
@@ -268,6 +268,16 @@ describe('Priority 4: Stage 2 (Empathy)', () => {
 // ============================================================================
 
 describe('Priority 5: Stage 3 (Needs)', () => {
+  it('returns needs-pending when my needs are confirmed but not shared', () => {
+    const inputs = createDefaultInputs({
+      myStage: Stage.NEED_MAPPING,
+      needs: { allConfirmed: true, shared: false, revealReady: false },
+      needsRevealValidation: { count: 0 },
+    });
+
+    expect(computeWaitingStatus(inputs)).toBe('needs-pending');
+  });
+
   it('returns needs-waiting-for-partner when needs are shared but reveal is not ready yet', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.NEED_MAPPING,
@@ -282,6 +292,16 @@ describe('Priority 5: Stage 3 (Needs)', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.PERSPECTIVE_STRETCH,
       needs: { allConfirmed: true },
+      needsRevealValidation: { count: 0 },
+    });
+
+    expect(computeWaitingStatus(inputs)).toBeNull();
+  });
+
+  it('does not enter a Stage 3 wait state before needs are confirmed or shared', () => {
+    const inputs = createDefaultInputs({
+      myStage: Stage.NEED_MAPPING,
+      needs: { allConfirmed: false, shared: false, revealReady: false },
       needsRevealValidation: { count: 0 },
     });
 

--- a/mobile/src/utils/__tests__/realtimeInvalidation.test.ts
+++ b/mobile/src/utils/__tests__/realtimeInvalidation.test.ts
@@ -1,5 +1,6 @@
-import { messageKeys, notificationKeys, sessionKeys, stageKeys } from '../../hooks/queryKeys';
+import { messageKeys, notificationKeys, sessionKeys, stageKeys, timelineKeys } from '../../hooks/queryKeys';
 import {
+  getPersistedMessageRefreshQueryKeys,
   getStage2RealtimeInvalidationQueryKeys,
   getStage3RealtimeInvalidationQueryKeys,
   getStage4RealtimeInvalidationQueryKeys,
@@ -8,14 +9,25 @@ import {
 describe('realtime invalidation key sets', () => {
   const sessionId = 'session-1';
 
+  it('covers all persisted message refresh caches used by the active session screen', () => {
+    expect(getPersistedMessageRefreshQueryKeys(sessionId)).toEqual([
+      messageKeys.infinite(sessionId),
+      messageKeys.list(sessionId),
+      timelineKeys.infinite(sessionId),
+      sessionKeys.state(sessionId),
+    ]);
+  });
+
   it('covers Stage 2 dependent state and message caches', () => {
     expect(getStage2RealtimeInvalidationQueryKeys(sessionId)).toEqual([
       stageKeys.empathyStatus(sessionId),
       stageKeys.partnerEmpathy(sessionId),
       stageKeys.empathyDraft(sessionId),
       stageKeys.progress(sessionId),
-      sessionKeys.state(sessionId),
       messageKeys.infinite(sessionId),
+      messageKeys.list(sessionId),
+      timelineKeys.infinite(sessionId),
+      sessionKeys.state(sessionId),
       stageKeys.pendingActions(sessionId),
       notificationKeys.badgeCount(),
     ]);
@@ -26,8 +38,10 @@ describe('realtime invalidation key sets', () => {
       stageKeys.needs(sessionId),
       stageKeys.needsComparison(sessionId),
       stageKeys.progress(sessionId),
-      sessionKeys.state(sessionId),
       messageKeys.infinite(sessionId),
+      messageKeys.list(sessionId),
+      timelineKeys.infinite(sessionId),
+      sessionKeys.state(sessionId),
       stageKeys.pendingActions(sessionId),
       notificationKeys.badgeCount(),
     ]);
@@ -39,8 +53,10 @@ describe('realtime invalidation key sets', () => {
       stageKeys.strategiesReveal(sessionId),
       stageKeys.agreements(sessionId),
       stageKeys.progress(sessionId),
-      sessionKeys.state(sessionId),
       messageKeys.infinite(sessionId),
+      messageKeys.list(sessionId),
+      timelineKeys.infinite(sessionId),
+      sessionKeys.state(sessionId),
       stageKeys.pendingActions(sessionId),
       notificationKeys.badgeCount(),
     ]);

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -574,6 +574,11 @@ function computeShouldHideInput(
   }
 
   if (
+    aboveInputPanel === 'topic-proposal' ||
+    aboveInputPanel === 'invitation' ||
+    aboveInputPanel === 'feel-heard' ||
+    aboveInputPanel === 'share-suggestion' ||
+    aboveInputPanel === 'empathy-statement' ||
     aboveInputPanel === 'needs-review' ||
     aboveInputPanel === 'needs-share' ||
     aboveInputPanel === 'needs-reveal-validation'
@@ -614,6 +619,14 @@ function computeShouldHideInput(
   if (currentStage === Stage.STRATEGIC_REPAIR &&
       inputs.strategyPhase &&
       inputs.strategyPhase !== 'COLLECTING') {
+    return true;
+  }
+
+  if (
+    currentStage === Stage.STRATEGIC_REPAIR &&
+    inputs.agreements &&
+    inputs.agreements.length > 0
+  ) {
     return true;
   }
 

--- a/mobile/src/utils/realtimeInvalidation.ts
+++ b/mobile/src/utils/realtimeInvalidation.ts
@@ -1,4 +1,13 @@
-import { messageKeys, notificationKeys, sessionKeys, stageKeys } from '../hooks/queryKeys';
+import { messageKeys, notificationKeys, sessionKeys, stageKeys, timelineKeys } from '../hooks/queryKeys';
+
+export function getPersistedMessageRefreshQueryKeys(sessionId: string) {
+  return [
+    messageKeys.infinite(sessionId),
+    messageKeys.list(sessionId),
+    timelineKeys.infinite(sessionId),
+    sessionKeys.state(sessionId),
+  ];
+}
 
 export function getStage2RealtimeInvalidationQueryKeys(sessionId: string) {
   return [
@@ -6,8 +15,7 @@ export function getStage2RealtimeInvalidationQueryKeys(sessionId: string) {
     stageKeys.partnerEmpathy(sessionId),
     stageKeys.empathyDraft(sessionId),
     stageKeys.progress(sessionId),
-    sessionKeys.state(sessionId),
-    messageKeys.infinite(sessionId),
+    ...getPersistedMessageRefreshQueryKeys(sessionId),
     stageKeys.pendingActions(sessionId),
     notificationKeys.badgeCount(),
   ];
@@ -18,8 +26,7 @@ export function getStage3RealtimeInvalidationQueryKeys(sessionId: string) {
     stageKeys.needs(sessionId),
     stageKeys.needsComparison(sessionId),
     stageKeys.progress(sessionId),
-    sessionKeys.state(sessionId),
-    messageKeys.infinite(sessionId),
+    ...getPersistedMessageRefreshQueryKeys(sessionId),
     stageKeys.pendingActions(sessionId),
     notificationKeys.badgeCount(),
   ];
@@ -31,8 +38,7 @@ export function getStage4RealtimeInvalidationQueryKeys(sessionId: string) {
     stageKeys.strategiesReveal(sessionId),
     stageKeys.agreements(sessionId),
     stageKeys.progress(sessionId),
-    sessionKeys.state(sessionId),
-    messageKeys.infinite(sessionId),
+    ...getPersistedMessageRefreshQueryKeys(sessionId),
     stageKeys.pendingActions(sessionId),
     notificationKeys.badgeCount(),
   ];


### PR DESCRIPTION
## Summary

Fixes the remaining Adam/Eve Stage 1 and Stage 3 stale-session issues by making persisted facilitator/message refreshes explicit and by tightening chat input ownership around gate, wait, and review states.

## What changed

- Added a shared persisted-message refresh key helper covering `messageKeys.infinite`, `messageKeys.list`, `timelineKeys.infinite`, and `sessionKeys.state`.
- Refetched persisted messages for Stage 3 realtime events that can produce facilitator/system messages or gate transitions.
- Reconciled SSE completion against persisted server messages immediately, with a short delayed fallback for backend follow-up messages.
- Made derived chat UI state hide freeform input while required panels or Stage 4 review/ranking/agreement flows own the next action.
- Added unit coverage for realtime invalidation keys, Stage 1/3 wait derivation, and authoritative input hiding.

## Root cause

Some realtime paths refreshed stage-specific state but only invalidated/refetched the infinite message cache, leaving list/timeline/session-derived surfaces stale until reload. Separately, the screen had an exception that kept chat input visible during required review panels.

## Validation

- `npm --workspace mobile run check`
- `npm --workspace backend run check`
- `npm --workspace e2e run check`
- `npm --workspace mobile test -- --runTestsByPath src/utils/__tests__/chatUIState.test.ts src/utils/__tests__/getWaitingStatus.test.ts src/utils/__tests__/realtimeInvalidation.test.ts`

Attempted relevant Playwright E2E specs, but the default config was blocked because `localhost:3000/health` was already occupied while `reuseExistingServer` is false.