### PR TITLE
[codex] Fix gold session chat and needs UI

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -110,7 +110,10 @@ const PLANNER_LINE_PREFIXES = [
   'i need to make sure both lists',
 ];
 
-export function scrubVisibleAIText(text: string): { text: string; scrubbed: boolean } {
+export function scrubVisibleAIText(
+  text: string,
+  options: { preserveBoundaryWhitespace?: boolean } = {}
+): { text: string; scrubbed: boolean } {
   const before = text;
   const plannerScrubbed = text
     .split(/\r?\n/)
@@ -121,7 +124,9 @@ export function scrubVisibleAIText(text: string): { text: string; scrubbed: bool
     .join('\n')
     .replace(/\bI should\b/gi, '')
     .replace(/\bso both lists should be available\b/gi, '');
-  const cleaned = cleanVisibleAIText(plannerScrubbed);
+  const cleaned = cleanVisibleAIText(plannerScrubbed, {
+    preserveBoundaryWhitespace: options.preserveBoundaryWhitespace,
+  });
 
   return { text: cleaned, scrubbed: cleaned !== before };
 }
@@ -543,7 +548,7 @@ export async function confirmFeelHeard(
         if (aiResponse) {
           // Parse the semantic tag response (micro-tag format)
           const parsed = parseMicroTagResponse(aiResponse);
-          transitionContent = parsed.response.trim() || `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\n${STAGE2_ROADMAP_COPY}\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partnerName || 'your partner'} might be experiencing, even though you might still be upset with them. I know that's a strange ask. But there's a lot of research showing that when each person genuinely tries to see what the other is going through, it's one of the strongest things you can do to actually work things out. It's a guess, not a test — you don't have to get it right. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partnerName || 'your partner'} in all of this?`;
+          transitionContent = cleanVisibleAIText(parsed.response) || `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\n${STAGE2_ROADMAP_COPY}\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partnerName || 'your partner'} might be experiencing, even though you might still be upset with them. I know that's a strange ask. But there's a lot of research showing that when each person genuinely tries to see what the other is going through, it's one of the strongest things you can do to actually work things out. It's a guess, not a test — you don't have to get it right. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partnerName || 'your partner'} in all of this?`;
         } else {
           transitionContent = `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\n${STAGE2_ROADMAP_COPY}\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partnerName || 'your partner'} might be experiencing, even though you might still be upset with them. I know that's a strange ask. But there's a lot of research showing that when each person genuinely tries to see what the other is going through, it's one of the strongest things you can do to actually work things out. It's a guess, not a test — you don't have to get it right. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partnerName || 'your partner'} in all of this?`;
         }
@@ -1598,7 +1603,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
           cleanText = cleanText.trimStart();
         }
 
-        const scrubbed = scrubVisibleAIText(cleanText);
+        const scrubbed = scrubVisibleAIText(cleanText, { preserveBoundaryWhitespace: true });
         cleanText = scrubbed.text;
 
         if (cleanText.length > 0) {

--- a/backend/src/routes/__tests__/messages.test.ts
+++ b/backend/src/routes/__tests__/messages.test.ts
@@ -140,6 +140,13 @@ describe('Messages API (Fire-and-Forget)', () => {
           scrubbed: false,
         });
       });
+
+      it('can preserve boundary whitespace for streamed chunks', () => {
+        expect(scrubVisibleAIText(' talk ', { preserveBoundaryWhitespace: true })).toEqual({
+          text: ' talk ',
+          scrubbed: false,
+        });
+      });
     });
 
     describe('isReadyForStage3RevealText', () => {

--- a/backend/src/services/needs.ts
+++ b/backend/src/services/needs.ts
@@ -84,7 +84,7 @@ export async function captureProposedNeedsForUser(
           vesselId: vessel.id,
           need: cleanVisibleAIText(item.description || item.need),
           category: item.category,
-          evidence: evidence.map(cleanVisibleAIText).filter(Boolean),
+          evidence: evidence.map((entry) => cleanVisibleAIText(entry)).filter(Boolean),
           aiConfidence: 0.85,
           confirmed: false,
         },

--- a/backend/src/utils/__tests__/visible-text.test.ts
+++ b/backend/src/utils/__tests__/visible-text.test.ts
@@ -24,4 +24,9 @@ describe('cleanVisibleAIText', () => {
       'I need room to be scared'
     );
   });
+
+  it('preserves boundary whitespace when cleaning streamed chunks', () => {
+    expect(cleanVisibleAIText(' talk ', { preserveBoundaryWhitespace: true })).toBe(' talk ');
+    expect(cleanVisibleAIText(' ', { preserveBoundaryWhitespace: true })).toBe(' ');
+  });
 });

