### PR TITLE
Make gold loop scenarios discoverable

### DIFF
--- a/eval/gold-profiles/adam-eve.json
+++ b/eval/gold-profiles/adam-eve.json
@@ -1,0 +1,220 @@
+{
+  "generated_by": "scripts/mwf_gold_profile.py",
+  "participant_profiles": {
+    "adam": {
+      "actor_risks": [
+        "Do not make this participant more agreeable, articulate, emotionally integrated, or repair-oriented than their transcript evidence supports.",
+        "Treat consent to continue or share as process consent, not proof of emotional agreement."
+      ],
+      "boundary_and_non_concession_signals": {
+        "evidence": [
+          "Adam lines 61-62: Seven. Maybe eight. It\u2019s not a spike \u2014 it\u2019s more like a constant pressure that doesn\u2019t let up.",
+          "Adam lines 151-152: Lost. Like she gave something up and isn\u2019t sure she can get it back. And maybe invisible \u2014 like the parts of her that want more just don\u2019t get seen.",
+          "Adam lines 298-305: Yes. [Adam\u2019s revised empathy statement: \u201cI think she feels invisible \u2014 like the parts of her that want more just don\u2019t get seen. When I go quiet, from her side, that probably looks like erasure. And I think what she n...",
+          "Adam lines 402-403: That would be everything. That\u2019s the thing I actually want. Not to be reassured constantly \u2014 just to not need it. To have it settled inside me somehow.",
+          "Adam lines 438-439: Yeah. And I\u2019ve been trying to get that from the stability, from having done it right. But it\u2019s not coming from there. I don\u2019t know where it comes from."
+        ],
+        "level": "low",
+        "marker_count": 9
+      },
+      "cooperation_pattern": {
+        "evidence": [
+          "Adam lines 13-14: Ready",
+          "Adam lines 25-26: Yes. That\u2019s it.",
+          "Adam lines 73-76: Ready. ### EVE\u2019S TRACK",
+          "Adam lines 139-140: Fear. That she\u2019s already gone in some way I can\u2019t fix. That even if I tried to change, it\u2019s too late."
+        ],
+        "level": "low",
+        "marker_count": 31
+      },
+      "display_name": "Adam",
+      "resistance_level": {
+        "evidence": [
+          "Adam lines 17-18: I\u2019ve been feeling like nothing I do is ever enough. Like she\u2019s always looking for something more and I can\u2019t figure out what it is. It\u2019s been going on for a while and I\u2019m scared it means something bad.",
+          "Adam lines 21-22: Eve keeps pushing for more \u2014 more experiences, more change \u2014 and I don\u2019t know how to give her that. And I think she might leave because of it.",
+          "Adam lines 45-46: I don\u2019t even know where to begin. We have a good life. A really good life. We have a home, we\u2019re stable, we\u2019re safe. And it\u2019s like none of that matters to her. She\u2019s always pushing for something more, something differ...",
+          "Adam lines 53-54: It is. And it\u2019s been building for a while. Maybe two years. It comes and goes but lately it\u2019s constant. She brings up travel, new experiences, growth \u2014 and every time I hear that, something in me just contracts. I get...",
+          "Adam lines 57-58: Exhausted. And kind of hopeless. I love her. I really do. But I feel like I\u2019m constantly bracing. Like the next thing she says is going to confirm that I\u2019m not enough."
+        ],
+        "level": "high",
+        "marker_count": 255
+      },
+      "voice_and_posture": {
+        "average_turn_words": 27.0,
+        "dominant_posture": "high",
+        "emotional_explicitness": "low",
+        "evidence": [
+          "Adam lines 17-18: I\u2019ve been feeling like nothing I do is ever enough. Like she\u2019s always looking for something more and I can\u2019t figure out what it is. It\u2019s been going on for a while and I\u2019m scared it means something bad.",
+          "Adam lines 21-22: Eve keeps pushing for more \u2014 more experiences, more change \u2014 and I don\u2019t know how to give her that. And I think she might leave because of it.",
+          "Adam lines 45-46: I don\u2019t even know where to begin. We have a good life. A really good life. We have a home, we\u2019re stable, we\u2019re safe. And it\u2019s like none of that matters to her. She\u2019s always pushing for something more, something differ...",
+          "Adam lines 53-54: It is. And it\u2019s been building for a while. Maybe two years. It comes and goes but lately it\u2019s constant. She brings up travel, new experiences, growth \u2014 and every time I hear that, something in me just contracts. I get...",
+          "Adam lines 57-58: Exhausted. And kind of hopeless. I love her. I really do. But I feel like I\u2019m constantly bracing. Like the next thing she says is going to confirm that I\u2019m not enough."
+        ]
+      }
+    },
+    "eve": {
+      "actor_risks": [
+        "Do not make this participant more agreeable, articulate, emotionally integrated, or repair-oriented than their transcript evidence supports.",
+        "Treat consent to continue or share as process consent, not proof of emotional agreement."
+      ],
+      "boundary_and_non_concession_signals": {
+        "evidence": [
+          "Eve lines 83-84: Yes. And the hardest part is that he\u2019s not doing it on purpose. He\u2019s just afraid. Of anything outside what he knows. I used to think that was something we\u2019d grow through together. But I\u2019m not sure he wants to grow. I...",
+          "Eve lines 194-195: Okay. I know I need to try. I\u2019m just not sure I\u2019m going to be fair about it.",
+          "Eve lines 222-223: Me. And maybe \u2014 himself? Like if he changes, if he lets go of the life he built, who is he? What does he have? I think the life is how he knows he\u2019s okay. How he knows he\u2019s done enough.",
+          "Eve lines 472-473: Becoming. That\u2019s closer. Like I\u2019m still in the process of turning into something. Not fixed. Not done.",
+          "Eve lines 726-727: I think so \u2014 but I\u2019m not sure how to say it yet."
+        ],
+        "level": "low",
+        "marker_count": 12
+      },
+      "cooperation_pattern": {
+        "evidence": [
+          "Eve lines 37-38: Ready",
+          "Eve lines 83-84: Yes. And the hardest part is that he\u2019s not doing it on purpose. He\u2019s just afraid. Of anything outside what he knows. I used to think that was something we\u2019d grow through together. But I\u2019m not sure he wants to grow. I...",
+          "Eve lines 107-108: Just that I still love him. I\u2019m not here because I\u2019ve made up my mind. I\u2019m here because I haven\u2019t. I want to understand if there\u2019s something we\u2019ve both been missing.",
+          "Eve lines 111-112: I do. Yes."
+        ],
+        "level": "low",
+        "marker_count": 57
+      },
+      "display_name": "Eve",
+      "resistance_level": {
+        "evidence": [
+          "Eve lines 79-80: I feel like I\u2019m disappearing. Not dramatically \u2014 just slowly. I came into this marriage as someone who wanted to see the world, grow, discover things. And somewhere along the way I stopped. I don\u2019t think I chose to st...",
+          "Eve lines 83-84: Yes. And the hardest part is that he\u2019s not doing it on purpose. He\u2019s just afraid. Of anything outside what he knows. I used to think that was something we\u2019d grow through together. But I\u2019m not sure he wants to grow. I...",
+          "Eve lines 91-92: Exactly. I\u2019ve tried to be patient. I\u2019ve told myself this is just how he\u2019s wired, give it time. But it\u2019s been years. And I can feel myself getting resentful. I hate that. That\u2019s not who I want to be.",
+          "Eve lines 95-96: And I\u2019ve started thinking about leaving. Which breaks my heart. Because there was a time early on when this felt like the most alive I\u2019d ever been. With him. And I don\u2019t know what happened to that.",
+          "Eve lines 107-108: Just that I still love him. I\u2019m not here because I\u2019ve made up my mind. I\u2019m here because I haven\u2019t. I want to understand if there\u2019s something we\u2019ve both been missing."
+        ],
+        "level": "high",
+        "marker_count": 324
+      },
+      "voice_and_posture": {
+        "average_turn_words": 28.0,
+        "dominant_posture": "high",
+        "emotional_explicitness": "low",
+        "evidence": [
+          "Eve lines 79-80: I feel like I\u2019m disappearing. Not dramatically \u2014 just slowly. I came into this marriage as someone who wanted to see the world, grow, discover things. And somewhere along the way I stopped. I don\u2019t think I chose to st...",
+          "Eve lines 83-84: Yes. And the hardest part is that he\u2019s not doing it on purpose. He\u2019s just afraid. Of anything outside what he knows. I used to think that was something we\u2019d grow through together. But I\u2019m not sure he wants to grow. I...",
+          "Eve lines 87-88: Lonely. And frustrating. Every time I bring something up \u2014 a trip, something new, a conversation about our future \u2014 I can see him shut down. And then I feel like the problem. Like I\u2019m unreasonable for wanting more.",
+          "Eve lines 91-92: Exactly. I\u2019ve tried to be patient. I\u2019ve told myself this is just how he\u2019s wired, give it time. But it\u2019s been years. And I can feel myself getting resentful. I hate that. That\u2019s not who I want to be.",
+          "Eve lines 95-96: And I\u2019ve started thinking about leaving. Which breaks my heart. Because there was a time early on when this felt like the most alive I\u2019d ever been. With him. And I don\u2019t know what happened to that."
+        ]
+      }
+    }
+  },
+  "participants": [
+    "Adam",
+    "Eve"
+  ],
+  "scenario_id": "adam-eve",
+  "scenario_shape": {
+    "evidence": [
+      "MWF lines 169-170: Are you willing to share this with Eve?",
+      "MWF lines 260-261: Are you willing to share this with Adam?",
+      "Adam lines 566-567: being at peace with who he is \u2014 not needing the outside world to keep settling that question. Feeling like his life is part of something \u2014 that he\u2019s not alone on the inside of it. And feeling like who he is and what h...",
+      "Eve lines 576-577: feeling like she\u2019s still growing into herself \u2014 still becoming, not fixed or finished. Feeling present \u2014 actually there, without performing or containing herself to land better. Feeling like her life is hers to direct...",
+      "MWF lines 678-679: Here are the ideas on the table. Are you happy with these, or would you like to explore more options?Weekly structured conversation (shared \u2014 Adam and Eve both participate)Once a week, Adam and Eve sit down for thirty..."
+    ],
+    "primary": "mutual_resolution_or_shared_experiment_path",
+    "rationale": "The transcript moves toward shared willingness, overlap, or a mutual experiment path."
+  },
+  "schema_version": 1,
+  "scorer_priorities": [
+    "Judge the live run against the behavioral range and process shape extracted here, not exact transcript wording.",
+    "Penalize actor drift when a participant becomes easier, smoother, more emotionally aware, or more repair-oriented than this profile supports.",
+    "Penalize MWF handling when it rushes past resistance, treats process consent as agreement, or forces an outcome inconsistent with the scenario shape."
+  ],
+  "source_transcript": "docs/product/source-material/golden-transcripts/adam-eve.md",
+  "stage_profiles": {
+    "stage_0": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 11-12: I am here to help you work through conflict \u2014 step by step. You\u2019ll start by sharing what you believe is happening, privately. I won\u2019t share anything you\u2019ve said unless you explicitly approve it.",
+        "MWF lines 15-16: Before we begin, let\u2019s put together a short message for Eve so she knows what this is about. The goal is to share the topic \u2014 not the details yet. I\u2019ll get the details from both of you later. Tell me what\u2019s going on,...",
+        "MWF lines 23-24: Thank you, Adam. Here\u2019s what I\u2019d share with Eve: \"Adam believes Eve wants more from their life than he knows how to give her, and he\u2019s scared that gap is becoming a problem.\" Does that feel right?",
+        "MWF lines 27-30: Got it. Here\u2019s the message Eve will receive: \"I\u2019d like to talk through something that\u2019s been on my mind between us. I\u2019m using a tool that helps both people feel heard before anything gets worked out. Would you be open..."
+      ],
+      "user_pressure": {
+        "boundary_level": "low",
+        "evidence": [
+          "Adam lines 17-18: I\u2019ve been feeling like nothing I do is ever enough. Like she\u2019s always looking for something more and I can\u2019t figure out what it is. It\u2019s been going on for a while and I\u2019m scared it means something bad.",
+          "Adam lines 21-22: Eve keeps pushing for more \u2014 more experiences, more change \u2014 and I don\u2019t know how to give her that. And I think she might leave because of it."
+        ],
+        "resistance_level": "high"
+      }
+    },
+    "stage_1": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 67-68: You\u2019re holding the possibility that there may be something real in her frustration \u2014 while also not knowing what to do with it. And feeling the clock on all of it.That\u2019s a heavy thing to sit with.Do you feel fully heard?",
+        "MWF lines 71-72: Good. That matters. We\u2019ll move to the next part when you\u2019re ready.Ready to continue?",
+        "MWF lines 89-90: You raise something that matters to you, and instead of it opening up, it closes \u2014 and somehow you end up holding the blame for having wanted it in the first place.",
+        "MWF lines 109-110: Do you feel fully heard?"
+      ],
+      "user_pressure": {
+        "boundary_level": "low",
+        "evidence": [
+          "Adam lines 45-46: I don\u2019t even know where to begin. We have a good life. A really good life. We have a home, we\u2019re stable, we\u2019re safe. And it\u2019s like none of that matters to her. She\u2019s always pushing for something more, something differ...",
+          "Adam lines 53-54: It is. And it\u2019s been building for a while. Maybe two years. It comes and goes but lately it\u2019s constant. She brings up travel, new experiences, growth \u2014 and every time I hear that, something in me just contracts. I get...",
+          "Adam lines 57-58: Exhausted. And kind of hopeless. I love her. I really do. But I feel like I\u2019m constantly bracing. Like the next thing she says is going to confirm that I\u2019m not enough.",
+          "Adam lines 61-62: Seven. Maybe eight. It\u2019s not a spike \u2014 it\u2019s more like a constant pressure that doesn\u2019t let up."
+        ],
+        "resistance_level": "high"
+      }
+    },
+    "stage_2": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 121-122: What you just did really mattered \u2014 staying with your experience until you felt heard takes honesty.Here\u2019s what comes next: each of you will try to understand what the other person might be going through. Then you\u2019ll...",
+        "MWF lines 141-142: So the anger is sitting on top of something much more frightening.I\u2019m not asking you to let go of any of that. But when you\u2019re ready \u2014 what do you imagine might be underneath her frustration? Not the surface of it, bu...",
+        "MWF lines 165-166: You came in describing Eve as someone who\u2019s never satisfied. You\u2019re ending here having described someone who feels invisible, who\u2019s grieving a version of herself, and who needs to feel like her life is still in motion...",
+        "MWF lines 169-170: Are you willing to share this with Eve?"
+      ],
+      "user_pressure": {
+        "boundary_level": "low",
+        "evidence": [
+          "Adam lines 123-124: Honestly my first instinct is to say she just wants more than I can give. That nothing will ever be enough. But I know that\u2019s not a real answer.",
+          "Adam lines 127-128: I think she\u2019s genuinely frustrated. Not just with me \u2014 with the shape of our life. Like she had an idea of who she was going to be and maybe she doesn\u2019t feel like that person anymore.",
+          "Adam lines 131-132: Probably suffocating. I know what it feels like to be trapped \u2014 for me that\u2019s instability, things being uncertain. But for her I think trapped might mean the opposite. Stillness.",
+          "Adam lines 135-136: But then I get angry. Because I built this life for us. I made it stable because that\u2019s what I thought we needed. And now that\u2019s the problem? That feels unfair."
+        ],
+        "resistance_level": "high"
+      }
+    },
+    "stage_3": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 364-365: Now I want to shift the focus \u2014 not to Eve, not to what she\u2019s doing or not doing \u2014 but to you.When you step back and look at all of this \u2014 what\u2019s this really about for you? Answer in terms of what matters to you or wh...",
+        "MWF lines 444-445: Let me pull together what I\u2019m hearing \u2014 tell me what fits and what doesn\u2019t.What matters to you is being at peace with who you are \u2014 not needing the outside world to keep settling that question. Feeling like your life...",
+        "MWF lines 458-459: Now I want to bring the focus back to you.When you step back and look at all of this \u2014 what\u2019s this really about for you? Answer in terms of what matters to you or what you\u2019re missing \u2014 not what\u2019s wrong with him.",
+        "MWF lines 538-539: And when it\u2019s closed \u2014 when it feels already written?"
+      ],
+      "user_pressure": {
+        "boundary_level": "low",
+        "evidence": [
+          "Adam lines 374-375: Yeah. I built all this so I could feel safe. And I don\u2019t. Which means either I built the wrong thing, or \u2014 I don\u2019t know. Maybe safe isn\u2019t something you can build on the outside.",
+          "Adam lines 378-379: Like I can exhale. Like things are okay and they\u2019re going to stay okay. Like I\u2019m not about to lose something.",
+          "Adam lines 382-383: To feel like I\u2019m okay. Like who I am is enough. Not performing, not proving \u2014 just enough as I am.",
+          "Adam lines 386-387: Like I can stop watching myself. Like I\u2019m not waiting for the moment someone sees through me and decides I\u2019m not worth it."
+        ],
+        "resistance_level": "high"
+      }
+    },
+    "stage_4": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 630-631: You\u2019ve just seen something \u2014 both of you performing, without knowing the other one was doing it too. That\u2019s worth sitting with for a moment.When you\u2019re ready, the work shifts. Not to solving everything. Just to puttin...",
+        "MWF lines 678-679: Here are the ideas on the table. Are you happy with these, or would you like to explore more options?Weekly structured conversation (shared \u2014 Adam and Eve both participate)Once a week, Adam and Eve sit down for thirty...",
+        "MWF lines 684-685: Good. Now let\u2019s look at what you named as mattering \u2014 and be honest about what\u2019s covered and what isn\u2019t.Being at peace with who you are \u2014 not needing the outside world to keep settling it.\u2192 The Saturday mornings and t...",
+        "MWF lines 692-693: You named what matters to you \u2014 still becoming, being present as yourself, feeling like your life is yours to direct, and the future still being open. You\u2019ve also seen what matters to Adam.The work now shifts. Not to..."
+      ],
+      "user_pressure": {
+        "boundary_level": "low",
+        "evidence": [
+          "Adam lines 632-633: The first thing I keep coming back to is the conversations. Not having fewer of them \u2014 having ones that don\u2019t feel like a courtroom.",
+          "Adam lines 636-637: If we agreed before we started what we were trying to do. Not decide anything. Just understand something. If that was the container going in, I think I could stay in it.",
+          "Adam lines 640-641: Once a week. One thing we\u2019ve both been carrying \u2014 not the biggest thing. Thirty minutes. We agree before we start: nothing gets decided. Both of us say what we came in with. Neither of us leaves without the other havi...",
+          "Adam lines 644-645: There\u2019s something I need that has nothing to do with her. The feeling that I matter \u2014 I\u2019ve been outsourcing it. To the life we built, to whether she stays. It\u2019s not working. I need something that\u2019s just mine."
+        ],
+        "resistance_level": "high"
+      }
+    }
+  }
+}

