### PR TITLE
fix(sessions): 404 for missing sessions, stop client retry flood (#323)

### DIFF
--- a/backend/src/middleware/__tests__/auth.test.ts
+++ b/backend/src/middleware/__tests__/auth.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
-import { requireAuth, optionalAuth, getUser } from '../auth';
+import { requireAuth, optionalAuth, getUser, requireSessionAccess } from '../auth';
+import { ForbiddenError, NotFoundError } from '../errors';
 import { prisma } from '../../lib/prisma';
 
 // Mock Prisma
@@ -456,6 +457,66 @@ describe('Auth Middleware', () => {
       expect(mockVerifyToken).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalled();
       expect(req.user).toEqual(e2eUser);
+    });
+  });
+
+  describe('requireSessionAccess', () => {
+    const user = {
+      id: 'user-1',
+      clerkId: 'clerk-1',
+      email: 'a@b.com',
+      name: null,
+      firstName: null,
+      lastName: null,
+      pushToken: null,
+      biometricEnabled: false,
+      biometricEnrolledAt: null,
+      lastMoodIntensity: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('passes when user is a relationship member', async () => {
+      (prisma.session.findFirst as jest.Mock).mockResolvedValueOnce({ id: 'sess-1' });
+      const req = createMockRequest({ user, params: { id: 'sess-1' } });
+      const { res } = createMockResponse();
+      const next = jest.fn();
+      await requireSessionAccess(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledWith();
+    });
+
+    it('throws NotFoundError when session does not exist', async () => {
+      (prisma.session.findFirst as jest.Mock).mockResolvedValueOnce(null);
+      (prisma.session.findUnique as jest.Mock).mockResolvedValueOnce(null);
+      const req = createMockRequest({ user, params: { id: 'missing' } });
+      const { res } = createMockResponse();
+      const next = jest.fn();
+      await requireSessionAccess(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+    });
+
+    it('throws ForbiddenError when session exists but user has no access', async () => {
+      (prisma.session.findFirst as jest.Mock)
+        .mockResolvedValueOnce(null) // membership check
+        .mockResolvedValueOnce(null); // invitation fallback
+      (prisma.session.findUnique as jest.Mock).mockResolvedValueOnce({ id: 'sess-2' });
+      const req = createMockRequest({ user, params: { id: 'sess-2' } });
+      const { res } = createMockResponse();
+      const next = jest.fn();
+      await requireSessionAccess(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledWith(expect.any(ForbiddenError));
+    });
+
+    it('passes for invitee via invitation fallback', async () => {
+      (prisma.session.findFirst as jest.Mock)
+        .mockResolvedValueOnce(null) // membership
+        .mockResolvedValueOnce({ id: 'sess-3' }); // invitation
+      (prisma.session.findUnique as jest.Mock).mockResolvedValueOnce({ id: 'sess-3' });
+      const req = createMockRequest({ user, params: { id: 'sess-3' } });
+      const { res } = createMockResponse();
+      const next = jest.fn();
+      await requireSessionAccess(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledWith();
     });
   });
 });

--- a/backend/src/middleware/__tests__/auth.test.ts
+++ b/backend/src/middleware/__tests__/auth.test.ts
@@ -493,6 +493,7 @@ describe('Auth Middleware', () => {
       const next = jest.fn();
       await requireSessionAccess(req as Request, res as Response, next);
       expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'Session not found' }));
     });
 
     it('throws ForbiddenError when session exists but user has no access', async () => {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -6,7 +6,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
-import { UnauthorizedError, ForbiddenError } from './errors';
+import { UnauthorizedError, ForbiddenError, NotFoundError } from './errors';
 import { prisma } from '../lib/prisma';
 import { ApiResponse, ErrorCode } from '@meet-without-fear/shared';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
@@ -342,6 +342,16 @@ export async function requireSessionAccess(
     if (session) {
       next();
       return;
+    }
+
+    // Distinguish "session does not exist" from "exists but you can't access it".
+    // Without this, deleted/stale sessionIds polled by clients flood Sentry as 403s.
+    const exists = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { id: true },
+    });
+    if (!exists) {
+      throw new NotFoundError('Session not found');
     }
 
     // Fallback: allow access for invitees during the acceptance timing gap.

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -351,7 +351,7 @@ export async function requireSessionAccess(
       select: { id: true },
     });
     if (!exists) {
-      throw new NotFoundError('Session not found');
+      throw new NotFoundError('Session');
     }
 
     // Fallback: allow access for invitees during the acceptance timing gap.

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -237,17 +237,13 @@ export function useUnifiedSession(
   // Consolidated Session State (reduces initial requests from ~5 to 1)
   // Returns session, progress, messages, invitation, and compact in one request
   // -------------------------------------------------------------------------
-  const { data: stateData, isLoading: loadingState, error: stateError } = useSessionState(sessionId, {
-    retry: (failureCount, error) => {
-      // Don't retry 403s — user simply doesn't have access
-      if (error instanceof ApiClientError && error.status === 403) return false;
-      return failureCount < 3;
-    },
-  });
+  const { data: stateData, isLoading: loadingState, error: stateError } = useSessionState(sessionId);
 
-  // If the /state endpoint returns 403, the user has no access to this session.
-  // Disable all child queries to prevent hundreds of redundant 403s from polling.
-  const accessDenied = stateError instanceof ApiClientError && stateError.status === 403;
+  // If the /state endpoint returns 403 (no access) or 404 (session deleted/missing),
+  // disable all child queries to prevent hundreds of redundant errors from polling.
+  const accessDenied =
+    stateError instanceof ApiClientError &&
+    (stateError.status === 403 || stateError.status === 404);
 
   // Extract core data from consolidated state
   const sessionData = stateData ? { session: stateData.session } : undefined;

--- a/mobile/src/providers/QueryProvider.tsx
+++ b/mobile/src/providers/QueryProvider.tsx
@@ -66,8 +66,16 @@ function createQueryClient(): QueryClient {
         // Cache data for 5 minutes
         gcTime: 5 * 60_000,
 
-        // Retry failed requests up to 3 times
-        retry: 3,
+        // Retry failed requests up to 3 times, but never on 401/403/404 —
+        // those are terminal client errors and retrying just floods Sentry.
+        retry: (failureCount, error) => {
+          if (error instanceof ApiClientError) {
+            if (error.status === 401 || error.status === 403 || error.status === 404) {
+              return false;
+            }
+          }
+          return failureCount < 3;
+        },
 
         // Exponential backoff for retries
         retryDelay: (attemptIndex) =>

--- a/mobile/src/providers/QueryProvider.tsx
+++ b/mobile/src/providers/QueryProvider.tsx
@@ -50,6 +50,15 @@ function trackNetworkError(error: unknown): void {
   }
 }
 
+function shouldRetryApiError(failureCount: number, error: unknown, maxRetries: number): boolean {
+  if (error instanceof ApiClientError) {
+    if (error.status === 401 || error.status === 403 || error.status === 404) {
+      return false;
+    }
+  }
+  return failureCount < maxRetries;
+}
+
 function createQueryClient(): QueryClient {
   return new QueryClient({
     queryCache: new QueryCache({
@@ -68,14 +77,7 @@ function createQueryClient(): QueryClient {
 
         // Retry failed requests up to 3 times, but never on 401/403/404 —
         // those are terminal client errors and retrying just floods Sentry.
-        retry: (failureCount, error) => {
-          if (error instanceof ApiClientError) {
-            if (error.status === 401 || error.status === 403 || error.status === 404) {
-              return false;
-            }
-          }
-          return failureCount < 3;
-        },
+        retry: (failureCount, error) => shouldRetryApiError(failureCount, error, 3),
 
         // Exponential backoff for retries
         retryDelay: (attemptIndex) =>
@@ -94,8 +96,8 @@ function createQueryClient(): QueryClient {
         networkMode: 'offlineFirst',
       },
       mutations: {
-        // Retry failed mutations once
-        retry: 1,
+        // Retry failed mutations once, but never on terminal client errors.
+        retry: (failureCount, error) => shouldRetryApiError(failureCount, error, 1),
 
         // Network mode for mutations
         networkMode: 'offlineFirst',


### PR DESCRIPTION
## Summary
- Backend `requireSessionAccess` now throws `NotFoundError` (404) when the session row doesn't exist, instead of `ForbiddenError` (403). PR #321's invitee fallback is preserved for the real "exists but no access" case.
- Mobile `QueryClient` defaults: never retry on 401/403/404 — these are terminal client errors, retrying just floods Sentry.
- Mobile `useUnifiedSession`: gate all 8 child queries off when `/state` returns 403 **or** 404 (was 403 only). Removed the now-redundant per-call 403-retry override.

## Why
Sentry issue [MWF-BACKEND-12](https://meet-without-fear.sentry.io/issues/7457481620/) — 880 events labeled "Access to this session denied" since May 3. The bot's earlier patches (#321 invitee fallback, #341 error renaming) held; they just weren't the right fix.

Investigation: every one of the 880 events was for the **same** session id `cmokigesd000dma1wsv7wink1`, polling 9 different session endpoints. The session does not exist in the DB. With `retry: 3` + exp backoff + `refetchOnWindowFocus`, a single client with a stale session id produced ~36 errors per app focus across all the stage-gated endpoints. The auth middleware was 403-ing missing sessions as if they were access denials.

## Changes
- `backend/src/middleware/auth.ts` — add `NotFoundError` path before invitation fallback
- `backend/src/middleware/__tests__/auth.test.ts` — 4 new unit tests (member / not-found / forbidden / invitee-fallback). All 21 auth tests pass.
- `mobile/src/providers/QueryProvider.tsx` — function-form `retry` that short-circuits on 401/403/404
- `mobile/src/hooks/useUnifiedSession.ts` — `accessDenied` covers 404; drop redundant local override

## Test plan
- [x] `npm run check` passes
- [x] `npm -w @meet-without-fear/backend test -- --testPathPattern=auth` — 21/21 pass
- [ ] Manual: open mobile app with a deleted/stale session id in cache → expect one 404 on `/state`, no waterfall of empathy/needs/strategies errors
- [ ] Sentry: confirm MWF-BACKEND-12 stops growing within 24h of deploy

## Notes
Pre-existing failures on main (circuit-breaker timing tests, 7 mobile suites) are unrelated and reproduce without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)