### PR TITLE
[codex] Close remaining gold-session findings

### DIFF
--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -759,6 +759,7 @@ export async function createAgreement(req: Request, res: Response): Promise<void
       {
         agreement: {
           id: agreement.id,
+          strategyId: agreement.proposalId,
           description: agreement.description,
           type: agreement.type,
           duration: null,
@@ -942,6 +943,7 @@ export async function confirmAgreement(req: Request, res: Response): Promise<voi
     successResponse(res, {
       agreement: {
         id: updatedAgreement.id,
+        strategyId: updatedAgreement.proposalId,
         description: updatedAgreement.description,
         type: updatedAgreement.type,
         duration: null, // Field not in Prisma model
@@ -1216,6 +1218,7 @@ export async function getAgreements(req: Request, res: Response): Promise<void> 
     successResponse(res, {
       agreements: agreements.map((a) => ({
         id: a.id,
+        strategyId: a.proposalId,
         description: a.description,
         type: a.type,
         duration: null, // Field removed from schema

--- a/backend/src/utils/__tests__/micro-tag-parser.test.ts
+++ b/backend/src/utils/__tests__/micro-tag-parser.test.ts
@@ -244,6 +244,37 @@ Visible response.`;
       expect(result.offerReadyToShare).toBe(false);
     });
 
+    it('strips visible ProposedStrategy lines while preserving extracted strategies', () => {
+      const raw = `<thinking>Mode:STRATEGIC_REPAIR | StrategyProposed:Y</thinking>
+ProposedStrategy: Ceramics class on Tuesday evenings for eight weeks
+ProposedStrategy: Sunday morning walk, 45 minutes, once a week for four weeks
+That's solid. Which one feels easiest to start with?`;
+
+      const result = parseMicroTagResponse(raw);
+
+      expect(result.response).toBe("That's solid. Which one feels easiest to start with?");
+      expect(result.response).not.toContain('ProposedStrategy:');
+      expect(result.proposedStrategies).toEqual([
+        'Ceramics class on Tuesday evenings for eight weeks',
+        'Sunday morning walk, 45 minutes, once a week for four weeks',
+      ]);
+    });
+
+    it('does not treat follow-up timing as a rankable strategy', () => {
+      const raw = `<thinking>
+StrategyProposed:Y
+ProposedStrategy: Ceramics class on Tuesday evenings for eight weeks
+ProposedStrategy: Follow-up check-in after eight weeks
+</thinking>
+That gives you a concrete experiment and a time to revisit it.`;
+
+      const result = parseMicroTagResponse(raw);
+
+      expect(result.proposedStrategies).toEqual([
+        'Ceramics class on Tuesday evenings for eight weeks',
+      ]);
+    });
+
     it('defaults flags to false when not present', () => {
       const raw = `<thinking>Just some analysis</thinking>Response`;
       const result = parseMicroTagResponse(raw);

--- a/backend/src/utils/__tests__/strategy-dedupe.test.ts
+++ b/backend/src/utils/__tests__/strategy-dedupe.test.ts
@@ -41,4 +41,13 @@ describe('strategy dedupe', () => {
     expect(result.supersededIds).toEqual([]);
     expect(result.newStrategies).toEqual([]);
   });
+
+  it('does not let a broader later draft replace a more specific existing strategy', () => {
+    expect(
+      isSupersededStrategy(
+        'Sunday morning walk, 45 minutes, once a week for four weeks, no relationship agenda',
+        'Sunday morning walk once a week'
+      )
+    ).toBe(false);
+  });
 });

--- a/backend/src/utils/micro-tag-parser.ts
+++ b/backend/src/utils/micro-tag-parser.ts
@@ -86,6 +86,46 @@ function parseNeedsBlock(rawNeeds: string | null): CapturedNeedInput[] {
   }
 }
 
+function isFollowUpTimingOnlyStrategy(strategy: string): boolean {
+  const normalized = strategy.toLowerCase().replace(/[^a-z0-9\s-]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!normalized) return true;
+
+  const mentionsFollowUpTiming =
+    /\bfollow[- ]?up\b/.test(normalized) ||
+    /\bcheck back\b/.test(normalized) ||
+    /\bcheck in on how (?:it|this|that) (?:went|goes)\b/.test(normalized) ||
+    /\bwhen should we check in\b/.test(normalized);
+  if (!mentionsFollowUpTiming) return false;
+
+  const hasExperimentAction = /\b(?:try|do|take|schedule|practice|write|use|pause|walk|talk|meet|plan|attend|share|listen|ask|choose|spend|set aside|commit)\b/.test(normalized);
+  return !hasExperimentAction;
+}
+
+function addProposedStrategy(proposedStrategies: string[], rawStrategy: string): void {
+  const strategy = cleanVisibleAIText(rawStrategy);
+  if (strategy.length > 0 && !isFollowUpTimingOnlyStrategy(strategy)) {
+    proposedStrategies.push(strategy);
+  }
+}
+
+function stripVisibleProposedStrategyLines(responseText: string): {
+  responseText: string;
+  visibleStrategies: string[];
+} {
+  const visibleStrategies: string[] = [];
+  const cleanedLines = responseText.split('\n').filter((line) => {
+    const match = line.match(/^\s*ProposedStrategy:\s*(.+?)\s*$/i);
+    if (!match) return true;
+    visibleStrategies.push(match[1]);
+    return false;
+  });
+
+  return {
+    responseText: cleanedLines.join('\n').trim(),
+    visibleStrategies,
+  };
+}
+
 /**
  * Parse the micro-tag response format.
  * Extracts semantic blocks and flags from the raw AI response.
@@ -123,6 +163,9 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
     });
   }
 
+  const strippedVisibleStrategies = stripVisibleProposedStrategyLines(responseText);
+  responseText = strippedVisibleStrategies.responseText;
+
   // 3. Extract flags from thinking string (no JSON needed!)
   const offerFeelHeardCheck = /FeelHeardCheck:\s*Y/i.test(thinking);
   const offerReadyToShare = /ReadyShare:\s*Y/i.test(thinking);
@@ -132,10 +175,10 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
   const strategyRegex = /ProposedStrategy:\s*(.+)/gi;
   let strategyMatch: RegExpExecArray | null;
   while ((strategyMatch = strategyRegex.exec(thinking)) !== null) {
-    const strategy = cleanVisibleAIText(strategyMatch[1]);
-    if (strategy.length > 0) {
-      proposedStrategies.push(strategy);
-    }
+    addProposedStrategy(proposedStrategies, strategyMatch[1]);
+  }
+  for (const visibleStrategy of strippedVisibleStrategies.visibleStrategies) {
+    addProposedStrategy(proposedStrategies, visibleStrategy);
   }
 
   const needRegex = /ProposedNeed:\s*([^|]+)\|([^|]+)\|(.+)/gi;

--- a/backend/src/utils/strategy-dedupe.ts
+++ b/backend/src/utils/strategy-dedupe.ts
@@ -11,13 +11,17 @@ function normalizeStrategy(value: string): string[] {
     .filter((word) => word.length > 2);
 }
 
+function isMoreSpecificStrategy(existing: string, next: string): boolean {
+  return normalizeStrategy(next).length >= normalizeStrategy(existing).length;
+}
+
 export function isSupersededStrategy(existing: string, next: string): boolean {
   const existingWords = new Set(normalizeStrategy(existing));
   const nextWords = new Set(normalizeStrategy(next));
   if (existingWords.size === 0 || nextWords.size === 0) return false;
   const intersection = [...existingWords].filter((word) => nextWords.has(word)).length;
   const smallerSetSize = Math.min(existingWords.size, nextWords.size);
-  return intersection / smallerSetSize >= 0.65;
+  return intersection / smallerSetSize >= 0.65 && isMoreSpecificStrategy(existing, next);
 }
 
 export function filterNewStrategiesAgainstExisting(

--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -326,8 +326,10 @@ export function NeedsDrawer({
               }}
               activeOpacity={0.7}
               testID={`${testID}-not-valid-yet`}
+              accessibilityRole="button"
+              accessibilityLabel="Needs not reviewed yet"
             >
-              <Text style={styles.secondaryButtonText}>Not valid yet</Text>
+              <Text style={styles.secondaryButtonText}>Not reviewed yet</Text>
             </TouchableOpacity>
           )}
           {onValidateNeeds && (
@@ -339,6 +341,8 @@ export function NeedsDrawer({
               }}
               activeOpacity={0.7}
               testID={`${testID}-validate-needs`}
+              accessibilityRole="button"
+              accessibilityLabel="Validate needs"
             >
               <Text style={styles.primaryButtonText}>Validate needs</Text>
             </TouchableOpacity>

--- a/mobile/src/components/OverlapReveal.tsx
+++ b/mobile/src/components/OverlapReveal.tsx
@@ -30,6 +30,8 @@ interface OverlapRevealProps {
   onCreateAgreement?: (strategy: { id: string; description: string }) => void;
   /** Whether to disable the next-step button (max agreements reached) */
   disableCreate?: boolean;
+  /** Strategy ids that already have a proposed or confirmed next step */
+  existingAgreementStrategyIds?: string[];
 }
 
 // ============================================================================
@@ -51,9 +53,11 @@ export function OverlapReveal({
   uniqueToPartner,
   onCreateAgreement,
   disableCreate,
+  existingAgreementStrategyIds = [],
 }: OverlapRevealProps) {
   const hasOverlap = overlapping.length > 0;
   const hasUnique = uniqueToMe.length > 0 || uniqueToPartner.length > 0;
+  const existingAgreementStrategyIdSet = new Set(existingAgreementStrategyIds);
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -65,29 +69,37 @@ export function OverlapReveal({
       {hasOverlap && (
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Both Marked Worth Discussing</Text>
-          {overlapping.map((strategy) => (
-            <View key={strategy.id}>
-              <StrategyCard strategy={strategy} isOverlap />
-              {onCreateAgreement && (
-                <>
-                  <TouchableOpacity
-                    style={[styles.createAgreementButton, disableCreate && styles.createAgreementButtonDisabled]}
-                    onPress={() => !disableCreate && onCreateAgreement({ id: strategy.id, description: strategy.description })}
-                    accessibilityRole="button"
-                    accessibilityLabel={`Use as next step: ${strategy.description}`}
-                    accessibilityState={{ disabled: disableCreate }}
-                    testID="create-agreement-button"
-                    disabled={disableCreate}
-                  >
-                    <Text style={[styles.createAgreementText, disableCreate && styles.createAgreementTextDisabled]}>Use as Next Step</Text>
-                  </TouchableOpacity>
-                  {disableCreate && (
-                    <Text style={styles.maxAgreementsText}>You can choose up to 2 next steps per session.</Text>
-                  )}
-                </>
-              )}
-            </View>
-          ))}
+          {overlapping.map((strategy) => {
+            const hasExistingAgreement = existingAgreementStrategyIdSet.has(strategy.id);
+            const createDisabled = disableCreate || hasExistingAgreement;
+
+            return (
+              <View key={strategy.id}>
+                <StrategyCard strategy={strategy} isOverlap />
+                {onCreateAgreement && !hasExistingAgreement && (
+                  <>
+                    <TouchableOpacity
+                      style={[styles.createAgreementButton, createDisabled && styles.createAgreementButtonDisabled]}
+                      onPress={() => !createDisabled && onCreateAgreement({ id: strategy.id, description: strategy.description })}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Use as next step: ${strategy.description}`}
+                      accessibilityState={{ disabled: createDisabled }}
+                      testID="create-agreement-button"
+                      disabled={createDisabled}
+                    >
+                      <Text style={[styles.createAgreementText, createDisabled && styles.createAgreementTextDisabled]}>Use as Next Step</Text>
+                    </TouchableOpacity>
+                    {disableCreate && (
+                      <Text style={styles.maxAgreementsText}>You can choose up to 2 next steps per session.</Text>
+                    )}
+                  </>
+                )}
+                {hasExistingAgreement && (
+                  <Text style={styles.existingAgreementText}>Next step already proposed.</Text>
+                )}
+              </View>
+            );
+          })}
         </View>
       )}
 
@@ -168,6 +180,13 @@ const styles = StyleSheet.create({
     opacity: 0.8,
   },
   maxAgreementsText: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    textAlign: 'center',
+    marginBottom: 12,
+    marginTop: -4,
+  },
+  existingAgreementText: {
     fontSize: 13,
     color: colors.textSecondary,
     textAlign: 'center',

--- a/mobile/src/components/__tests__/NeedsDrawer.test.tsx
+++ b/mobile/src/components/__tests__/NeedsDrawer.test.tsx
@@ -48,6 +48,25 @@ describe('NeedsDrawer', () => {
     expect(screen.getByText('Review both needs lists side by side, then validate whether they feel accurate.')).toBeTruthy();
   });
 
+  it('uses neutral copy and accessibility labels for reveal actions', () => {
+    render(
+      <NeedsDrawer
+        visible
+        onClose={jest.fn()}
+        mode="reveal"
+        needs={needs}
+        partnerNeeds={partnerNeeds}
+        onValidateNeeds={jest.fn()}
+        onNeedsNotValidYet={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Not reviewed yet')).toBeTruthy();
+    expect(screen.queryByText('Not valid yet')).toBeNull();
+    expect(screen.getByLabelText('Needs not reviewed yet')).toBeTruthy();
+    expect(screen.getByLabelText('Validate needs')).toBeTruthy();
+  });
+
   it('validates the side-by-side needs reveal from reveal mode', () => {
     const onValidateNeeds = jest.fn();
     const onNeedsNotValidYet = jest.fn();

--- a/mobile/src/components/__tests__/OverlapReveal.test.tsx
+++ b/mobile/src/components/__tests__/OverlapReveal.test.tsx
@@ -144,4 +144,19 @@ describe('OverlapReveal', () => {
 
     expect(screen.queryByText(/different preferences/i)).toBeNull();
   });
+
+  it('hides the create next-step button for strategies that already have agreements', () => {
+    render(
+      <OverlapReveal
+        overlapping={[overlappingStrategies[0]]}
+        uniqueToMe={[]}
+        uniqueToPartner={[]}
+        onCreateAgreement={jest.fn()}
+        existingAgreementStrategyIds={['strategy-1']}
+      />
+    );
+
+    expect(screen.queryByTestId('create-agreement-button')).toBeNull();
+    expect(screen.getByText('Next step already proposed.')).toBeTruthy();
+  });
 });

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -1940,13 +1940,17 @@ export function useCreateAgreement(
         request
       );
     },
-    onSuccess: (data, { sessionId }) => {
+    onSuccess: (data, { sessionId, strategyId }) => {
       queryClient.setQueryData<{ agreements: AgreementDTO[] }>(
         stageKeys.agreements(sessionId),
         (old) => {
           const existing = old?.agreements ?? [];
-          const withoutDuplicate = existing.filter((a) => a.id !== data.agreement.id);
-          return { agreements: [...withoutDuplicate, data.agreement] };
+          const agreement = {
+            ...data.agreement,
+            strategyId: data.agreement.strategyId ?? strategyId ?? null,
+          };
+          const withoutDuplicate = existing.filter((a) => a.id !== agreement.id);
+          return { agreements: [...withoutDuplicate, agreement] };
         }
       );
       queryClient.setQueryData<GetStrategiesResponse>(
@@ -1956,7 +1960,10 @@ export function useCreateAgreement(
           : old
       );
       queryClient.refetchQueries({ queryKey: stageKeys.agreements(sessionId) });
+      queryClient.refetchQueries({ queryKey: stageKeys.strategies(sessionId) });
+      queryClient.refetchQueries({ queryKey: stageKeys.strategiesReveal(sessionId) });
       queryClient.refetchQueries({ queryKey: stageKeys.progress(sessionId) });
+      queryClient.refetchQueries({ queryKey: sessionKeys.state(sessionId) });
     },
     ...options,
   });

--- a/mobile/src/screens/StrategicRepairScreen.tsx
+++ b/mobile/src/screens/StrategicRepairScreen.tsx
@@ -649,6 +649,7 @@ export function StrategicRepairScreen() {
           uniqueToMe={[]}
           uniqueToPartner={[]}
           onCreateAgreement={handleCreateAgreementFromOverlap}
+          existingAgreementStrategyIds={agreements.map((a) => a.strategyId).filter((id): id is string => typeof id === 'string')}
         />
       </SafeAreaView>
     );

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -2210,6 +2210,7 @@ export function UnifiedSessionScreen({
               uniqueToPartner={[]}
               onCreateAgreement={handleCreateAgreementFromOverlap}
               disableCreate={agreements.length >= MAX_AGREEMENTS}
+              existingAgreementStrategyIds={agreements.map((a) => a.strategyId).filter((id): id is string => typeof id === 'string')}
             />
             <TouchableOpacity style={styles.closeOverlay} onPress={closeOverlay}>
               <Text style={styles.closeOverlayText}>Continue</Text>
@@ -2830,6 +2831,7 @@ export function UnifiedSessionScreen({
             uniqueToMe={[]}
             uniqueToPartner={[]}
             onCreateAgreement={handleCreateAgreementFromOverlap}
+            existingAgreementStrategyIds={agreements.map((a) => a.strategyId).filter((id): id is string => typeof id === 'string')}
           />
         ) : (
           <WaitingRoom

--- a/shared/src/dto/strategy.ts
+++ b/shared/src/dto/strategy.ts
@@ -109,6 +109,7 @@ export type RevealOverlapResponse = {
 
 export interface AgreementDTO {
   id: string;
+  strategyId?: string | null;
   description: string;
   type?: AgreementType;
   duration: string | null;


### PR DESCRIPTION
## Summary

- strip leaked `ProposedStrategy:` extraction markers from user-visible AI text while preserving strategy capture
- filter follow-up timing out of rankable strategy proposals and avoid replacing specific proposals with broader later drafts
- return agreement `strategyId`s and use them on mobile to hide overlap next-step CTAs that already have an agreement
- refresh agreement, strategy, reveal, progress, and session-state caches after agreement creation
- rename the Stage 3 reveal fallback action to `Not reviewed yet` and add accessibility labels

## Validation

- `npm --workspace backend test -- --runInBand src/utils/__tests__/micro-tag-parser.test.ts src/utils/__tests__/strategy-dedupe.test.ts src/routes/__tests__/stage4.test.ts`
- `npm --workspace mobile test -- --runInBand src/components/__tests__/NeedsDrawer.test.tsx src/components/__tests__/OverlapReveal.test.tsx src/hooks/__tests__/useStages.test.ts src/utils/__tests__/realtimeInvalidation.test.ts`
- `npm --workspace backend run check`
- `npm --workspace mobile run check`
- `npm --workspace shared run check`
- `git diff --check`

Note: the selected mobile Jest tests passed, but Jest emitted the existing open-handle warning and had to be stopped after reporting success.