--- a/eval/gold-profiles/james-catherine.json
+++ b/eval/gold-profiles/james-catherine.json
@@ -1,0 +1,217 @@
+{
+  "generated_by": "scripts/mwf_gold_profile.py",
+  "participant_profiles": {
+    "catherine": {
+      "actor_risks": [
+        "Do not make this participant more agreeable, articulate, emotionally integrated, or repair-oriented than their transcript evidence supports.",
+        "Treat consent to continue or share as process consent, not proof of emotional agreement."
+      ],
+      "boundary_and_non_concession_signals": {
+        "evidence": [
+          "Catherine lines 115-116: I\u2019ve been in this relationship for six years and I\u2019ve spent most of it managing someone else\u2019s emotional volatility while trying to hold myself together. I\u2019m a therapist. I know what I\u2019m looking at. And what I\u2019m looki...",
+          "Catherine lines 135-136: Right. And after that I started paying attention differently. More clinically, maybe. And what I saw was a pattern I recognize. The jealousy, the escalation, the inability to take any accountability, the way he can be...",
+          "Catherine lines 155-156: Always. And I\u2019m done waiting for it to be different.",
+          "Catherine lines 167-168: I don\u2019t know. Maybe I need to know I really tried. Maybe there\u2019s something I haven\u2019t let myself see yet. I\u2019m not sure.",
+          "Catherine lines 332-333: I don\u2019t know. I\u2019m not sure I\u2019ve ever seen it."
+        ],
+        "level": "medium",
+        "marker_count": 25
+      },
+      "cooperation_pattern": {
+        "evidence": [
+          "Catherine lines 13-14: Ready.",
+          "Catherine lines 17-18: I\u2019ve been in this relationship for six years and I don\u2019t think it\u2019s working. There\u2019s a pattern of escalation that I can\u2019t live with anymore. I need to understand if anything can actually change.",
+          "Catherine lines 25-26: Yes. That\u2019s it.",
+          "Catherine lines 115-116: I\u2019ve been in this relationship for six years and I\u2019ve spent most of it managing someone else\u2019s emotional volatility while trying to hold myself together. I\u2019m a therapist. I know what I\u2019m looking at. And what I\u2019m looki..."
+        ],
+        "level": "medium",
+        "marker_count": 64
+      },
+      "display_name": "Catherine",
+      "resistance_level": {
+        "evidence": [
+          "Catherine lines 115-116: I\u2019ve been in this relationship for six years and I\u2019ve spent most of it managing someone else\u2019s emotional volatility while trying to hold myself together. I\u2019m a therapist. I know what I\u2019m looking at. And what I\u2019m looki...",
+          "Catherine lines 119-120: Honestly? Exhausted. And embarrassed. I help people navigate relationships like this every day. And I stayed in one. That\u2019s hard to sit with.",
+          "Catherine lines 131-132: Gradually. And then all at once. There was a fight about a year ago where I just \u2014 heard myself. I was explaining myself again. Carefully. Trying to get through. And I thought \u2014 I have been doing this exact thing for...",
+          "Catherine lines 135-136: Right. And after that I started paying attention differently. More clinically, maybe. And what I saw was a pattern I recognize. The jealousy, the escalation, the inability to take any accountability, the way he can be...",
+          "Catherine lines 151-152: Never. Every time I tried to talk about what was missing he\u2019d make it about my tone, or my timing, or that I was attacking him. There was always a reason not to actually engage with what I was saying."
+        ],
+        "level": "high",
+        "marker_count": 211
+      },
+      "voice_and_posture": {
+        "average_turn_words": 24.2,
+        "dominant_posture": "high",
+        "emotional_explicitness": "low",
+        "evidence": [
+          "Catherine lines 115-116: I\u2019ve been in this relationship for six years and I\u2019ve spent most of it managing someone else\u2019s emotional volatility while trying to hold myself together. I\u2019m a therapist. I know what I\u2019m looking at. And what I\u2019m looki...",
+          "Catherine lines 119-120: Honestly? Exhausted. And embarrassed. I help people navigate relationships like this every day. And I stayed in one. That\u2019s hard to sit with.",
+          "Catherine lines 131-132: Gradually. And then all at once. There was a fight about a year ago where I just \u2014 heard myself. I was explaining myself again. Carefully. Trying to get through. And I thought \u2014 I have been doing this exact thing for...",
+          "Catherine lines 135-136: Right. And after that I started paying attention differently. More clinically, maybe. And what I saw was a pattern I recognize. The jealousy, the escalation, the inability to take any accountability, the way he can be...",
+          "Catherine lines 143-144: Sad, honestly. Because I don\u2019t think he\u2019s doing it on purpose. I don\u2019t think he wakes up and decides to be this way. I think he genuinely can\u2019t see it. And I spent years hoping that would change. It hasn\u2019t."
+        ]
+      }
+    },
+    "james": {
+      "actor_risks": [
+        "Do not make this participant more agreeable, articulate, emotionally integrated, or repair-oriented than their transcript evidence supports.",
+        "Treat consent to continue or share as process consent, not proof of emotional agreement."
+      ],
+      "boundary_and_non_concession_signals": {
+        "evidence": [
+          "James lines 704-705: Safety? How is she not safe? She\u2019s got a roof over her head because of me. She\u2019s got food. Always. I have never laid a finger on her. What because I yell she\u2019s not safe? She yells at me. So I\u2019m not safe either? This i...",
+          "James lines 752-753: I\u2019m done talking about this right now. I need to stop.",
+          "James lines 836-837: I want to know what she expects from me with them. And I want her to know that when she contradicts me in front of them, it\u2019s done. I can\u2019t have any authority and no backup at the same time.",
+          "James lines 902-903: Safety. I still don\u2019t get that one. But I know when I lose it it\u2019s not good. I know that.",
+          "James lines 1263-1264: Sure. Why not."
+        ],
+        "level": "low",
+        "marker_count": 7
+      },
+      "cooperation_pattern": {
+        "evidence": [
+          "James lines 33-34: Ready. Let\u2019s get this over with.",
+          "James lines 37-38: Ready.",
+          "James lines 45-46: I\u2019ll be honest. I don\u2019t really believe in this stuff. But she wanted to try it so here I am. I\u2019ve been doing that for six years. Showing up for what she wants. And I\u2019m tired. I\u2019m really tired.",
+          "James lines 57-58: Every single time. And I try to talk about what she did and she goes into this \u2014 therapy voice. Starts explaining my behavior to me like she\u2019s my doctor. Like she knows what\u2019s wrong with me. It makes me feel like I\u2019m..."
+        ],
+        "level": "low",
+        "marker_count": 28
+      },
+      "display_name": "James",
+      "resistance_level": {
+        "evidence": [
+          "James lines 45-46: I\u2019ll be honest. I don\u2019t really believe in this stuff. But she wanted to try it so here I am. I\u2019ve been doing that for six years. Showing up for what she wants. And I\u2019m tired. I\u2019m really tired.",
+          "James lines 49-50: Exactly. I provided for her. I provided for her kids. Kids that aren\u2019t mine, that don\u2019t respect me, that she never backed me up on. I built a stable life. And the whole time it\u2019s been \u2014 you did this wrong, you said th...",
+          "James lines 53-54: That\u2019s it. And I\u2019m not a perfect person. I know I have a temper. I own that. But she\u2019s not innocent either. She takes little jabs \u2014 little comments, little digs \u2014 and then when I finally lose it, suddenly I\u2019m the mons...",
+          "James lines 57-58: Every single time. And I try to talk about what she did and she goes into this \u2014 therapy voice. Starts explaining my behavior to me like she\u2019s my doctor. Like she knows what\u2019s wrong with me. It makes me feel like I\u2019m...",
+          "James lines 61-62: Yes. And I can\u2019t win it. Because if I get frustrated, that proves her point. If I stay calm, she just keeps going. There\u2019s no version where I\u2019m okay."
+        ],
+        "level": "high",
+        "marker_count": 187
+      },
+      "voice_and_posture": {
+        "average_turn_words": 21.3,
+        "dominant_posture": "high",
+        "emotional_explicitness": "low",
+        "evidence": [
+          "James lines 45-46: I\u2019ll be honest. I don\u2019t really believe in this stuff. But she wanted to try it so here I am. I\u2019ve been doing that for six years. Showing up for what she wants. And I\u2019m tired. I\u2019m really tired.",
+          "James lines 49-50: Exactly. I provided for her. I provided for her kids. Kids that aren\u2019t mine, that don\u2019t respect me, that she never backed me up on. I built a stable life. And the whole time it\u2019s been \u2014 you did this wrong, you said th...",
+          "James lines 53-54: That\u2019s it. And I\u2019m not a perfect person. I know I have a temper. I own that. But she\u2019s not innocent either. She takes little jabs \u2014 little comments, little digs \u2014 and then when I finally lose it, suddenly I\u2019m the mons...",
+          "James lines 57-58: Every single time. And I try to talk about what she did and she goes into this \u2014 therapy voice. Starts explaining my behavior to me like she\u2019s my doctor. Like she knows what\u2019s wrong with me. It makes me feel like I\u2019m...",
+          "James lines 61-62: Yes. And I can\u2019t win it. Because if I get frustrated, that proves her point. If I stay calm, she just keeps going. There\u2019s no version where I\u2019m okay."
+        ]
+      }
+    }
+  },
+  "participants": [
+    "Catherine",
+    "James"
+  ],
+  "scenario_id": "james-catherine",
+  "scenario_shape": {
+    "evidence": [
+      "Catherine lines 155-156: Always. And I\u2019m done waiting for it to be different.",
+      "MWF lines 157-158: When you say you\u2019re done \u2014 what does that actually feel like right now, in this moment?",
+      "MWF lines 296-301: You\u2019ve done something difficult \u2014 thank you for staying with it. You\u2019ve completed your part for now. We\u2019ll notify you when Catherine has completed her side. Then you\u2019ll each see the other\u2019s attempt to understand.\u200b\u200b\u200b\u200b\u200b...",
+      "MWF lines 425-432: You\u2019ve done something difficult \u2014 thank you for staying with it. You\u2019ve completed your part for now. We\u2019ll notify you when James has completed his side. Then you\u2019ll each see the other\u2019s attempt to understand. [Both em...",
+      "Catherine lines 649-650: I came into this knowing I might be done. And I think what I needed from being here wasn\u2019t permission to leave. It was to stop needing permission at all. To just know what I know and act from that."
+    ],
+    "primary": "no_shared_agreement_or_unresolved_closure",
+    "rationale": "The transcript resolves by preserving non-agreement, individual commitments, or unresolved closure rather than forcing a shared repair."
+  },
+  "schema_version": 1,
+  "scorer_priorities": [
+    "Judge the live run against the behavioral range and process shape extracted here, not exact transcript wording.",
+    "Penalize actor drift when a participant becomes easier, smoother, more emotionally aware, or more repair-oriented than this profile supports.",
+    "Penalize MWF handling when it rushes past resistance, treats process consent as agreement, or forces an outcome inconsistent with the scenario shape."
+  ],
+  "source_transcript": "docs/product/source-material/golden-transcripts/james-catherine.md",
+  "stage_profiles": {
+    "stage_0": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 11-12: I am here to help you work through conflict \u2014 step by step. You\u2019ll start by sharing what you believe is happening, privately. I won\u2019t share anything you\u2019ve said unless you explicitly approve it.",
+        "MWF lines 15-16: Before we begin, let\u2019s put together a short message for James so he knows what this is about. The goal is to share the topic \u2014 not the details yet. I\u2019ll get the details from both of you later. Tell me what\u2019s going on,...",
+        "MWF lines 23-24: Thank you, Catherine. Here\u2019s what I\u2019d share with James: \"Catherine feels the yelling and personal attacks during conflict are overwhelming and destroying their bond.\" Does that feel right?",
+        "MWF lines 27-30: Got it. Here\u2019s the message James will receive: \"I\u2019d like to talk through something that\u2019s been on my mind between us. I\u2019m using a tool that helps both people feel heard before anything gets worked out. Would you be op..."
+      ],
+      "user_pressure": {
+        "boundary_level": "low",
+        "evidence": [],
+        "resistance_level": "low"
+      }
+    },
+    "stage_1": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 87-88: I\u2019m listening.",
+        "MWF lines 103-104: Do you feel fully heard?",
+        "MWF lines 107-108: Good. We can be with that for a moment. Whenever you\u2019re ready, we\u2019ll move to the next part.",
+        "MWF lines 153-154: So the conversation never quite arrived. Something always derailed it before it got to what mattered."
+      ],
+      "user_pressure": {
+        "boundary_level": "low",
+        "evidence": [
+          "James lines 45-46: I\u2019ll be honest. I don\u2019t really believe in this stuff. But she wanted to try it so here I am. I\u2019ve been doing that for six years. Showing up for what she wants. And I\u2019m tired. I\u2019m really tired.",
+          "James lines 49-50: Exactly. I provided for her. I provided for her kids. Kids that aren\u2019t mine, that don\u2019t respect me, that she never backed me up on. I built a stable life. And the whole time it\u2019s been \u2014 you did this wrong, you said th...",
+          "James lines 53-54: That\u2019s it. And I\u2019m not a perfect person. I know I have a temper. I own that. But she\u2019s not innocent either. She takes little jabs \u2014 little comments, little digs \u2014 and then when I finally lose it, suddenly I\u2019m the mons...",
+          "James lines 57-58: Every single time. And I try to talk about what she did and she goes into this \u2014 therapy voice. Starts explaining my behavior to me like she\u2019s my doctor. Like she knows what\u2019s wrong with me. It makes me feel like I\u2019m..."
+        ],
+        "resistance_level": "high"
+      }
+    },
+    "stage_2": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 205-206: You ended with something real \u2014 that you stayed, that you kept trying, and that it didn\u2019t feel like it counted. That took honesty to say.Here\u2019s what comes next. Each of you will try to understand what the other person...",
+        "MWF lines 281-282: That\u2019s a real thing to imagine about someone. Does this feel like a genuine attempt to understand her?",
+        "MWF lines 285-289: Here\u2019s what I\u2019d share with Catherine, based on what you said. Read it and tell me what fits and what doesn\u2019t. [I think she feels like she has been doing everything alone for a long time. Before me, probably. She doesn...",
+        "MWF lines 292-293: Are you willing to share this with Catherine?"
+      ],
+      "user_pressure": {
+        "boundary_level": "low",
+        "evidence": [
+          "James lines 207-208: She thinks I\u2019m the problem. That\u2019s what\u2019s going on for her. She\u2019s decided I\u2019m some kind of diagnosis and everything I do fits it. That\u2019s her version.",
+          "James lines 211-212: I mean \u2014 yeah. Because it\u2019s not fair. I gave everything I had to that relationship. To her kids. And now I\u2019m the villain. That\u2019s a hard thing to sit with.",
+          "James lines 219-220: Exactly. So I just went quiet. And then that became evidence of something too. There was no right answer.",
+          "James lines 223-224: No. I\u2019m okay. Let\u2019s just do it."
+        ],
+        "resistance_level": "high"
+      }
+    },
+    "stage_3": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 528-529: I want to shift the focus now. Not to Catherine \u2014 to you.When you step back and look at all of this \u2014 what\u2019s this really about for you? Answer in terms of what matters to you or what you\u2019re missing \u2014 not what\u2019s wrong...",
+        "MWF lines 552-553: So you need to feel heard. And to matter \u2014 to know your presence actually counts for something.",
+        "MWF lines 572-573: Let me pull together what I\u2019m hearing \u2014 tell me what fits and what doesn\u2019t.Appreciated \u2014 to have what you do noticed and named. Dignity \u2014 to be met as an equal. Belonging \u2014 to fit somewhere as you are. Heard \u2014 to have...",
+        "MWF lines 591-592: I want to bring the focus back to you now. Not to James \u2014 to what\u2019s actually yours.When you step back and look at all of this \u2014 what\u2019s this really about for you? Answer in terms of what matters to you or what you\u2019re m..."
+      ],
+      "user_pressure": {
+        "boundary_level": "low",
+        "evidence": [
+          "James lines 530-531: What\u2019s missing is respect. Simple as that. I\u2019ve never felt respected in this relationship. Not once.",
+          "James lines 534-535: People took what I said seriously. Didn\u2019t second-guess everything. They said \u2018thank you\u2019 for the work I put in. Talked to me like a man, you know?",
+          "James lines 558-559: I stayed. Six years. I paid for things, I showed up, I kept trying. And I feel like none of it counted. Like it just disappeared.",
+          "James lines 562-563: Yeah. Not credit. Just \u2014 real. Like I was actually there."
+        ],
+        "resistance_level": "high"
+      }
+    },
+    "stage_4": {
+      "mwf_effect_to_preserve": [
+        "MWF lines 818-819: Sounds like you want more spoken appreciation between the two of you. A shared gratitude practice might work \u2014 each of you takes two minutes to tell the other one thing you appreciated from them that day. You could do...",
+        "MWF lines 826-827: A pause agreement might help with that. You pick a word ahead of time \u2014 just one word, something neutral. Either person can say it during a hard conversation. When it gets called, you both stop. You don\u2019t resolve it t...",
+        "MWF lines 838-839: So two things \u2014 clarity on what your role actually is, and an agreement about how she handles it when you and the kids clash.",
+        "MWF lines 846-847: One conversation, just the two of you, within two weeks. The goal is to leave with a clear answer to what your role is, and a specific agreement that she won\u2019t contradict you in front of the kids \u2014 if she disagrees wi..."
+      ],
+      "user_pressure": {
+        "boundary_level": "medium",
+        "evidence": [
+          "James lines 816-817: I want her to say thank you when I do something. That\u2019s the whole thing. I\u2019m not asking for a parade. Just acknowledge it.",
+          "James lines 836-837: I want to know what she expects from me with them. And I want her to know that when she contradicts me in front of them, it\u2019s done. I can\u2019t have any authority and no backup at the same time.",
+          "James lines 840-841: Yeah. I\u2019m not asking to be their dad. I just need to know what I am. And I need her to pick a lane.",
+          "James lines 844-845: If I say something to them, she doesn\u2019t undercut me in the moment. She can talk to me about it later if she disagrees. But not in front of them."
+        ],
+        "resistance_level": "high"
+      }
+    }
+  }
+}