--- a/backend/src/utils/micro-tag-parser.ts
+++ b/backend/src/utils/micro-tag-parser.ts
@@ -67,7 +67,7 @@ function parseNeedsBlock(rawNeeds: string | null): CapturedNeedInput[] {
       const evidence = Array.isArray(candidate.evidence)
         ? candidate.evidence
             .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
-            .map(cleanVisibleAIText)
+            .map((entry) => cleanVisibleAIText(entry))
             .filter(Boolean)
         : [];
 

--- a/backend/src/utils/visible-text.ts
+++ b/backend/src/utils/visible-text.ts
@@ -4,7 +4,30 @@
  * This is intentionally narrow: it removes serialization and markdown artifacts
  * that the prompt format can leak, without rewriting normal prose.
  */
-export function cleanVisibleAIText(text: string): string {
+export interface CleanVisibleAITextOptions {
+  /**
+   * Streaming chunks may begin or end with semantically meaningful whitespace.
+   * Preserve it when cleaning per-chunk text so chunk boundaries do not collapse
+   * words together in the streamed or persisted response.
+   */
+  preserveBoundaryWhitespace?: boolean;
+}
+
+export function cleanVisibleAIText(
+  text: string,
+  options: CleanVisibleAITextOptions = {}
+): string {
+  if (options.preserveBoundaryWhitespace && text.trim().length === 0) {
+    return text;
+  }
+
+  const leadingWhitespace = options.preserveBoundaryWhitespace
+    ? text.match(/^\s*/)?.[0] ?? ''
+    : '';
+  const trailingWhitespace = options.preserveBoundaryWhitespace
+    ? text.match(/\s*$/)?.[0] ?? ''
+    : '';
+
   let cleaned = text
     .replace(/\\"/g, '"')
     .replace(/\r\n/g, '\n')
@@ -36,6 +59,10 @@ export function cleanVisibleAIText(text: string): string {
       cleaned = quoteMatch[1].trim();
     }
     if (cleaned === before) break;
+  }
+
+  if (options.preserveBoundaryWhitespace && cleaned.length > 0) {
+    return `${leadingWhitespace}${cleaned}${trailingWhitespace}`;
   }
 
   return cleaned;

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -127,6 +127,8 @@ interface ChatInterfaceProps {
   onHighEmotion?: (value: number) => void;
   compactEmotionSlider?: boolean;
   renderAboveInput?: () => React.ReactNode;
+  /** Render content below the input area (e.g., persistent review affordances) */
+  renderBelowInput?: () => React.ReactNode;
   /** Render content above the emotion slider / input area (e.g., inline cards) */
   renderBelowChat?: () => React.ReactNode;
   /** Render card-shaped content in the chronological chat stream */
@@ -208,6 +210,7 @@ export function ChatInterface({
   onHighEmotion,
   compactEmotionSlider = false,
   renderAboveInput,
+  renderBelowInput,
   renderBelowChat,
   customCards,
   renderMessageExtra,
@@ -842,6 +845,7 @@ export function ChatInterface({
             onVoicePress={onVoicePress}
           />
         )}
+        {renderBelowInput?.()}
       </View>
     </KeyboardAvoidingView>
   );

--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -210,7 +210,6 @@ export function NeedsDrawer({
   // -------------------------------------------------------------------------
   const renderNeedsMode = () => (
     <>
-      <Text style={styles.sectionTitle}>Your Needs</Text>
       <Text style={styles.sectionSubtitle}>
         Review and confirm the needs you named in this conversation.
       </Text>
@@ -235,22 +234,12 @@ export function NeedsDrawer({
     return (
       <View style={[styles.fixedButtonArea, { paddingBottom: Math.max(16, insets.bottom + 8) }]}>
         <View style={styles.buttonRow}>
-          {onAdjustNeeds && (
-            <TouchableOpacity
-              style={styles.secondaryButton}
-              onPress={() => {
-                closeDrawer();
-                onAdjustNeeds();
-              }}
-              activeOpacity={0.7}
-              testID={`${testID}-adjust`}
-            >
-              <Text style={styles.secondaryButtonText}>Adjust these</Text>
-            </TouchableOpacity>
-          )}
           {onConfirmNeeds && (
             <TouchableOpacity
-              style={[styles.primaryButton, isConfirming && styles.primaryButtonDisabled]}
+              style={[
+                styles.primaryButton,
+                isConfirming && styles.primaryButtonDisabled,
+              ]}
               onPress={() => {
                 if (!isConfirming) onConfirmNeeds();
               }}
@@ -261,6 +250,19 @@ export function NeedsDrawer({
               <Text style={styles.primaryButtonText}>
                 {isConfirming ? confirmingNeedsLabel : confirmNeedsLabel}
               </Text>
+            </TouchableOpacity>
+          )}
+          {onAdjustNeeds && (
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={() => {
+                closeDrawer();
+                onAdjustNeeds();
+              }}
+              activeOpacity={0.7}
+              testID={`${testID}-adjust`}
+            >
+              <Text style={styles.secondaryButtonText}>Chat to refine</Text>
             </TouchableOpacity>
           )}
         </View>
@@ -303,7 +305,7 @@ export function NeedsDrawer({
   const renderRevealMode = () => (
     <>
       <Text style={styles.sectionSubtitle}>
-        Review both needs lists side by side. What do you notice?
+        Review both needs lists side by side, then validate whether they feel accurate.
       </Text>
       {renderSideBySideNeeds()}
     </>

--- a/mobile/src/components/__tests__/NeedsDrawer.test.tsx
+++ b/mobile/src/components/__tests__/NeedsDrawer.test.tsx
@@ -45,7 +45,7 @@ describe('NeedsDrawer', () => {
     expect(screen.getByText('Darryl')).toBeTruthy();
     expect(screen.getByText('Being heard')).toBeTruthy();
     expect(screen.getByText('Room to choose')).toBeTruthy();
-    expect(screen.getByText('Review both needs lists side by side. What do you notice?')).toBeTruthy();
+    expect(screen.getByText('Review both needs lists side by side, then validate whether they feel accurate.')).toBeTruthy();
   });
 
   it('validates the side-by-side needs reveal from reveal mode', () => {

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -729,7 +729,12 @@ export function useUnifiedSession(
     // Stage 4: Strategic Repair cards
     if (currentStage === Stage.STRATEGIC_REPAIR) {
       // Strategy pool preview (hide after session is resolved)
-      if (strategyPhase === StrategyPhase.COLLECTING && !myReadyToRank && session?.status !== SessionStatus.RESOLVED) {
+      if (
+        strategyPhase === StrategyPhase.COLLECTING &&
+        strategies.length > 0 &&
+        !myReadyToRank &&
+        session?.status !== SessionStatus.RESOLVED
+      ) {
         cards.push({
           id: 'strategy-pool-preview',
           type: 'strategy-pool-preview',

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -257,10 +257,12 @@ function NeedsIdentifiedChatCard({
   needs,
   status,
   onReview,
+  compact = false,
 }: {
   needs: Array<{ id: string; need: string; category: string }>;
   status: 'ready' | 'confirmed' | 'shared';
   onReview: () => void;
+  compact?: boolean;
 }) {
   const styles = useStyles();
   const visibleNeeds = needs.slice(0, 3);
@@ -270,32 +272,51 @@ function NeedsIdentifiedChatCard({
     : status === 'confirmed'
       ? 'Confirmed'
       : 'Ready to review';
-  const actionLabel = status === 'ready' ? 'Review and confirm' : 'Open review';
+  const actionLabel = compact ? 'Review' : status === 'ready' ? 'Review and confirm' : 'Open review';
+  const countLabel = `${needs.length} ${needs.length === 1 ? 'need' : 'needs'} captured`;
 
   return (
     <TouchableOpacity
-      style={styles.needsSummaryCard}
+      style={[styles.needsSummaryCard, compact && styles.needsSummaryCardCompact]}
       onPress={onReview}
       activeOpacity={0.8}
       testID="needs-identified-chat-card"
     >
-      <View style={styles.needsSummaryHeader}>
-        <Text style={styles.needsSummaryEyebrow}>WHAT MATTERS</Text>
-        <Text style={styles.needsSummaryStatus}>{statusLabel}</Text>
-      </View>
-      <Text style={styles.needsSummaryTitle}>Your needs so far</Text>
-      <View style={styles.needsSummaryList}>
-        {visibleNeeds.map((need) => (
-          <View key={need.id} style={styles.needsSummaryRow}>
-            <Text style={styles.needsSummaryCategory}>{need.category}</Text>
-            <Text style={styles.needsSummaryText}>{need.need}</Text>
-          </View>
-        ))}
-        {extraCount > 0 ? (
-          <Text style={styles.needsSummaryMore}>+{extraCount} more</Text>
+      {!compact ? (
+        <View style={styles.needsSummaryHeader}>
+          <Text style={styles.needsSummaryEyebrow}>WHAT MATTERS</Text>
+          <Text style={styles.needsSummaryStatus}>{statusLabel}</Text>
+        </View>
+      ) : null}
+      <View style={compact ? styles.needsSummaryCompactBody : undefined}>
+        <View style={compact ? styles.needsSummaryCompactText : undefined}>
+          <Text style={compact ? styles.needsSummaryCompactTitle : styles.needsSummaryTitle}>
+            {compact ? 'What Matters' : 'Your needs so far'}
+          </Text>
+          {compact ? (
+            <Text style={styles.needsSummaryCount}>{countLabel}</Text>
+          ) : null}
+        </View>
+        {compact ? (
+          <Text style={styles.needsSummaryActionCompact}>{actionLabel}</Text>
         ) : null}
       </View>
-      <Text style={styles.needsSummaryAction}>{actionLabel}</Text>
+      {!compact ? (
+        <>
+          <View style={styles.needsSummaryList}>
+            {visibleNeeds.map((need) => (
+              <View key={need.id} style={styles.needsSummaryRow}>
+                <Text style={styles.needsSummaryCategory}>{need.category}</Text>
+                <Text style={styles.needsSummaryText}>{need.need}</Text>
+              </View>
+            ))}
+            {extraCount > 0 ? (
+              <Text style={styles.needsSummaryMore}>+{extraCount} more</Text>
+            ) : null}
+          </View>
+          <Text style={styles.needsSummaryAction}>{actionLabel}</Text>
+        </>
+      ) : null}
     </TouchableOpacity>
   );
 }
@@ -1757,6 +1778,8 @@ export function UnifiedSessionScreen({
 
         case 'strategy-pool-preview': {
           const stratCount = card.props.strategyCount as number;
+          if (stratCount === 0) return null;
+
           const canMarkReadyToRank = card.props.canMarkReadyToRank === true;
           const canRank = card.props.canRank === true;
           const showPoolActions = stratCount > 0 && canRank;
@@ -1764,9 +1787,7 @@ export function UnifiedSessionScreen({
             <View style={styles.inlineCard} key={card.id}>
               <Text style={styles.cardTitle}>Ideas So Far</Text>
               <Text style={styles.cardSubtitle}>
-                {stratCount === 0
-                  ? 'Strategies are being gathered from your conversation...'
-                  : canRank
+                {canRank
                     ? `${stratCount} ${stratCount === 1 ? 'strategy' : 'strategies'} ready to review`
                     : `${stratCount} ${stratCount === 1 ? 'strategy' : 'strategies'} saved from your side`}
               </Text>
@@ -2021,6 +2042,7 @@ export function UnifiedSessionScreen({
   const needsReviewCards = useMemo((): ChatCustomCardItem[] => {
     if (currentStage !== Stage.NEED_MAPPING) return [];
     if (!needsData?.synthesizedAt || !needs || needs.length === 0) return [];
+    if (aboveInputPanel === 'needs-review' || aboveInputPanel === 'needs-share') return [];
     const gates = myProgress?.gatesSatisfied as Record<string, unknown> | undefined;
     let needsStatus: 'ready' | 'confirmed' | 'shared' = 'ready';
     if (gates?.needsShared === true) {
@@ -2049,7 +2071,7 @@ export function UnifiedSessionScreen({
         />
       ),
     }];
-  }, [currentStage, needsData?.synthesizedAt, needs, myProgress?.gatesSatisfied, allNeedsConfirmed]);
+  }, [currentStage, needsData?.synthesizedAt, needs, myProgress?.gatesSatisfied, allNeedsConfirmed, aboveInputPanel]);
 
   const chatCustomCards = useMemo(
     () => [...inviteeOpeningCards, ...needsReviewCards],
@@ -2440,80 +2462,10 @@ export function UnifiedSessionScreen({
         return undefined;
 
       case 'needs-review':
-        return (
-          <Animated.View
-            style={{
-              opacity: needsReviewAnim,
-              maxHeight: needsReviewAnim.interpolate({
-                inputRange: [0, 1],
-                outputRange: [0, 100],
-              }),
-              transform: [{
-                translateY: needsReviewAnim.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [20, 0],
-                }),
-              }],
-              overflow: 'hidden',
-            }}
-            pointerEvents="auto"
-          >
-            <View style={styles.needsReviewContainer}>
-              <TouchableOpacity
-                style={styles.needsReviewButton}
-                onPress={() => {
-                  setShowActivityMenu(false);
-                  setNeedsDrawerMode('needs');
-                  setShowNeedsDrawer(true);
-                }}
-                activeOpacity={0.7}
-                testID="needs-review-button"
-              >
-                <Text style={styles.needsReviewButtonText}>
-                  Review and confirm your needs
-                </Text>
-              </TouchableOpacity>
-            </View>
-          </Animated.View>
-        );
+        return undefined;
 
       case 'needs-share':
-        return (
-          <Animated.View
-            style={{
-              opacity: needsReviewAnim,
-              maxHeight: needsReviewAnim.interpolate({
-                inputRange: [0, 1],
-                outputRange: [0, 100],
-              }),
-              transform: [{
-                translateY: needsReviewAnim.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [20, 0],
-                }),
-              }],
-              overflow: 'hidden',
-            }}
-            pointerEvents="auto"
-          >
-            <View style={styles.needsReviewContainer}>
-              <TouchableOpacity
-                style={styles.needsReviewButton}
-                onPress={() => {
-                  setShowActivityMenu(false);
-                  setNeedsDrawerMode('needs');
-                  setShowNeedsDrawer(true);
-                }}
-                activeOpacity={0.7}
-                testID="needs-share-button"
-              >
-                <Text style={styles.needsReviewButtonText}>
-                  Share my needs
-                </Text>
-              </TouchableOpacity>
-            </View>
-          </Animated.View>
-        );
+        return undefined;
 
       case 'needs-reveal-validation':
         return (
@@ -2605,6 +2557,60 @@ export function UnifiedSessionScreen({
     onStageComplete,
     openOverlay,
   ]);
+
+  const renderBelowInput = useCallback((): React.ReactNode | undefined => {
+    if (aboveInputPanel !== 'needs-review' && aboveInputPanel !== 'needs-share') {
+      return undefined;
+    }
+    if (!needs || needs.length === 0) {
+      return undefined;
+    }
+
+    const gates = myProgress?.gatesSatisfied as Record<string, unknown> | undefined;
+    let needsStatus: 'ready' | 'confirmed' | 'shared' = 'ready';
+    if (gates?.needsShared === true) {
+      needsStatus = 'shared';
+    } else if (allNeedsConfirmed) {
+      needsStatus = 'confirmed';
+    }
+
+    return (
+      <Animated.View
+        style={{
+          opacity: needsReviewAnim,
+          maxHeight: needsReviewAnim.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, 420],
+          }),
+          transform: [{
+            translateY: needsReviewAnim.interpolate({
+              inputRange: [0, 1],
+              outputRange: [20, 0],
+            }),
+          }],
+          overflow: 'hidden',
+        }}
+        pointerEvents="auto"
+      >
+        <View style={styles.needsReviewBelowInputContainer}>
+          <NeedsIdentifiedChatCard
+            needs={needs.map((need) => ({
+              id: need.id,
+              need: need.need,
+              category: String(need.category),
+            }))}
+            status={needsStatus}
+            compact
+            onReview={() => {
+              setShowActivityMenu(false);
+              setNeedsDrawerMode('needs');
+              setShowNeedsDrawer(true);
+            }}
+          />
+        </View>
+      </Animated.View>
+    );
+  }, [aboveInputPanel, needsReviewAnim, styles, needs, myProgress?.gatesSatisfied, allNeedsConfirmed]);
 
   // -------------------------------------------------------------------------
   // Loading State
@@ -2930,6 +2936,11 @@ export function UnifiedSessionScreen({
               : undefined
           }
           renderAboveInput={aboveInputPanel ? renderAboveInput : undefined}
+          renderBelowInput={
+            aboveInputPanel === 'needs-review' || aboveInputPanel === 'needs-share'
+              ? renderBelowInput
+              : undefined
+          }
           renderBelowChat={(inlineCards.length > 0 || memorySuggestion) ? () => (
             <>
               {inlineCards.map((card) => renderInlineCard(card))}
@@ -3153,7 +3164,7 @@ export function UnifiedSessionScreen({
           confirmed: n.confirmed,
         }))}
         onAdjustNeeds={() => {
-          sendMessage('I would like to adjust my identified needs');
+          setShowNeedsDrawer(false);
         }}
         onConfirmNeeds={() => {
           if (allNeedsConfirmed) {
@@ -3750,6 +3761,14 @@ const useStyles = () =>
       borderTopWidth: 1,
       borderTopColor: t.colors.border,
     },
+    needsReviewBelowInputContainer: {
+      paddingHorizontal: t.spacing.lg,
+      paddingTop: t.spacing.sm,
+      paddingBottom: t.spacing.md,
+      backgroundColor: t.colors.bgSecondary,
+      borderTopWidth: 1,
+      borderTopColor: t.colors.border,
+    },
     needsReviewButton: {
       paddingVertical: t.spacing.sm,
       paddingHorizontal: t.spacing.md,
@@ -3808,6 +3827,12 @@ const useStyles = () =>
       borderWidth: 1,
       borderColor: t.colors.border,
     },
+    needsSummaryCardCompact: {
+      marginHorizontal: 0,
+      marginVertical: 0,
+      paddingVertical: 12,
+      paddingHorizontal: 14,
+    },
     needsSummaryHeader: {
       flexDirection: 'row',
       alignItems: 'center',
@@ -3830,6 +3855,27 @@ const useStyles = () =>
       fontWeight: '700',
       color: t.colors.textPrimary,
       marginBottom: 12,
+    },
+    needsSummaryCompactBody: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: 12,
+    },
+    needsSummaryCompactText: {
+      flex: 1,
+      minWidth: 0,
+    },
+    needsSummaryCompactTitle: {
+      fontSize: 15,
+      lineHeight: 20,
+      fontWeight: '700',
+      color: t.colors.textPrimary,
+    },
+    needsSummaryCount: {
+      fontSize: 13,
+      lineHeight: 18,
+      color: t.colors.textSecondary,
     },
     needsSummaryList: {
       gap: 8,
@@ -3862,6 +3908,18 @@ const useStyles = () =>
       fontSize: 14,
       fontWeight: '700',
       color: t.colors.brandBlue,
+    },
+    needsSummaryActionCompact: {
+      paddingVertical: 8,
+      paddingHorizontal: 12,
+      borderRadius: 8,
+      backgroundColor: t.colors.bgPrimary,
+      borderWidth: 1,
+      borderColor: t.colors.border,
+      fontSize: 14,
+      fontWeight: '700',
+      color: t.colors.brandBlue,
+      overflow: 'hidden',
     },
     shareActions: {
       flexDirection: 'row',

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -579,8 +579,6 @@ function computeShouldHideInput(
     aboveInputPanel === 'feel-heard' ||
     aboveInputPanel === 'share-suggestion' ||
     aboveInputPanel === 'empathy-statement' ||
-    aboveInputPanel === 'needs-review' ||
-    aboveInputPanel === 'needs-share' ||
     aboveInputPanel === 'needs-reveal-validation'
   ) {
     return true;


### PR DESCRIPTION
## Summary

This PR packages the gold-session fixes from the Adam/Eve run:

- Preserve whitespace boundaries while scrubbing visible AI text during streaming, so protected tags do not collapse adjacent words.
- Keep the Stage 3 chat composer primary by moving the needs review affordance below the input.
- Collapse the below-input needs affordance to `What Matters`, a captured-needs count, and a `Review` action.
- Clean up the needs drawer copy/actions: remove duplicate `Your Needs`, use `Chat to refine`, and update the side-by-side validation copy.
- Hide the Stage 4 `Ideas So Far` preview until at least one strategy exists.

## Why

The gold-session run exposed a few user-facing issues: AI responses had missing spaces, Stage 3 needs review crowded the active chat area, the drawer repeated labels and had unclear action copy, and Stage 4 showed an empty ideas panel before ideas existed.

## Validation

- `backend`: `npm test -- --runTestsByPath src/utils/__tests__/visible-text.test.ts src/routes/__tests__/messages.test.ts --runInBand`
- `backend`: `npm run check`
- `mobile`: `npm test -- --runTestsByPath src/utils/__tests__/chatUIState.test.ts src/components/__tests__/NeedsDrawer.test.tsx --runInBand`
- `mobile`: `npm run check`