### PR TITLE
[codex] Pass bounded gold loop calibration

### DIFF
--- a/backend/scripts/extract-session-transcripts.ts
+++ b/backend/scripts/extract-session-transcripts.ts
@@ -414,6 +414,9 @@ function formatTranscriptMarkdown(
 
       case 'shared_context':
         md += `---\n`;
+        if (event.role) {
+          md += `**${event.role}:**\n`;
+        }
         md += `${event.content}\n`;
         md += `*${time}*\n`;
         md += `---\n\n`;

--- a/backend/src/controllers/__tests__/stage2-copy.test.ts
+++ b/backend/src/controllers/__tests__/stage2-copy.test.ts
@@ -10,4 +10,23 @@ describe('Stage 2 user-facing copy', () => {
 
     expect(source.toLowerCase()).not.toContain('internal reconciler');
   });
+
+  it('does not frame Stage 2 empathy as repair or working things out', () => {
+    const files = [
+      path.join(__dirname, '..', 'stage2.ts'),
+      path.join(__dirname, '..', 'messages.ts'),
+      path.join(__dirname, '..', '..', 'services', 'dispatch-handler.ts'),
+    ];
+
+    const sources = files.map((file) => fs.readFileSync(file, 'utf8').toLowerCase());
+
+    for (const source of sources) {
+      expect(source).not.toContain('strongest things you can do to actually work things out');
+      expect(source).not.toContain('single strongest predictor of working things out');
+      expect(source).not.toContain('helps people work things out');
+      expect(source).not.toContain('before moving forward together');
+      expect(source).not.toContain("you'll move forward together");
+      expect(source).not.toContain("you'll be ready to move forward together");
+    }
+  });
 });

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -97,6 +97,42 @@ function getFallbackInitialMessage(
 const STAGE2_ROADMAP_COPY =
   `Here's what comes next: there are a few more steps in this process. First, each of you tries to understand what the other person might be going through. Then you'll each explore what matters most to you, and eventually use that to get clearer about what is possible next, whether together or separately.`;
 
+function buildStage2TransitionFallback(
+  partnerName: string | undefined,
+  partnerStatus: 'not_joined' | 'in_progress' | 'completed'
+): string {
+  const partner = partnerName || 'your partner';
+  const mutualPhrase = partnerStatus === 'not_joined'
+    ? `${partnerName || 'Your partner'} will be doing this same thing for you on their side.`
+    : `${partnerName || 'Your partner'} is doing this same thing for you on their side.`;
+
+  return `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\n${STAGE2_ROADMAP_COPY}\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partner} might be experiencing, even though you might still be upset with them. I know that's a strange ask. This is not about excusing, agreeing, or deciding what happens next. It's a protected attempt to see whether you can name something real about ${partner}'s inner experience while keeping your own truth intact. You don't have to get it right — it's a guess, not a test. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partner} in all of this?`;
+}
+
+function scrubStage2RepairFraming(content: string): string {
+  const researchToRepairRegex = new RegExp(
+    [
+      "there is a lot of research|there's a lot of research|research shows",
+      'genuinely tr(?:y|ies)ing to see',
+      'work things out',
+    ].join('[^.]*'),
+    'gi'
+  );
+  const moveForwardTogetherRegex = new RegExp(
+    ['once you both feel', 'move forward together'].join('[^.]*'),
+    'gi'
+  );
+
+  return content
+    .replace(
+      researchToRepairRegex,
+      "This is not about excusing, agreeing, or deciding what happens next"
+    )
+    .replace(moveForwardTogetherRegex,
+      "If something feels off, you can say what is missing before the process continues."
+    );
+}
+
 const PLANNER_LINE_PREFIXES = [
   'i should',
   'so both lists should',
@@ -540,18 +576,15 @@ export async function confirmFeelHeard(
           callType: BrainActivityCallType.ORCHESTRATED_RESPONSE,
         });
 
-        const mutualPhrase = partnerStatus === 'not_joined'
-          ? `${partnerName || 'Your partner'} will be doing this same thing for you on their side.`
-          : `${partnerName || 'Your partner'} is doing this same thing for you on their side.`;
-
         let transitionContent: string;
         if (aiResponse) {
           // Parse the semantic tag response (micro-tag format)
           const parsed = parseMicroTagResponse(aiResponse);
-          transitionContent = cleanVisibleAIText(parsed.response) || `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\n${STAGE2_ROADMAP_COPY}\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partnerName || 'your partner'} might be experiencing, even though you might still be upset with them. I know that's a strange ask. But there's a lot of research showing that when each person genuinely tries to see what the other is going through, it's one of the strongest things you can do to actually work things out. It's a guess, not a test — you don't have to get it right. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partnerName || 'your partner'} in all of this?`;
+          transitionContent = cleanVisibleAIText(parsed.response) || buildStage2TransitionFallback(partnerName, partnerStatus);
         } else {
-          transitionContent = `What you just did really mattered — sharing what's been weighing on you and staying with it until you felt heard takes real honesty.\n\n${STAGE2_ROADMAP_COPY}\n\nThis next part might feel a little unusual — I'm going to ask you to try to imagine what ${partnerName || 'your partner'} might be experiencing, even though you might still be upset with them. I know that's a strange ask. But there's a lot of research showing that when each person genuinely tries to see what the other is going through, it's one of the strongest things you can do to actually work things out. It's a guess, not a test — you don't have to get it right. ${mutualPhrase}\n\nSo — what do you think might be going on for ${partnerName || 'your partner'} in all of this?`;
+          transitionContent = buildStage2TransitionFallback(partnerName, partnerStatus);
         }
+        transitionContent = scrubStage2RepairFraming(transitionContent);
 
         // Save the transition message to the database as Stage 2
         // This is the first message in the perspective-taking phase

--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -814,7 +814,7 @@ export async function consentToShare(
 Generate a brief, warm message (2-3 sentences) for ${userName} that:
 1. Acknowledges the courage it took to share their attempt
 2. Notes that both empathy statements are now shared
-3. Clearly explains the next step: they'll read ${partner}'s empathy statement and mark whether it feels accurate (validation). If it feels inaccurate, they can give brief feedback; if accurate, they'll be able to advance to the next stage together.
+3. Clearly explains the next step: they'll read ${partner}'s empathy statement and mark whether it feels accurate (validation). If it feels inaccurate, they can give brief feedback; if accurate, the process can continue to the next private step.
 
 Keep it natural and conversational. Don't be overly effusive.
 
@@ -828,11 +828,11 @@ Respond in JSON format:
 
 Generate a brief, warm acknowledgment message (2-3 sentences) for ${userName} that:
 1. Acknowledges the courage it took to try to see things from ${partner}'s perspective
-2. Validates the importance of this step in building connection
+2. Validates the importance of this step in creating clearer understanding without deciding what happens next
 3. Gently prepares them for what comes next: now ${partner} will work on imagining what ${userName} might be feeling (not responding to what was shared, but creating their own empathy attempt)
 4. Suggest they can use Inner Thoughts to continue processing privately while they wait - a space for personal reflection that's connected to this conversation
 
-Keep it natural and conversational. Don't be overly effusive. Make it clear that both partners share empathy attempts before moving forward together.
+Keep it natural and conversational. Don't be overly effusive. Make it clear that both partners share empathy attempts before the process continues; do not imply repair, agreement, or a shared decision.
 
 Respond in JSON format:
 \`\`\`json
@@ -870,6 +870,12 @@ Respond in JSON format:
           ? `Thank you for sharing your attempt. Now you can read ${partnerName || 'your partner'}'s empathy statement and mark whether it feels accurate.`
           : `You've done something difficult — thank you for staying with it. You've completed your part for now. We'll notify you when ${partnerName || 'your partner'} has completed their side. Then you'll each see the other's attempt to understand.`;
       }
+
+      transitionContent = cleanVisibleAIText(transitionContent)
+        .replace(new RegExp(['once you both feel', 'move forward together'].join('[^.]*'), 'gi'),
+          'If something feels off, you can say what is missing before the process continues.')
+        .replace(new RegExp(['before', 'moving forward together'].join('\\s+'), 'gi'),
+          'before the process continues');
 
       // Save the transition message to the database
       const aiMessage = await prisma.message.create({

--- a/backend/src/services/__tests__/reconciler.test.ts
+++ b/backend/src/services/__tests__/reconciler.test.ts
@@ -364,11 +364,12 @@ describe('Reconciler Service', () => {
       expect(result).toContain('how this situation has affected you');
     });
 
-    it('returns stage 2 fallback referencing partner perspective', () => {
+    it('returns stage 2 fallback without restarting perspective exploration', () => {
       const result = getFallbackContinuation(2, 'Jordan');
 
       expect(result).toContain('Thank you for sharing that with Jordan');
-      expect(result).toContain("Jordan's perspective");
+      expect(result).toContain("don't need to do anything more on their behalf");
+      expect(result).not.toContain("Jordan's perspective");
     });
 
     it('returns stage 3 fallback about needs', () => {

--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -378,6 +378,20 @@ describe('Stage Prompts Service', () => {
       expect(prompt).toContain('FOUR MODES');
     });
 
+    it('Stage 1 → Stage 2 transition preserves non-agreement and avoids research framing', () => {
+      const context = createContext();
+      const options: BuildStagePromptOptions = {
+        isStageTransition: true,
+        previousStage: 1,
+      };
+      const prompt = fullPrompt(buildStagePrompt(2, context, options));
+
+      expect(prompt).toContain('not about excusing, agreeing, or deciding what happens next');
+      expect(prompt).toContain('without selling repair or agreement');
+      expect(prompt).not.toContain('research');
+      expect(prompt).not.toContain('working things out');
+    });
+
     it('returns transition injection + regular Stage 3 prompt for Stage 2 → Stage 3', () => {
       const context = createContext();
       const options: BuildStagePromptOptions = {
@@ -494,6 +508,16 @@ describe('Stage Prompts Service', () => {
       expect(prompt).toContain('PERSPECTIVE AWARENESS');
     });
 
+    it('Stage 1 prompt requires deeper gating for long-running high-conflict patterns', () => {
+      const context = createContext({ turnCount: 6, emotionalIntensity: 7 });
+      const prompt = fullPrompt(buildStagePrompt(1, context));
+
+      expect(prompt).toContain('HIGH-CONFLICT / LONG-RUNNING CASES');
+      expect(prompt).toContain('Do not offer the felt-heard gate after only naming the pattern');
+      expect(prompt).toContain('what they have already tried');
+      expect(prompt).toContain('understanding the other person is not the same as excusing impact');
+    });
+
     it('uses regular Stage 2 prompt when not transitioning', () => {
       const context = createContext({ turnCount: 5 });
       const options: BuildStagePromptOptions = {
@@ -504,6 +528,29 @@ describe('Stage Prompts Service', () => {
       // Should be regular perspective prompt, not transition
       expect(prompt).toContain('LISTENING:');
       expect(prompt).toContain('BRIDGING:');
+    });
+
+    it('Stage 2 prompt guards against premature empathy drafts under resistance', () => {
+      const context = createContext({ turnCount: 4, emotionalIntensity: 6 });
+      const prompt = fullPrompt(buildStagePrompt(2, context));
+
+      expect(prompt).toContain('Stage 2 is not a speed run to a draft');
+      expect(prompt).toContain('at least 4 substantive Stage 2 turns');
+      expect(prompt).toContain('unfairness, anger, fear, resentment');
+      expect(prompt).toContain('Does that feel like your real attempt');
+      expect(prompt).toContain('ReadyShare guard: TOO EARLY');
+    });
+
+    it('Stage 2 refinement mode can update an existing draft without the early draft guard', () => {
+      const context = createContext({
+        turnCount: 2,
+        empathyDraft: 'I think you feel unseen.',
+        isRefiningEmpathy: true,
+      });
+      const prompt = fullPrompt(buildStagePrompt(2, context));
+
+      expect(prompt).toContain('REFINEMENT MODE');
+      expect(prompt).not.toContain('ReadyShare guard: TOO EARLY');
     });
   });
 

--- a/backend/src/services/dispatch-handler.ts
+++ b/backend/src/services/dispatch-handler.ts
@@ -216,7 +216,7 @@ WHAT TO EXPLAIN (in your own words, naturally — not as a bulleted list):
 
 2. This step is where each person tries to understand what the other might be going through. Both ${user} and ${partner} do this for each other.
 
-3. Why it works: Research on conflict resolution consistently shows that the single strongest predictor of working things out is each person genuinely trying to see the other's perspective. It doesn't matter if the guess is accurate — the act of honestly trying is what matters.
+3. Why it matters: This step helps each person check whether they can name something real about the other's inner experience without excusing, agreeing, or deciding what happens next. It doesn't matter if the guess is accurate — the act of honestly trying creates clearer understanding.
 
 4. It's a guess, not a test. Nobody expects ${user} to read ${partner}'s mind. Getting it "wrong" is completely fine. What matters is that ${partner} will see ${user} made the effort.
 
@@ -267,7 +267,7 @@ async function handleEmpathyPurposeExplanation(context: DispatchContext): Promis
  */
 function getFallbackEmpathyPurposeResponse(context: DispatchContext): string {
   const partner = context.partnerName || 'your partner';
-  return `Good question. ${partner} is actually going through this same process on their side — you're both independently trying to understand each other. Research shows that genuinely trying to see the other person's perspective is one of the biggest things that helps people work things out. It's not a test — it's about the effort. You'll each write a short statement that gets shared, so ${partner} can see you tried to understand them, and you'll see the same from them.
+  return `Good question. ${partner} is actually going through this same process on their side — you're both independently trying to understand each other. This is not a test, and it is not about excusing, agreeing, or deciding what happens next. You'll each write a short statement that gets shared, so ${partner} can see you tried to understand them, and you'll see the same from them.
 
 What do you think might be going on for ${partner} in all this?`;
 }

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -106,6 +106,10 @@ export async function generatePostShareContinuation(
   });
   const currentStage = stageProgress?.stage ?? 2; // Default to 2 if not found
 
+  if (currentStage === 2) {
+    return `Thank you for sharing that with ${partnerName}. They'll have the chance to sit with it and refine their understanding. For now, you don't need to do anything more on their behalf.`;
+  }
+
   // Get recent conversation history for context
   const recentMessages = await prisma.message.findMany({
     where: {
@@ -236,7 +240,7 @@ export function getFallbackContinuation(stage: number, partnerName: string): str
       continuation = `Is there anything else about how this situation has affected you that feels important to express?`;
       break;
     case 2:
-      continuation = `Let's continue exploring ${partnerName}'s perspective. What do you imagine might be going on for ${partnerName} in all of this?`;
+      continuation = `For now, you don't need to do anything more on their behalf.`;
       break;
     case 3:
       continuation = `Let's continue identifying what you truly need here. What feels most important to you?`;

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -252,6 +252,14 @@ Now you know enough to be useful. Reflect using THEIR words, not your interpreta
 - Still ask questions, but now they come from understanding, not just information-gathering
 - Keep it short. One reflection + one question max.
 
+HIGH-CONFLICT / LONG-RUNNING CASES:
+Some users are not mainly asking to be soothed; they are trying to see whether anything is still possible after a long, painful pattern.
+This includes yelling/escalation, jealousy, control, dysregulation, repeated repair attempts, feeling done, or uncertainty about why they are still trying.
+- Do not offer the felt-heard gate after only naming the pattern.
+- Before FeelHeardCheck:Y, make sure you have heard the emotional cost, what they have already tried, what feels embarrassing or grief-heavy, and what boundary or non-equivalence matters to them.
+- If they sound resolved, checked out, or clinically clear, do not mistake that for being complete. Ask what it has cost them, what still hurts, or what they are no longer willing to carry.
+- Honor boundaries explicitly: understanding the other person is not the same as excusing impact, agreeing to continue, or promising repair.
+
 AT ANY POINT:
 - If emotional intensity is high (8+), slow way down. Just be present. Short sentences. No questions unless they're ready.
 - If they're brief or guarded, try a different angle — ask about something adjacent (timeline, what matters to them, what's at stake) instead of pushing deeper on the same thread.
@@ -277,12 +285,13 @@ const STAGE2_PURPOSE_CONTEXT = `
 WHY THIS STEP EXISTS (share this with the user when they seem unsure, resistant, or ask why):
 - Their partner is also talking to the AI separately, working through their own side of things.
 - Both people independently try to understand the other person — that's what makes this work.
-- Research on conflict resolution consistently shows that the single strongest predictor of working things out is each person genuinely trying to see the other's perspective.
+- This is not about excusing, agreeing, or deciding what happens next. It is a protected attempt to see whether each person can name something real about the other's inner experience.
 - This is a guess, not a test. Nobody expects them to read minds. The act of honestly trying to imagine what the other person might be going through is what matters.
 - At the end, they'll write a short statement about what they think their partner might be feeling. That statement gets shared so each person can see how the other sees them.
 - Getting it "wrong" is completely fine — it still shows their partner they made the effort.
 
-NOTE: You can cite the research behind this step (it's what makes the purpose credible). But don't use psychological frameworks to analyze the partner's behavior — no "this is probably driven by attachment" or "people act from fear." Help the user discover things through their own thinking.
+NOTE: Do not cite studies or outcomes as pressure. In high-resistance or no-agreement cases, the user's honest boundary must remain just as legitimate as any softening.
+Do not use psychological frameworks to analyze the partner's behavior — no "this is probably driven by attachment" or "people act from fear." Help the user discover things through their own thinking.
 `;
 
 /**
@@ -543,8 +552,8 @@ Do NOT match the user's emotional intensity in your tone — stay steady regardl
 ${process.env.MWF_STAGE1_PROMPT_APPEND ? `Moment-eval Stage 1 addendum:\n${process.env.MWF_STAGE1_PROMPT_APPEND}\n` : ''}
 
 Feel-heard check:
-- Set FeelHeardCheck:Y when ALL of these are true: (1) they've affirmed something you reflected back, (2) you can name their core concern, and (3) their intensity is stabilizing or steady.
-- Be proactive — when the moment feels right, set it. Don't wait for a perfect signal.
+- Set FeelHeardCheck:Y only when ALL of these are true: (1) they've affirmed something you reflected back, (2) you can name their core concern, (3) their intensity is stabilizing or steady, and (4) for long-running/high-conflict patterns, you have also heard the cost, what they tried, and the boundary or grief underneath.
+- Be proactive only after the real emotional shape is present. Don't wait for perfect wording, but don't offer the gate just because the factual pattern is clear.
 - When FeelHeardCheck:Y, end your response with a gentle acknowledgment that they can confirm below. Example: "...if that captures it, you can let me know below when you're ready." Do NOT invite more freeform chat unless the input remains visible. Do NOT say "tap the button" or mention UI elements directly. Keep it conversational. Keep setting Y until they act on the prompt.
 - Even when FeelHeardCheck:Y, stay in listening mode. Do NOT pivot to advice, action, or next steps.
 
@@ -616,7 +625,14 @@ Length: default 1-3 sentences. Go longer only if explaining the purpose of this 
 Do NOT match the user's emotional intensity in your tone.
 
 READY TO SHARE (ReadyShare:Y):
-Set ReadyShare:Y when ${userName} can describe what ${partnerName} might be feeling or going through without blame — curiosity over defensiveness, "they might feel" over "they always."
+Do NOT set ReadyShare:Y just because ${userName} named one plausible fear, feeling, or need. Stage 2 is not a speed run to a draft.
+Before ReadyShare:Y, ${userName} needs at least 4 substantive Stage 2 turns exploring ${partnerName}'s side unless they are explicitly refining an existing draft.
+
+Set ReadyShare:Y only when ${userName} can describe what ${partnerName} might be feeling or going through without blame — curiosity over defensiveness, "they might feel" over "they always" — AND they have stayed with at least two layers of ${partnerName}'s inner experience (for example fear + need, shame + protective strategy, grief + what they are trying to preserve).
+
+If ${userName} still names unfairness, anger, fear, resentment, "but I'm the one paying for it," "that doesn't excuse it," or similar resistance in the same turn, keep ReadyShare:N. Validate the tension and ask one more question that helps them make their genuine attempt clearer.
+
+Before offering a draft, include a checkpoint in your own words: "Does that feel like your real attempt at what might be happening for ${partnerName}, or is there another layer?" If they answer yes or deepen it, then ReadyShare:Y can be appropriate.
 
 When ReadyShare:Y, include a 2-4 sentence empathy statement in <draft> tags — what ${userName} imagines ${partnerName} is experiencing, written as ${userName} speaking to ${partnerName} (e.g., "I think you might be feeling..."). Focus purely on ${partnerName}'s inner experience — their feelings, fears, or needs.
 
@@ -629,11 +645,11 @@ ${buildResponseProtocol(2, { includesDraft: true, draftPurpose: 'empathy' })}`;
   const baseDynamic = buildBaseDynamicGuidance(context);
   if (baseDynamic) dynamicParts.push(baseDynamic);
 
-  const earlyStage2 = context.turnCount <= 3;
-  const tooEarlyForDraft = context.turnCount < 4;
+  const earlyStage2 = context.turnCount <= 4;
+  const tooEarlyForDraft = context.turnCount < 5 && !context.isRefiningEmpathy;
 
   if (earlyStage2) {
-    dynamicParts.push(`EARLY IN THIS STEP: ${userName} may still have leftover feelings. Start in LISTENING mode. Give space before trying to shift their focus.`);
+    dynamicParts.push(`EARLY IN THIS STEP: ${userName} may still have leftover feelings. Start in LISTENING or BRIDGING mode. Give space before trying to shift their focus, and do not draft yet.`);
   }
   if (context.emotionalIntensity >= 8) {
     dynamicParts.push(`HIGH INTENSITY: ${userName} is really upset right now. Stay in LISTENING mode. Be calm and steady — don't match their intensity. Let them settle first.`);
@@ -667,7 +683,7 @@ ${partnerName} shared this so ${userName} can understand them better. Use it to 
   dynamicParts.push(`Turn: ${context.turnCount}`);
 
   if (tooEarlyForDraft) {
-    dynamicParts.push('ReadyShare guard: TOO EARLY (Turn < 4). Keep exploring through conversation. Don\'t rush to a draft.');
+    dynamicParts.push('ReadyShare guard: TOO EARLY (fewer than 4 substantive Stage 2 user turns). Keep exploring through conversation. Don\'t rush to a draft.');
   }
 
   return { staticBlock, dynamicBlock: dynamicParts.join('\n') };
@@ -999,17 +1015,17 @@ Your message should cover these things in a natural, conversational flow — not
 
 1. VALIDATE: Acknowledge what ${userName} just did — they shared something difficult, stayed with it, and let themselves be heard. That took real honesty.
 
-2. BRIEF ROADMAP: Give ${userName} a sense of the journey ahead. There are a few more steps: first, each person tries to understand what the other might be going through. Then you'll each figure out what you actually need. Eventually, you'll use that to get clearer about what is possible next, whether together or separately. Keep this to 1-2 sentences — it's a preview, not a syllabus.
+2. BRIEF ROADMAP: Give ${userName} a sense of the journey ahead. First, each person tries to understand what the other might be going through. Later, you'll each look at what matters most to you and what is or is not possible from here. Keep this to 1-2 sentences — it's a preview, not a syllabus.
 
 3. FRAME THE NEXT STEP: Be upfront that what comes next might feel a little unusual. You're going to ask ${userName} to try to imagine what ${partnerName} might be going through — even though ${userName} might still be upset with them. Name that this is a strange ask.
 
-4. EXPLAIN WHY: There's a lot of research on what helps people work through conflict, and this comes up over and over — when each person genuinely tries to see what the other is going through, it's one of the strongest predictors of actually working things out. Not because ${userName} has to get it right — it's a guess, not a test. The act of honestly trying is what changes things.
+4. EXPLAIN WHY: This step is not about excusing, agreeing, or deciding what happens next. It is a protected attempt to see whether ${userName} can name something real about ${partnerName}'s inner experience while still keeping ${userName}'s own truth intact. They don't have to get it right — it's a guess, not a test.
 
 5. MUTUAL: ${context.partnerStatus === 'not_joined' ? `${partnerName} will be going through this same process on their side — they'll also be asked to try to understand ${userName}'s experience. This isn't one-sided.` : `${partnerName} is going through this same process on their side — they're also being asked to try to understand ${userName}'s experience. This isn't one-sided.`}
 
 6. OPENING QUESTION: End with a genuine, open question inviting ${userName} to start thinking about what ${partnerName}'s experience might look like.
 
-Take the sentences you need to be clear — probably 6-8 sentences total. This is NOT the place to be brief at the expense of clarity. But keep it conversational and warm, not clinical. Sound like a thoughtful person explaining something that genuinely helps, not a therapist reading a protocol.\n\n`;
+Take the sentences you need to be clear — probably 4-6 sentences total. This is NOT the place to be brief at the expense of clarity. But keep it conversational and warm, not clinical. Sound like a thoughtful person explaining a hard step without selling repair or agreement.\n\n`;
   }
 
   // Stage 2 → Stage 3: Empathy work done, shift to What Matters

--- a/backend/src/utils/__tests__/micro-tag-parser.test.ts
+++ b/backend/src/utils/__tests__/micro-tag-parser.test.ts
@@ -34,6 +34,31 @@ I hear you. That sounds really difficult.`;
       expect(result.offerFeelHeardCheck).toBe(true);
     });
 
+    it('extracts and strips visible XML feel-heard control tags', () => {
+      const raw = `<feel_heard_check>Y</feel_heard_check>
+
+That sounds exhausting to keep carrying.`;
+
+      const result = parseMicroTagResponse(raw);
+
+      expect(result.offerFeelHeardCheck).toBe(true);
+      expect(result.response).toBe('That sounds exhausting to keep carrying.');
+      expect(result.response).not.toContain('feel_heard_check');
+    });
+
+    it('extracts and strips dashed XML ready-share control tags', () => {
+      const raw = `<ready-share>Y</ready-share>
+<draft>I think you might feel alone here.</draft>
+I've prepared a draft for you to review.`;
+
+      const result = parseMicroTagResponse(raw);
+
+      expect(result.offerReadyToShare).toBe(true);
+      expect(result.draft).toBe('I think you might feel alone here.');
+      expect(result.response).toBe("I've prepared a draft for you to review.");
+      expect(result.response).not.toContain('ready-share');
+    });
+
     it('extracts FeelHeardCheck:N as false', () => {
       const raw = `<thinking>FeelHeardCheck:N</thinking>Response text`;
       const result = parseMicroTagResponse(raw);

--- a/backend/src/utils/micro-tag-parser.ts
+++ b/backend/src/utils/micro-tag-parser.ts
@@ -126,11 +126,27 @@ function stripVisibleProposedStrategyLines(responseText: string): {
   };
 }
 
+function extractBooleanControlTag(rawResponse: string, tagName: string): boolean | null {
+  const tagPattern = tagName.replace(/_/g, '[_-]?');
+  const match = rawResponse.match(new RegExp(`<${tagPattern}>\\s*([YN])\\s*<\\/${tagPattern}>`, 'i'));
+  if (!match) return null;
+  return match[1].toUpperCase() === 'Y';
+}
+
+function stripKnownControlTags(rawResponse: string): string {
+  return rawResponse
+    .replace(/<feel[_-]?heard[_-]?check>\s*[YN]\s*<\/feel[_-]?heard[_-]?check>/gi, '')
+    .replace(/<ready[_-]?share>\s*[YN]\s*<\/ready[_-]?share>/gi, '');
+}
+
 /**
  * Parse the micro-tag response format.
  * Extracts semantic blocks and flags from the raw AI response.
  */
 export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagResponse {
+  const feelHeardControlTag = extractBooleanControlTag(rawResponse, 'feel_heard_check');
+  const readyShareControlTag = extractBooleanControlTag(rawResponse, 'ready_share');
+
   // 1. Extract blocks using regex
   const thinkingMatch = rawResponse.match(/<thinking>([\s\S]*?)<\/thinking>/i);
   const draftMatch = rawResponse.match(/<draft>([\s\S]*?)<\/draft>/i);
@@ -150,6 +166,7 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
     .replace(/<needs>[\s\S]*?<\/needs>/gi, '')
     .replace(/<dispatch>[\s\S]*?<\/dispatch>/gi, '')
     .trim();
+  responseText = stripKnownControlTags(responseText).trim();
 
   // If everything landed inside tags, leave response empty and let the caller
   // decide what to do. A dispatch handler may still fill it in; otherwise the
@@ -167,8 +184,8 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
   responseText = strippedVisibleStrategies.responseText;
 
   // 3. Extract flags from thinking string (no JSON needed!)
-  const offerFeelHeardCheck = /FeelHeardCheck:\s*Y/i.test(thinking);
-  const offerReadyToShare = /ReadyShare:\s*Y/i.test(thinking);
+  const offerFeelHeardCheck = feelHeardControlTag ?? /FeelHeardCheck:\s*Y/i.test(thinking);
+  const offerReadyToShare = readyShareControlTag ?? /ReadyShare:\s*Y/i.test(thinking);
 
   // 4. Extract proposed strategies from thinking (Stage 4)
   const proposedStrategies: string[] = [];

--- a/scripts/mwf_gold_loop.py
+++ b/scripts/mwf_gold_loop.py
@@ -357,6 +357,17 @@ def start_background_command(
     return ManagedService(name=name, command=cmd, cwd=cwd, log_path=log_path, started=True, pid=process.pid, process=process)
 
 
+def build_loop_service_env(args: argparse.Namespace, base_env: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(base_env if base_env is not None else os.environ)
+    env.setdefault("E2E_AUTH_BYPASS", "true")
+    env.setdefault("MOCK_LLM", "false")
+    env.setdefault("E2E_APP_BASE_URL", args.app_url)
+    env.setdefault("EXPO_PUBLIC_E2E_MODE", "true")
+    env.setdefault("EXPO_PUBLIC_API_URL", args.api_url)
+    env.setdefault("BROWSER", "none")
+    return env
+
+
 def wait_for_http(url: str, timeout: int = 90) -> bool:
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -402,13 +413,7 @@ def write_service_start_info(
 def start_loop_services(args: argparse.Namespace, service_dir: Path) -> tuple[list[ManagedService], dict[str, Any]]:
     services: list[ManagedService] = []
     service_dir.mkdir(parents=True, exist_ok=True)
-    env = os.environ.copy()
-    env.setdefault("E2E_AUTH_BYPASS", "true")
-    env.setdefault("MOCK_LLM", "true")
-    env.setdefault("E2E_APP_BASE_URL", args.app_url)
-    env.setdefault("EXPO_PUBLIC_E2E_MODE", "true")
-    env.setdefault("EXPO_PUBLIC_API_URL", args.api_url)
-    env.setdefault("BROWSER", "none")
+    env = build_loop_service_env(args)
 
     backend_started = False
     try:
@@ -1345,7 +1350,7 @@ def extract_transcripts(session_id: str, run_dir: Path, scenario: str, max_stage
 
 
 CONTROL_TAG_RE = re.compile(
-    r"</?(?:thinking|draft|dispatch|message|stage|private|shared|tool|analysis|commentary|final)\b[^>]*>",
+    r"</?(?:thinking|draft|dispatch|message|stage|private|shared|tool|analysis|commentary|final|feel[_-]?heard[_-]?check|ready[_-]?share|needs)\b[^>]*>",
     re.I,
 )
 TRANSCRIPT_METADATA_RE = re.compile(r"^- (side|stage|privacy|visible_cta_state):\s*(.+?)\s*$", re.MULTILINE)
@@ -1594,7 +1599,16 @@ def check_chat_copy_has_visible_input(transcripts: list[tuple[Path, str]]) -> di
         visible_cta_state = metadata.get("visible_cta_state", "")
         if INPUT_VISIBLE_RE.search(visible_cta_state):
             continue
+        side = metadata.get("side", "").strip("`").lower()
+        side_label = side.capitalize()
         for match in CHAT_PROMISE_RE.finditer(text):
+            following_text = text[match.end():]
+            next_user_message = (
+                bool(side_label)
+                and re.search(rf"^\*\*\[[^\]]+\]\s+{re.escape(side_label)}:\*\*", following_text, re.MULTILINE)
+            )
+            if next_user_message:
+                continue
             start = max(0, match.start() - 80)
             end = min(len(text), match.end() + 80)
             snippet = " ".join(text[start:end].split())
@@ -1628,11 +1642,45 @@ def check_partner_private_leakage(transcripts: list[tuple[Path, str]]) -> dict[s
     )
 
 
+SEPARATOR_BLOCK_RE = re.compile(r"---\s*\n(?P<body>.*?)\n\*20\d\d-\d\d-\d\d [^*]+\*\n---", re.S)
+LABELED_SHARED_BLOCK_RE = re.compile(
+    r"^(?:\*\*)?(?:[📤💡📝💜❓⚠️✅👁️📊]|YOU SHARED|SHARE SUGGESTION|RECEIVED|AI \(SHARE SUGGESTION\)|[^:\n]+ SHARED WITH YOU)",
+    re.I,
+)
+
+
+def check_transcript_shared_context_blocks_labeled(transcripts: list[tuple[Path, str]]) -> dict[str, Any]:
+    evidence: list[str] = []
+    for path, text in transcripts:
+        for match in SEPARATOR_BLOCK_RE.finditer(text):
+            body = match.group("body").strip()
+            if not body:
+                continue
+            first_line = body.splitlines()[0].strip()
+            if LABELED_SHARED_BLOCK_RE.search(first_line):
+                continue
+            if first_line.startswith("**"):
+                continue
+            snippet = " ".join(body.split())[:160]
+            evidence.append(f"{path.name}: unlabeled separator block: {snippet}")
+            if len(evidence) >= 10:
+                break
+    return invariant_result(
+        "transcript_shared_context_blocks_labeled",
+        not evidence,
+        owner="eval_harness",
+        dimension="transcript_extraction",
+        details="Stable transcript separator blocks must carry explicit labels so private suggestions and shared events are not confused.",
+        evidence=evidence,
+    )
+
+
 def run_invariant_checks(run_dir: Path, run_data: dict[str, Any], scenario: str, max_stage: int) -> dict[str, Any]:
     transcripts = read_transcript_texts(run_data.get("transcripts") or [])
     checks: list[dict[str, Any]] = []
     checks.append(check_no_visible_control_tags(transcripts))
     checks.extend(check_transcript_side_stage_metadata(transcripts, scenario, max_stage))
+    checks.append(check_transcript_shared_context_blocks_labeled(transcripts))
     checks.append(check_partner_private_leakage(transcripts))
     checks.append(check_stage_limit_reached(run_data, scenario, max_stage))
     checks.append(check_actor_operated_correct_side(run_data, scenario))

--- a/scripts/test_mwf_moment_eval.py
+++ b/scripts/test_mwf_moment_eval.py
@@ -140,6 +140,157 @@ class TestYamlParsing(unittest.TestCase):
         self.assertEqual(result["status"], "fail")
         self.assertIn("profile initiator", result["evidence"][0])
 
+    def test_visible_control_tag_invariant_catches_feel_heard_xml_tag(self) -> None:
+        transcripts = [
+            (
+                Path("catherine-stage1.md"),
+                "- side: `catherine`\n- stage: `1`\n\n**[2026-05-06 15:00:00] AI:**\n<feel_heard_check>Y</feel_heard_check>\n\n",
+            )
+        ]
+
+        result = gold_loop.check_no_visible_control_tags(transcripts)
+
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("<feel_heard_check>", result["evidence"][0])
+
+    def test_visible_control_tag_invariant_catches_ready_share_xml_tag(self) -> None:
+        transcripts = [
+            (
+                Path("james-stage2.md"),
+                "- side: `james`\n- stage: `2`\n\n**[2026-05-06 15:00:00] AI:**\n<ready-share>Y</ready-share>\n\n",
+            )
+        ]
+
+        result = gold_loop.check_no_visible_control_tags(transcripts)
+
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("<ready-share>", result["evidence"][0])
+
+    def test_chat_copy_visible_input_invariant_accepts_following_user_turn(self) -> None:
+        transcripts = [
+            (
+                Path("adam-stage1.md"),
+                "\n".join(
+                    [
+                        "# Adam Stage 1 Transcript",
+                        "",
+                        "- side: `adam`",
+                        "- stage: `1`",
+                        "- visible_cta_state: see milestone/system lines when captured",
+                        "",
+                        "**[2026-05-06 15:00:00] AI:**",
+                        "In the meantime, let's keep going so you're not just sitting here.",
+                        "",
+                        "**[2026-05-06 15:00:10] Adam:**",
+                        "It starts gently sometimes, but I hear urgency in it.",
+                        "",
+                    ]
+                ),
+            )
+        ]
+
+        result = gold_loop.check_chat_copy_has_visible_input(transcripts)
+
+        self.assertEqual(result["status"], "pass")
+
+    def test_chat_copy_visible_input_invariant_fails_without_metadata_or_user_turn(self) -> None:
+        transcripts = [
+            (
+                Path("adam-stage1.md"),
+                "\n".join(
+                    [
+                        "# Adam Stage 1 Transcript",
+                        "",
+                        "- side: `adam`",
+                        "- stage: `1`",
+                        "- visible_cta_state: see milestone/system lines when captured",
+                        "",
+                        "**[2026-05-06 15:00:00] AI:**",
+                        "In the meantime, let's keep going so you're not just sitting here.",
+                        "",
+                        "### STAGE 1 COMPLETED",
+                        "",
+                    ]
+                ),
+            )
+        ]
+
+        result = gold_loop.check_chat_copy_has_visible_input(transcripts)
+
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("adam-stage1.md", result["evidence"][0])
+
+    def test_shared_context_blocks_must_be_labeled_in_stable_transcripts(self) -> None:
+        transcripts = [
+            (
+                Path("adam-stage2.md"),
+                "\n".join(
+                    [
+                        "# Adam Stage 2 Transcript",
+                        "",
+                        "- side: `adam`",
+                        "- stage: `2`",
+                        "",
+                        "---",
+                        "The resentment is already here, and I hate that I carry it.",
+                        "*2026-05-07 00:31:15*",
+                        "---",
+                        "",
+                    ]
+                ),
+            )
+        ]
+
+        result = gold_loop.check_transcript_shared_context_blocks_labeled(transcripts)
+
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("unlabeled separator block", result["evidence"][0])
+
+    def test_shared_context_blocks_accept_explicit_partner_label(self) -> None:
+        transcripts = [
+            (
+                Path("adam-stage2.md"),
+                "\n".join(
+                    [
+                        "# Adam Stage 2 Transcript",
+                        "",
+                        "- side: `adam`",
+                        "- stage: `2`",
+                        "",
+                        "---",
+                        "**📤 Eve SHARED WITH YOU:**",
+                        "The resentment is already here, and I hate that I carry it.",
+                        "*2026-05-07 00:31:15*",
+                        "---",
+                        "",
+                    ]
+                ),
+            )
+        ]
+
+        result = gold_loop.check_transcript_shared_context_blocks_labeled(transcripts)
+
+        self.assertEqual(result["status"], "pass")
+
+    def test_gold_loop_service_env_defaults_to_real_llm(self) -> None:
+        args = gold_loop.build_parser().parse_args(
+            ["run", "--api-url", "http://localhost:3000", "--app-url", "http://localhost:8082"]
+        )
+
+        env = gold_loop.build_loop_service_env(args, base_env={})
+
+        self.assertEqual(env["MOCK_LLM"], "false")
+        self.assertEqual(env["E2E_AUTH_BYPASS"], "true")
+
+    def test_gold_loop_service_env_preserves_explicit_mock_llm_override(self) -> None:
+        args = gold_loop.build_parser().parse_args(
+            ["run", "--api-url", "http://localhost:3000", "--app-url", "http://localhost:8082"]
+        )
+
+        env = gold_loop.build_loop_service_env(args, base_env={"MOCK_LLM": "true"})
+
+        self.assertEqual(env["MOCK_LLM"], "true")
+
     def test_gold_profile_generator_emits_role_shape(self) -> None:
         profile = gold_profile.build_profile(
             REPO_ROOT / "docs/product/source-material/golden-transcripts/james-catherine.md",


### PR DESCRIPTION
## Summary

This PR fixes the deterministic gold-loop blockers and prompt pacing issues found while calibrating the bounded Adam/Eve and James/Catherine loops.

Changes include:
- strip XML-style visible control tags such as `<feel_heard_check>Y</feel_heard_check>` and `<ready-share>Y</ready-share>` before rendering
- make gold-loop service startup default to real LLM (`MOCK_LLM=false`) while preserving explicit overrides
- tighten transcript/invariant checks for visible control tags and labeled shared-context blocks
- avoid false failing chat-copy/input checks when a valid user follow-up turn exists
- adjust Stage 1 and Stage 2 prompt guidance for long-running/high-conflict cases
- remove repair/reconciliation pressure from Stage 2 transition and purpose copy
- prevent Stage 2 post-share continuation from restarting partner-perspective work
- add focused backend and Python regression tests

## Validation

Focused tests:

```bash
npm --workspace backend test -- --runTestsByPath src/utils/__tests__/micro-tag-parser.test.ts src/services/__tests__/stage-prompts.test.ts src/controllers/__tests__/stage2-copy.test.ts src/services/__tests__/reconciler.test.ts src/routes/__tests__/reconciler.test.ts src/routes/__tests__/stage2.test.ts src/routes/__tests__/messages.test.ts
python3 scripts/test_mwf_moment_eval.py
```

Results:
- Jest: 7 suites passed, 242 tests passed
- Python: 65 tests passed

Bounded real-LLM gold-loop validation:
- Adam/Eve: `eval/runs/20260506-173725-adam-eve-iter-01`, score `4.0`, verdict `eval_warn`, hard invariants pass
- James/Catherine: `eval/runs/20260506-175333-james-catherine-iter-01`, score `4.0`, verdict `eval_warn`, hard invariants pass

## Notes

Raw run artifacts, scratch logs, and extracted transcripts were intentionally left out of this PR. They remain local evidence rather than committed fixtures.

Follow-up recommended but not blocking this pass:
- Stage 2 post-empathy validation/action boundary can still be made clearer when partner validation copy appears before the exact validation controls are visible.
- Stage 1 calibration can be refined further to avoid reflecting one participant's narrative as product truth too strongly.

@slam-paws please review.
