### PR TITLE
[codex] Animate queued live chat messages

### DIFF
--- a/mobile/src/components/ChatBubble.tsx
+++ b/mobile/src/components/ChatBubble.tsx
@@ -110,9 +110,17 @@ export function ChatBubble({
   // Determine if we should use fade-in effect (non-AI, non-USER messages that should animate)
   const shouldUseFadeIn = !isUser && !isAI && enableTypewriter && !message.skipTypewriter && !hasAnimatedRef.current;
 
-  // Track whether this message is next to animate (callback is provided)
-  // This allows the effect to re-run when the message becomes "next"
+  // Track whether this message is next to animate (callback is provided).
+  // Animatable live messages that are not next stay hidden so they do not pop
+  // in fully rendered before their queued animation turn.
   const isNextToAnimate = onAnimationStart !== undefined;
+  const isWaitingForAnimationTurn =
+    !isUser &&
+    enableTypewriter &&
+    !message.skipTypewriter &&
+    !hasAnimatedRef.current &&
+    !isNextToAnimate &&
+    !hasStartedRef.current;
 
   // Handle fade-in animation for non-typewriter messages
   // Only starts when this message is next in the animation queue (onAnimationStart is provided)
@@ -237,6 +245,10 @@ export function ChatBubble({
   const isFadeInAnimating = willAnimate && !hasAnimatedRef.current && isNextToAnimate;
 
   const renderContent = () => {
+    if (isWaitingForAnimationTurn) {
+      return null;
+    }
+
     // Empathy statements - use fade-in for new messages
     if (isEmpathyStatement) {
       const deliveryStatus = message.sharedContentDeliveryStatus;
@@ -316,10 +328,6 @@ export function ChatBubble({
     // Use typewriter effect for new AI messages - animates word-by-word at consistent pace
     // This normalizes display speed regardless of how fast streaming arrives
     if (shouldUseTypewriter) {
-      if (!isNextToAnimate && !hasStartedRef.current) {
-        // Not this message's turn and hasn't started yet — render instant text (never hide)
-        return <Text style={getTextStyle()}>{message.content}</Text>;
-      }
       return (
         <TypewriterText
           text={message.content}

--- a/mobile/src/components/__tests__/ChatInterface.test.tsx
+++ b/mobile/src/components/__tests__/ChatInterface.test.tsx
@@ -10,6 +10,7 @@ import { Text } from 'react-native';
 import { screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { render } from '../../utils/test-utils';
 import { ChatInterface } from '../ChatInterface';
+import { ChatBubble } from '../ChatBubble';
 import { MessageDTO, MessageRole, Stage } from '@meet-without-fear/shared';
 
 // ============================================================================
@@ -339,6 +340,60 @@ describe('ChatBubble', () => {
 
     const bubble = screen.getByTestId('chat-bubble-1');
     expect(bubble).toBeTruthy();
+  });
+
+  it('hides queued live AI messages until their typewriter turn', () => {
+    render(
+      <ChatBubble
+        message={{
+          id: 'queued-ai',
+          role: MessageRole.AI,
+          content: 'Queued AI response',
+          timestamp: new Date().toISOString(),
+          skipTypewriter: false,
+        }}
+        enableTypewriter
+      />
+    );
+
+    expect(screen.getByTestId('chat-bubble-queued-ai')).toBeTruthy();
+    expect(screen.queryByText('Queued AI response')).toBeNull();
+    expect(screen.queryByTestId('typewriter-text')).toBeNull();
+  });
+
+  it('hides queued live system messages until their fade-in turn', () => {
+    render(
+      <ChatBubble
+        message={{
+          id: 'queued-system',
+          role: MessageRole.SYSTEM,
+          content: 'Queued system transition',
+          timestamp: new Date().toISOString(),
+          skipTypewriter: false,
+        }}
+        enableTypewriter
+      />
+    );
+
+    expect(screen.getByTestId('chat-bubble-queued-system')).toBeTruthy();
+    expect(screen.queryByText('Queued system transition')).toBeNull();
+  });
+
+  it('renders history messages immediately without animation', () => {
+    render(
+      <ChatBubble
+        message={{
+          id: 'history-ai',
+          role: MessageRole.AI,
+          content: 'Loaded history response',
+          timestamp: new Date().toISOString(),
+          skipTypewriter: true,
+        }}
+        enableTypewriter
+      />
+    );
+
+    expect(screen.getByText('Loaded history response')).toBeTruthy();
   });
 
   it('displays message content correctly', () => {


### PR DESCRIPTION
## Summary

Fix queued live chat messages so action-generated AI/system messages do not pop in fully rendered before their animation turn.

Root cause:
- `ChatInterface` correctly marked newly arrived non-user messages as animatable.
- `ChatBubble` still rendered animatable messages at full opacity when they were waiting behind another message in the animation queue.
- This made multi-message action responses, including transition/system-style messages, appear unanimated even though the first item in the batch animated.

Changes:
- hide animatable live messages until `ChatInterface` passes them the animation-start callback for their queue turn
- preserve instant rendering for loaded/history messages via `skipTypewriter`
- add focused tests for queued AI, queued system, and history rendering behavior

## Validation

```bash
npm --workspace mobile test -- --runTestsByPath src/components/__tests__/ChatInterface.test.tsx --runInBand
npm --workspace mobile run check
```

Results:
- ChatInterface focused test suite: 25 tests passed
- Mobile typecheck: passed

## Notes

I installed dependencies in the isolated worktree with `npm ci` to run the checks. The npm install reported existing audit warnings, but no lockfile or package changes were produced.