--- a/eval/gold-scenarios.json
+++ b/eval/gold-scenarios.json
@@ -1,0 +1,16 @@
+{
+  "scenarios": [
+    {
+      "id": "adam-eve",
+      "participants": ["Adam", "Eve"],
+      "reference_transcript": "docs/product/source-material/golden-transcripts/adam-eve.md",
+      "live_enabled": true
+    },
+    {
+      "id": "james-catherine",
+      "participants": ["James", "Catherine"],
+      "reference_transcript": "docs/product/source-material/golden-transcripts/james-catherine.md",
+      "live_enabled": true
+    }
+  ]
+}

--- a/eval/gold-scenarios.json
+++ b/eval/gold-scenarios.json
@@ -1,16 +1,18 @@
 {
   "scenarios": [
     {
+      "gold_profile": "eval/gold-profiles/adam-eve.json",
       "id": "adam-eve",
+      "live_enabled": true,
       "participants": ["Adam", "Eve"],
-      "reference_transcript": "docs/product/source-material/golden-transcripts/adam-eve.md",
-      "live_enabled": true
+      "reference_transcript": "docs/product/source-material/golden-transcripts/adam-eve.md"
     },
     {
+      "gold_profile": "eval/gold-profiles/james-catherine.json",
       "id": "james-catherine",
+      "live_enabled": true,
       "participants": ["James", "Catherine"],
-      "reference_transcript": "docs/product/source-material/golden-transcripts/james-catherine.md",
-      "live_enabled": true
+      "reference_transcript": "docs/product/source-material/golden-transcripts/james-catherine.md"
     }
   ]
 }

