### PR TITLE
fix: circuit-breaker for session-not-found prevents 60-error bursts

### DIFF
--- a/mobile/src/hooks/usePendingActions.ts
+++ b/mobile/src/hooks/usePendingActions.ts
@@ -35,12 +35,13 @@ interface BadgeCountResponse {
 
 /**
  * Fetch pending actions for a specific session.
+ * Pass enabled: false to disable polling (e.g. when session is invalid/deleted).
  */
-export function usePendingActions(sessionId: string | undefined) {
+export function usePendingActions(sessionId: string | undefined, options?: { enabled?: boolean }) {
   return useQuery<PendingActionsResponse>({
     queryKey: stageKeys.pendingActions(sessionId!),
     queryFn: () => get<PendingActionsResponse>(`/sessions/${sessionId}/pending-actions`),
-    enabled: !!sessionId,
+    enabled: !!sessionId && (options?.enabled !== false),
     refetchOnWindowFocus: true,
     staleTime: 5_000, // 5s debounce — prevents rapid-fire refetches from multiple Ably invalidations
   });

--- a/mobile/src/hooks/useRealtime.ts
+++ b/mobile/src/hooks/useRealtime.ts
@@ -43,6 +43,8 @@ import { isRealtimePayloadAddressedToCurrentUser } from '../utils/realtimePrivac
 export interface RealtimeConfig {
   /** Session ID to subscribe to */
   sessionId: string;
+  /** Whether to enable the realtime subscription (default: true). Set false to pause. */
+  enabled?: boolean;
   /** Whether to enable presence tracking */
   enablePresence?: boolean;
   /** Callback when connection state changes */
@@ -127,6 +129,7 @@ function mapAblyState(state: string): ConnectionStatus {
 export function useRealtime(config: RealtimeConfig): RealtimeState & RealtimeActions {
   const {
     sessionId,
+    enabled: realtimeEnabled = true,
     enablePresence = true,
     onConnectionChange,
     onPresenceChange,
@@ -316,7 +319,7 @@ export function useRealtime(config: RealtimeConfig): RealtimeState & RealtimeAct
   // ============================================================================
 
   useEffect(() => {
-    if (!sessionId || !user?.id) return;
+    if (!sessionId || !user?.id || !realtimeEnabled) return;
 
     let isCleanedUp = false;
     let channel: AblyRealtimeChannel | null = null;
@@ -487,7 +490,7 @@ export function useRealtime(config: RealtimeConfig): RealtimeState & RealtimeAct
         typingTimeoutRef.current = null;
       }
     };
-  }, [sessionId, user?.id, user?.name, enablePresence, handleMessage, handleConnectionStateChange]);
+  }, [sessionId, user?.id, user?.name, enablePresence, realtimeEnabled, handleMessage, handleConnectionStateChange]);
 
   // ============================================================================
   // Track Mounted State

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -261,6 +261,8 @@ export function useUnifiedSession(
 
   // Messages - use infinite scroll for pagination
   // The useSessionState hook hydrates the messages cache, so this will get a cache hit
+  // Gate behind !loadingState to prevent initial parallel burst before /state resolves (see #428)
+  const stateResolved = !loadingState;
   const {
     data: messagesData,
     isLoading: loadingMessages,
@@ -269,7 +271,7 @@ export function useUnifiedSession(
     isFetchingNextPage,
   } = useInfiniteMessages(
     { sessionId: sessionId!, limit: 25 },
-    { enabled: !!sessionId && !accessDenied }
+    { enabled: !!sessionId && !accessDenied && stateResolved }
   );
 
   // Stage-gated queries: only fetch data for the user's current stage to avoid
@@ -282,16 +284,16 @@ export function useUnifiedSession(
 
   // Stage 2: Empathy
   const { data: empathyDraftData } = useEmpathyDraft(sessionId, {
-    enabled: !!sessionId && !accessDenied && isStage2Plus,
+    enabled: !!sessionId && !accessDenied && stateResolved && isStage2Plus,
   });
   const { data: partnerEmpathyData } = usePartnerEmpathy(sessionId, {
-    enabled: !!sessionId && !accessDenied && isStage2Plus,
+    enabled: !!sessionId && !accessDenied && stateResolved && isStage2Plus,
   });
   const partnerEmpathy = partnerEmpathyData?.attempt ?? null;
 
   // Stage 3: Needs
   const { data: needsData } = useNeeds(sessionId, {
-    enabled: !!sessionId && !accessDenied && isStage3Plus,
+    enabled: !!sessionId && !accessDenied && stateResolved && isStage3Plus,
   });
 
   // Derive needs state for gating the side-by-side reveal query.
@@ -302,23 +304,23 @@ export function useUnifiedSession(
 
   const { data: needsComparisonData } = useNeedsComparison(
     sessionId,
-    !accessDenied && (allNeedsConfirmedForGating || myNeedsSharedForGating)
+    !accessDenied && stateResolved && (allNeedsConfirmedForGating || myNeedsSharedForGating)
   );
 
   // Stage 4: Strategies
   const { data: strategyData } = useStrategies(sessionId, {
-    enabled: !!sessionId && !accessDenied && isStage4,
+    enabled: !!sessionId && !accessDenied && stateResolved && isStage4,
   });
   const { data: revealData } = useStrategiesReveal(sessionId, {
-    enabled: !!sessionId && !accessDenied && isStage4,
+    enabled: !!sessionId && !accessDenied && stateResolved && isStage4,
   });
   const { data: agreementsData } = useAgreements(sessionId, {
-    enabled: !!sessionId && !accessDenied && isStage4,
+    enabled: !!sessionId && !accessDenied && stateResolved && isStage4,
   });
 
   // Empathy Reconciler Data — only active during Stage 2
   const { data: empathyStatusData } = useEmpathyStatus(sessionId, {
-    enabled: !!sessionId && !accessDenied && isStage2Plus,
+    enabled: !!sessionId && !accessDenied && stateResolved && isStage2Plus,
   });
   const { data: shareOfferData } = useShareOffer(sessionId, {
     enabled: shouldFetchShareOffer({

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -511,9 +511,6 @@ export function UnifiedSessionScreen({
   const queryClient = useQueryClient();
   const { showError } = useToast();
 
-  // Server-side pending actions for badge count (replaces client-side computation)
-  const pendingActionsQuery = usePendingActions(sessionId);
-
   // Real-time presence tracking
 
   const {
@@ -637,6 +634,10 @@ export function UnifiedSessionScreen({
 
   } = useUnifiedSession(sessionId);
 
+  // Server-side pending actions for badge count (replaces client-side computation)
+  // Gate behind !accessDenied to prevent polling when session is deleted (#428)
+  const pendingActionsQuery = usePendingActions(sessionId, { enabled: !accessDenied });
+
   // Sharing status for the header button. Keep these duplicate header queries
   // behind the same stage/access gates as useUnifiedSession so the badge does
   // not reintroduce the Stage 2 share-offer request storm this PR removes.
@@ -717,8 +718,10 @@ export function UnifiedSessionScreen({
   });
 
   // Real-time presence and event tracking
+  // Disable when session is invalid to prevent Ably subscription cascading errors (#428)
   const { partnerOnline, connectionStatus, reconnect: _reconnectRealtime } = useRealtime({
     sessionId,
+    enabled: !accessDenied,
     enablePresence: true,
     onSessionEvent: (event, data) => {
       console.log('[UnifiedSessionScreen] Received realtime event:', event);


### PR DESCRIPTION
## Changes
- Fix: Waterfall child queries behind `/state` resolution — prevents initial parallel burst of requests before 404 arrives
- Fix: Gate `usePendingActions` with `enabled: !accessDenied` so it stops polling when session is deleted
- Fix: Add `enabled` prop to `useRealtime` hook so Ably subscription tears down when session is invalid
- Fix: Move `usePendingActions` call after `useUnifiedSession` destructuring so `accessDenied` is available

Related to #428

## Provenance
- **Channel:** GitHub Issues
- **Requested by:** slam-paws (bot detection)
- **Original message:** Mixpanel scanner detected 60 error events in one burst from a single deleted session
- **Prompt(s) used:** general-pr workspace

## Docs updated
No doc changes needed — bug fix adding guards to existing hooks, no architectural change.