### PR TITLE
[codex] Make ICM gold gate scenario driven

### DIFF
--- a/eval/gold-scenarios.json
+++ b/eval/gold-scenarios.json
@@ -2,6 +2,11 @@
   "scenarios": [
     {
       "gold_profile": "eval/gold-profiles/adam-eve.json",
+      "gate": {
+        "max_iterations": 1,
+        "stop_after_stage": 2,
+        "target_score": 4.0
+      },
       "id": "adam-eve",
       "live_enabled": true,
       "participants": ["Adam", "Eve"],
@@ -9,6 +14,11 @@
     },
     {
       "gold_profile": "eval/gold-profiles/james-catherine.json",
+      "gate": {
+        "max_iterations": 1,
+        "stop_after_stage": 2,
+        "target_score": 4.0
+      },
       "id": "james-catherine",
       "live_enabled": true,
       "participants": ["James", "Catherine"],

--- a/eval/icm/COMPLETION_CRITERIA.md
+++ b/eval/icm/COMPLETION_CRITERIA.md
@@ -4,14 +4,25 @@ A cycle is complete only when all requirements below are met with actual artifac
 
 ## Clean Pass
 
-- Adam/Eve bounded loop passes the target score with `MOCK_LLM=false`.
-- James/Catherine bounded loop passes the target score with `MOCK_LLM=false`.
-- Both bounded loops pass hard invariants.
-- Both bounded loops produce complete transcripts, `score.json`, `invariants.json`, loop summary, and scratch logs when relevant.
+- Every live-enabled scenario in `eval/gold-scenarios.json` passes its configured gate target with `MOCK_LLM=false`.
+- Every required bounded loop passes hard invariants.
+- Every required bounded loop produces complete transcripts, `score.json`, `invariants.json`, loop summary, and scratch logs when relevant.
 - No run is `not_evaluable_for_prompt_quality` because of seeding, access, transcript extraction, browser orchestration, or scoring failure.
 - Confirmed bugs discovered during the cycle have regression coverage or an explicit tracked exception.
 - Local test services, browser sessions, and `agent-browser` daemons are cleaned up.
 - The final cycle report maps failures, fixes, tests, reruns, scores, invariant status, cleanup status, and remaining risks.
+
+## Required Scenario Set
+
+The required gate is data-driven. Read `eval/gold-scenarios.json` and include every scenario where `live_enabled` is `true` or omitted. Exclude only scenarios with `live_enabled: false`.
+
+Each scenario may define gate settings under `gate`:
+
+- `target_score`
+- `stop_after_stage`
+- `max_iterations`
+
+If a legacy scenario omits one of these settings, use the current bounded defaults: target score `4.0`, stop after Stage `2`, and max iterations `1`.
 
 ## Not A Pass
 

--- a/eval/icm/CONTEXT.md
+++ b/eval/icm/CONTEXT.md
@@ -21,7 +21,7 @@ Use this file to route the current task. Work through stages in order for a full
 3. Plan the highest-priority real blocker first.
 4. Implement only changes justified by artifacts.
 5. Verify focused behavior before rerunning full bounded loops.
-6. Rerun Adam/Eve and James/Catherine with `MOCK_LLM=false`, unless a human-decision blocker is recorded.
+6. Rerun every live-enabled scenario in `eval/gold-scenarios.json` with `MOCK_LLM=false`, unless a human-decision blocker is recorded.
 7. Judge against `COMPLETION_CRITERIA.md`.
 8. Write a cycle report and promote only durable records.
 9. Propose eval-machine improvements separately from product fixes.
@@ -41,6 +41,7 @@ This ICM tree defines decision policy and audit contracts. It does not replace t
 - User goal or cycle objective.
 - Current repository state.
 - Existing stage outputs, if resuming.
+- Required live-enabled scenario set from `eval/gold-scenarios.json`.
 - Canonical artifacts and working-memory artifacts named by the relevant stage.
 
 ## Process

--- a/eval/icm/RUN_SELF_IMPROVEMENT_LOOP.md
+++ b/eval/icm/RUN_SELF_IMPROVEMENT_LOOP.md
@@ -24,7 +24,7 @@ The loop may improve either MWF itself or the eval machine, depending on artifac
 4. Run Stage 03 repair plan.
 5. Implement the highest-priority artifact-backed fix.
 6. Run focused verification.
-7. Rerun Adam/Eve and James/Catherine bounded loops with `MOCK_LLM=false`.
+7. Rerun every live-enabled scenario in `eval/gold-scenarios.json` with `MOCK_LLM=false`.
 8. Judge against `eval/icm/COMPLETION_CRITERIA.md`.
 9. Write report outputs.
 10. Improve the eval machine if the cycle exposed routing, scoring, actor, reporter, harness, or ICM weaknesses.

--- a/eval/icm/cycles/cycle-report-template.md
+++ b/eval/icm/cycles/cycle-report-template.md
@@ -9,8 +9,8 @@
 
 ## Artifacts
 
-- Adam/Eve run dir:
-- James/Catherine run dir:
+- Required scenarios from `eval/gold-scenarios.json`:
+- Run dirs by scenario:
 - Loop summaries:
 - Scores:
 - Invariants:
@@ -37,7 +37,7 @@
 
 ## Reruns
 
-| Pair | Command | Run Dir | Score | Invariants | Result |
+| Scenario | Command | Run Dir | Score | Invariants | Result |
 |---|---|---|---|---|---|
 
 ## Cleanup

--- a/eval/icm/references/gold-loop-commands.md
+++ b/eval/icm/references/gold-loop-commands.md
@@ -4,11 +4,43 @@ Use `scripts/mwf_gold_loop.py` as the canonical bounded loop runner. Do not repl
 
 ## Required Reruns
 
-Run both canonical pairs with real LLM mode:
+Read required scenarios from `eval/gold-scenarios.json`. Rerun every scenario where `live_enabled` is `true` or omitted with real LLM mode. Exclude only scenarios with `live_enabled: false`.
+
+Use the scenario's `gate` values when present:
+
+- `target_score`
+- `stop_after_stage`
+- `max_iterations`
+
+Use bounded defaults for legacy entries that omit gate settings: target score `4.0`, stop after Stage `2`, and max iterations `1`.
+
+Command template:
 
 ```sh
-MOCK_LLM=false python3 scripts/mwf_gold_loop.py run --scenario adam-eve --max-iterations 1 --stop-after-stage 2 --target-score 4.0 --start-services --no-improve-on-final-fail
-MOCK_LLM=false python3 scripts/mwf_gold_loop.py run --scenario james-catherine --max-iterations 1 --stop-after-stage 2 --target-score 4.0 --start-services --no-improve-on-final-fail
+MOCK_LLM=false python3 scripts/mwf_gold_loop.py run --scenario <scenario-id> --max-iterations <max-iterations> --stop-after-stage <stop-after-stage> --target-score <target-score> --start-services --no-improve-on-final-fail
+```
+
+Current registry expansion:
+
+```sh
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+payload = json.loads(Path("eval/gold-scenarios.json").read_text())
+for item in payload.get("scenarios", []):
+    if not item.get("live_enabled", True):
+        continue
+    gate = item.get("gate", {})
+    print(
+        "MOCK_LLM=false python3 scripts/mwf_gold_loop.py run "
+        f"--scenario {item['id']} "
+        f"--max-iterations {gate.get('max_iterations', 1)} "
+        f"--stop-after-stage {gate.get('stop_after_stage', 2)} "
+        f"--target-score {gate.get('target_score', 4.0)} "
+        "--start-services --no-improve-on-final-fail"
+    )
+PY
 ```
 
 If the CLI shape changes, inspect `python scripts/mwf_gold_loop.py --help` and record the exact commands used in `stages/06-rerun/output/run-results.md`.

--- a/eval/icm/references/gold-loop-commands.md
+++ b/eval/icm/references/gold-loop-commands.md
@@ -20,7 +20,7 @@ Command template:
 MOCK_LLM=false python3 scripts/mwf_gold_loop.py run --scenario <scenario-id> --max-iterations <max-iterations> --stop-after-stage <stop-after-stage> --target-score <target-score> --start-services --no-improve-on-final-fail
 ```
 
-Current registry expansion:
+Current registry expansion (run this to see actual commands — do not treat the output as static):
 
 ```sh
 python3 - <<'PY'

--- a/eval/icm/stages/01-intake/CONTEXT.md
+++ b/eval/icm/stages/01-intake/CONTEXT.md
@@ -2,14 +2,17 @@
 
 ## Inputs
 
+- `eval/gold-scenarios.json`.
 - Latest `eval/runs/*-loop-summary.md`, if present.
-- Latest Adam/Eve and James/Catherine run directories under `eval/runs/`, if present.
+- Latest run directories under `eval/runs/` for every live-enabled scenario, if present.
 - `git status --short`.
 - Prior `eval/icm/cycles/<cycle-id>/cycle-report.md`, if resuming.
 
 ## Process
 
 Build an artifact index. Prefer paths and short descriptions over copied content.
+
+Identify the required scenario set from `eval/gold-scenarios.json`. Include every scenario where `live_enabled` is `true` or omitted, exclude scenarios with `live_enabled: false`, and record gate settings when present.
 
 Check for expected run outputs: transcripts, `score.json`, `invariants.json`, loop summary, and scratch logs when relevant.
 

--- a/eval/icm/stages/06-rerun/CONTEXT.md
+++ b/eval/icm/stages/06-rerun/CONTEXT.md
@@ -2,16 +2,16 @@
 
 ## Inputs
 
+- `eval/gold-scenarios.json`
 - `references/gold-loop-commands.md`
 - `references/real-llm-policy.md`
 - `stages/05-verify/output/test-results.md`
 
 ## Process
 
-Rerun both bounded gold loops with `MOCK_LLM=false`:
+Rerun every live-enabled scenario from `eval/gold-scenarios.json` with `MOCK_LLM=false`.
 
-- Adam/Eve
-- James/Catherine
+Use each scenario's configured `gate` values for `target_score`, `stop_after_stage`, and `max_iterations`. If a legacy scenario omits one of these settings, use target score `4.0`, stop after Stage `2`, and max iterations `1`.
 
 If a rerun is skipped, record the explicit blocker and route it to `human_decision` or the appropriate failure owner.
 
@@ -21,4 +21,4 @@ If a rerun is skipped, record the explicit blocker and route it to `human_decisi
 
 ## Audit
 
-Commands must use `MOCK_LLM=false`. Both bounded loops must be rerun or skipped only with explicit reason. Record run dirs, summary paths, `score.json`, `invariants.json`, transcript status, exit status, and cleanup status.
+Commands must use `MOCK_LLM=false`. Every required scenario must be rerun or skipped only with explicit reason. Record scenario id, command, run dir, summary path, `score.json`, `invariants.json`, transcript status, exit status, and cleanup status.


### PR DESCRIPTION
## Summary

Make the ICM gold-loop gate scenario-driven instead of hardcoding Adam/Eve and James/Catherine in the control-plane contracts.

Changes include:
- add per-scenario `gate` settings to `eval/gold-scenarios.json`
- update ICM completion criteria to require every live-enabled scenario from the registry
- update the self-improvement entrypoint, context router, intake, rerun, command reference, and cycle report template to iterate scenarios from the registry
- keep current bounded defaults for legacy scenario entries that omit gate settings

## Validation

```bash
python3 -m json.tool eval/gold-scenarios.json >/dev/null
python3 scripts/mwf_gold_loop.py run --dry-run --scenario adam-eve --max-iterations 1 --stop-after-stage 2 --target-score 4.0 --skip-service-preflight
python3 - <<'PY'
import json
from pathlib import Path
payload = json.loads(Path('eval/gold-scenarios.json').read_text())
for item in payload.get('scenarios', []):
    if not item.get('live_enabled', True):
        continue
    gate = item.get('gate', {})
    print(f"{item['id']} target={gate.get('target_score', 4.0)} stop={gate.get('stop_after_stage', 2)} max={gate.get('max_iterations', 1)}")
PY
rg -n "Adam/Eve|James/Catherine|adam-eve|james-catherine|both bounded|both canonical|both loops" eval/icm || true
```

Results:
- gold scenario JSON validates
- gold-loop dry preflight succeeds for an existing scenario
- registry expansion prints the current two live scenarios with target `4.0`, stop stage `2`, max iterations `1`
- no scenario-specific pair names remain in `eval/icm`

## Notes

This intentionally does not change the moment alignment config, prompt-version coverage, cost caps, or gold-example onboarding automation. Those are still good follow-up self-improvement items, but this PR fixes the ICM gate definition before the next autonomous run depends on it.
