### PR TITLE
[codex] Fix stale sweeper follow-ups

### DIFF
--- a/.claude/config/services.json
+++ b/.claude/config/services.json
@@ -30,6 +30,8 @@
   },
   "slack": {
     "channels": {
+      "bot-ops": "C0ASSFTB7H9",
+      "agentic-devs": "C0ATAE7QP3P",
       "most-important-thing": "C0AU9Q3DENQ",
       "daily-summary": "C0AT7EV1C4B"
     },

--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -1405,8 +1405,27 @@ export async function skipRefinement(
         willingToAccept,
       });
 
-      // Check for mutual completion
-      triggerStage3Transition(sessionId, user.id, partnerId).catch((e) => logger.error('[Stage2] Stage 3 transition failed:', e));
+      const partnerStage2Progress = await prisma.stageProgress.findUnique({
+        where: {
+          sessionId_userId_stage: {
+            sessionId,
+            userId: partnerId,
+            stage: 2,
+          },
+        },
+      });
+      const partnerGates = partnerStage2Progress?.gatesSatisfied as Record<string, unknown> | null | undefined;
+      const partnerCompletedEmpathy = partnerGates?.empathyValidated === true;
+
+      if (partnerCompletedEmpathy) {
+        triggerStage3Transition(sessionId, user.id, partnerId).catch((e) => logger.error('[Stage2] Stage 3 transition failed:', e));
+      } else {
+        logger.info('[skipRefinement] Waiting for partner Stage 2 empathy completion before Stage 3 transition', {
+          sessionId,
+          userId: user.id,
+          partnerId,
+        });
+      }
     }
 
     successResponse(res, { success: true });

