### PR TITLE
[codex] Fix gold loop seeding and chat panel input flow

### DIFF
--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -699,6 +699,7 @@ describe('Stage Prompts Service', () => {
       // The flag instruction is in format "FeelHeardCheck: [Y if ready..., N otherwise]"
       expect(prompt).toContain('FeelHeardCheck:');
       expect(prompt).toMatch(/FeelHeardCheck.*Y.*N/s);
+      expect(prompt).toContain('Do NOT invite more freeform chat unless the input remains visible');
     });
 
     it('Stage 2 protocol includes ReadyShare flag instruction', () => {
@@ -709,6 +710,7 @@ describe('Stage Prompts Service', () => {
       // The flag instruction is in format "ReadyShare: [Y if ready..., N otherwise]"
       expect(prompt).toContain('ReadyShare:');
       expect(prompt).toMatch(/ReadyShare.*Y.*N/s);
+      expect(prompt).toContain('Do NOT invite more freeform chat unless the input remains visible');
     });
 
     it('Stage 0 protocol instructs the AI to emit a topic via <draft> tags', () => {
@@ -718,6 +720,7 @@ describe('Stage Prompts Service', () => {
 
       // Stage 0 now emits the proposed TOPIC inline as <draft> (not an invitation message).
       expect(prompt).toContain('<draft>');
+      expect(prompt).toContain('without inviting freeform chat unless the input remains visible');
     });
 
     it('protocol includes dispatch tag instruction', () => {

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -489,7 +489,7 @@ LISTENING: Ask warm, specific questions that surface what the situation is about
 
 Keep responses short (1-2 sentences) until you have enough to propose a topic.
 
-WHEN YOU HAVE ENOUGH CONTEXT: Propose a topic in <draft>...</draft> tags. The user confirms via the UI; do NOT ask in chat for explicit consent. Continue the conversation warmly after the draft (e.g., "Take a look at that framing when you're ready, or tell me what to change.").
+WHEN YOU HAVE ENOUGH CONTEXT: Propose a topic in <draft>...</draft> tags. The user confirms via the UI; do NOT ask in chat for explicit consent. Continue warmly after the draft without inviting freeform chat unless the input remains visible (e.g., "Take a look at that framing when you're ready.").
 
 DRAFT PROTOCOL — CONSTRAINTS ON THE TOPIC:
 - One phrase or sentence (no lists, no multiple options).
@@ -545,7 +545,7 @@ ${process.env.MWF_STAGE1_PROMPT_APPEND ? `Moment-eval Stage 1 addendum:\n${proce
 Feel-heard check:
 - Set FeelHeardCheck:Y when ALL of these are true: (1) they've affirmed something you reflected back, (2) you can name their core concern, and (3) their intensity is stabilizing or steady.
 - Be proactive — when the moment feels right, set it. Don't wait for a perfect signal.
-- When FeelHeardCheck:Y, end your response with a gentle acknowledgment that they can confirm below OR keep talking. Example: "...if that captures it, you can let me know below — or if there's more, I'm still here." Do NOT say "tap the button" or mention UI elements directly. Keep it conversational. Keep setting Y until they act on the prompt.
+- When FeelHeardCheck:Y, end your response with a gentle acknowledgment that they can confirm below. Example: "...if that captures it, you can let me know below when you're ready." Do NOT invite more freeform chat unless the input remains visible. Do NOT say "tap the button" or mention UI elements directly. Keep it conversational. Keep setting Y until they act on the prompt.
 - Even when FeelHeardCheck:Y, stay in listening mode. Do NOT pivot to advice, action, or next steps.
 
 ${buildResponseProtocol(1)}`;
@@ -620,7 +620,7 @@ Set ReadyShare:Y when ${userName} can describe what ${partnerName} might be feel
 
 When ReadyShare:Y, include a 2-4 sentence empathy statement in <draft> tags — what ${userName} imagines ${partnerName} is experiencing, written as ${userName} speaking to ${partnerName} (e.g., "I think you might be feeling..."). Focus purely on ${partnerName}'s inner experience — their feelings, fears, or needs.
 
-When ReadyShare:Y and you include a <draft>, end your response by letting ${userName} know you've prepared something for them to review, while making clear they can keep exploring. Example: "I've put together a draft — take a look when you're ready, or we can keep talking." Do NOT reference UI elements directly. One sentence max.
+When ReadyShare:Y and you include a <draft>, end your response by letting ${userName} know you've prepared something for them to review. Example: "I've put together a draft for you to review when you're ready." Do NOT invite more freeform chat unless the input remains visible. Do NOT reference UI elements directly. One sentence max.
 
 ${buildResponseProtocol(2, { includesDraft: true, draftPurpose: 'empathy' })}`;
 
@@ -713,7 +713,7 @@ Set ReadyShare:Y ONLY when ${userName} has:
 2. Connected it to ${partnerName}'s experience in their own words
 Include an updated empathy statement in <draft> tags.
 
-When ReadyShare:Y and you include a <draft>, end your response by letting ${userName} know you've prepared something for them to review, while making clear they can keep exploring. Example: "I've put together an updated draft — you can revisit what you'll share below when you're ready, or we can keep talking." Do NOT reference specific UI element names (like button labels). One sentence max.
+When ReadyShare:Y and you include a <draft>, end your response by letting ${userName} know you've prepared something for them to review. Example: "I've put together an updated draft for you to review when you're ready." Do NOT invite more freeform chat unless the input remains visible. Do NOT reference specific UI element names (like button labels). One sentence max.
 
 ${buildResponseProtocol(2, { includesDraft: true, draftPurpose: 'empathy' })}`;
 

--- a/backend/src/testing/__tests__/state-factory.test.ts
+++ b/backend/src/testing/__tests__/state-factory.test.ts
@@ -1,0 +1,59 @@
+import { prisma } from '../../lib/prisma';
+import { StateFactory, TargetStage } from '../state-factory';
+
+jest.mock('../../lib/prisma');
+
+describe('StateFactory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('attaches both users to fresh CREATED E2E sessions when userB is provided', async () => {
+    (prisma.user.upsert as jest.Mock)
+      .mockResolvedValueOnce({
+        id: 'user-a',
+        email: 'catherine@e2e.test',
+        name: 'Catherine',
+      })
+      .mockResolvedValueOnce({
+        id: 'user-b',
+        email: 'james@e2e.test',
+        name: 'James',
+      });
+    (prisma.relationship.create as jest.Mock).mockResolvedValue({
+      id: 'relationship-1',
+    });
+    (prisma.session.create as jest.Mock).mockResolvedValue({
+      id: 'session-1',
+      status: 'CREATED',
+      relationshipId: 'relationship-1',
+    });
+    (prisma.invitation.create as jest.Mock).mockResolvedValue({
+      id: 'invitation-1',
+      status: 'PENDING',
+    });
+
+    await new StateFactory('http://localhost:8082').createSessionAtStage({
+      userA: { email: 'catherine@e2e.test', name: 'Catherine' },
+      userB: { email: 'james@e2e.test', name: 'James' },
+      targetStage: TargetStage.CREATED,
+    });
+
+    expect(prisma.relationship.create).toHaveBeenCalledWith({
+      data: {
+        members: {
+          create: [
+            { userId: 'user-a', nickname: 'James' },
+            { userId: 'user-b', nickname: 'Catherine' },
+          ],
+        },
+      },
+    });
+    expect(prisma.userVessel.create).toHaveBeenCalledWith({
+      data: { sessionId: 'session-1', userId: 'user-a' },
+    });
+    expect(prisma.userVessel.create).toHaveBeenCalledWith({
+      data: { sessionId: 'session-1', userId: 'user-b' },
+    });
+  });
+});

--- a/backend/src/testing/state-factory.ts
+++ b/backend/src/testing/state-factory.ts
@@ -172,8 +172,9 @@ export class StateFactory {
         },
       ];
 
-      // Add User B as member for stages where both users are active
-      if (TWO_USER_ACTIVE_TARGETS.has(targetStage) && userBRecord) {
+      // Add User B whenever provided. Some E2E fresh-session callers need
+      // both URLs to be authorized before the real invitation UI is driven.
+      if (userBRecord) {
         memberData.push({
           userId: userBRecord.id,
           nickname: userA.name, // What B calls A
@@ -239,8 +240,9 @@ export class StateFactory {
         },
       });
 
-      // 8b. Create UserVessel for User B (if both users are active)
-      if (TWO_USER_ACTIVE_TARGETS.has(targetStage) && userBRecord) {
+      // 8b. Create UserVessel for User B whenever they were attached to the
+      // relationship so both E2E URLs resolve to a complete per-user shell.
+      if (userBRecord) {
         await tx.userVessel.create({
           data: {
             sessionId: session.id,

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -126,6 +126,7 @@ interface ChatInterfaceProps {
   onEmotionChange?: (value: number) => void;
   onHighEmotion?: (value: number) => void;
   compactEmotionSlider?: boolean;
+  /** Render guided action content after the input so chat remains attached to the transcript. */
   renderAboveInput?: () => React.ReactNode;
   /** Render content below the input area (e.g., persistent review affordances) */
   renderBelowInput?: () => React.ReactNode;
@@ -837,7 +838,6 @@ export function ChatInterface({
             testID="chat-emotion-slider"
           />
         )}
-        {renderAboveInput?.()}
         {!hideInput && (
           <ChatInput
             onSend={onSendMessage}
@@ -845,6 +845,7 @@ export function ChatInterface({
             onVoicePress={onVoicePress}
           />
         )}
+        {renderAboveInput?.()}
         {renderBelowInput?.()}
       </View>
     </KeyboardAvoidingView>

--- a/mobile/src/components/ChatTimeline.tsx
+++ b/mobile/src/components/ChatTimeline.tsx
@@ -64,7 +64,7 @@ export interface ChatTimelineProps {
   onHighEmotion?: (value: number) => void;
   /** Use compact emotion slider */
   compactEmotionSlider?: boolean;
-  /** Render content above the input */
+  /** Render guided action content after the input so chat remains attached to the transcript. */
   renderAboveInput?: () => React.ReactNode;
   /** Keyboard vertical offset for iOS */
   keyboardVerticalOffset?: number;
@@ -353,13 +353,13 @@ export function ChatTimeline({
             testID="chat-emotion-slider"
           />
         )}
-        {renderAboveInput?.()}
         {!hideInput && (
           <ChatInput
             onSend={onSendMessage}
             disabled={isInputDisabled}
           />
         )}
+        {renderAboveInput?.()}
       </View>
     </KeyboardAvoidingView>
   );

--- a/mobile/src/components/__tests__/ChatInterface.test.tsx
+++ b/mobile/src/components/__tests__/ChatInterface.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { Text } from 'react-native';
 import { screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { render } from '../../utils/test-utils';
 import { ChatInterface } from '../ChatInterface';
@@ -187,6 +188,34 @@ describe('ChatInterface', () => {
 
       const input = screen.getByTestId('chat-input');
       expect(input.props.editable).toBe(false);
+    });
+
+    it('keeps guided action panels below the chat input', () => {
+      render(
+        <ChatInterface
+          messages={[]}
+          onSendMessage={mockOnSendMessage}
+          renderAboveInput={() => <Text testID="guided-panel">Guided action</Text>}
+        />
+      );
+
+      const input = screen.getByTestId('chat-input');
+      const panel = screen.getByTestId('guided-panel');
+      const contains = (root: any, child: any): boolean => (
+        root === child ||
+        root.children?.some((candidate: any) => typeof candidate !== 'string' && contains(candidate, child)) === true
+      );
+
+      let ancestor: any = input.parent;
+      while (ancestor && !contains(ancestor, panel)) {
+        ancestor = ancestor.parent;
+      }
+
+      const inputBranch = ancestor?.children.find((child: any) => typeof child !== 'string' && contains(child, input));
+      const panelBranch = ancestor?.children.find((child: any) => typeof child !== 'string' && contains(child, panel));
+
+      expect(ancestor).toBeTruthy();
+      expect(ancestor.children.indexOf(panelBranch)).toBeGreaterThan(ancestor.children.indexOf(inputBranch));
     });
   });
 

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -2428,7 +2428,7 @@ export function UnifiedSessionScreen({
   ]);
 
   // -------------------------------------------------------------------------
-  // Render Above Input (switch on aboveInputPanel from useChatUIState)
+  // Render guided input panel (now positioned below the chat input by ChatInterface)
   // -------------------------------------------------------------------------
   const renderAboveInput = useCallback((): React.ReactNode | undefined => {
     switch (aboveInputPanel) {
@@ -3151,7 +3151,7 @@ export function UnifiedSessionScreen({
           onValidateNotQuite={handleValidationNotQuite}
         />
 
-        {/* Waiting banner removed - now handled in renderAboveInput */}
+        {/* Waiting banner removed - now handled by the guided input panel renderer */}
 
         {/* Note: Compact is now rendered via renderCustomEmptyState in ChatInterface */}
 

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -325,7 +325,7 @@ describe('Input Hiding (shouldHideInput)', () => {
     expect(result.shouldHideInput).toBe(false);
   });
 
-  it('hides input while the empathy review panel owns the next action', () => {
+  it('keeps input visible while the empathy review panel is offered', () => {
     const inputs = createInputs({
       myStage: Stage.PERSPECTIVE_STRETCH,
       compactMySigned: true,
@@ -336,10 +336,10 @@ describe('Input Hiding (shouldHideInput)', () => {
 
     const result = computeChatUIState(inputs);
     expect(result.aboveInputPanel).toBe('empathy-statement');
-    expect(result.shouldHideInput).toBe(true);
+    expect(result.shouldHideInput).toBe(false);
   });
 
-  it('hides input while the feel-heard panel owns the next action', () => {
+  it('keeps input visible while the feel-heard panel is offered', () => {
     const inputs = createInputs({
       myStage: Stage.WITNESS,
       compactMySigned: true,
@@ -350,7 +350,7 @@ describe('Input Hiding (shouldHideInput)', () => {
 
     const result = computeChatUIState(inputs);
     expect(result.aboveInputPanel).toBe('feel-heard');
-    expect(result.shouldHideInput).toBe(true);
+    expect(result.shouldHideInput).toBe(false);
   });
 
   it('hides input while empathy review is running', () => {
@@ -438,7 +438,7 @@ describe('Input Hiding (shouldHideInput)', () => {
     expect(result.shouldHideInput).toBe(true);
   });
 
-  it('hides input while the needs reveal validation panel owns the next action', () => {
+  it('keeps input visible while the needs reveal validation panel is offered', () => {
     const inputs = createInputs({
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
@@ -456,7 +456,7 @@ describe('Input Hiding (shouldHideInput)', () => {
 
     const result = computeChatUIState(inputs);
     expect(result.aboveInputPanel).toBe('needs-reveal-validation');
-    expect(result.shouldHideInput).toBe(true);
+    expect(result.shouldHideInput).toBe(false);
   });
 
   it('hides input while Stage 4 agreement review owns the next action', () => {

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -585,13 +585,7 @@ function computeShouldHideInput(
     return true;
   }
 
-  if (
-    aboveInputPanel === 'topic-proposal' ||
-    aboveInputPanel === 'invitation' ||
-    aboveInputPanel === 'feel-heard' ||
-    aboveInputPanel === 'empathy-statement' ||
-    aboveInputPanel === 'needs-reveal-validation'
-  ) {
+  if (aboveInputPanel === 'invitation') {
     return true;
   }
 
@@ -609,6 +603,7 @@ function computeShouldHideInput(
     currentStage === Stage.PERSPECTIVE_STRETCH &&
     inputs.empathyDraft === undefined &&
     inputs.empathyStatus === undefined &&
+    aboveInputPanel !== 'empathy-statement' &&
     !hasShareSuggestion
   ) {
     return true;

--- a/scripts/mwf_gold_loop.py
+++ b/scripts/mwf_gold_loop.py
@@ -543,16 +543,43 @@ def parse_key_values(text: str) -> dict[str, str]:
 
 
 def create_gold_session(character: str, api_url: str, app_url: str) -> dict[str, str]:
-    env = os.environ.copy()
-    env["MWF_API_URL"] = api_url
-    env["MWF_APP_URL"] = app_url
-    result = run_command([str(TESTER_SCRIPT), character], env=env, timeout=60)
-    if result.returncode != 0:
-        raise GoldLoopError(f"create_gold_session.sh failed:\n{result.stderr}\n{result.stdout}")
-    values = parse_key_values(result.stdout)
-    for key in ("SESSION_ID", "ASSIGNED_URL", "PARTNER_URL", "ASSIGNED_CHARACTER", "PARTNER_CHARACTER"):
-        require(key in values, f"create_gold_session.sh output missing {key}")
-    return values
+    scenarios_by_character = {
+        "adam": ("Adam", "Eve"),
+        "eve": ("Eve", "Adam"),
+        "james": ("James", "Catherine"),
+        "catherine": ("Catherine", "James"),
+    }
+    assigned_name, partner_name = scenarios_by_character.get(character.lower(), (None, None))
+    if not assigned_name or not partner_name:
+        raise GoldLoopError(f"Unknown character {character!r}; expected Adam, Eve, James, or Catherine")
+
+    stamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    assigned_email = f"gold-loop-{assigned_name.lower()}-{stamp}@e2e.test"
+    partner_email = f"gold-loop-{partner_name.lower()}-{stamp}@e2e.test"
+    seeded = post_json(
+        f"{api_url}/api/e2e/seed-session",
+        {
+            "userA": {"email": assigned_email, "name": assigned_name},
+            "userB": {"email": partner_email, "name": partner_name},
+            "targetStage": "CREATED",
+        },
+    )
+    if not seeded.get("success"):
+        raise GoldLoopError(f"seed-session failed: {seeded}")
+    data = seeded["data"]
+    page_urls = data.get("pageUrls") or {}
+    require(page_urls.get("userA") and page_urls.get("userB"), f"seed-session response missing both page URLs: {seeded}")
+    return {
+        "SESSION_ID": data["session"]["id"],
+        "ASSIGNED_CHARACTER": assigned_name,
+        "PARTNER_CHARACTER": partner_name,
+        "ASSIGNED_ID": data["userA"]["id"],
+        "ASSIGNED_EMAIL": data["userA"]["email"],
+        "PARTNER_ID": data["userB"]["id"],
+        "PARTNER_EMAIL": data["userB"]["email"],
+        "ASSIGNED_URL": page_urls["userA"].replace("http://localhost:8081", app_url),
+        "PARTNER_URL": page_urls["userB"].replace("http://localhost:8081", app_url),
+    }
 
 
 def seeded_session_from_target_stage(scenario: str, target_stage: str, api_url: str, app_url: str) -> dict[str, str]:
@@ -1323,6 +1350,11 @@ CONTROL_TAG_RE = re.compile(
 )
 TRANSCRIPT_METADATA_RE = re.compile(r"^- (side|stage|privacy|visible_cta_state):\s*(.+?)\s*$", re.MULTILINE)
 TRANSCRIPT_EVENT_RE = re.compile(r"^(?:\d+\.|\*\*\[|###|---|\[)", re.MULTILINE)
+CHAT_PROMISE_RE = re.compile(
+    r"\b(?:keep (?:talking|exploring|going)|tell me what needs to change|if there's more|if there is more|I'm still here|I am still here)\b",
+    re.I,
+)
+INPUT_VISIBLE_RE = re.compile(r"\b(?:input|textbox|chat-input|text input)\s*(?:=|:|is)?\s*(?:visible|shown|available|enabled)\b", re.I)
 
 
 def invariant_result(
@@ -1555,6 +1587,30 @@ def check_felt_heard_gate_after_witnessing(transcripts: list[tuple[Path, str]]) 
     )
 
 
+def check_chat_copy_has_visible_input(transcripts: list[tuple[Path, str]]) -> dict[str, Any]:
+    evidence: list[str] = []
+    for path, text in transcripts:
+        metadata = transcript_metadata(text)
+        visible_cta_state = metadata.get("visible_cta_state", "")
+        if INPUT_VISIBLE_RE.search(visible_cta_state):
+            continue
+        for match in CHAT_PROMISE_RE.finditer(text):
+            start = max(0, match.start() - 80)
+            end = min(len(text), match.end() + 80)
+            snippet = " ".join(text[start:end].split())
+            evidence.append(f"{path.name}: chat-promising copy without input-visible metadata: {snippet}")
+            if len(evidence) >= 10:
+                break
+    return invariant_result(
+        "chat_copy_promises_visible_input",
+        not evidence,
+        owner="product_code",
+        dimension="ui_state",
+        details="If visible copy invites the user to keep talking, transcript state must show a visible/enabled textbox.",
+        evidence=evidence,
+    )
+
+
 def check_partner_private_leakage(transcripts: list[tuple[Path, str]]) -> dict[str, Any]:
     evidence: list[str] = []
     leak_markers = ("PRIVATE_LEAK", "PARTNER_PRIVATE_LEAK")
@@ -1582,6 +1638,7 @@ def run_invariant_checks(run_dir: Path, run_data: dict[str, Any], scenario: str,
     checks.append(check_actor_operated_correct_side(run_data, scenario))
     checks.append(check_session_started_with_profile_initiator(run_data, scenario))
     checks.append(check_felt_heard_gate_after_witnessing(transcripts))
+    checks.append(check_chat_copy_has_visible_input(transcripts))
     hard_failures = [check for check in checks if check["severity"] == "hard" and check["status"] == "fail"]
     result = {
         "schema_version": 1,
@@ -1599,6 +1656,21 @@ def apply_invariants_to_score(score: dict[str, Any], invariants: dict[str, Any],
         score["hard_invariants"] = []
         return score
     score["hard_invariants"] = hard_failures
+    not_evaluable_failures = [
+        failure for failure in hard_failures
+        if failure.get("dimension") in {"actor_orchestration", "transcript_extraction"}
+        or failure.get("id") in {"stage_limit_reached_correctly", "transcript_side_stage_complete"}
+    ]
+    if not_evaluable_failures:
+        score["evaluation_scope"] = {
+            **(score.get("evaluation_scope") if isinstance(score.get("evaluation_scope"), dict) else {}),
+            "prompt_quality": "not_evaluable_for_prompt_quality",
+            "reasons": [failure.get("id") for failure in not_evaluable_failures],
+        }
+        gold_alignment = score.get("gold_alignment") if isinstance(score.get("gold_alignment"), dict) else {}
+        gold_alignment["status"] = "not_evaluable_for_prompt_quality"
+        gold_alignment["notes"] = "Prompt-quality conclusions are blocked by seeding/access/orchestration/transcript failures."
+        score["gold_alignment"] = gold_alignment
     score["verdict"] = "eval_fail"
     try:
         current = float(score.get("overall_score"))
@@ -1918,6 +1990,7 @@ Scenario: {scenario}
 {regression_context_prompt(regression_context or {"status": "none"})}
 
 Use transcripts/*.md as the primary evidence when present; use codex-*.jsonl only to understand execution errors or missing transcript gaps.
+If seeding, access control, browser orchestration, or transcript extraction failed before both sides produced usable stage evidence, mark prompt-quality/MWF-quality conclusions as not_evaluable_for_prompt_quality and route the primary target to eval_harness or product_code instead of scoring the MWF prompt as if the conversation completed.
 When prior context is available, compare this run against the previous score, gold_alignment, improvement_targets, and patch/proposal artifacts. Identify likely regression causes when score drops.
 Use the golden references, gold scenario profile, and rubric in the meet-without-fear repo. The output must be valid JSON matching the rubric shape from docs/product/gold-flow-eval-harness-spec.md.
 """


### PR DESCRIPTION
## Summary
- Fix fresh E2E gold-loop session seeding so both participants are relationship members and both receive user vessels, including CREATED sessions.
- Keep conversational guided panels attached to the chat flow by rendering them below the input and keeping input visible for feel-heard, topic proposal, empathy review, and needs reveal validation panels.
- Tighten gold-loop evaluation routing with an automatic invariant for copy that promises continued chat without visible input, plus not-evaluable prompt-quality scope when orchestration/access/transcript failures block the run.
- Update Stage 0/1/2 prompt guidance so copy does not invite freeform chat unless the input remains visible.

## Root Cause
- The fresh-session seed path only attached the second participant for later active stages, which left Catherine unauthorized in CREATED James/Catherine runs.
- The chat UI hid input for panels whose copy still implied the user could continue talking.
- The browser loop was allowing orchestration/access/UI-state failures to contaminate prompt-quality evaluation.

## Validation
- `npm --workspace backend test -- --runTestsByPath src/testing/__tests__/state-factory.test.ts src/services/__tests__/stage-prompts.test.ts`
- `npm --workspace mobile test -- --runTestsByPath src/utils/__tests__/chatUIState.test.ts src/components/__tests__/ChatInterface.test.tsx`
- `python3 -m py_compile scripts/mwf_gold_loop.py`
- `npm --workspace mobile run check`

## Notes
- Left unrelated local retention/render edits and raw run artifacts out of this PR.