### PR TITLE
[codex] Unify web chat action surfaces

### DIFF
--- a/mobile/src/components/AccuracyFeedbackDrawer.tsx
+++ b/mobile/src/components/AccuracyFeedbackDrawer.tsx
@@ -20,7 +20,7 @@ import {
 } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { X, Check, Minus, XCircle, ChevronLeft } from 'lucide-react-native';
-import { colors } from '@/theme';
+import { appWidthStyle, colors, modalPageStyle } from '@/theme';
 
 export interface AccuracyFeedbackDrawerProps {
   /** Whether the drawer is visible */
@@ -104,6 +104,7 @@ export function AccuracyFeedbackDrawer({
       onRequestClose={onClose}
     >
       <SafeAreaProvider>
+        <View style={styles.modalPage}>
         <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
           {/* Header with close button */}
           <View style={styles.header}>
@@ -252,15 +253,20 @@ export function AccuracyFeedbackDrawer({
             </ScrollView>
           </KeyboardAvoidingView>
         </SafeAreaView>
+        </View>
       </SafeAreaProvider>
     </Modal>
   );
 }
 
 const styles = StyleSheet.create({
+  modalPage: {
+    ...modalPageStyle,
+  },
   container: {
     flex: 1,
     backgroundColor: colors.bgPrimary,
+    ...appWidthStyle,
   },
   header: {
     flexDirection: 'row',

--- a/mobile/src/components/CompactAgreementBar.tsx
+++ b/mobile/src/components/CompactAgreementBar.tsx
@@ -5,8 +5,7 @@
  * Replaces the previous checkbox + "Sign and Begin" flow with a single tap to proceed.
  */
 
-import { View, Text, TouchableOpacity } from 'react-native';
-import { createStyles } from '../theme/styled';
+import { GuidedActionPanel } from './GuidedActionPanel';
 
 // ============================================================================
 // Types
@@ -36,59 +35,24 @@ export function CompactAgreementBar({
   buttonLabel,
   testID,
 }: CompactAgreementBarProps) {
-  const styles = useStyles();
-
   const label = buttonLabel ?? (isFirstSession ? 'Ready' : "Let's go");
 
   return (
-    <View style={styles.container} testID={testID || 'compact-agreement-bar'}>
-      <TouchableOpacity
-        style={[styles.readyButton, isPending && styles.readyButtonDisabled]}
-        onPress={onSign}
-        disabled={isPending}
-        accessibilityRole="button"
-        accessibilityState={{ disabled: isPending }}
-        testID="compact-sign-button"
-      >
-        <Text style={styles.readyButtonText}>
-          {isPending ? '...' : label}
-        </Text>
-      </TouchableOpacity>
-    </View>
+    <GuidedActionPanel
+      tone="topic"
+      eyebrow="Curiosity compact"
+      title="Ready to begin?"
+      subtitle={isFirstSession ? 'Start with the compact, then name the conversation topic.' : undefined}
+      primaryAction={{
+        label,
+        onPress: onSign,
+        disabled: isPending,
+        loading: isPending,
+        testID: 'compact-sign-button',
+      }}
+      testID={testID || 'compact-agreement-bar'}
+    />
   );
 }
-
-// ============================================================================
-// Styles
-// ============================================================================
-
-const useStyles = () =>
-  createStyles((t) => ({
-    container: {
-      paddingHorizontal: t.spacing.lg,
-      paddingVertical: t.spacing.md,
-      backgroundColor: t.colors.bgSecondary,
-      borderTopWidth: 1,
-      borderTopColor: t.colors.border,
-      alignItems: 'center',
-    },
-    readyButton: {
-      backgroundColor: 'rgb(59, 130, 246)',
-      paddingVertical: t.spacing.sm,
-      paddingHorizontal: t.spacing.xl,
-      borderRadius: t.radius.lg,
-      alignItems: 'center',
-      justifyContent: 'center',
-      minWidth: 120,
-    },
-    readyButtonDisabled: {
-      backgroundColor: t.colors.textMuted,
-    },
-    readyButtonText: {
-      color: 'white',
-      fontSize: t.typography.fontSize.md,
-      fontWeight: '600',
-    },
-  }));
 
 export default CompactAgreementBar;

--- a/mobile/src/components/FeelHeardConfirmation.tsx
+++ b/mobile/src/components/FeelHeardConfirmation.tsx
@@ -5,8 +5,7 @@
  * Single button to confirm feeling heard.
  */
 
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { colors } from '@/theme';
+import { GuidedActionPanel } from './GuidedActionPanel';
 
 // ============================================================================
 // Types
@@ -28,65 +27,27 @@ export function FeelHeardConfirmation({
   isPending = false,
 }: FeelHeardConfirmationProps) {
   return (
-    <View style={styles.container}>
-      {onContinue && (
-        <TouchableOpacity
-          style={[styles.button, styles.secondaryButton]}
-          onPress={onContinue}
-          disabled={isPending}
-          activeOpacity={0.7}
-          testID="feel-heard-not-yet"
-        >
-          <Text style={styles.secondaryButtonText}>Not yet</Text>
-        </TouchableOpacity>
-      )}
-      <TouchableOpacity
-        style={styles.button}
-        onPress={onConfirm}
-        disabled={isPending}
-        activeOpacity={0.7}
-        testID="feel-heard-yes"
-      >
-        <Text style={styles.buttonText}>I feel heard</Text>
-      </TouchableOpacity>
-    </View>
+    <GuidedActionPanel
+      tone="success"
+      eyebrow="Ready check"
+      title="Do you feel heard enough to continue?"
+      subtitle="You can keep talking, or move into the next part when this feels complete."
+      secondaryAction={onContinue ? {
+        label: 'Not yet',
+        onPress: onContinue,
+        disabled: isPending,
+        testID: 'feel-heard-not-yet',
+      } : undefined}
+      primaryAction={{
+        label: 'I feel heard',
+        onPress: onConfirm,
+        disabled: isPending,
+        loading: isPending,
+        testID: 'feel-heard-yes',
+      }}
+      testID="feel-heard-panel"
+    />
   );
 }
-
-// ============================================================================
-// Styles
-// ============================================================================
-
-const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    backgroundColor: colors.bgSecondary,
-    borderTopWidth: 1,
-    borderTopColor: colors.border,
-  },
-  button: {
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    backgroundColor: 'rgb(20, 184, 166)', // Teal green to match "Felt Heard" indicator
-    borderRadius: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  buttonText: {
-    color: 'white',
-    fontSize: 15,
-    fontWeight: '600',
-  },
-  secondaryButton: {
-    backgroundColor: 'transparent',
-    marginBottom: 8,
-  },
-  secondaryButtonText: {
-    color: colors.textSecondary,
-    fontSize: 15,
-    fontWeight: '500',
-  },
-});
 
 export default FeelHeardConfirmation;

--- a/mobile/src/components/GuidedActionPanel.tsx
+++ b/mobile/src/components/GuidedActionPanel.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  Check,
+  Lightbulb,
+  MessageCircle,
+  Pencil,
+  Target,
+} from 'lucide-react-native';
+import { colors } from '@/theme';
+
+type GuidedActionTone = 'topic' | 'review' | 'share' | 'success' | 'needs';
+
+interface GuidedActionButton {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  testID?: string;
+}
+
+export interface GuidedActionPanelProps {
+  tone: GuidedActionTone;
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+  primaryAction?: GuidedActionButton;
+  secondaryAction?: GuidedActionButton;
+  compact?: boolean;
+  testID?: string;
+}
+
+const toneColors: Record<GuidedActionTone, string> = {
+  topic: colors.accent,
+  review: colors.brandBlue,
+  share: colors.warning,
+  success: 'rgb(20, 184, 166)',
+  needs: colors.brandPurple,
+};
+
+function ToneIcon({ tone, color }: { tone: GuidedActionTone; color: string }) {
+  const iconProps = { color, size: 17, strokeWidth: 2.4 };
+  switch (tone) {
+    case 'topic':
+      return <Target {...iconProps} />;
+    case 'review':
+      return <MessageCircle {...iconProps} />;
+    case 'share':
+      return <Lightbulb {...iconProps} />;
+    case 'success':
+      return <Check {...iconProps} />;
+    case 'needs':
+      return <Pencil {...iconProps} />;
+    default:
+      return <Target {...iconProps} />;
+  }
+}
+
+export function GuidedActionPanel({
+  tone,
+  eyebrow,
+  title,
+  subtitle,
+  primaryAction,
+  secondaryAction,
+  compact = false,
+  testID,
+}: GuidedActionPanelProps) {
+  const accent = toneColors[tone];
+  const actions = [secondaryAction, primaryAction].filter(Boolean) as GuidedActionButton[];
+
+  return (
+    <View
+      style={[
+        styles.container,
+        compact && styles.containerCompact,
+        { borderLeftColor: accent },
+      ]}
+      testID={testID}
+    >
+      <View style={styles.iconWrap}>
+        <View style={styles.icon}>
+          <ToneIcon tone={tone} color={accent} />
+        </View>
+      </View>
+      <View style={styles.body}>
+        {eyebrow ? (
+          <Text style={[styles.eyebrow, { color: accent }]}>{eyebrow}</Text>
+        ) : null}
+        <Text style={styles.title}>{title}</Text>
+        {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+        {actions.length > 0 ? (
+          <View style={[styles.actions, actions.length === 1 && styles.actionsSingle]}>
+            {actions.map((action) => {
+              const isPrimary = action === primaryAction;
+              return (
+                <TouchableOpacity
+                  key={action.label}
+                  style={[
+                    styles.button,
+                    isPrimary ? [styles.primaryButton, { backgroundColor: accent, borderColor: accent }] : styles.secondaryButton,
+                    action.disabled && styles.buttonDisabled,
+                  ]}
+                  onPress={action.onPress}
+                  disabled={action.disabled || action.loading}
+                  activeOpacity={0.75}
+                  testID={action.testID}
+                >
+                  {action.loading ? (
+                    <ActivityIndicator size="small" color={isPrimary ? colors.textOnAccent : accent} />
+                  ) : (
+                    <Text style={[
+                      styles.buttonText,
+                      isPrimary ? styles.primaryButtonText : [styles.secondaryButtonText, { color: accent }],
+                    ]}>
+                      {action.label}
+                    </Text>
+                  )}
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 13,
+    backgroundColor: colors.bgSecondary,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    borderLeftWidth: 3,
+  },
+  containerCompact: {
+    paddingVertical: 10,
+  },
+  iconWrap: {
+    paddingTop: 1,
+  },
+  icon: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(15, 23, 42, 0.32)',
+  },
+  body: {
+    flex: 1,
+    minWidth: 0,
+  },
+  eyebrow: {
+    fontSize: 11,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    marginBottom: 3,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '700',
+    lineHeight: 20,
+    color: colors.textPrimary,
+  },
+  subtitle: {
+    marginTop: 4,
+    fontSize: 13,
+    lineHeight: 18,
+    color: colors.textSecondary,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 10,
+  },
+  actionsSingle: {
+    justifyContent: 'flex-end',
+  },
+  button: {
+    flex: 1,
+    minHeight: 38,
+    borderRadius: 8,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+  },
+  primaryButton: {},
+  secondaryButton: {
+    backgroundColor: 'rgba(15, 23, 42, 0.24)',
+    borderColor: colors.border,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  primaryButtonText: {
+    color: colors.textOnAccent,
+  },
+  secondaryButtonText: {},
+});
+
+export default GuidedActionPanel;

--- a/mobile/src/components/GuidedDraftChatModal.tsx
+++ b/mobile/src/components/GuidedDraftChatModal.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { X } from 'lucide-react-native';
-import { colors } from '@/theme';
+import { appWidthStyle, colors, modalPageStyle } from '@/theme';
 import { ChatInterface, ChatMessage } from './ChatInterface';
 
 export interface GuidedDraftMessage extends ChatMessage {
@@ -108,38 +108,44 @@ export function GuidedDraftChatModal({
       onRequestClose={onClose}
       testID={testID}
     >
-      <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-        <View style={[styles.header, { paddingTop: Math.max(insets.top, 12) }]}>
-          <Text style={styles.headerTitle}>{title}</Text>
-          <TouchableOpacity
-            style={styles.closeButton}
-            onPress={onClose}
-            testID={`${testID}-close`}
-          >
-            <X color={colors.textPrimary} size={24} />
-          </TouchableOpacity>
-        </View>
+      <View style={styles.modalPage}>
+        <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+          <View style={[styles.header, { paddingTop: Math.max(insets.top, 12) }]}>
+            <Text style={styles.headerTitle}>{title}</Text>
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={onClose}
+              testID={`${testID}-close`}
+            >
+              <X color={colors.textPrimary} size={24} />
+            </TouchableOpacity>
+          </View>
 
-        <ChatInterface
-          sessionId={sessionKey}
-          messages={messages}
-          onSendMessage={onSendMessage}
-          isLoading={isLoading}
-          isInputDisabled={isFinalizing}
-          partnerName={partnerName}
-          renderMessageExtra={renderMessageExtra}
-          emptyStateTitle={emptyStateTitle}
-          emptyStateMessage={emptyStateMessage}
-        />
-      </SafeAreaView>
+          <ChatInterface
+            sessionId={sessionKey}
+            messages={messages}
+            onSendMessage={onSendMessage}
+            isLoading={isLoading}
+            isInputDisabled={isFinalizing}
+            partnerName={partnerName}
+            renderMessageExtra={renderMessageExtra}
+            emptyStateTitle={emptyStateTitle}
+            emptyStateMessage={emptyStateMessage}
+          />
+        </SafeAreaView>
+      </View>
     </Modal>
   );
 }
 
 const styles = StyleSheet.create({
+  modalPage: {
+    ...modalPageStyle,
+  },
   container: {
     flex: 1,
     backgroundColor: colors.bgPrimary,
+    ...appWidthStyle,
   },
   header: {
     flexDirection: 'row',

--- a/mobile/src/components/ShareTopicDrawer.tsx
+++ b/mobile/src/components/ShareTopicDrawer.tsx
@@ -20,7 +20,7 @@ import {
 } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { X, Lightbulb } from 'lucide-react-native';
-import { colors } from '@/theme';
+import { appWidthStyle, colors, modalPageStyle } from '@/theme';
 
 // ============================================================================
 // Types
@@ -93,6 +93,7 @@ export function ShareTopicDrawer({
       onRequestClose={onClose}
     >
       <SafeAreaProvider>
+        <View style={styles.modalPage}>
         <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
           {/* Header with close button */}
           <View style={styles.header}>
@@ -159,6 +160,7 @@ export function ShareTopicDrawer({
             </TouchableOpacity>
           </View>
         </SafeAreaView>
+        </View>
       </SafeAreaProvider>
     </Modal>
   );
@@ -169,9 +171,13 @@ export function ShareTopicDrawer({
 // ============================================================================
 
 const styles = StyleSheet.create({
+  modalPage: {
+    ...modalPageStyle,
+  },
   container: {
     flex: 1,
     backgroundColor: colors.bgPrimary,
+    ...appWidthStyle,
   },
   header: {
     flexDirection: 'row',

--- a/mobile/src/components/ShareTopicPanel.tsx
+++ b/mobile/src/components/ShareTopicPanel.tsx
@@ -9,9 +9,7 @@
  * 2. If user accepts → AI generates draft via chat → Opens ShareSuggestionDrawer
  */
 
-import { TouchableOpacity, Text, StyleSheet } from 'react-native';
-import { Lightbulb } from 'lucide-react-native';
-import { colors } from '@/theme';
+import { GuidedActionPanel } from './GuidedActionPanel';
 
 // ============================================================================
 // Types
@@ -40,43 +38,16 @@ export function ShareTopicPanel({
 }: ShareTopicPanelProps) {
   if (!visible) return null;
 
-  // Use orange for OFFER_SHARING (significant gaps), blue for OFFER_OPTIONAL (moderate gaps)
-  const iconColor = action === 'OFFER_SHARING' ? colors.warning : colors.brandBlue;
-  const textColor = action === 'OFFER_SHARING' ? colors.warning : colors.brandBlue;
-
   return (
-    <TouchableOpacity
-      style={styles.panel}
-      onPress={onPress}
-      activeOpacity={0.7}
+    <GuidedActionPanel
+      tone={action === 'OFFER_SHARING' ? 'share' : 'review'}
+      eyebrow="Share suggestion"
+      title={`Help ${partnerName} understand you better`}
+      subtitle="Review the suggested context before deciding whether to share it."
+      primaryAction={{ label: 'Review', onPress }}
       testID="share-topic-panel"
-    >
-      <Lightbulb color={iconColor} size={18} />
-      <Text style={[styles.panelText, { color: textColor }]}>
-        Help {partnerName} understand you better
-      </Text>
-    </TouchableOpacity>
+    />
   );
 }
-
-// ============================================================================
-// Styles
-// ============================================================================
-
-const styles = StyleSheet.create({
-  panel: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    paddingVertical: 10,
-    paddingHorizontal: 16,
-    backgroundColor: colors.bgSecondary,
-  },
-  panelText: {
-    fontSize: 14,
-    fontWeight: '500',
-  },
-});
 
 export default ShareTopicPanel;

--- a/mobile/src/components/ViewEmpathyStatementDrawer.tsx
+++ b/mobile/src/components/ViewEmpathyStatementDrawer.tsx
@@ -20,7 +20,7 @@ import {
 } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { X, Send, MessageCircle } from 'lucide-react-native';
-import { colors } from '@/theme';
+import { appWidthStyle, colors, modalPageStyle } from '@/theme';
 
 export interface ViewEmpathyStatementDrawerProps {
   /** Whether the drawer is visible */
@@ -89,6 +89,7 @@ export function ViewEmpathyStatementDrawer({
       onRequestClose={onClose}
     >
       <SafeAreaProvider>
+        <View style={styles.modalPage}>
         <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
           <KeyboardAvoidingView
             style={styles.keyboardAvoid}
@@ -207,15 +208,20 @@ export function ViewEmpathyStatementDrawer({
           </ScrollView>
           </KeyboardAvoidingView>
         </SafeAreaView>
+        </View>
       </SafeAreaProvider>
     </Modal>
   );
 }
 
 const styles = StyleSheet.create({
+  modalPage: {
+    ...modalPageStyle,
+  },
   container: {
     flex: 1,
     backgroundColor: colors.bgPrimary,
+    ...appWidthStyle,
   },
   keyboardAvoid: {
     flex: 1,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -58,6 +58,7 @@ import { NeedsDrawer, NeedsDrawerMode } from '../components/NeedsDrawer';
 import { RefinementModalScreen } from './RefinementModalScreen';
 import { GuidedDraftChatModal } from '../components/GuidedDraftChatModal';
 import { TypewriterText } from '../components/TypewriterText';
+import { GuidedActionPanel } from '../components/GuidedActionPanel';
 
 import { useUnifiedSession, InlineChatCard } from '../hooks/useUnifiedSession';
 import { useConfirmTopicFrame } from '../hooks/useSessions';
@@ -90,6 +91,7 @@ import {
 } from '../utils/realtimeInvalidation';
 import { useToast } from '../contexts/ToastContext';
 import { createStyles } from '../theme/styled';
+import { appWidthStyle } from '../theme';
 import { WaitingBanner } from '../components/WaitingBanner';
 import {
   trackInvitationSent,
@@ -2451,29 +2453,20 @@ export function UnifiedSessionScreen({
       case 'topic-proposal':
         if (!topicFrame) return undefined;
         return (
-          <View style={styles.topicProposalContainer} testID="topic-proposal-panel">
-            <Text style={styles.topicProposalLabel}>Proposed topic</Text>
-            <Text style={styles.topicProposalText}>{topicFrame}</Text>
-            <Text style={styles.topicProposalHint}>To change it, just tell me below.</Text>
-            <View style={styles.topicProposalActions}>
-              <TouchableOpacity
-                style={[
-                  styles.topicProposalButton,
-                  styles.topicProposalPrimaryButton,
-                  isConfirmingTopicFrame && styles.topicProposalButtonDisabled,
-                ]}
-                onPress={handleConfirmTopicFrame}
-                disabled={isConfirmingTopicFrame}
-                testID="topic-proposal-use-button"
-              >
-                {isConfirmingTopicFrame ? (
-                  <ActivityIndicator size="small" color={styles.topicProposalPrimaryButtonText.color} />
-                ) : (
-                  <Text style={styles.topicProposalPrimaryButtonText}>Use this topic</Text>
-                )}
-              </TouchableOpacity>
-            </View>
-          </View>
+          <GuidedActionPanel
+            tone="topic"
+            eyebrow="Topic frame"
+            title={topicFrame}
+            subtitle="This stays above the input at the end of Stage 0. To change it, tell me below."
+            primaryAction={{
+              label: 'Use this topic',
+              onPress: handleConfirmTopicFrame,
+              disabled: isConfirmingTopicFrame,
+              loading: isConfirmingTopicFrame,
+              testID: 'topic-proposal-use-button',
+            }}
+            testID="topic-proposal-panel"
+          />
         );
 
       case 'feel-heard':
@@ -2495,17 +2488,15 @@ export function UnifiedSessionScreen({
             }}
             pointerEvents="auto"
           >
-            <View style={styles.feelHeardContainer}>
-              <FeelHeardConfirmation
-                onConfirm={() => {
-                  // Track felt heard response
-                  trackFeltHeardResponse(sessionId, 'yes');
-                  // Cache-First: useConfirmFeelHeard.onMutate sets milestones.feelHeardConfirmedAt optimistically
-                  handleConfirmFeelHeard(() => onStageComplete?.(Stage.WITNESS));
-                }}
-                isPending={isConfirmingFeelHeard}
-              />
-            </View>
+            <FeelHeardConfirmation
+              onConfirm={() => {
+                // Track felt heard response
+                trackFeltHeardResponse(sessionId, 'yes');
+                // Cache-First: useConfirmFeelHeard.onMutate sets milestones.feelHeardConfirmedAt optimistically
+                handleConfirmFeelHeard(() => onStageComplete?.(Stage.WITNESS));
+              }}
+              isPending={isConfirmingFeelHeard}
+            />
           </Animated.View>
         );
 
@@ -2528,18 +2519,20 @@ export function UnifiedSessionScreen({
             }}
             pointerEvents={!isSharingEmpathy ? 'auto' : 'none'}
           >
-            <View style={styles.empathyReviewContainer}>
-              <TouchableOpacity
-                style={styles.empathyReviewButton}
-                onPress={() => setShowEmpathyDrawer(true)}
-                activeOpacity={0.7}
-                testID="empathy-review-button"
-              >
-                <Text style={styles.empathyReviewButtonText}>
-                  {isRefiningEmpathy ? 'Revisit what you\'ll share' : 'Review what you\'ll share'}
-                </Text>
-              </TouchableOpacity>
-            </View>
+            <GuidedActionPanel
+              tone="review"
+              eyebrow={isRefiningEmpathy ? 'Revision' : 'Empathy draft'}
+              title={isRefiningEmpathy ? 'Revisit what you’ll share' : 'Review what you’ll share'}
+              subtitle={isRefiningEmpathy
+                ? `${partnerName} shared more context. Check whether your understanding should change.`
+                : `Open your draft before sending it to ${partnerName}.`}
+              primaryAction={{
+                label: 'Review',
+                onPress: () => setShowEmpathyDrawer(true),
+                testID: 'empathy-review-button',
+              }}
+              testID="empathy-review-panel"
+            />
           </Animated.View>
         );
 
@@ -2605,22 +2598,22 @@ export function UnifiedSessionScreen({
             }}
             pointerEvents="auto"
           >
-            <View style={styles.needsReviewContainer}>
-              <TouchableOpacity
-                style={styles.needsReviewButton}
-                onPress={() => {
+            <GuidedActionPanel
+              tone="needs"
+              eyebrow="Needs review"
+              title="Review needs together"
+              subtitle="Open both needs lists side by side before continuing."
+              primaryAction={{
+                label: 'Review',
+                onPress: () => {
                   setShowActivityMenu(false);
                   setNeedsDrawerMode('reveal');
                   setShowNeedsDrawer(true);
-                }}
-                activeOpacity={0.7}
-                testID="needs-reveal-validate-button"
-              >
-                <Text style={styles.needsReviewButtonText}>
-                  Review needs together
-                </Text>
-              </TouchableOpacity>
-            </View>
+                },
+                testID: 'needs-reveal-validate-button',
+              }}
+              testID="needs-reveal-validate-panel"
+            />
           </Animated.View>
         );
 
@@ -3563,6 +3556,7 @@ const useStyles = () =>
     container: {
       flex: 1,
       backgroundColor: t.colors.bgPrimary,
+      ...appWidthStyle,
     },
     content: {
       flex: 1,
@@ -3824,129 +3818,7 @@ const useStyles = () =>
       lineHeight: 28,
       textAlign: 'center' as const,
     },
-    topicProposalContainer: {
-      marginHorizontal: t.spacing.lg,
-      marginTop: t.spacing.sm,
-      marginBottom: t.spacing.xs,
-      paddingHorizontal: t.spacing.md,
-      paddingTop: t.spacing.lg,
-      paddingBottom: t.spacing.md,
-      borderRadius: t.radius.md,
-      borderWidth: 1,
-      borderColor: t.colors.border,
-      backgroundColor: t.colors.bgPrimary,
-    },
-    topicProposalLabel: {
-      fontSize: t.typography.fontSize.sm,
-      color: t.colors.textSecondary,
-      fontWeight: '600' as const,
-      marginBottom: t.spacing.sm,
-    },
-    topicProposalText: {
-      fontSize: t.typography.fontSize.lg,
-      color: t.colors.textPrimary,
-      fontWeight: '600' as const,
-      lineHeight: 30,
-      marginBottom: t.spacing.sm,
-    },
-    topicProposalHint: {
-      fontSize: t.typography.fontSize.sm,
-      color: t.colors.textSecondary,
-      marginBottom: t.spacing.md,
-    },
-    topicProposalActions: {
-      flexDirection: 'row',
-      gap: t.spacing.sm,
-      marginTop: t.spacing.md,
-    },
-    topicProposalButton: {
-      flex: 1,
-      minHeight: 40,
-      borderRadius: t.radius.md,
-      alignItems: 'center',
-      justifyContent: 'center',
-      paddingHorizontal: t.spacing.md,
-    },
-    topicProposalPrimaryButton: {
-      backgroundColor: t.colors.accent,
-    },
-    topicProposalSecondaryButton: {
-      backgroundColor: t.colors.bgSecondary,
-      borderWidth: 1,
-      borderColor: t.colors.border,
-    },
-    topicProposalButtonDisabled: {
-      opacity: 0.6,
-    },
-    topicProposalPrimaryButtonText: {
-      color: t.colors.textOnAccent,
-      fontSize: t.typography.fontSize.md,
-      fontWeight: '600' as const,
-    },
-    topicProposalSecondaryButtonText: {
-      color: t.colors.textPrimary,
-      fontSize: t.typography.fontSize.md,
-      fontWeight: '600' as const,
-    },
-
-    // Feel Heard Panel
-    feelHeardContainer: {
-      backgroundColor: t.colors.bgSecondary,
-      borderTopWidth: 1,
-      borderTopColor: t.colors.border,
-    },
-    // Empathy Review Panel
-    empathyReviewContainer: {
-      paddingHorizontal: t.spacing.lg,
-      paddingVertical: t.spacing.md,
-      backgroundColor: t.colors.bgSecondary,
-      borderTopWidth: 1,
-      borderTopColor: t.colors.border,
-    },
-    empathyReviewButton: {
-      paddingVertical: t.spacing.sm,
-      paddingHorizontal: t.spacing.md,
-      backgroundColor: t.colors.bgPrimary,
-      borderRadius: 8,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    empathyReviewButtonText: {
-      fontSize: t.typography.fontSize.md,
-      fontWeight: '500',
-      color: t.colors.brandBlue,
-    },
-
-    // Share Suggestion Panel
-    shareSuggestionContainer: {
-      paddingHorizontal: t.spacing.lg,
-      paddingVertical: t.spacing.md,
-      backgroundColor: t.colors.bgSecondary,
-      borderTopWidth: 1,
-      borderTopColor: t.colors.border,
-    },
-    shareSuggestionButton: {
-      paddingVertical: t.spacing.sm,
-      paddingHorizontal: t.spacing.md,
-      backgroundColor: '#005AC1',
-      borderRadius: 8,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    shareSuggestionButtonText: {
-      fontSize: t.typography.fontSize.md,
-      fontWeight: '500',
-      color: 'white',
-    },
-
     // Needs Review Panel (Stage 3)
-    needsReviewContainer: {
-      paddingHorizontal: t.spacing.lg,
-      paddingVertical: t.spacing.md,
-      backgroundColor: t.colors.bgSecondary,
-      borderTopWidth: 1,
-      borderTopColor: t.colors.border,
-    },
     needsReviewBelowInputContainer: {
       paddingHorizontal: t.spacing.lg,
       paddingTop: t.spacing.sm,
@@ -3954,47 +3826,6 @@ const useStyles = () =>
       backgroundColor: t.colors.bgSecondary,
       borderTopWidth: 1,
       borderTopColor: t.colors.border,
-    },
-    needsReviewButton: {
-      paddingVertical: t.spacing.sm,
-      paddingHorizontal: t.spacing.md,
-      backgroundColor: t.colors.bgPrimary,
-      borderRadius: 8,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    needsReviewButtonText: {
-      fontSize: t.typography.fontSize.md,
-      fontWeight: '500',
-      color: t.colors.brandBlue,
-    },
-
-    // Needs Validation Panel (Stage 3)
-    needsRevealContainer: {
-      paddingHorizontal: t.spacing.lg,
-      paddingVertical: t.spacing.md,
-      backgroundColor: t.colors.bgSecondary,
-      borderTopWidth: 1,
-      borderTopColor: t.colors.border,
-    },
-    needsRevealButton: {
-      paddingVertical: t.spacing.sm,
-      paddingHorizontal: t.spacing.md,
-      backgroundColor: t.colors.bgPrimary,
-      borderRadius: 8,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    needsRevealButtonText: {
-      fontSize: t.typography.fontSize.md,
-      fontWeight: '500',
-      color: t.colors.brandBlue,
-    },
-    noOverlapText: {
-      fontSize: t.typography.fontSize.sm,
-      color: t.colors.textSecondary,
-      textAlign: 'center' as const,
-      marginBottom: t.spacing.sm,
     },
 
     // Inline Cards

--- a/mobile/src/theme/index.ts
+++ b/mobile/src/theme/index.ts
@@ -14,3 +14,4 @@ export type Theme = typeof theme;
 
 // Re-export individual modules
 export { colors, spacing, typography, radius };
+export { APP_MAX_WIDTH, appWidthStyle, modalPageStyle } from './layout';

--- a/mobile/src/theme/layout.ts
+++ b/mobile/src/theme/layout.ts
@@ -1,0 +1,22 @@
+import { Platform } from 'react-native';
+
+export const APP_MAX_WIDTH = 480;
+
+export const appWidthStyle = Platform.OS === 'web'
+  ? {
+      width: '100%' as const,
+      maxWidth: APP_MAX_WIDTH,
+      alignSelf: 'center' as const,
+    }
+  : {};
+
+export const modalPageStyle = Platform.OS === 'web'
+  ? {
+      flex: 1,
+      width: '100%' as const,
+      alignItems: 'center' as const,
+      backgroundColor: '#0f172a',
+    }
+  : {
+      flex: 1,
+    };


### PR DESCRIPTION
## Summary
- Add a shared web app-width helper so web-only modal and drawer content stays inside the existing app column.
- Add a reusable `GuidedActionPanel` for the CTAs that appear around the chat input.
- Move the Stage 0 topic confirmation into that shared above-input action surface and update related chat CTAs to use the same visual system.
- Constrain refinement and review surfaces on web without changing their native behavior.

## Validation
- `npm run check` in `mobile`

## Notes
- Mockup-only HTML and React Native routes were removed before opening this PR; this PR contains only production app changes.