--- a/backend/src/routes/__tests__/stage2.test.ts
+++ b/backend/src/routes/__tests__/stage2.test.ts
@@ -779,6 +779,9 @@ describe('Validation Feedback Routes', () => {
       (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue({
         gatesSatisfied: {},
       });
+      (prisma.stageProgress.findUnique as jest.Mock).mockResolvedValue({
+        gatesSatisfied: { empathyValidated: false },
+      });
       (prisma.empathyValidation.upsert as jest.Mock).mockResolvedValue({});
       (prisma.stageProgress.update as jest.Mock).mockResolvedValue({});
 
@@ -791,6 +794,41 @@ describe('Validation Feedback Routes', () => {
         })
       );
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    });
+
+    it('does not advance to Stage 3 until partner has completed Stage 2 empathy', async () => {
+      const req = mockRequest({
+        body: { willingToAccept: true },
+      });
+      const res = mockResponse();
+
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.empathyAttempt.findFirst as jest.Mock).mockResolvedValue({ id: 'attempt-1' });
+      (prisma.empathyValidation.upsert as jest.Mock).mockResolvedValue({});
+      (prisma.empathyAttempt.update as jest.Mock).mockResolvedValue({});
+      (prisma.stageProgress.update as jest.Mock).mockResolvedValue({});
+      (prisma.stageProgress.findUnique as jest.Mock).mockResolvedValue({
+        gatesSatisfied: { empathyValidated: false },
+      });
+
+      await skipRefinement(req, res);
+      await Promise.resolve();
+
+      expect(prisma.stageProgress.findUnique).toHaveBeenCalledWith({
+        where: {
+          sessionId_userId_stage: {
+            sessionId: 'session-123',
+            userId: 'partner-1',
+            stage: 2,
+          },
+        },
+      });
+      expect(prisma.user.findMany).not.toHaveBeenCalled();
+      expect(publishSessionEvent).not.toHaveBeenCalledWith(
+        'session-123',
+        'stage.progress',
+        expect.anything()
+      );
     });
 
     it('records refusal', async () => {
@@ -806,6 +844,9 @@ describe('Validation Feedback Routes', () => {
       (prisma.empathyAttempt.update as jest.Mock).mockResolvedValue({});
       (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue({
         gatesSatisfied: {},
+      });
+      (prisma.stageProgress.findUnique as jest.Mock).mockResolvedValue({
+        gatesSatisfied: { empathyValidated: false },
       });
       (prisma.empathyValidation.upsert as jest.Mock).mockResolvedValue({});
 

--- a/backend/src/services/__tests__/dispatch-handler.test.ts
+++ b/backend/src/services/__tests__/dispatch-handler.test.ts
@@ -38,6 +38,14 @@ describe('dispatch-handler', () => {
       expect(result).toContain('Things to Remember');
     });
 
+    it('returns retry guidance for safety concern tags', async () => {
+      const result = await handleDispatch('SAFETY_CONCERN_MENTAL_HEALTH_CRISIS', mockContext);
+
+      expect(result).toContain("I'm sorry");
+      expect(result).toContain('safety-sensitive');
+      expect(result).toContain('try again');
+    });
+
     it('returns null for unknown dispatch tag (falls through to original AI response)', async () => {
       const result = await handleDispatch('UNKNOWN_TAG', mockContext);
 

--- a/backend/src/services/dispatch-handler.ts
+++ b/backend/src/services/dispatch-handler.ts
@@ -116,6 +116,13 @@ export async function handleDispatch(
 Is there something specific you'd like to note down?`;
 
     default:
+      if (/^SAFETY_CONCERN/i.test(dispatchTag)) {
+        logger.info(`[Dispatch Handler] Routing safety tag "${dispatchTag}" to retry guidance`);
+        return `I'm sorry, I had trouble responding to that safely. Something in the wording appears to touch on safety-sensitive harm, crisis, or risk, so I paused instead of guessing.
+
+Could you try again with a little more concrete context and less shorthand? For example, name what happened, who is currently safe or unsafe, and what kind of help you want from me right now.`;
+      }
+
       // Sharing/process-related tags the AI freelances (e.g. EXPLAIN_WHAT_WAS_SHARED,
       // SHOW_SHARING_HISTORY, CLARIFY_SHARE_HISTORY) — route to the process explainer
       // rather than falling through to an empty response (issue #312).

--- a/scripts/ec2-bot/configure-slack.sh
+++ b/scripts/ec2-bot/configure-slack.sh
@@ -15,7 +15,11 @@ read -rsp "Bot User OAuth Token (xoxb-...): " SLACK_BOT_TOKEN; echo
 read -rsp "App-Level Token (xapp-...):      " SLACK_APP_TOKEN; echo
 read -rp  "DM channel ID (D...):                " SHANTAM_SLACK_DM
 read -rp  "#slam-bot channel ID (C...):         " SLAM_BOT_CHANNEL_ID
+read -rp  "#bot-ops channel ID (C...):          " BOT_OPS_CHANNEL_ID
+read -rp  "#agentic-devs channel ID (C...):     " AGENTIC_DEVS_CHANNEL_ID
+read -rp  "#daily-summary channel ID (C...):    " DAILY_SUMMARY_CHANNEL_ID
 read -rp  "#bugs-and-requests channel ID (C...):" BUGS_AND_REQUESTS_CHANNEL_ID
+read -rp  "#most-important-thing channel ID (C...):" MOST_IMPORTANT_THING_CHANNEL_ID
 
 [[ "$SLACK_BOT_TOKEN" == xoxb-* ]] || { echo "ERROR: bot token should start with xoxb-"; exit 1; }
 [[ "$SLACK_APP_TOKEN" == xapp-* ]] || { echo "ERROR: app token should start with xapp-"; exit 1; }
@@ -40,7 +44,11 @@ SLACK_APP_TOKEN=$SLACK_APP_TOKEN
 SLAM_BOT_USER_ID=$SLAM_BOT_USER_ID
 SHANTAM_SLACK_DM=$SHANTAM_SLACK_DM
 SLAM_BOT_CHANNEL_ID=$SLAM_BOT_CHANNEL_ID
+BOT_OPS_CHANNEL_ID=$BOT_OPS_CHANNEL_ID
+AGENTIC_DEVS_CHANNEL_ID=$AGENTIC_DEVS_CHANNEL_ID
+DAILY_SUMMARY_CHANNEL_ID=$DAILY_SUMMARY_CHANNEL_ID
 BUGS_AND_REQUESTS_CHANNEL_ID=$BUGS_AND_REQUESTS_CHANNEL_ID
+MOST_IMPORTANT_THING_CHANNEL_ID=$MOST_IMPORTANT_THING_CHANNEL_ID
 ENV
 
 scp -q "$TMP" slam-bot:/tmp/slack-env.new
@@ -49,7 +57,7 @@ shred -u "$TMP" 2>/dev/null || rm -f "$TMP"
 ssh slam-bot bash <<'REMOTE'
 set -e
 # Strip any prior Slack keys from existing .env, then append the new ones
-grep -vE '^(SLACK_BOT_TOKEN|SLACK_APP_TOKEN|SLAM_BOT_USER_ID|SHANTAM_SLACK_DM|SLAM_BOT_CHANNEL_ID|BUGS_AND_REQUESTS_CHANNEL_ID)=' /opt/slam-bot/.env > /tmp/.env.base 2>/dev/null || touch /tmp/.env.base
+grep -vE '^(SLACK_BOT_TOKEN|SLACK_APP_TOKEN|SLAM_BOT_USER_ID|SHANTAM_SLACK_DM|SLAM_BOT_CHANNEL_ID|BOT_OPS_CHANNEL_ID|AGENTIC_DEVS_CHANNEL_ID|DAILY_SUMMARY_CHANNEL_ID|BUGS_AND_REQUESTS_CHANNEL_ID|MOST_IMPORTANT_THING_CHANNEL_ID)=' /opt/slam-bot/.env > /tmp/.env.base 2>/dev/null || touch /tmp/.env.base
 cat /tmp/.env.base /tmp/slack-env.new > /opt/slam-bot/.env
 chmod 600 /opt/slam-bot/.env
 rm -f /tmp/.env.base /tmp/slack-env.new

--- a/scripts/ec2-bot/scripts/lib/config.sh
+++ b/scripts/ec2-bot/scripts/lib/config.sh
@@ -61,6 +61,11 @@ HARD_CAP_MIN="${HARD_CAP_MIN:-45}"
 
 # ── Slack ───────────────────────────────────────────────────────────────────
 BOT_OPS_CHANNEL_ID="${BOT_OPS_CHANNEL_ID:-}"
+AGENTIC_DEVS_CHANNEL_ID="${AGENTIC_DEVS_CHANNEL_ID:-}"
+DAILY_SUMMARY_CHANNEL_ID="${DAILY_SUMMARY_CHANNEL_ID:-}"
+MOST_IMPORTANT_THING_CHANNEL_ID="${MOST_IMPORTANT_THING_CHANNEL_ID:-}"
+BUGS_AND_REQUESTS_CHANNEL_ID="${BUGS_AND_REQUESTS_CHANNEL_ID:-}"
+SLAM_BOT_CHANNEL_ID="${SLAM_BOT_CHANNEL_ID:-}"
 
 # ── Heartbeats ──────────────────────────────────────────────────────────────
 HEARTBEAT_DIR="${HEARTBEAT_DIR:-${BOT_STATE_DIR}/heartbeats}"

--- a/scripts/ec2-bot/scripts/stale-sweeper.sh
+++ b/scripts/ec2-bot/scripts/stale-sweeper.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/lib/shared.sh"
 LOGFILE="$BOT_LOG_DIR/stale-sweeper.log"
 REPO="$GITHUB_REPO"
 SLACK_SCRIPT="$BOT_SCRIPTS_DIR/slack-post.sh"
-AGENTIC_DEVS="C0AM2J47R4L"
+AGENTIC_DEVS="${AGENTIC_DEVS_CHANNEL_ID:-C0ATAE7QP3P}"
 STALE_HOURS=24
 
 # Labels that exempt items from sweeping


### PR DESCRIPTION
## Summary

- Fix #296 follow-ups by preventing `skipRefinement()` from advancing both users to Stage 3 until the partner's Stage 2 empathy gate is complete.
- Add explicit retry guidance for `SAFETY_CONCERN_*` dispatch tags so safety-tag-only responses do not collapse into generic empty-response errors.
- Fix #50 routing drift by adding bot-ops / agentic-devs channel config and removing the stale hardcoded stale-sweeper #agentic-devs ID.

## Validation

- `bash -n scripts/ec2-bot/configure-slack.sh scripts/ec2-bot/scripts/lib/config.sh scripts/ec2-bot/scripts/stale-sweeper.sh`
- `npm test -- --runTestsByPath src/services/__tests__/dispatch-handler.test.ts src/routes/__tests__/stage2.test.ts --runInBand` (backend)

## Notes

This PR intentionally excludes existing unrelated mobile/shared/docs working-tree changes.