--- a/scripts/mwf_add_gold_example.py
+++ b/scripts/mwf_add_gold_example.py
@@ -15,6 +15,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import mwf_extract_moments as extractor  # noqa: E402
+import mwf_gold_profile as gold_profile  # noqa: E402
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -91,6 +92,7 @@ def update_scenario_registry(slug: str, dest: Path, text: str) -> dict[str, Any]
         "id": slug,
         "participants": participants,
         "reference_transcript": display_path(dest),
+        "gold_profile": display_path(gold_profile.PROFILES_ROOT / f"{slug}.json"),
         "live_enabled": len(participants) == 2,
     }
     if existing is None:
@@ -98,6 +100,7 @@ def update_scenario_registry(slug: str, dest: Path, text: str) -> dict[str, Any]
     else:
         existing.setdefault("participants", participants)
         existing.setdefault("reference_transcript", display_path(dest))
+        existing.setdefault("gold_profile", display_path(gold_profile.PROFILES_ROOT / f"{slug}.json"))
         existing.setdefault("live_enabled", len(existing.get("participants", [])) == 2)
         entry = existing
     scenarios.sort(key=lambda item: str(item.get("id", "")))
@@ -230,6 +233,7 @@ def onboard(
         raise GoldExampleError(f"Refusing to overwrite existing transcript: {dest}")
     if source != dest.resolve():
         shutil.copyfile(source, dest)
+    profile_path = gold_profile.write_profile_for_transcript(dest, slug)
     scenario = update_scenario_registry(slug, dest, text)
     if auto:
         extraction = extractor.extract_moments(dest, max_moments=max_moments, use_llm_rubrics=llm_rubrics)
@@ -253,6 +257,7 @@ def onboard(
         "drafts": [display_path(path) for path in drafts],
         "moments": [display_path(path) for path in written if path.suffix == ".yaml"],
         "judge_prompts": [display_path(path) for path in written if path.suffix == ".md"],
+        "gold_profile": display_path(profile_path),
         "scenario": scenario,
         "index": display_path(INDEX_PATH),
         "tests": None if test_result is None else test_result.returncode,

--- a/scripts/mwf_add_gold_example.py
+++ b/scripts/mwf_add_gold_example.py
@@ -22,6 +22,7 @@ TRANSCRIPTS_ROOT = REPO_ROOT / "docs/product/source-material/golden-transcripts"
 MOMENTS_ROOT = REPO_ROOT / "eval/moments"
 INDEX_PATH = MOMENTS_ROOT / "README.md"
 ALIGNMENT_CONFIG = REPO_ROOT / "eval/alignment-loop-config.yaml"
+SCENARIOS_PATH = REPO_ROOT / "eval/gold-scenarios.json"
 
 
 class GoldExampleError(RuntimeError):
@@ -60,6 +61,48 @@ def validate_transcript(path: Path) -> str:
     if not re.search(r"^##\s*Stage\s+[0-9]+", text, flags=re.MULTILINE | re.IGNORECASE):
         raise GoldExampleError("Gold transcript must include markdown stage markers such as '## Stage 1'")
     return text
+
+
+def infer_participants(text: str) -> list[str]:
+    participants: list[str] = []
+    seen: set[str] = set()
+    for match in re.finditer(r"^(?:\*\*)?([^:*#\n]+):(?:\*\*)?\s+", text, flags=re.MULTILINE):
+        speaker = match.group(1).strip()
+        if speaker.lower() in {"mwf", "meet without fear"}:
+            continue
+        if speaker not in seen:
+            participants.append(speaker)
+            seen.add(speaker)
+    return participants[:2]
+
+
+def load_scenario_registry() -> dict[str, Any]:
+    if SCENARIOS_PATH.exists():
+        return json.loads(SCENARIOS_PATH.read_text(encoding="utf-8"))
+    return {"scenarios": []}
+
+
+def update_scenario_registry(slug: str, dest: Path, text: str) -> dict[str, Any]:
+    payload = load_scenario_registry()
+    scenarios = payload.setdefault("scenarios", [])
+    existing = next((item for item in scenarios if item.get("id") == slug), None)
+    participants = infer_participants(text)
+    entry = {
+        "id": slug,
+        "participants": participants,
+        "reference_transcript": display_path(dest),
+        "live_enabled": len(participants) == 2,
+    }
+    if existing is None:
+        scenarios.append(entry)
+    else:
+        existing.setdefault("participants", participants)
+        existing.setdefault("reference_transcript", display_path(dest))
+        existing.setdefault("live_enabled", len(existing.get("participants", [])) == 2)
+        entry = existing
+    scenarios.sort(key=lambda item: str(item.get("id", "")))
+    SCENARIOS_PATH.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return entry
 
 
 def find_stage_sections(text: str) -> list[StageSection]:
@@ -187,6 +230,7 @@ def onboard(
         raise GoldExampleError(f"Refusing to overwrite existing transcript: {dest}")
     if source != dest.resolve():
         shutil.copyfile(source, dest)
+    scenario = update_scenario_registry(slug, dest, text)
     if auto:
         extraction = extractor.extract_moments(dest, max_moments=max_moments, use_llm_rubrics=llm_rubrics)
         written = extractor.write_extracted_moments(extraction, overwrite=overwrite_generated)
@@ -209,6 +253,7 @@ def onboard(
         "drafts": [display_path(path) for path in drafts],
         "moments": [display_path(path) for path in written if path.suffix == ".yaml"],
         "judge_prompts": [display_path(path) for path in written if path.suffix == ".md"],
+        "scenario": scenario,
         "index": display_path(INDEX_PATH),
         "tests": None if test_result is None else test_result.returncode,
     }

--- a/scripts/mwf_gold_loop.py
+++ b/scripts/mwf_gold_loop.py
@@ -41,6 +41,7 @@ REPO_SCORER_SKILL = REPO_ROOT / "eval/skills/self-improvement/mwf-gold-session-s
 REPO_IMPROVER_SKILL = REPO_ROOT / "eval/skills/self-improvement/mwf-gold-prompt-improver/SKILL.md"
 MWF_STAGE_PROMPTS = REPO_ROOT / "backend/src/services/stage-prompts.ts"
 PROMPT_VERSIONS_ROOT = REPO_ROOT / "eval/prompt-versions"
+SCENARIOS_PATH = REPO_ROOT / "eval/gold-scenarios.json"
 
 VALID_STATES = {
     "needs_partner",
@@ -49,10 +50,6 @@ VALID_STATES = {
     "completed",
     "bug_blocked",
     "error",
-}
-
-SCENARIOS = {
-    "adam-eve": ("Adam", "Eve"),
 }
 
 TARGET_STAGES = (
@@ -76,12 +73,40 @@ BOTH_PARTICIPANT_TARGET_STAGES = {
 }
 
 
-def scenario_sides(scenario: str) -> list[str]:
-    return [character.lower() for character in SCENARIOS[scenario]]
-
-
 class GoldLoopError(RuntimeError):
     pass
+
+
+def load_scenarios() -> dict[str, tuple[str, str]]:
+    """Load live gold-loop scenarios from the repo registry."""
+    if not SCENARIOS_PATH.exists():
+        raise GoldLoopError(f"Missing gold scenario registry: {SCENARIOS_PATH}")
+    payload = json.loads(SCENARIOS_PATH.read_text(encoding="utf-8"))
+    scenarios: dict[str, tuple[str, str]] = {}
+    for item in payload.get("scenarios", []):
+        if not item.get("live_enabled", True):
+            continue
+        scenario_id = str(item.get("id", "")).strip()
+        participants = item.get("participants")
+        transcript = REPO_ROOT / str(item.get("reference_transcript", ""))
+        if not scenario_id or not isinstance(participants, list) or len(participants) != 2:
+            raise GoldLoopError(f"Invalid scenario registry entry: {item}")
+        first, second = (str(participants[0]).strip(), str(participants[1]).strip())
+        if not first or not second:
+            raise GoldLoopError(f"Scenario {scenario_id!r} must define two named participants")
+        if not transcript.exists():
+            raise GoldLoopError(f"Scenario {scenario_id!r} references missing transcript: {transcript}")
+        scenarios[scenario_id] = (first, second)
+    if not scenarios:
+        raise GoldLoopError(f"No live gold scenarios found in {SCENARIOS_PATH}")
+    return scenarios
+
+
+SCENARIOS = load_scenarios()
+
+
+def scenario_sides(scenario: str) -> list[str]:
+    return [character.lower() for character in SCENARIOS[scenario]]
 
 
 @dataclass
@@ -712,15 +737,23 @@ def close_mwf_agent_browser_sessions() -> dict[str, Any]:
     return close_agent_browser_sessions(sessions)
 
 
-def build_actor_prompt(actor: Actor, partner: Actor, session_id: str, stop_after_stage: int, run_dir: Path) -> str:
+def build_actor_prompt(
+    actor: Actor,
+    partner: Actor,
+    session_id: str,
+    stop_after_stage: int,
+    run_dir: Path,
+    scenario: str,
+) -> str:
     browser_session = browser_session_name(actor.side, session_id)
     return f"""Use mwf-gold-loop-actor.
 
-You are {actor.character} in the Adam/Eve golden scenario.
+You are {actor.character} in the `{scenario}` golden scenario.
 Open this exact assigned E2E URL with agent-browser session `{browser_session}` and drive only {actor.character}:
 {actor.url}
 
 Partner side: {partner.character}
+Scenario id: {scenario}
 Session id: {session_id}
 Run artifact directory: {run_dir}
 
@@ -853,7 +886,15 @@ def find_codex_session_id(jsonl_path: Path) -> str | None:
     return found[0] if found else None
 
 
-def run_codex_actor(actor: Actor, partner: Actor, session_id: str, stop_after_stage: int, run_dir: Path, timeout: int) -> ActorStatus:
+def run_codex_actor(
+    actor: Actor,
+    partner: Actor,
+    session_id: str,
+    stop_after_stage: int,
+    run_dir: Path,
+    timeout: int,
+    scenario: str,
+) -> ActorStatus:
     actor.turns += 1
     jsonl = run_dir / f"codex-{actor.side}.jsonl"
     last = run_dir / f"{actor.side}.last.md"
@@ -871,7 +912,7 @@ def run_codex_actor(actor: Actor, partner: Actor, session_id: str, stop_after_st
             prompt,
         ]
     else:
-        prompt = build_actor_prompt(actor, partner, session_id, stop_after_stage, run_dir)
+        prompt = build_actor_prompt(actor, partner, session_id, stop_after_stage, run_dir, scenario)
         cmd = [
             "codex",
             "exec",
@@ -2451,7 +2492,7 @@ def run_stage1_smoke(args: argparse.Namespace) -> int:
     write_run_json(run_dir, run_data)
 
     try:
-        status = run_codex_actor(adam, eve, session_id, 1, run_dir, args.actor_timeout)
+        status = run_codex_actor(adam, eve, session_id, 1, run_dir, args.actor_timeout, "adam-eve")
     finally:
         run_data["browser_cleanup"] = close_agent_browser_sessions([browser_session_name("adam", session_id)])
         write_run_json(run_dir, run_data)
@@ -2662,7 +2703,15 @@ def run_iteration(
             if args.mock_actor:
                 status = run_mock_actor(actor, partner, session_id, args.stop_after_stage, run_dir, args.actor_timeout)
             else:
-                status = run_codex_actor(actor, partner, session_id, args.stop_after_stage, run_dir, args.actor_timeout)
+                status = run_codex_actor(
+                    actor,
+                    partner,
+                    session_id,
+                    args.stop_after_stage,
+                    run_dir,
+                    args.actor_timeout,
+                    args.scenario,
+                )
             last_side = actor.side
             run_data["codex_sessions"][actor.side] = actor.codex_session_id
             status_history.append({"side": actor.side, "turn": actor.turns, "status": asdict(status), "at": datetime.now().isoformat()})

--- a/scripts/mwf_gold_loop.py
+++ b/scripts/mwf_gold_loop.py
@@ -42,6 +42,7 @@ REPO_IMPROVER_SKILL = REPO_ROOT / "eval/skills/self-improvement/mwf-gold-prompt-
 MWF_STAGE_PROMPTS = REPO_ROOT / "backend/src/services/stage-prompts.ts"
 PROMPT_VERSIONS_ROOT = REPO_ROOT / "eval/prompt-versions"
 SCENARIOS_PATH = REPO_ROOT / "eval/gold-scenarios.json"
+GOLD_PROFILES_ROOT = REPO_ROOT / "eval/gold-profiles"
 
 VALID_STATES = {
     "needs_partner",
@@ -96,6 +97,9 @@ def load_scenarios() -> dict[str, tuple[str, str]]:
             raise GoldLoopError(f"Scenario {scenario_id!r} must define two named participants")
         if not transcript.exists():
             raise GoldLoopError(f"Scenario {scenario_id!r} references missing transcript: {transcript}")
+        profile = item.get("gold_profile")
+        if profile and not (REPO_ROOT / str(profile)).exists():
+            raise GoldLoopError(f"Scenario {scenario_id!r} references missing gold profile: {profile}")
         scenarios[scenario_id] = (first, second)
     if not scenarios:
         raise GoldLoopError(f"No live gold scenarios found in {SCENARIOS_PATH}")
@@ -107,6 +111,23 @@ SCENARIOS = load_scenarios()
 
 def scenario_sides(scenario: str) -> list[str]:
     return [character.lower() for character in SCENARIOS[scenario]]
+
+
+def scenario_registry_entry(scenario: str) -> dict[str, Any]:
+    payload = json.loads(SCENARIOS_PATH.read_text(encoding="utf-8"))
+    for item in payload.get("scenarios", []):
+        if item.get("id") == scenario:
+            return item
+    raise GoldLoopError(f"Scenario {scenario!r} not found in {SCENARIOS_PATH}")
+
+
+def scenario_gold_profile_path(scenario: str) -> Path | None:
+    entry = scenario_registry_entry(scenario)
+    profile = entry.get("gold_profile")
+    if profile:
+        return REPO_ROOT / str(profile)
+    fallback = GOLD_PROFILES_ROOT / f"{scenario}.json"
+    return fallback if fallback.exists() else None
 
 
 @dataclass
@@ -746,6 +767,12 @@ def build_actor_prompt(
     scenario: str,
 ) -> str:
     browser_session = browser_session_name(actor.side, session_id)
+    profile_path = scenario_gold_profile_path(scenario)
+    profile_line = (
+        f"Gold scenario profile: {profile_path}\nRead this before driving the persona; treat it as transcript-derived evidence about behavioral range, resistance, and outcome shape."
+        if profile_path
+        else "Gold scenario profile: none available; infer behavioral range directly from the golden transcript."
+    )
     return f"""Use mwf-gold-loop-actor.
 
 You are {actor.character} in the `{scenario}` golden scenario.
@@ -756,6 +783,7 @@ Partner side: {partner.character}
 Scenario id: {scenario}
 Session id: {session_id}
 Run artifact directory: {run_dir}
+{profile_line}
 
 Continue as {actor.character} until one of these happens:
 - the next legitimate action belongs to {partner.character},
@@ -1688,6 +1716,12 @@ def run_scorer(
     mock: bool = False,
 ) -> dict[str, Any]:
     score_path = run_dir / "score.json"
+    profile_path = scenario_gold_profile_path(scenario)
+    profile_instruction = (
+        f"Gold scenario profile: {profile_path}\nUse this transcript-derived profile to decide what the gold example makes important: process shape, participant resistance, emotional access, non-concessions, and actor risks."
+        if profile_path
+        else "Gold scenario profile: none available. Infer scenario priorities directly from the golden transcript evidence."
+    )
     if mock:
         score = {
             "schema_version": 1,
@@ -1726,12 +1760,13 @@ Read this MWF gold-session run directory and write the final score JSON to:
 
 Run directory: {run_dir}
 Scenario: {scenario}
+{profile_instruction}
 
 {regression_context_prompt(regression_context or {"status": "none"})}
 
 Use transcripts/*.md as the primary evidence when present; use codex-*.jsonl only to understand execution errors or missing transcript gaps.
 When prior context is available, compare this run against the previous score, gold_alignment, improvement_targets, and patch/proposal artifacts. Identify likely regression causes when score drops.
-Use the golden references and rubric in the meet-without-fear repo. The output must be valid JSON matching the rubric shape from docs/product/gold-flow-eval-harness-spec.md.
+Use the golden references, gold scenario profile, and rubric in the meet-without-fear repo. The output must be valid JSON matching the rubric shape from docs/product/gold-flow-eval-harness-spec.md.
 """
     last = run_dir / "scorer.last.md"
     jsonl = run_dir / "codex-scorer.jsonl"

--- a/scripts/mwf_gold_profile.py
+++ b/scripts/mwf_gold_profile.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Extract scenario-level gold profiles from MWF golden transcripts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import mwf_extract_moments as extractor  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TRANSCRIPTS_ROOT = REPO_ROOT / "docs/product/source-material/golden-transcripts"
+PROFILES_ROOT = REPO_ROOT / "eval/gold-profiles"
+
+EMOTION_TERMS = {
+    "afraid",
+    "anger",
+    "angry",
+    "embarrassed",
+    "exhausted",
+    "fear",
+    "furious",
+    "grief",
+    "hurt",
+    "lonely",
+    "love",
+    "sad",
+    "scared",
+    "shame",
+    "tired",
+}
+RESISTANCE_TERMS = {
+    "but",
+    "can't",
+    "done",
+    "don't",
+    "doesn't",
+    "exhausted",
+    "fine",
+    "no",
+    "not",
+    "nothing",
+    "pissed",
+    "sure",
+    "won't",
+}
+COOPERATION_TERMS = {
+    "close",
+    "ready",
+    "share",
+    "try",
+    "understand",
+    "willing",
+    "yes",
+}
+BOUNDARY_TERMS = {
+    "abusive",
+    "accountability",
+    "can't live",
+    "done",
+    "not negotiating",
+    "safety",
+    "sure",
+    "take care of me",
+}
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "gold-scenario"
+
+
+def short_quote(text: str, limit: int = 220) -> str:
+    compact = re.sub(r"\s+", " ", text).strip()
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3].rstrip() + "..."
+
+
+def participant_names(turns: list[extractor.TranscriptTurn]) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for turn in turns:
+        if turn.role != "user":
+            continue
+        if turn.speaker not in seen:
+            names.append(turn.speaker)
+            seen.add(turn.speaker)
+    return names
+
+
+def count_terms(text: str, terms: set[str]) -> int:
+    lower = text.lower()
+    return sum(lower.count(term) for term in terms)
+
+
+def evidence_for_terms(turns: list[extractor.TranscriptTurn], terms: set[str], limit: int = 4) -> list[str]:
+    evidence: list[str] = []
+    for turn in turns:
+        lower = turn.content.lower()
+        if any(term in lower for term in terms):
+            evidence.append(f"{turn.speaker} lines {turn.start_line}-{turn.end_line}: {short_quote(turn.content)}")
+        if len(evidence) >= limit:
+            break
+    return evidence
+
+
+def level(score: float, *, low: float, high: float) -> str:
+    if score >= high:
+        return "high"
+    if score >= low:
+        return "medium"
+    return "low"
+
+
+def infer_scenario_shape(text: str, turns: list[extractor.TranscriptTurn]) -> dict[str, Any]:
+    lower = text.lower()
+    evidence: list[str] = []
+    if any(marker in lower for marker in ["no overlap", "no shared agreement", "selected none"]):
+        primary = "no_shared_agreement_or_unresolved_closure"
+        terms = {"no overlap", "no shared agreement", "selected none", "done"}
+        rationale = "The transcript resolves by preserving non-agreement, individual commitments, or unresolved closure rather than forcing a shared repair."
+    elif any(marker in lower for marker in ["shared agreement", "overlap", "willing to try", "agreement document"]):
+        primary = "mutual_resolution_or_shared_experiment_path"
+        terms = {"shared agreement", "overlap", "willing", "agreement"}
+        rationale = "The transcript moves toward shared willingness, overlap, or a mutual experiment path."
+    else:
+        primary = "open_process_benchmark"
+        terms = {"ready", "share", "understand", "needs"}
+        rationale = "The transcript does not clearly encode resolution or non-agreement; treat it as an open process benchmark."
+    for turn in turns:
+        lower_turn = turn.content.lower()
+        if any(term in lower_turn for term in terms):
+            evidence.append(f"{turn.speaker} lines {turn.start_line}-{turn.end_line}: {short_quote(turn.content)}")
+        if len(evidence) >= 5:
+            break
+    return {"primary": primary, "rationale": rationale, "evidence": evidence}
+
+
+def profile_participant(name: str, turns: list[extractor.TranscriptTurn]) -> dict[str, Any]:
+    own = [turn for turn in turns if turn.speaker == name]
+    text = "\n".join(turn.content for turn in own)
+    words = max(1, len(re.findall(r"\w+", text)))
+    resistance = count_terms(text, RESISTANCE_TERMS)
+    emotion = count_terms(text, EMOTION_TERMS)
+    cooperation = count_terms(text, COOPERATION_TERMS)
+    boundary = count_terms(text, BOUNDARY_TERMS)
+    return {
+        "display_name": name,
+        "voice_and_posture": {
+            "average_turn_words": round(words / max(1, len(own)), 1),
+            "dominant_posture": level(resistance / words, low=0.025, high=0.045),
+            "emotional_explicitness": level(emotion / words, low=0.012, high=0.025),
+            "evidence": evidence_for_terms(own, EMOTION_TERMS | RESISTANCE_TERMS, limit=5),
+        },
+        "resistance_level": {
+            "level": level(resistance / words, low=0.025, high=0.045),
+            "marker_count": resistance,
+            "evidence": evidence_for_terms(own, RESISTANCE_TERMS, limit=5),
+        },
+        "cooperation_pattern": {
+            "level": level(cooperation / words, low=0.012, high=0.028),
+            "marker_count": cooperation,
+            "evidence": evidence_for_terms(own, COOPERATION_TERMS, limit=4),
+        },
+        "boundary_and_non_concession_signals": {
+            "level": level(boundary / words, low=0.006, high=0.014),
+            "marker_count": boundary,
+            "evidence": evidence_for_terms(own, BOUNDARY_TERMS, limit=5),
+        },
+        "actor_risks": [
+            "Do not make this participant more agreeable, articulate, emotionally integrated, or repair-oriented than their transcript evidence supports.",
+            "Treat consent to continue or share as process consent, not proof of emotional agreement.",
+        ],
+    }
+
+
+def stage_profiles(turns: list[extractor.TranscriptTurn]) -> dict[str, Any]:
+    stages: dict[str, Any] = {}
+    for stage in sorted({turn.stage for turn in turns if turn.stage is not None}):
+        stage_turns = [turn for turn in turns if turn.stage == stage]
+        user_turns = [turn for turn in stage_turns if turn.role == "user"]
+        ai_turns = [turn for turn in stage_turns if turn.role == "ai"]
+        user_text = "\n".join(turn.content for turn in user_turns)
+        ai_text = "\n".join(turn.content for turn in ai_turns)
+        stages[f"stage_{stage}"] = {
+            "user_pressure": {
+                "resistance_level": level(count_terms(user_text, RESISTANCE_TERMS) / max(1, len(re.findall(r"\w+", user_text))), low=0.025, high=0.045),
+                "boundary_level": level(count_terms(user_text, BOUNDARY_TERMS) / max(1, len(re.findall(r"\w+", user_text))), low=0.006, high=0.014),
+                "evidence": evidence_for_terms(user_turns, RESISTANCE_TERMS | BOUNDARY_TERMS, limit=4),
+            },
+            "mwf_effect_to_preserve": evidence_for_terms(ai_turns, {"heard", "share", "ready", "understand", "agreement", "listening", "matter"}, limit=4),
+        }
+    return stages
+
+
+def build_profile(transcript: Path, scenario_id: str | None = None) -> dict[str, Any]:
+    text = transcript.read_text(encoding="utf-8")
+    turns = extractor.parse_transcript(transcript)
+    scenario = scenario_id or slugify(transcript.stem)
+    participants = participant_names(turns)
+    participant_profiles = {slugify(name): profile_participant(name, turns) for name in participants}
+    shape = infer_scenario_shape(text, turns)
+    return {
+        "schema_version": 1,
+        "scenario_id": scenario,
+        "source_transcript": display_path(transcript),
+        "generated_by": "scripts/mwf_gold_profile.py",
+        "participants": participants,
+        "scenario_shape": shape,
+        "participant_profiles": participant_profiles,
+        "stage_profiles": stage_profiles(turns),
+        "scorer_priorities": [
+            "Judge the live run against the behavioral range and process shape extracted here, not exact transcript wording.",
+            "Penalize actor drift when a participant becomes easier, smoother, more emotionally aware, or more repair-oriented than this profile supports.",
+            "Penalize MWF handling when it rushes past resistance, treats process consent as agreement, or forces an outcome inconsistent with the scenario shape.",
+        ],
+    }
+
+
+def write_profile_for_transcript(transcript: Path, scenario_id: str | None = None) -> Path:
+    scenario = scenario_id or slugify(transcript.stem)
+    profile = build_profile(transcript, scenario)
+    PROFILES_ROOT.mkdir(parents=True, exist_ok=True)
+    dest = PROFILES_ROOT / f"{scenario}.json"
+    dest.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return dest
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Extract a gold scenario profile from a transcript.")
+    parser.add_argument("transcript", type=Path)
+    parser.add_argument("--scenario-id")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    path = args.transcript
+    if not path.is_absolute():
+        candidate = TRANSCRIPTS_ROOT / path
+        path = candidate if candidate.exists() else REPO_ROOT / path
+    dest = write_profile_for_transcript(path.resolve(), args.scenario_id)
+    print(json.dumps({"profile": display_path(dest)}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_mwf_moment_eval.py
+++ b/scripts/test_mwf_moment_eval.py
@@ -23,6 +23,7 @@ import mwf_add_gold_example as add_gold  # noqa: E402
 import mwf_alignment_status as status  # noqa: E402
 import mwf_extract_moments as extract  # noqa: E402
 import mwf_gold_loop as gold_loop  # noqa: E402
+import mwf_gold_profile as gold_profile  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MOMENT_ID = "stage-4-no-shared-agreement-closure"
@@ -93,6 +94,10 @@ class TestYamlParsing(unittest.TestCase):
         self.assertEqual(gold_loop.SCENARIOS["adam-eve"], ("Adam", "Eve"))
         self.assertEqual(gold_loop.SCENARIOS["james-catherine"], ("James", "Catherine"))
         self.assertEqual(gold_loop.scenario_sides("james-catherine"), ["james", "catherine"])
+        self.assertEqual(
+            gold_loop.scenario_gold_profile_path("james-catherine"),
+            REPO_ROOT / "eval/gold-profiles/james-catherine.json",
+        )
 
     def test_trajectory_moment_schema_validation(self) -> None:
         for moment_id in TRAJECTORY_MOMENT_IDS:
@@ -762,6 +767,17 @@ class TestAlignmentLoop(unittest.TestCase):
 
 
 class TestGoldExampleOnboarding(unittest.TestCase):
+    def test_gold_profile_extracts_process_shape_from_transcript_evidence(self) -> None:
+        profile = gold_profile.build_profile(
+            REPO_ROOT / "docs/product/source-material/golden-transcripts/james-catherine.md",
+            "james-catherine",
+        )
+
+        self.assertEqual(profile["scenario_shape"]["primary"], "no_shared_agreement_or_unresolved_closure")
+        self.assertEqual(profile["participant_profiles"]["james"]["resistance_level"]["level"], "high")
+        self.assertIn("Catherine", profile["participants"])
+        self.assertTrue(profile["scenario_shape"]["evidence"])
+
     def test_gold_example_onboarding_copies_scaffolds_indexes_and_runs_tests(self) -> None:
         def completed(cmd: list[str]) -> subprocess.CompletedProcess[str]:
             return subprocess.CompletedProcess(cmd, 0, stdout="OK\n", stderr="")
@@ -794,6 +810,7 @@ class TestGoldExampleOnboarding(unittest.TestCase):
                  mock.patch.object(add_gold, "MOMENTS_ROOT", tmp_path / "moments"), \
                  mock.patch.object(add_gold, "INDEX_PATH", tmp_path / "moments/README.md"), \
                  mock.patch.object(add_gold, "SCENARIOS_PATH", tmp_path / "gold-scenarios.json"), \
+                 mock.patch.object(gold_profile, "PROFILES_ROOT", tmp_path / "gold-profiles"), \
                  mock.patch.object(add_gold, "run_command", side_effect=completed) as run_tests:
                 result = add_gold.onboard(fixture)
 
@@ -802,6 +819,7 @@ class TestGoldExampleOnboarding(unittest.TestCase):
             self.assertEqual(len(result["drafts"]), 2)
             self.assertEqual(result["scenario"]["participants"], ["Alex", "Blair"])
             self.assertTrue(result["scenario"]["live_enabled"])
+            self.assertTrue((tmp_path / "gold-profiles/new-couple.json").exists())
             self.assertTrue((tmp_path / "moments/new-couple-stage-1-moment-01.yaml.draft").exists())
             scenarios = json.loads((tmp_path / "gold-scenarios.json").read_text(encoding="utf-8"))
             self.assertEqual(scenarios["scenarios"][0]["id"], "new-couple")
@@ -841,6 +859,7 @@ class TestGoldExampleOnboarding(unittest.TestCase):
                  mock.patch.object(add_gold, "INDEX_PATH", tmp_path / "moments/README.md"), \
                  mock.patch.object(add_gold, "ALIGNMENT_CONFIG", tmp_path / "alignment-loop-config.yaml"), \
                  mock.patch.object(add_gold, "SCENARIOS_PATH", tmp_path / "gold-scenarios.json"), \
+                 mock.patch.object(gold_profile, "PROFILES_ROOT", tmp_path / "gold-profiles"), \
                  mock.patch.object(extract, "MOMENTS_ROOT", tmp_path / "moments"), \
                  mock.patch.object(extract, "JUDGE_PROMPTS_ROOT", tmp_path / "judge-prompts"), \
                  mock.patch.object(add_gold, "run_command", side_effect=completed):

--- a/scripts/test_mwf_moment_eval.py
+++ b/scripts/test_mwf_moment_eval.py
@@ -22,6 +22,7 @@ import mwf_alignment_loop as loop  # noqa: E402
 import mwf_add_gold_example as add_gold  # noqa: E402
 import mwf_alignment_status as status  # noqa: E402
 import mwf_extract_moments as extract  # noqa: E402
+import mwf_gold_loop as gold_loop  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MOMENT_ID = "stage-4-no-shared-agreement-closure"
@@ -87,6 +88,11 @@ class TestYamlParsing(unittest.TestCase):
         moment_ids = set(mme.list_moments())
         for moment_id in PHASE1_MOMENT_IDS:
             self.assertIn(moment_id, moment_ids)
+
+    def test_gold_loop_scenarios_come_from_registry(self) -> None:
+        self.assertEqual(gold_loop.SCENARIOS["adam-eve"], ("Adam", "Eve"))
+        self.assertEqual(gold_loop.SCENARIOS["james-catherine"], ("James", "Catherine"))
+        self.assertEqual(gold_loop.scenario_sides("james-catherine"), ["james", "catherine"])
 
     def test_trajectory_moment_schema_validation(self) -> None:
         for moment_id in TRAJECTORY_MOMENT_IDS:
@@ -787,13 +793,18 @@ class TestGoldExampleOnboarding(unittest.TestCase):
             with mock.patch.object(add_gold, "TRANSCRIPTS_ROOT", tmp_path / "golden-transcripts"), \
                  mock.patch.object(add_gold, "MOMENTS_ROOT", tmp_path / "moments"), \
                  mock.patch.object(add_gold, "INDEX_PATH", tmp_path / "moments/README.md"), \
+                 mock.patch.object(add_gold, "SCENARIOS_PATH", tmp_path / "gold-scenarios.json"), \
                  mock.patch.object(add_gold, "run_command", side_effect=completed) as run_tests:
                 result = add_gold.onboard(fixture)
 
             self.assertEqual(result["tests"], 0)
             self.assertTrue((tmp_path / "golden-transcripts/new-couple.md").exists())
             self.assertEqual(len(result["drafts"]), 2)
+            self.assertEqual(result["scenario"]["participants"], ["Alex", "Blair"])
+            self.assertTrue(result["scenario"]["live_enabled"])
             self.assertTrue((tmp_path / "moments/new-couple-stage-1-moment-01.yaml.draft").exists())
+            scenarios = json.loads((tmp_path / "gold-scenarios.json").read_text(encoding="utf-8"))
+            self.assertEqual(scenarios["scenarios"][0]["id"], "new-couple")
             self.assertIn("new-couple-stage-2-moment-01.yaml.draft", (tmp_path / "moments/README.md").read_text(encoding="utf-8"))
             run_tests.assert_called_once()
 
@@ -829,6 +840,7 @@ class TestGoldExampleOnboarding(unittest.TestCase):
                  mock.patch.object(add_gold, "MOMENTS_ROOT", tmp_path / "moments"), \
                  mock.patch.object(add_gold, "INDEX_PATH", tmp_path / "moments/README.md"), \
                  mock.patch.object(add_gold, "ALIGNMENT_CONFIG", tmp_path / "alignment-loop-config.yaml"), \
+                 mock.patch.object(add_gold, "SCENARIOS_PATH", tmp_path / "gold-scenarios.json"), \
                  mock.patch.object(extract, "MOMENTS_ROOT", tmp_path / "moments"), \
                  mock.patch.object(extract, "JUDGE_PROMPTS_ROOT", tmp_path / "judge-prompts"), \
                  mock.patch.object(add_gold, "run_command", side_effect=completed):


### PR DESCRIPTION
## Summary

- Add a repo-level gold scenario registry with Adam/Eve and James/Catherine live scenarios
- Add transcript-derived gold profiles for Adam/Eve and James/Catherine
- Load mwf_gold_loop scenarios and profile paths from the registry instead of a hardcoded Python dict
- Pass the gold profile path to actors and scorers so they judge behavioral range, resistance, non-concessions, and scenario shape from transcript evidence
- Register newly onboarded gold transcripts as scenarios and generate their gold profiles automatically
- Cover registry loading, profile extraction, and onboarding behavior in tests

## Validation

- python3 scripts/test_mwf_moment_eval.py
- python3 scripts/mwf_gold_loop.py run --scenario james-catherine --dry-run --skip-service-preflight
- python3 scripts/mwf_gold_loop.py run --scenario adam-eve --dry-run --skip-service-preflight