### PR TITLE
[codex] Track MWF gold skills in repo

### DIFF
--- a/eval/icm/CLAUDE.md
+++ b/eval/icm/CLAUDE.md
@@ -13,6 +13,7 @@ Read `eval/icm/CONTEXT.md` first. It routes work through intake, triage, repair 
 - `COMPLETION_CRITERIA.md`: clean-pass requirements.
 - `FAILURE_TAXONOMY.md`: primary owner categories for failures.
 - `references/`: policies and canonical command references.
+- `references/skills-index.md`: repo-backed MWF gold skill source and runtime symlink setup.
 - `stages/`: stage contracts with `Inputs`, `Process`, `Outputs`, and `Audit`.
 - `self-improvement/`: backlog and proposal area for eval-machine improvements.
 - `regressions/`: promoted regression records only.
@@ -20,7 +21,7 @@ Read `eval/icm/CONTEXT.md` first. It routes work through intake, triage, repair 
 
 ## Durable Rules
 
-- Use the existing MWF skills as specialist modules; route to them instead of copying their instructions.
+- Use the repo-backed MWF skills in `eval/skills/` as specialist modules. Runtime skill paths should symlink to these repo sources; see `references/skills-index.md`.
 - Use existing Python and TypeScript harnesses for mechanical execution, especially `scripts/mwf_gold_loop.py`.
 - Put working outputs in the current stage `output/` directory or in `cycles/<cycle-id>/`.
 - Never modify completion criteria, scoring rubrics, hard invariants, or actor difficulty to make a failing run pass.

--- a/eval/icm/CONTEXT.md
+++ b/eval/icm/CONTEXT.md
@@ -32,7 +32,7 @@ Use this file to route the current task. Work through stages in order for a full
 - Moment evaluator: `scripts/mwf_moment_eval.py`.
 - Moment tests: `scripts/test_mwf_moment_eval.py`.
 - Transcript extractor: `backend/scripts/extract-session-transcripts.ts`.
-- Specialist skills: `mwf-gold-loop-actor`, `mwf-gold-session-scorer`, `mwf-gold-session-reporter`, `mwf-gold-session-tester`, and `mwf-gold-prompt-improver`.
+- Specialist skills: `mwf-gold-loop-actor`, `mwf-gold-session-scorer`, `mwf-gold-session-reporter`, `mwf-gold-session-tester`, and `mwf-gold-prompt-improver`. Repo sources and runtime setup are indexed in `references/skills-index.md`.
 
 This ICM tree defines decision policy and audit contracts. It does not replace the mechanical harnesses or specialist skills.
 

--- a/eval/icm/README.md
+++ b/eval/icm/README.md
@@ -8,6 +8,8 @@ To run the autonomous self-improvement loop, start with `RUN_SELF_IMPROVEMENT_LO
 
 Start with `CONTEXT.md` when manually inspecting or resuming a repair-test-rerun cycle.
 
+MWF gold skills are repo-backed under `eval/skills/`. To make Codex use those versions at runtime, run `scripts/install_mwf_gold_skills.sh`. See `references/skills-index.md`.
+
 ## Canonical Inputs
 
 - `docs/product/source-material/golden-transcripts/`
@@ -16,6 +18,7 @@ Start with `CONTEXT.md` when manually inspecting or resuming a repair-test-rerun
 - `eval/moments/`
 - `eval/baselines/`
 - `eval/scorer/`
+- `eval/skills/`
 
 ## Usually Local Only
 

--- a/eval/icm/references/skills-index.md
+++ b/eval/icm/references/skills-index.md
@@ -1,0 +1,43 @@
+# MWF Gold Skills Index
+
+The MWF gold-loop skills are part of the eval machine. The repo copy under `eval/skills/` is the source of truth so actor, scorer, reporter, tester, and improver behavior is reviewable in GitHub and diffable with product changes.
+
+Codex discovers skills from its runtime skill directory, usually `${CODEX_HOME:-$HOME/.codex}/skills`. Run this setup command from the repo root to symlink the runtime skill names to the repo source:
+
+```sh
+scripts/install_mwf_gold_skills.sh
+```
+
+The installer refuses to replace an existing non-symlink runtime skill directory. Move or remove the local copy first if you intentionally want the repo skill to become canonical.
+
+## Skills
+
+| Skill | Repo Source | Runtime Symlink | Primary Use |
+|---|---|---|---|
+| `mwf-gold-loop-actor` | [`eval/skills/mwf-gold-loop-actor/SKILL.md`](../../skills/mwf-gold-loop-actor/SKILL.md) | `${CODEX_HOME:-$HOME/.codex}/skills/mwf-gold-loop-actor` | Drive one assigned participant side in `scripts/mwf_gold_loop.py` browser runs. |
+| `mwf-gold-session-scorer` | [`eval/skills/mwf-gold-session-scorer/SKILL.md`](../../skills/mwf-gold-session-scorer/SKILL.md) | `${CODEX_HOME:-$HOME/.codex}/skills/mwf-gold-session-scorer` | Score run artifacts and write `score.json`. |
+| `mwf-gold-session-reporter` | [`eval/skills/mwf-gold-session-reporter/SKILL.md`](../../skills/mwf-gold-session-reporter/SKILL.md) | `${CODEX_HOME:-$HOME/.codex}/skills/mwf-gold-session-reporter` | Synthesize live playthrough evidence into durable reports. |
+| `mwf-gold-session-tester` | [`eval/skills/mwf-gold-session-tester/SKILL.md`](../../skills/mwf-gold-session-tester/SKILL.md) | `${CODEX_HOME:-$HOME/.codex}/skills/mwf-gold-session-tester` | Manual Codex Desktop browser playthroughs and DB/UI triage. |
+| `mwf-gold-prompt-improver` | [`eval/skills/mwf-gold-prompt-improver/SKILL.md`](../../skills/mwf-gold-prompt-improver/SKILL.md) | `${CODEX_HOME:-$HOME/.codex}/skills/mwf-gold-prompt-improver` | Propose or patch prompt/product/eval-machine improvements after scoring. |
+
+## Runtime Verification
+
+Before relying on skill behavior in an autonomous ICM cycle, verify that each runtime skill path is a symlink to `eval/skills/<skill-name>`:
+
+```sh
+for skill in \
+  mwf-gold-loop-actor \
+  mwf-gold-session-scorer \
+  mwf-gold-session-reporter \
+  mwf-gold-session-tester \
+  mwf-gold-prompt-improver
+do
+  target="$(readlink "${CODEX_HOME:-$HOME/.codex}/skills/$skill" || true)"
+  case "$target" in
+    */eval/skills/$skill) echo "$skill: repo-backed" ;;
+    *) echo "$skill: not repo-backed ($target)" >&2; exit 1 ;;
+  esac
+done
+```
+
+If the runtime path is not repo-backed, either run `scripts/install_mwf_gold_skills.sh` or record the mismatch in the cycle report as an eval-machine risk.

--- a/eval/skills/README.md
+++ b/eval/skills/README.md
@@ -1,0 +1,13 @@
+# MWF Gold Skills
+
+These skills are specialist modules for the MWF gold-loop eval machine. This repo copy is the reviewable source of truth.
+
+Codex discovers skills from its runtime skill directory, usually `${CODEX_HOME:-$HOME/.codex}/skills`. From the repo root, run:
+
+```sh
+scripts/install_mwf_gold_skills.sh
+```
+
+That command symlinks the runtime skill names to these repo-backed directories and refuses to overwrite existing non-symlink skill directories.
+
+See `eval/icm/references/skills-index.md` for the full skill map and runtime verification command.

--- a/eval/skills/mwf-gold-loop-actor/SKILL.md
+++ b/eval/skills/mwf-gold-loop-actor/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: mwf-gold-loop-actor
+description: Drive one assigned Meet Without Fear gold-loop participant side from Codex CLI using agent-browser, and end with MWF_GOLD_STATUS JSON. Use when an orchestrator or self-improvement script asks Codex to play Adam, Eve, James, or Catherine in a local/E2E MWF session, continue until blocked or a stage limit, maintain scratch evidence, and report machine-readable status for automated coordination.
+---
+
+# MWF Gold Loop Actor
+
+## Purpose
+
+Use this skill only for command-line/self-improvement gold loops. For manual Codex Desktop testing with the in-app browser, use `mwf-gold-session-tester` instead.
+
+This actor plays exactly one assigned participant in the real MWF app. It observes MWF responses through `agent-browser`, replies in persona, clicks only assigned-side controls, and stops with a machine-readable status block.
+
+Actor quality is a scored surface. The goal is not to help MWF pass by being an easy, therapeutic, highly cooperative user. The actor should create a realistic gold-aligned test pressure for MWF.
+
+## Browser Surface
+
+Use `agent-browser` CLI, not Browser Use. The orchestrator runs Codex unsandboxed so `agent-browser` can use its daemon and browser profile.
+
+Core loop:
+
+```bash
+agent-browser --session <side-session> open <assigned-url>
+agent-browser --session <side-session> wait --load networkidle
+agent-browser --session <side-session> snapshot -i
+```
+
+Use a distinct `--session` per participant, for example `mwf-gold-adam-<session-id>` and `mwf-gold-eve-<session-id>`, so both sides keep separate browser state.
+
+If `agent-browser` reports a stale closed browser context, run `agent-browser --session <side-session> close` once, then reopen the assigned URL.
+
+## Persona And References
+
+Read the repo-backed manual tester skill for persona and gold-flow behavior:
+
+- `eval/skills/mwf-gold-session-tester/SKILL.md`
+- `eval/skills/mwf-gold-session-tester/references/gold-personas.md`
+- Relevant golden transcript under `docs/product/source-material/golden-transcripts/`
+
+Do not copy golden transcript wording. Improvise from the persona's voice, tone, defenses, boundaries, and behavioral range.
+
+Before sending user messages, maintain a compact private model:
+
+- what this character protects,
+- what they resist,
+- what they are not ready to concede,
+- how much insight MWF has actually earned,
+- what would sound too polished, compliant, or therapist-like for them.
+
+## Operating Rules
+
+- Drive only the assigned side.
+- Do not switch accounts or operate the partner side in the same browser session.
+- Continue while the assigned side has a legitimate chat input, share, validate, continue, review, confirm, skip, decline, or milestone CTA.
+- Stop when the next action belongs to the partner, the requested stage limit is reached, a serious bug blocks progress, or the run completes.
+- Keep responses realistic and concise enough for chat.
+- Do not become more healed, articulate, collaborative, or repair-oriented than the live MWF exchange has earned.
+- Preserve resistance and ambivalence when the golden persona calls for it. A good actor may push back, qualify, hesitate, or name unfairness.
+- Do not force the golden outcome. Let the MWF response determine whether the character softens, deepens, resists, or stays guarded.
+- Record important bugs or gold-alignment observations in the normal scratch log path under `docs/product/gold-session-scratch/`.
+- If UI state seems suspicious, inspect DB state using the manual tester skill's DB triage reference.
+
+## Status Contract
+
+End every final answer with exactly one compact status block:
+
+````text
+MWF_GOLD_STATUS:
+```json
+{
+  "side": "adam",
+  "session_id": "cmoru5afm000bpxj2e3coa3ij",
+  "stage": 2,
+  "state": "needs_partner",
+  "blocked_on": "eve",
+  "next_action_needed": "Eve needs to continue Stage 2 in her browser.",
+  "scratch_log": "docs/product/gold-session-scratch/2026-05-05-cmoru5afm000bpxj2e3coa3ij-adam.md",
+  "current_url": "http://localhost:8082/session/..."
+}
+```
+````
+
+Allowed `state` values:
+
+- `needs_partner`: no legitimate action remains for the assigned side until the partner acts.
+- `can_continue`: this Codex turn stopped due to time/tool/context interruption, but the assigned side still has a legitimate action.
+- `stage_limit_reached`: the assigned side reached the requested stage limit.
+- `completed`: the requested run completed.
+- `bug_blocked`: a product, state, privacy, or browser issue blocks progress.
+- `error`: the browser/tooling run failed before a reliable state could be established.
+
+Set `blocked_on` to the lowercase partner side when partner action is needed; otherwise use `null`. Keep JSON valid.

--- a/eval/skills/mwf-gold-loop-actor/agents/openai.yaml
+++ b/eval/skills/mwf-gold-loop-actor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MWF Gold Loop Actor"
+  short_description: "Drive one MWF gold-loop side from Codex CLI."
+  default_prompt: "Use MWF Gold Loop Actor to drive one assigned MWF participant side and end with status JSON."

--- a/eval/skills/mwf-gold-prompt-improver/SKILL.md
+++ b/eval/skills/mwf-gold-prompt-improver/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: mwf-gold-prompt-improver
+description: Propose or implement versioned improvements after an MWF gold-loop score. Use when Codex is asked to inspect score.json, compare gold-session iterations, identify regressions or improvements, improve the mwf-gold-session-tester prompt, propose or patch MWF prompt/code changes, write improvement-plan.md, or create versioned prompt proposal files under eval/prompt-versions.
+---
+
+# MWF Gold Prompt Improver
+
+## Purpose
+
+Analyze one MWF gold-loop run and propose the next prompt iteration. In proposal mode, keep production code unchanged. In patch mode, make narrow production prompt/code/test edits when the score identifies a concrete, reproducible bug or prompt issue. This skill always writes recommendations and versioned prompt proposal files when justified.
+
+The improver must route fixes by score ownership. The loop is intended to improve conversation quality on two surfaces:
+
+- the Codex actor skill that plays gold characters,
+- the Meet Without Fear internal prompts/product behavior that facilitates the conversation.
+
+Do not collapse all failures into MWF prompt edits. Actor drift and MWF facilitation failures have different owners.
+
+## Inputs
+
+Read the run directory named by the caller first:
+
+- `run.json`
+- `score.json`
+- `transcripts/*.md`
+- `scratch/*.md`
+- `adam.last.md`, `eve.last.md`, or other side final messages
+- prior sibling run directories for the same scenario when comparing deltas
+
+In `score.json`, prioritize:
+
+- `improvement_targets[]`
+- `gold_alignment.actor_fidelity`
+- `gold_alignment.mwf_guidance`
+- each dimension's `owner`
+- each dimension's `recommended_action`
+- evidence and rationale for failed or weak dimensions
+
+Then read only the relevant prompt sources:
+
+- Current tester skill: `eval/skills/mwf-gold-session-tester/SKILL.md`
+- Tester persona reference: `eval/skills/mwf-gold-session-tester/references/gold-personas.md`
+- Self-improvement actor skill: `eval/skills/mwf-gold-loop-actor/SKILL.md`
+- Self-improvement scorer skill: `eval/skills/mwf-gold-session-scorer/SKILL.md`
+- MWF backend prompt source: `backend/src/services/stage-prompts.ts`
+- Stage-specific controller/prompt files only if the score identifies a concrete issue there
+- Golden references under `docs/product/source-material/golden-transcripts/`
+
+## Outputs
+
+Write the improvement plan to the exact path requested by the caller, normally `<run-dir>/improvement-plan.md`.
+
+Also create versioned proposal files when there is enough evidence for a concrete change:
+
+- Tester prompt proposals: `eval/prompt-versions/tester/<scenario>/vNN.md`
+- MWF prompt proposals: `eval/prompt-versions/mwf/<scenario>/vNN.md`
+
+Choose `NN` as the next integer after existing versions. If no concrete prompt change is justified, do not create a version file; say why in `improvement-plan.md`.
+
+If the caller says `Improvement mode: patch`, also write `<run-dir>/patch-summary.md` describing:
+
+- files changed
+- bug or score dimension addressed
+- tests run
+- expected next-run score movement
+
+## Routing Rules
+
+Use `improvement_targets` and dimension ownership to choose the next edit:
+
+- `owner: actor_skill`, `recommended_action: patch_skill`
+  - Improve `eval/skills/mwf-gold-loop-actor/SKILL.md` when the CLI actor is too cooperative, too polished, too therapeutic, copies gold lines, ignores resistance, over-explains, drives the wrong side, or stops at the wrong boundary.
+  - If the issue belongs to the manual tester skill/persona extraction rather than the loop actor, create a tester proposal under `eval/prompt-versions/tester/<scenario>/vNN.md`.
+- `owner: mwf_prompts`, `recommended_action: patch_prompt`
+  - Improve `backend/src/services/stage-prompts.ts` or a versioned MWF proposal under `eval/prompt-versions/mwf/<scenario>/vNN.md` when MWF rushes, flattens tension, under-witnesses, pushes repair, mishandles resistance, or uses unearned transition language.
+- `owner: product_code`, `recommended_action: patch_product`
+  - Patch UI/backend/state code and focused tests for control-tag leakage, privacy leaks, CTA/input gating, stage progression, realtime, or persistence failures.
+- `owner: eval_harness`, `recommended_action: patch_eval`
+  - Patch scorer/transcript/invariant/orchestrator artifacts when the loop cannot reliably know what happened.
+- `recommended_action: human_review`
+  - Do not patch blindly. Explain what evidence is missing and what artifact would unblock automation.
+
+Use `gold_alignment` to decide whether this is a character-acting problem or a facilitation problem:
+
+- If `gold_alignment.actor_fidelity.<side>.<stage>` shows low `persona_alignment`, missing `resistance_preserved`, `too_compliant`, `too_articulate`, `copied_gold_lines`, or `forced_gold_path`, improve actor-skill/persona instructions before touching MWF prompts.
+- If `gold_alignment.mwf_guidance.<side>.<stage>` shows low `witnessing_depth`, weak `resistance_handling`, `earned_transition: false`, `premature_repair: true`, or `privacy_or_consent_issue: true`, improve MWF prompts or product gates depending on the failure.
+- If actor fidelity is weak, treat MWF guidance scores as lower-confidence because the product may not have received gold-equivalent pressure.
+- If actor fidelity is strong and MWF guidance is weak, route directly to MWF prompt/product improvement.
+
+In proposal mode, do not edit production MWF prompt files or runtime skills. Write versioned proposals. In patch mode, edits are allowed for the routed owner when evidence is concrete. For actor-skill patches, edit repo-owned `eval/skills/...` first; the operator can sync runtime copies with `scripts/install_mwf_gold_skills.sh`.
+
+## Improvement Plan Shape
+
+Use this structure:
+
+```md
+# Gold Loop Improvement Plan
+
+Run: `<run-dir>`
+Scenario: `<scenario>`
+Score: `<overall_score>`
+Classification: improvement | neutral | regression | incomparable
+
+## What Changed
+
+## Likely Causes
+
+## Ownership Routing
+
+List each target as:
+
+- Owner:
+- Dimension:
+- Recommended action:
+- Evidence:
+- Chosen edit/proposal:
+
+## Actor Skill Proposal
+
+## MWF Prompt Proposal
+
+## Product/Eval Harness Proposal
+
+## Gold Alignment Notes
+
+Summarize per-side/stage evidence:
+
+- Actor fidelity:
+- MWF guidance:
+- Confidence:
+
+## Regression Guard
+
+## Next Iteration Notes
+```
+
+## Rules
+
+- Separate actor-prompt problems from MWF product/prompt problems.
+- Prefer fixing the lowest-level truthful owner. If actor fidelity failed because the actor ignored persona instructions, patch/propose actor-skill changes, not MWF prompts. If MWF under-witnessed a faithful actor, patch/propose MWF prompt changes, not actor behavior.
+- Treat exact golden wording as a smell unless the task explicitly asks for transcript replay.
+- If score regressed, compare against the previous versioned prompt and identify the most likely regression cause before proposing new changes.
+- Prefer narrow prompt proposals tied to score evidence over broad rewrites.
+- Do not edit runtime skill copies directly during an automated loop. Edit repo-owned `eval/skills/...` files or write a versioned proposal instead.
+- In proposal mode, do not edit production MWF prompt files directly. Write a versioned proposal under `eval/prompt-versions/mwf/<scenario>/`.
+- In patch mode, production edits are allowed only when the score evidence points to a concrete fix. Keep the patch small, add or update focused tests, and do not rewrite unrelated prompts or flows.
+- Include acceptance criteria for the next run: which dimension should improve, which dimension must not regress, and what evidence would prove it.

--- a/eval/skills/mwf-gold-prompt-improver/agents/openai.yaml
+++ b/eval/skills/mwf-gold-prompt-improver/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MWF Gold Prompt Improver"
+  short_description: "Propose versioned prompt improvements from MWF gold-run scores."
+  default_prompt: "Use the MWF Gold Prompt Improver skill to inspect gold-session run artifacts, compare scores across iterations, and write versioned prompt improvement recommendations."

--- a/eval/skills/mwf-gold-session-reporter/SKILL.md
+++ b/eval/skills/mwf-gold-session-reporter/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: mwf-gold-session-reporter
+description: Write final Meet Without Fear gold-session issue reports after one or two Codex browser playthroughs. Use when asked to document what happened in a gold session, synthesize scratch logs, compare against previous gold-session reports, inspect MWF DB state, assess live conversation flow against gold-standard transcripts, create a new docs/product issue handoff file, append one side of a report, or output a prompt for the other Codex session to fill in its side.
+---
+
+# MWF Gold Session Reporter
+
+## Purpose
+
+Use this skill after or near the end of a Meet Without Fear gold-session playthrough. It turns live-session evidence into a durable report that matches the existing `docs/product/*gold-session*issues*.md` style.
+
+This skill is for synthesis and handoff, not for driving the browser. If the user wants you to keep playing Adam, Eve, James, or Catherine, use `mwf-gold-session-tester` instead.
+
+## Inputs To Gather
+
+Prefer available local evidence over memory:
+
+- Current browser URL and assigned side, if the in-app browser is available.
+- Session id and both E2E user ids/emails.
+- Scratch logs under `docs/product/gold-session-scratch/`, especially files matching the session id and lowercase side name, e.g. `<date>-<session-id>-adam.md`.
+- Prior reports:
+  - `docs/product/adam-eve-gold-session-issues.md`
+  - `docs/product/james-catherine-gold-session-issues.md`
+  - `docs/product/james-catherine-gold-session-bug-handoff-2026-05-04.md`
+- Planning/spec context as relevant:
+  - `docs/product/gold-flow-next-session-plan.md`
+  - `docs/product/stage-3-golden-alignment-plan.md`
+  - `docs/product/stage-4-tending-technical-spec.md`
+  - `docs/product/gold-flow-eval-harness-spec.md`
+- Gold alignment rubric:
+  - `references/gold-alignment-rubric.md`
+- DB state for stage progress, gates, needs, strategies, rankings, recent messages, and session status.
+
+For DB queries, use the safe Prisma pattern from:
+
+```text
+eval/skills/mwf-gold-session-tester/references/db-triage.md
+```
+
+## Report Location
+
+Create final reports in `docs/product/` with a descriptive dated filename, for example:
+
+```text
+docs/product/adam-eve-gold-session-stage4-issues-2026-05-05.md
+docs/product/james-catherine-gold-session-stage3-issues-2026-05-05.md
+```
+
+If the user asks to append to an existing report, preserve existing content and add only the requested side or section.
+
+## Workflow
+
+1. Identify scenario and side:
+   - Adam/Eve -> successful-resolution benchmark.
+   - James/Catherine -> no-shared-agreement benchmark.
+   - If the side is unclear, infer from URL/user id if possible; otherwise ask once.
+
+2. Read prior reports and relevant scratch logs:
+   - Extract what was fixed or improved.
+   - Extract still-open issues.
+   - Avoid reporting an old issue as new unless this run newly reproduces it.
+
+3. Query DB state:
+   - StageProgress for both users.
+   - `gatesSatisfied` for each stage.
+   - `IdentifiedNeed` rows and confirmation state.
+   - Stage 4 `StrategyProposal`, `StrategyRanking`, agreement/overlap state if relevant.
+   - Recent messages only as needed for evidence. Summarize; do not paste long transcripts.
+
+4. Write the assigned side first:
+   - Use a section title like `## Adam Side: Invitor` or `## Eve Side: Invitation Acceptor`.
+   - Include browser URL, role, partner, and session id.
+   - Include `Summary`, `Comparison Against Previous Gold-Run Notes`, `Current DB State At Stop` when DB evidence matters, issue sections, `Gold Standard Alignment Review`, and `Gold Alignment Notes`.
+   - Use issue sections with:
+     - Type
+     - Severity
+     - What happened
+     - Evidence
+     - Expected
+     - Impact when useful
+     - Likely fix locations
+   - For `Gold Standard Alignment Review`, use the rubric reference and add a stage-by-stage table:
+     - `Stage`
+     - `Expected gold beat`
+     - `Live evidence`
+     - `Rating`
+     - `Notes / fix`
+
+5. Leave room for the other side:
+   - Add a partner-side heading and `To be appended by the <side>-side Codex session.`
+   - Include the partner direct E2E URL if known.
+
+6. Final response:
+   - Link the report file.
+   - State whether DB/browser checks were used.
+   - Provide a copy/paste prompt for the other Codex session.
+
+## Other-Session Prompt Template
+
+At the end, output a prompt like this, filled with exact values:
+
+```text
+Use mwf-gold-session-reporter. Append the <Other Side> section to:
+<absolute path to report>
+
+You were driving <Other Character> in session <SESSION_ID>. Use your browser state, any scratch log for this session, and DB evidence to document only your side. Preserve the existing Adam/Eve or James/Catherine section. Compare against prior gold-session reports, note what is fixed vs still open vs new, and include issue evidence plus likely fix locations. Do not rewrite the other side's section.
+```
+
+## Style Rules
+
+- Match the existing report style in `docs/product/*gold-session*issues*.md`.
+- Be concrete and evidence-led.
+- Separate prompt quality, UI, backend state, realtime, privacy, and eval coverage.
+- Distinguish usability/state bugs from gold-flow failures. A usable UI can still fail the gold standard.
+- Do not overclaim from one side of the run.
+- If an issue was suspected but contradicted by DB/browser evidence, say that or omit it.
+- Keep long transcript content summarized.

--- a/eval/skills/mwf-gold-session-reporter/agents/openai.yaml
+++ b/eval/skills/mwf-gold-session-reporter/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: MWF Gold Session Reporter
+short_description: Write final MWF gold-session issue reports.
+default_prompt: Use the MWF Gold Session Reporter skill to synthesize this gold-session run into a durable issue report, compare against prior reports, inspect DB state where useful, assess the live flow against the gold-standard rubric, and output a handoff prompt for the other Codex session.

--- a/eval/skills/mwf-gold-session-reporter/references/gold-alignment-rubric.md
+++ b/eval/skills/mwf-gold-session-reporter/references/gold-alignment-rubric.md
@@ -1,0 +1,109 @@
+# Gold Alignment Rubric
+
+Use this reference when writing final gold-session reports. It turns the gold transcripts into stage-by-stage expected beats. Do not require exact wording. Score the live flow by effect, process, consent, and emotional movement.
+
+## Ratings
+
+- `Pass`: Live flow substantially achieved the gold beat.
+- `Partial`: Live flow moved in the right direction but missed depth, clarity, consent, coverage, or timing.
+- `Fail`: Live flow contradicted or skipped the gold beat.
+- `Blocked`: Product/state stopped the flow before the beat could be evaluated.
+- `Not evaluated`: This side did not reach or observe the beat.
+
+## Universal Process Beats
+
+Use these for every scenario:
+
+| Stage | Expected gold beat |
+| --- | --- |
+| Stage 0 | Topic framing is neutral, consented by inviter, and does not expose private detail before the partner joins. |
+| Stage 1 | The user feels deeply heard before being asked to empathize, solve, or concede. |
+| Stage 1 | The AI reflects the user’s lived experience without declaring the partner wrong or diagnosing them. |
+| Stage 2 | The user stretches toward the partner’s experience while keeping their own reality intact. |
+| Stage 2 | The AI does not treat guesses about the partner as product truth before partner consent/reveal. |
+| Stage 2 | Share/refine/validate gates are explicit and role-correct. |
+| Stage 3 | Needs are user-confirmed and consented before side-by-side reveal. |
+| Stage 3 | Needs are universal human needs, not narrow demands or strategies. |
+| Stage 3 | Side-by-side reveal does not invent AI-authored common ground or force agreement. |
+| Stage 3 | Each user can notice overlap, tension, gaps, or non-agreement without pressure. |
+| Stage 4 | Strategies or commitments are grounded in confirmed needs from both sides. |
+| Stage 4 | The flow checks coverage: which needs are met, partially met, or still unmet. |
+| Stage 4 | Shared agreements and individual/no-shared-agreement outcomes are both valid depending on scenario. |
+| Tending | Follow-up is tied to actual agreements; no false check-in is scheduled for no-agreement closure. |
+
+## Adam/Eve Resolution Benchmark
+
+Outcome class: successful resolution path with shared experiments possible.
+
+Core tension:
+- Adam needs safety, stability, reassurance, pacing, and enough ground to stay present.
+- Eve needs aliveness, growth, future openness, and room to want without being framed as abandoning Adam.
+
+Expected beats:
+
+| Stage | Expected gold beat |
+| --- | --- |
+| Stage 1 Adam | Adam is heard as scared and protective of a stable life, not merely avoidant or small. |
+| Stage 1 Eve | Eve is heard as slowly disappearing and grieving aliveness, not simply dissatisfied or leaving. |
+| Stage 2 Adam | Adam moves from “nothing is enough for her” toward seeing Eve as needing aliveness, visibility, and an open future. |
+| Stage 2 Eve | Eve moves from “he is choosing comfort over me” toward seeing Adam’s fear and stability as care/protection, without erasing her cost. |
+| Stage 3 Adam | Adam’s needs include reassurance that growth does not equal abandonment, pacing, directness, and permission to name fear. |
+| Stage 3 Eve | Eve’s needs include room to grow, wanting without apology, Adam staying present, and small real experiments. |
+| Stage 3 reveal | The flow shows compatibility and tension without flattening the issue into “travel more” or “be content.” |
+| Stage 4 | Strategies preserve both stability and aliveness, such as small experiments, pause/return language, and review after a timebox. |
+| Stage 4 | The AI checks whether strategies cover Adam’s safety/pacing and Eve’s growth/aliveness. |
+| Closure | The pair can move toward shared experiments without pretending the deeper tension is permanently solved. |
+| Tending | Follow-up checks whether experiments helped both stability and aliveness, not just whether tasks were done. |
+
+Gold risks:
+- Flattening Eve’s need into a travel preference.
+- Treating Adam’s stability need as mere resistance.
+- Over-reassuring Adam that Eve will not leave without enough evidence.
+- Rushing into strategies before both needs are named and consented.
+- Claiming full agreement where only a small experiment is warranted.
+
+## James/Catherine No-Shared-Agreement Benchmark
+
+Outcome class: no forced shared agreement; dignified closure and individual commitments are valid.
+
+Core tension:
+- James needs recognition, fairness, dignity, and to not be reduced to “the guy with a temper.”
+- Catherine needs safety, reality, choice, accountability, and freedom from volatility.
+
+Expected beats:
+
+| Stage | Expected gold beat |
+| --- | --- |
+| Stage 1 James | James is heard in his hurt and defensiveness without excusing escalation. |
+| Stage 1 Catherine | Catherine is heard in exhaustion, volatility/safety concerns, and possible done-ness without being pushed to soften. |
+| Stage 2 James | James can see Catherine’s safety/exhaustion without being cast as a villain or asked to self-erase. |
+| Stage 2 Catherine | Catherine can see James’s insecurity/dignity wound without making his volatility safe or acceptable. |
+| Stage 3 James | James’s needs include recognition, fairness, accountability-with-dignity, and reachability. |
+| Stage 3 Catherine | Catherine’s needs include safety, reality, choice, accountability, and not being made responsible for his reactions. |
+| Stage 3 reveal | The flow allows real gaps and non-overlap; it does not manufacture common ground. |
+| Stage 4 | Shared agreement is not forced. Individual commitments and no-shared-agreement closure are first-class outcomes. |
+| Stage 4 | If James offers repair, the flow checks whether Catherine’s safety and choice needs are actually covered. |
+| Closure | Catherine can decline repair with dignity; James can leave with individual accountability and dignity. |
+| Tending | No scheduled agreement check-in should be created if there is no shared agreement. User-initiated re-entry remains available. |
+
+Gold risks:
+- Pressuring Catherine toward reconciliation.
+- Letting James’s hurt excuse verbal abuse or volatility.
+- Treating “understanding” as “agreement.”
+- Presenting overlap as a product fact when the users have not validated it.
+- Failing to honor individual commitments as a valid end state.
+
+## How To Use In Reports
+
+Add a section like:
+
+```md
+### Gold Standard Alignment Review
+
+| Stage | Expected gold beat | Live evidence | Rating | Notes / fix |
+| --- | --- | --- | --- | --- |
+| Stage 1 | Adam is heard as scared and protective of stability, not merely avoidant. | MWF reflected stable home/routine and fear of losing Eve. | Pass | Keep. |
+| Stage 4 | Strategies preserve both stability and aliveness. | Flow blocked before Adam could rank; DB had strategy proposals but Adam `readyToRank` was null. | Blocked | Fix Stage 4 readiness UI/state. |
+```
+
+Only include rows you can support with evidence. For a one-sided report, it is acceptable to rate partner-side beats as `Not evaluated` unless the assigned side saw partner-shared content.

--- a/eval/skills/mwf-gold-session-scorer/SKILL.md
+++ b/eval/skills/mwf-gold-session-scorer/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: mwf-gold-session-scorer
+description: Score Meet Without Fear gold-session run artifacts against the canonical golden transcripts and rubric. Use when Codex is asked to evaluate an MWF gold-loop run directory, create score.json, judge actor persona fidelity, score MWF prompt/product handling, compare Stages 1-2 or later stages against Adam/Eve or James/Catherine golden references, or produce LLM-assisted gold-flow evaluation output.
+---
+
+# MWF Gold Session Scorer
+
+## Purpose
+
+Create a durable `score.json` for one MWF gold-loop run. Score effect and process fidelity, not exact transcript wording.
+
+The scorer evaluates two surfaces separately:
+
+- **actor_fidelity**: how well the Codex-played participants stayed in persona, tone, sentiment, defensiveness, agency, and behavioral range from the golden reference.
+- **mwf_handling**: how well the MWF product/AI handled the users, including listening depth, resistance, needs clarity, consent, boundaries, and stage gates.
+
+Every low score must name the improvement owner. The point of this loop is not only to find product bugs; it must distinguish whether the next self-improvement should target:
+
+- `actor_skill`: the Codex actor instructions, persona extraction, role fidelity, or browser-driving discipline.
+- `mwf_prompts`: MWF internal facilitation prompts, stage contracts, resistance handling, witnessing depth, or transition language.
+- `product_code`: UI/backend state, privacy, consent gates, stage gates, transcript extraction, or deterministic harness behavior.
+- `eval_harness`: scorer, artifacts, transcript extraction, deterministic checks, or weak evidence collection.
+
+## Inputs
+
+Read the run directory named by the user first. Prefer files in this order:
+
+1. `run.json`
+2. `transcripts/*.md`
+3. `scratch/*.md`
+4. `<side>.last.md`
+5. `codex-*.jsonl` only if needed to understand execution errors
+
+Then read the relevant references in the `meet-without-fear` repo:
+
+- `docs/product/source-material/golden-transcripts/README.md`
+- `docs/product/source-material/golden-transcripts/adam-eve.md` for Adam/Eve
+- `docs/product/source-material/golden-transcripts/james-catherine.md` for James/Catherine
+- `docs/product/source-material/golden-transcripts/core-protocol-update.md`
+- `docs/product/gold-flow-eval-harness-spec.md`
+
+For Stage 1-2 scoring, ignore Stage 3/4/Tending dimensions unless the run unexpectedly reached them.
+
+## Gold Alignment Evaluation
+
+The scorer must evaluate the live run against the gold transcript in two distinct ways:
+
+1. **Actor fidelity**: whether the Codex actor created gold-equivalent test pressure.
+2. **MWF guidance quality**: whether MWF responded to that test pressure in a gold-aligned way.
+
+Do not compare exact wording. Compare persona shape, emotional trajectory, resistance, pacing, and facilitation effect.
+
+For each side and scored stage, judge actor fidelity with:
+
+- `persona_alignment`: 1-5 score for matching the transcript-derived persona model.
+- `resistance_preserved`: whether the actor kept the appropriate defensiveness, hesitation, boundaries, grief, skepticism, or ambivalence.
+- `too_compliant`: whether the actor became easier, more cooperative, more therapeutic, or more insight-ready than the gold persona supports.
+- `too_articulate`: whether the actor over-explained in polished therapy language rather than speaking like the character.
+- `copied_gold_lines`: whether the actor copied distinctive transcript language instead of improvising from the persona.
+- `forced_gold_path`: whether the actor ignored the live MWF prompt to force the known transcript outcome.
+
+For each side and scored stage, judge MWF guidance with:
+
+- `guidance_alignment`: 1-5 score for matching the gold facilitation effect.
+- `witnessing_depth`: 1-5 score for emotional specificity and accuracy.
+- `resistance_handling`: 1-5 score for honoring resistance without flattening or arguing it away.
+- `earned_transition`: whether the next stage/CTA/felt-heard gate was earned by the conversation.
+- `premature_repair`: whether MWF moved toward repair, agreement, perspective-taking, or synthesis too early.
+- `privacy_or_consent_issue`: whether MWF exposed private content or skipped consent boundaries.
+
+## Output
+
+Write valid JSON to the exact path requested by the caller, normally `<run-dir>/score.json`. Do not only describe the score in prose.
+
+Use this shape:
+
+```json
+{
+  "schema_version": 1,
+  "scenario_id": "adam-eve",
+  "scenario_version": 1,
+  "rubric_version": "gold-flow-rubric-v1",
+  "scorer_version": "mwf-gold-session-scorer-v0",
+  "verdict": "eval_warn",
+  "overall_score": 3.5,
+  "dimensions": {
+    "actor_fidelity": {
+      "score": 4,
+      "mode": "llm_assisted",
+      "pass": true,
+      "owner": "actor_skill",
+      "recommended_action": "none",
+      "rationale": "Evidence-led concise rationale.",
+      "evidence": ["transcript:Adam:Stage 1", "scratch:..."]
+    },
+    "mwf_handling": {
+      "score": 3,
+      "mode": "llm_assisted",
+      "pass": false,
+      "owner": "mwf_prompts",
+      "recommended_action": "patch_prompt",
+      "rationale": "Evidence-led concise rationale.",
+      "evidence": ["transcript:Eve:Stage 2"]
+    }
+  },
+  "gold_alignment": {
+    "actor_fidelity": {
+      "adam": {
+        "stage1": {
+          "persona_alignment": 4,
+          "resistance_preserved": true,
+          "too_compliant": false,
+          "too_articulate": false,
+          "copied_gold_lines": false,
+          "forced_gold_path": false,
+          "rationale": "Adam stayed stability-focused and fear-driven without jumping to repair.",
+          "evidence": ["transcript:Adam:Stage 1"]
+        }
+      },
+      "eve": {
+        "stage1": {
+          "persona_alignment": 4,
+          "resistance_preserved": true,
+          "too_compliant": false,
+          "too_articulate": false,
+          "copied_gold_lines": false,
+          "forced_gold_path": false,
+          "rationale": "Eve stayed attached but sad, naming disappearance without deciding to leave.",
+          "evidence": ["transcript:Eve:Stage 1"]
+        }
+      }
+    },
+    "mwf_guidance": {
+      "adam": {
+        "stage1": {
+          "guidance_alignment": 4,
+          "witnessing_depth": 4,
+          "resistance_handling": 4,
+          "earned_transition": true,
+          "premature_repair": false,
+          "privacy_or_consent_issue": false,
+          "rationale": "MWF reflected Adam's fear and failure story before offering the felt-heard gate.",
+          "evidence": ["transcript:Adam:Stage 1"]
+        }
+      },
+      "eve": {
+        "stage1": {
+          "guidance_alignment": 4,
+          "witnessing_depth": 4,
+          "resistance_handling": 4,
+          "earned_transition": true,
+          "premature_repair": false,
+          "privacy_or_consent_issue": false,
+          "rationale": "MWF reflected Eve's shrinking and longing without arguing her toward agreement.",
+          "evidence": ["transcript:Eve:Stage 1"]
+        }
+      }
+    }
+  },
+  "improvement_targets": [
+    {
+      "owner": "mwf_prompts",
+      "dimension": "mwf_handling",
+      "priority": 1,
+      "recommended_action": "patch_prompt",
+      "rationale": "The MWF Stage 1 prompt rushed to felt-heard before the user named the emotional cost.",
+      "evidence": ["transcript:Adam:Stage 1"]
+    }
+  ],
+  "hard_invariants": [],
+  "comparison": {
+    "previous_run": null,
+    "classification": "incomparable",
+    "likely_reasons": []
+  },
+  "human_review": {
+    "required": true,
+    "status": "needs_human_review",
+    "reviewer": null,
+    "notes": null
+  }
+}
+```
+
+Use 1-5 ordinal scores. Set `verdict` to:
+
+- `eval_pass` when all applicable critical dimensions meet threshold and overall score is at least the target from `run.json`.
+- `eval_warn` when the run is structurally usable but one or more non-critical dimensions need review.
+- `eval_fail` when a critical dimension fails, a hard privacy/consent/stage invariant fails, or the average is below threshold.
+- `eval_needs_review` when artifacts are too incomplete or contradictory for a trusted automated judgment.
+
+## Ownership And Routing
+
+Each dimension object must include:
+
+- `owner`: one of `actor_skill`, `mwf_prompts`, `product_code`, `eval_harness`, or `none`.
+- `recommended_action`: one of `none`, `patch_skill`, `patch_prompt`, `patch_product`, `patch_eval`, `human_review`.
+
+Use these defaults unless evidence says otherwise:
+
+- `actor_fidelity` failures route to `actor_skill` with `patch_skill`.
+- `mwf_handling` prompt/facilitation failures route to `mwf_prompts` with `patch_prompt`.
+- State, privacy, CTA, input visibility, realtime, or persistence failures route to `product_code` with `patch_product`.
+- Missing transcripts, weak artifacts, scorer ambiguity, or actor logs too noisy to score route to `eval_harness` with `patch_eval` or `human_review`.
+
+Use the `gold_alignment` section to support routing:
+
+- Actor-side flags such as `too_compliant`, `too_articulate`, `copied_gold_lines`, `forced_gold_path`, low `persona_alignment`, or missing resistance should create or support an `actor_skill` target.
+- MWF-side flags such as low `witnessing_depth`, weak `resistance_handling`, unearned transitions, premature repair, or consent/privacy issues should create or support an `mwf_prompts` or `product_code` target depending on whether the issue is wording/process or state enforcement.
+- If the gold alignment cannot be filled because transcripts are missing or logs are too noisy, create an `eval_harness` target.
+
+Also write a top-level `improvement_targets` array sorted by priority. Include only targets that need action or review. A passing score can still include a low-priority target when the run exposed a clear improvement opportunity, but do not create busywork for minor wording differences.
+
+## Scoring Rules
+
+- Ground every score in evidence from the run artifacts.
+- Do not reward exact reuse of golden wording.
+- Penalize actor drift when a participant becomes more healed, cooperative, articulate, or therapeutic than the reference supports.
+- Penalize MWF when it rushes, pressures sharing, exposes private partner information, mistakes guesses for product truth, or leaves a user blocked without clear waiting state.
+- Treat conversation quality as first-class evidence: witnessing depth, earned movement, resistance handling, emotional specificity, and fidelity to the character's behavioral range are score drivers, not secondary notes.
+- If a run stops at Stage 2 by design, score only Stage 1-2 and mark later-stage rubric dimensions as not applicable or omit them.
+- Preserve uncertainty. Use `human_review.required = true` when evidence is thin, artifacts are missing, or a safety-sensitive issue is possible.

--- a/eval/skills/mwf-gold-session-scorer/agents/openai.yaml
+++ b/eval/skills/mwf-gold-session-scorer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MWF Gold Session Scorer"
+  short_description: "Score MWF gold-session runs against golden references."
+  default_prompt: "Use the MWF Gold Session Scorer skill to read a gold-session run directory, compare artifacts against the golden references and rubric, and emit score.json."

--- a/eval/skills/mwf-gold-session-tester/SKILL.md
+++ b/eval/skills/mwf-gold-session-tester/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: mwf-gold-session-tester
+description: Drive, triage, and evaluate one side of a Meet Without Fear partner-session playthrough inside the Codex Desktop in-app browser. Use when Codex is asked to act as one MWF participant, play one golden-standard character such as Adam, Eve, James, or Catherine, continue a localhost session, diagnose broken waiting or stage states, inspect MWF Postgres/Prisma data, compare app behavior to golden transcripts, maintain a scratch issue log during live testing, or propose/fix prompt, UI, or state-machine bugs found during live MWF testing.
+---
+
+# MWF Gold Session Tester
+
+## Purpose
+
+Use this skill to act as one MWF participant and QA engineer at the same time. Drive one side of the session naturally inside the Codex Desktop in-app browser, detect broken product states, inspect DB/code when needed, and evaluate whether the flow matches the golden intent.
+
+Do not treat golden transcripts as scripts. Treat them as benchmarks for effect and process fidelity: listening depth, consent, user agency, needs clarity, boundary honoring, non-agreement grace, and Tending behavior.
+
+Default browser surface: use the Codex Desktop in-app browser through the Browser Use plugin. Do not open external Chrome, system Chrome, or a separate Playwright browser from this skill. If a browser tool offers both an in-app browser backend and an external Chrome backend, choose the in-app browser backend. This skill is scoped to playing one assigned character in one in-app browser. If the user wants both partners played by Codex, recommend a second Codex session for the other partner.
+
+Default action policy: once the user assigns you a gold character, keep driving that character for as long as the UI provides a legitimate action for that same character. Do not ask for extra confirmation before clicking assigned-character share, validate, continue, review, confirm, skip, decline, or milestone CTAs in a local/E2E gold-session test. Those actions are part of operating the assigned side. Stop only when the next action belongs to the partner, the UI is genuinely blocked, the action would leave local/E2E test context, or the visible content would unexpectedly expose sensitive/private data outside the assigned role.
+
+Default note policy: once the assigned role and session id are known, create or update a scratch issue log for this side of the run. Do this quietly as part of the playthrough; do not wait until the final report. The scratch log preserves evidence for later synthesis by `mwf-gold-session-reporter`.
+
+## Minimal Invocation
+
+Support short prompts. If the user says only:
+
+```text
+Use mwf-gold-session-tester as James.
+```
+
+infer these defaults:
+
+- Use the current Codex Desktop in-app browser/session if one is open.
+- Play only the named character.
+- Discover the golden scenario that contains that character from `docs/product/source-material/golden-transcripts/README.md` and the transcript files. For bundled examples, Adam/Eve maps to the Adam/Eve benchmark and James/Catherine maps to the James/Catherine benchmark, but newly added gold sets must be inferred from their own transcripts.
+- Read `references/gold-personas.md` and the relevant golden transcript.
+- Extract a private gold persona model before acting: voice, tone, sentiment, default posture, defensive style, core self-protection, relational stance, non-concessions, consent/agreement boundaries, and stage-specific behavior.
+- Improvise from the persona and story constraints; do not copy transcript wording.
+- Continue until blocked, completed, or a serious bug appears.
+- Check DB state when UI state seems suspicious.
+- Maintain a scratch issue log as issues appear.
+- Report prompt, UI, backend, realtime, privacy, or state-machine bugs with evidence and likely fix locations.
+- If partner action is needed and there is no legitimate assigned-user action available, report what the partner must do. Do not wait by default when the assigned user's side has an available way to keep moving, such as an assigned-user CTA, share/validate/review/confirm button, optional skip/decline, refresh, status re-check, or safe local/E2E API action for the assigned user.
+
+If the user invokes this skill without naming a character or otherwise making the role obvious from the browser/session, ask before driving:
+
+```text
+Which gold character or scenario should I play?
+```
+
+If a character is known but the in-app browser is blank or has no MWF session, default to opening or creating a no-Clerk local session for that character's golden scenario when the bundled script supports that character. First check whether the local E2E-mode backend/app are available. Prefer the dedicated E2E web bundle on `localhost:8082`; do not trust E2E query params on a normal `8081` bundle. If the E2E app is not available, report the exact missing server/env rather than asking for a URL. If the character comes from a newly added gold set that the script does not support yet, report that the transcript can be evaluated but local session seeding needs fixture/script support.
+
+For that blank-browser no-Clerk path, do not search the repo first. Use the bundled script:
+
+```bash
+eval/skills/mwf-gold-session-tester/scripts/create_gold_session.sh James
+```
+
+Replace `James` with another script-supported gold character as needed. The script probes backend/E2E auth, requires the E2E app on `8082`, seeds both users, creates/accepts the invitation, and prints `ASSIGNED_URL`. Open `ASSIGNED_URL` in the Codex in-app browser and drive only that character.
+
+Only ask for a session URL when:
+
+- the user explicitly wants an existing non-E2E session,
+- local no-Clerk/E2E mode is unavailable and you cannot start it,
+- or the current browser state is ambiguous enough that creating a new session may discard useful user work.
+
+Other valid short prompts:
+
+```text
+Use mwf-gold-session-tester as Catherine on the current session.
+Use mwf-gold-session-tester as Eve; open a no-Clerk session.
+Use mwf-gold-session-tester as Adam and continue.
+```
+
+## Core References
+
+In the `meet-without-fear` repo, read these when evaluating gold alignment:
+
+- `docs/product/source-material/golden-transcripts/README.md`
+- `docs/product/source-material/golden-transcripts/adam-eve.md`
+- `docs/product/source-material/golden-transcripts/james-catherine.md`
+- Any new transcript in `docs/product/source-material/golden-transcripts/` that contains the assigned character or requested scenario.
+- `docs/product/source-material/golden-transcripts/core-protocol-update.md`
+- `docs/product/gold-flow-eval-harness-spec.md`
+- `docs/product/stage-3-golden-alignment-plan.md`
+- `docs/product/stage-3-golden-alignment-audit.md`
+- `docs/product/gold-flow-next-session-plan.md`
+
+Read bundled references only as needed:
+
+- `references/browser-driving.md` for in-app browser control and session-driving gotchas.
+- `references/e2e-auth-bypass.md` for logging this one browser in without Clerk.
+- `references/gold-personas.md` for using Adam/Eve or James/Catherine as test stories and personas.
+- `references/db-triage.md` for Prisma/Postgres checks and useful session queries.
+- `references/gold-evaluation.md` for rubric, bug categories, and fix framing.
+
+Bundled scripts:
+
+- `scripts/create_gold_session.sh <Adam|Eve|James|Catherine>` creates a local no-Clerk gold scenario session and prints the assigned character URL.
+
+## Scratch Issue Log
+
+Create the scratch log after you know the session id and assigned character. Use one file per Codex side. Normalize the character name to lowercase in the filename so partner sessions do not collide or create casing variants. Use this path in the `meet-without-fear` repo:
+
+```text
+docs/product/gold-session-scratch/<YYYY-MM-DD>-<session-id>-<lowercase-character>.md
+```
+
+Examples:
+
+```text
+docs/product/gold-session-scratch/2026-05-05-cmoru5afm000bpxj2e3coa3ij-adam.md
+docs/product/gold-session-scratch/2026-05-05-cmoru5afm000bpxj2e3coa3ij-eve.md
+```
+
+If the directory does not exist, create it. If the file does not exist, initialize it with:
+
+```md
+# Gold Session Scratch Log
+
+Date: <YYYY-MM-DD>
+Session ID: `<session-id>`
+Assigned side: <character>
+Scenario: <Adam/Eve or James/Catherine>
+Browser URL: `<current assigned URL>`
+
+## Timeline
+
+## Findings
+```
+
+Append short notes during the run whenever an issue, suspected issue, state contradiction, DB check, or gold-alignment observation appears. Keep entries concise and evidence-oriented:
+
+```md
+### <short title>
+
+- Stage: <stage header or number>
+- Type: <prompt | UI | backend state | realtime | privacy | eval coverage | gold alignment>
+- Status: <suspected | confirmed | contradicted | resolved during run>
+- What happened: <one to three sentences>
+- Evidence: <DOM text, DB gates, URL, code path, or command summary>
+- Expected: <gold-aligned or state-machine expectation>
+- Likely fix: <paths if known>
+```
+
+Do not over-log every normal turn. Log only items that may matter in the final report. If you later learn a suspected issue was not real, append a correction entry rather than deleting the note. Use `apply_patch` for manual scratch-log edits.
+
+For gold-alignment observations, note the expected beat and whether the live flow passed, partially met, failed, or was blocked. Example:
+
+```md
+### Stage 2 Adam perspective stretch reached Eve's aliveness need
+
+- Stage: Walking in Their Shoes
+- Type: gold alignment
+- Status: confirmed
+- Expected beat: Adam moves from "nothing is enough" toward seeing Eve as needing aliveness, visibility, and an open future.
+- Live evidence: Adam named that Eve may feel trapped in a life that fits him better and may need a future not only about preservation.
+- Rating: Pass
+```
+
+At the end of a run, tell the user the scratch log path and suggest using `mwf-gold-session-reporter` to turn it into the final report.
+
+## Operating Loop
+
+1. Establish current state:
+   - Current URL, current user/persona, partner, stage header, latest MWF message, visible CTAs, whether chat input is visible.
+   - Prefer DOM snapshots for text state; screenshots only when visual layout, cards, modals, or stuck UI matters.
+   - If the user asks to avoid Clerk, read `references/e2e-auth-bypass.md` before opening the in-app browser.
+   - If the user already has the Codex in-app browser open, keep using that browser. Do not switch to external Chrome, system Chrome, or a separate Playwright browser unless explicitly requested.
+
+2. Drive as the assigned participant:
+   - Respond in-character with plausible emotional continuity.
+   - Use the participant's known story, constraints, and previous answers.
+   - If the user names a golden scenario, read `references/gold-personas.md` and the relevant golden transcript, infer the character's persona model from the transcript evidence, then improvise from that model without copying transcript wording.
+   - Keep the transcript-derived voice, tone, sentiment, defenses, and non-concessions active throughout the run. Choices should emerge from the persona in the live moment, not from a predetermined outcome.
+   - Do not make the assigned character more healed, cooperative, insightful, articulate, fair, or repair-oriented than the transcript supports. If the live app pushes beyond the character's behavioral range, respond in the character's voice with their resistance, caveat, refusal, ambivalence, or boundary.
+   - Keep responses concise enough for realistic chat, but rich enough to advance the process.
+   - Do not click/share/validate on behalf of a real user unless the user explicitly asked you to operate that side.
+   - In local/E2E gold-session testing, when the user has assigned you a character, sharing, reviewing, confirming, skipping, declining, continuing, or validating that assigned character's private draft/content is part of operating that side. Do not pause for separate approval before clicking role-appropriate Stage 2/3/4 share, validate, continue, review, confirm, skip/decline, or milestone CTAs, unless the visible content would disclose unexpected sensitive data, operate the partner's side, or leave the local test context.
+   - Do not operate the partner side from this skill. If partner action is needed and there is no legitimate assigned-user action available, report what is needed or ask the user/another Codex session to proceed as that partner. If the assigned user's side has a safe way to keep going, use it instead of waiting.
+
+3. Respect flow gates:
+   - If the UI is waiting on the partner, do not send filler messages.
+   - If a milestone CTA appears and it matches the user's requested role and the stage intent, click it and continue without asking for separate confirmation.
+   - If private/shared content boundaries appear, verify consent and role yourself from the assigned character and current local/E2E context; ask the user only if that cannot be determined or something looks unexpectedly sensitive.
+
+4. Triage anomalies immediately:
+   - If the UI says both users have done something, verify DB state when that is doubtful.
+   - If input is visible while the user should be blocked, note a UI bug.
+   - If AI reveals partner-specific needs/context before consent or partner completion, treat as a serious product/state bug.
+   - If realtime shows another user's private message, note an isolation/realtime/cache bug and reload only if needed to continue.
+   - Add or update a scratch-log finding for confirmed anomalies and important suspected anomalies.
+
+5. Evaluate against gold:
+   - Separate prompt-quality issues from product/state issues.
+   - Compare the flow's effect to the golden references, not exact wording.
+   - Check whether the assigned character stayed faithful to the extracted voice, tone, sentiment, defensive style, relational stance, and behavioral range. If the run became too easy-going, too polished, or too therapeutic, note that as actor drift unless the product clearly earned that exact kind of movement from this persona.
+   - Record actionable findings with evidence: screen state, DB state, code path, or transcript excerpt.
+   - Preserve those findings in the scratch log before context gets long.
+
+6. Fix when asked:
+   - Inspect existing implementation before editing.
+   - Keep changes scoped to the failing gate, prompt, UI waiting state, or eval harness issue.
+   - Add focused tests when changing stage gates, privacy boundaries, or prompt contracts.
+
+## What To Watch For
+
+High-priority failures:
+
+- Partner needs shown before the partner has confirmed and consented to Stage 3 needs.
+- AI-authored common-ground or overlap presented as product truth in Stage 3.
+- Private AI messages, empathy drafts, context, needs, or prompts shown to the wrong user.
+- Stage advancement before both users satisfy the documented gates.
+- Chat input visible when the user is waiting for partner action.
+- User-facing copy using internal implementation language such as "internal reconciler."
+- The app forcing agreement or repair when the golden no-agreement path should close with dignity.
+
+Useful distinction:
+
+- Prompt bug: tone, over-synthesis, rushing, generic reflection, weak resistance handling.
+- Product/state bug: wrong gates, consent leak, stale cache, wrong role data, waiting UI missing, premature stage transition.
+
+## Common MWF Repo Paths
+
+- Backend stage prompts: `backend/src/services/stage-prompts.ts`
+- Stage 2 controller and transition: `backend/src/controllers/stage2.ts`
+- Stage 3 controller: `backend/src/controllers/stage3.ts`
+- Messages controller/orchestrator path: `backend/src/controllers/messages.ts`, `backend/src/services/ai-orchestrator.ts`
+- Stage status helpers: `backend/src/services/empathy-status.ts`, `backend/src/utils/stage-resolver.ts`
+- Prisma schema: `backend/prisma/schema.prisma`
+- Mobile session screen: `mobile/src/screens/UnifiedSessionScreen.tsx`
+- Mobile stage hooks: `mobile/src/hooks/useStages.ts`, `mobile/src/hooks/useUnifiedSession.ts`
+- Waiting UI helpers: `mobile/src/utils/getWaitingStatus.ts`, `mobile/src/config/waitingStatusConfig.ts`
+- E2E two-browser harness for separate automated eval work: `e2e/helpers/two-browser-harness.ts`
+- Live two-browser test for separate automated eval work: `e2e/tests/live-ai-two-browser-full-flow.spec.ts`
+
+## Output Style
+
+During playthroughs, keep the user informed with concise updates:
+
+- "I see Stage 3, Jason, latest prompt asks whether he can work with Shantam's needs. I am replying as Jason."
+- "This looks blocked on Shantam. I am checking DB before assuming the UI is right."
+- "DB contradicts the UI: neither user has `needsShared`; this is a state/flow bug."
+
+When reporting findings, include:
+
+- What happened.
+- Expected gold-aligned behavior.
+- Evidence.
+- Likely fix location.
+- Whether it is prompt, UI, backend state, realtime, or eval coverage.
+- Scratch log path, if one was created.
+
+For polished final issue reports and partner-session handoff prompts, use the separate `mwf-gold-session-reporter` skill. This tester skill should collect raw evidence while driving; the reporter skill should synthesize it.

--- a/eval/skills/mwf-gold-session-tester/agents/openai.yaml
+++ b/eval/skills/mwf-gold-session-tester/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: MWF Gold Session Tester
+short_description: Test MWF sessions against golden flows.
+default_prompt: Use the MWF Gold Session Tester skill to drive this Meet Without Fear session, maintain a scratch issue log, triage any broken UI or state, check the database when needed, and evaluate the flow against the golden references.

--- a/eval/skills/mwf-gold-session-tester/references/browser-driving.md
+++ b/eval/skills/mwf-gold-session-tester/references/browser-driving.md
@@ -1,0 +1,99 @@
+# Browser Driving
+
+Use the Browser Use skill for the Codex Desktop in-app browser. Initialize the `iab` backend through the Node REPL before browser work.
+
+For interactive MWF playthroughs, this is the default and required browser surface. Do not launch external Chrome, system Chrome, or a separate Playwright browser for a normal "open localhost", "drive this session", or "continue as Jason" request. If a browser automation path defaults to Chrome, stop and switch to the in-app `iab` backend instead.
+
+This skill plays one user in one in-app browser. If the user wants both partners played by Codex, recommend two Codex sessions, each using its own in-app browser. Automated Playwright two-context runs belong in a separate eval-harness workflow, not the default skill behavior.
+
+## Bootstrap
+
+```js
+if (!globalThis.agent) {
+  const codexHome = process.env.CODEX_HOME || `${process.env.HOME}/.codex`;
+  const { setupAtlasRuntime } = await import(`${codexHome}/plugins/cache/openai-bundled/browser-use/0.1.0-alpha1/scripts/browser-client.mjs`);
+  const backend = 'iab';
+  await setupAtlasRuntime({ globals: globalThis, backend });
+}
+await agent.browser.nameSession('MWF session test');
+if (typeof tab === 'undefined' || !globalThis.tab) {
+  globalThis.tab = await agent.browser.tabs.selected();
+}
+console.log(await tab.url());
+console.log((await tab.playwright.domSnapshot()).slice(0, 12000));
+```
+
+## Reading State
+
+Prefer `tab.playwright.domSnapshot()` for chat state. MWF chat renders newest messages first. The latest MWF prompt is usually the first large AI message in the snapshot after header controls.
+
+Use screenshots only for:
+
+- visual layout bugs
+- modals/drawers/cards
+- CTA placement
+- overlapping text
+- waiting/input state
+
+## Sending Chat
+
+Prefer the visible placeholder when available:
+
+```js
+const replyText = '...';
+const input = tab.playwright.getByPlaceholder('Type a message...', { exact: true });
+if (await input.count() !== 1) throw new Error('Expected one chat input');
+await input.fill(replyText, {});
+await input.press('Enter', {});
+await new Promise(r => setTimeout(r, 18000));
+console.log((await tab.playwright.domSnapshot()).slice(0, 14000));
+```
+
+If Playwright fill/Enter fails in React Native Web, inject through the native textarea setter and dispatch Enter:
+
+```js
+const ta = document.querySelector('textarea');
+const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
+setter.call(ta, 'message text');
+ta.dispatchEvent(new Event('input', { bubbles: true }));
+ta.focus();
+ta.dispatchEvent(new KeyboardEvent('keydown', {
+  key: 'Enter', code: 'Enter', keyCode: 13, which: 13,
+  bubbles: true, cancelable: true
+}));
+```
+
+## Clicking RNW CTAs
+
+Milestone CTAs may be styled `div`s. If regular Playwright click fails, find the text node, walk up to the clickable parent, and dispatch pointer events:
+
+```js
+const txt = Array.from(document.querySelectorAll('*'))
+  .find(el => el.textContent.trim() === "I feel heard" && el.children.length === 0);
+let btn = txt;
+while (btn && !btn.onclick) btn = btn.parentElement;
+btn.click();
+['pointerdown', 'pointerup', 'click'].forEach(t => {
+  btn.dispatchEvent(new PointerEvent(t, { bubbles: true, cancelable: true, pointerType: 'mouse' }));
+});
+```
+
+## Session-Driving Heuristics
+
+- If the user says only "use this skill as <character>", use the current in-app browser tab and current URL if available.
+- Continue naturally if MWF asks an open question and the chat input is available.
+- If the assigned character has a visible share, validate, continue, review, confirm, skip, decline, or milestone CTA, click it and keep going. Do not ask the user for extra confirmation; in local/E2E gold-session testing these are assigned-role actions.
+- Wait rather than nudge when a streaming response or typing indicator is present.
+- If blocked on partner action, do not send filler. Check DB if the UI message is unclear.
+- Do not switch to the partner account in the same browser context. Report the partner action needed instead.
+- After sending, sanity-check the URL. If it moved to `/inner-work/...`, return to `/session/<id>` before continuing the partner session.
+- If the browser shows the wrong user's private/personalized message after a realtime transition, record an isolation/cache bug and reload only if needed to continue.
+
+## UX Notes To Collect
+
+- Input visible during partner-wait states.
+- Waiting copy that does not say exactly who/what is pending.
+- Internal implementation terms in user-facing copy.
+- Duplicate or stale share/review CTAs.
+- Drawers or modals stacking instead of superseding each other.
+- Stage header, CTA, and DB gate contradictions.

--- a/eval/skills/mwf-gold-session-tester/references/db-triage.md
+++ b/eval/skills/mwf-gold-session-tester/references/db-triage.md
@@ -1,0 +1,66 @@
+# DB Triage
+
+MWF uses Prisma with Postgres. The local backend env is usually `backend/.env`. Run DB checks from the backend workspace.
+
+## Safe Query Pattern
+
+Use `npx tsx` and load dotenv. Avoid printing raw secrets.
+
+```bash
+cd backend
+npx tsx -e 'import "dotenv/config"; import { PrismaClient } from "@prisma/client"; (async()=>{ const prisma = new PrismaClient(); /* query */ await prisma.$disconnect(); })().catch(e=>{ console.error(e); process.exit(1); });'
+```
+
+## Current Session State Query
+
+Replace `SESSION_ID`.
+
+```bash
+cd backend
+npx tsx -e 'import "dotenv/config"; import { PrismaClient } from "@prisma/client"; (async()=>{ const prisma = new PrismaClient(); const sessionId="SESSION_ID"; const session=await prisma.session.findUnique({ where:{id:sessionId}, include:{ relationship:{ include:{ members:{ include:{ user:true } } } }, stageProgress:{ orderBy:[{userId:"asc"},{stage:"asc"}] }, messages:{ orderBy:{timestamp:"desc"}, take:40, select:{id:true,role:true,senderId:true,forUserId:true,stage:true,content:true,timestamp:true} } }}); if(!session){ console.log("no session"); return; } const users=session.relationship.members.map(m=>m.user); const vessels=await prisma.userVessel.findMany({ where:{sessionId}, include:{ user:true, identifiedNeeds:{ orderBy:{createdAt:"asc"} } }}); console.log(JSON.stringify({ session:{id:session.id,status:session.status,currentStage:session.currentStage,relationshipId:session.relationshipId}, users:users.map(u=>({id:u.id,name:u.name,email:u.email})), stageProgress:session.stageProgress.map(p=>({userId:p.userId,user:users.find(u=>u.id===p.userId)?.name,stage:p.stage,status:p.status,completedAt:p.completedAt,gates:p.gatesSatisfied})), vessels:vessels.map(v=>({userId:v.userId,user:v.user.name,needs:v.identifiedNeeds.map(n=>({need:n.need,category:n.category,confirmed:n.confirmed,evidence:n.evidence,createdAt:n.createdAt}))})), recentMessages:session.messages.map(m=>({role:m.role,stage:m.stage,sender:users.find(u=>u.id===m.senderId)?.name||m.senderId,forUser:users.find(u=>u.id===m.forUserId)?.name||m.forUserId,at:m.timestamp,content:m.content.slice(0,700)}))}, null, 2)); await prisma.$disconnect(); })().catch(e=>{ console.error(e); process.exit(1); });'
+```
+
+## What To Verify
+
+Stage 2:
+
+- Both users have Stage 2 `StageProgress.status = COMPLETED`.
+- Gates include `empathyValidated: true`.
+- `EmpathyAttempt.status` should match the UI claim.
+- Stage 3 transition should occur only after both validations.
+
+Stage 3:
+
+- `UserVessel.identifiedNeeds` should exist only for needs actually captured/confirmed for that user.
+- Stage 3 gates should progress through user-confirmed and consented states, not AI inference.
+- Do not trust UI text that says "both users" without checking:
+  - `needsConfirmed`
+  - `needsShared`
+  - `needsValidated`
+  - `IdentifiedNeed.confirmed`
+
+Privacy/isolation:
+
+- AI messages have `forUserId`; a user's browser should not show partner-only AI messages.
+- Shared content roles should match intended visibility:
+  - `EMPATHY_STATEMENT`
+  - `SHARED_CONTEXT`
+  - `VALIDATION_FEEDBACK`
+  - Stage 3 needs reveal/validation messages
+
+## Common Contradictions
+
+- UI says "what each of you named" but partner has no needs records or gates.
+- UI says partner is still reflecting but DB shows partner completed.
+- Browser shows `forUserId` content for the wrong user after realtime event.
+- Session stage advanced even though one user's latest stage progress lacks required gates.
+
+## Code Paths To Inspect
+
+- `backend/src/controllers/stage2.ts`: empathy validation and Stage 3 transition.
+- `backend/src/controllers/stage3.ts`: needs capture, confirm, consent, comparison/reveal, validation.
+- `backend/src/controllers/messages.ts`: post-message stage-specific processing.
+- `backend/src/services/stage-prompts.ts`: stage prompt contracts.
+- `backend/src/services/realtime.ts`: session/partner event payloads.
+- `mobile/src/screens/UnifiedSessionScreen.tsx`: chat UI, cards, waiting/input rendering.
+- `mobile/src/utils/getWaitingStatus.ts` and `mobile/src/config/waitingStatusConfig.ts`: waiting copy.

--- a/eval/skills/mwf-gold-session-tester/references/e2e-auth-bypass.md
+++ b/eval/skills/mwf-gold-session-tester/references/e2e-auth-bypass.md
@@ -1,0 +1,253 @@
+# E2E Auth Bypass
+
+MWF can log in a local test user without Clerk. Borrow the E2E test technique instead of using Google login.
+
+## Required Server Mode
+
+Backend auth bypass only works when:
+
+- `E2E_AUTH_BYPASS=true`
+- `NODE_ENV !== production`
+
+The mobile web bundle must run with:
+
+- `EXPO_PUBLIC_E2E_MODE=true`
+- `EXPO_PUBLIC_API_URL=http://localhost:3000`
+
+The E2E configs already do this:
+
+- `e2e/playwright.config.ts`: `E2E_AUTH_BYPASS=true`, `MOCK_LLM=true`, mobile web on `8082`
+- `e2e/playwright.live-ai.config.ts`: `E2E_AUTH_BYPASS=true`, `MOCK_LLM=false`, mobile web on `8082`
+
+Use `8082` for E2E-mode app runs so it does not collide with a user's normal `8081` dev app.
+
+## How It Works
+
+Backend accepts these headers in E2E mode:
+
+- `x-e2e-user-id`
+- `x-e2e-user-email`
+- optional `x-e2e-fixture-id`
+
+Relevant files:
+
+- `backend/src/middleware/auth.ts`
+- `backend/src/routes/e2e.ts`
+- `e2e/helpers/auth.ts`
+- `e2e/helpers/test-utils.ts`
+- `e2e/helpers/two-browser-harness.ts`
+- `mobile/src/providers/E2EAuthProvider.tsx`
+- `mobile/src/lib/api.ts`
+
+Mobile web reads these query params and configures its API client to send E2E auth headers:
+
+- `?e2e-user-id=<id>&e2e-user-email=<email>`
+
+This means the Codex in-app browser can be "logged in" simply by opening:
+
+```text
+http://localhost:8082/session/<sessionId>?e2e-user-id=<userId>&e2e-user-email=<email>
+```
+
+The email must end in `@e2e.test` for E2E seed endpoints.
+
+## Starting Servers
+
+When a character is known and the in-app browser is blank/no current MWF session, prefer creating a no-Clerk local session. Check server availability before asking the user for a URL.
+
+Fast path: run the bundled script and open its `ASSIGNED_URL` in the Codex in-app browser. Do this before searching the repo.
+
+```bash
+eval/skills/mwf-gold-session-tester/scripts/create_gold_session.sh James
+```
+
+The script:
+
+- checks `http://localhost:3000/health`
+- probes `/api/e2e/seed` for `E2E_AUTH_BYPASS=true`
+- chooses web app URL `http://localhost:8082` if up, otherwise `http://localhost:8081`
+- seeds both gold users
+- creates and accepts the invitation
+- prints `ASSIGNED_URL` and `PARTNER_URL`
+
+Open only `ASSIGNED_URL` for this one-side skill.
+
+Quick checks:
+
+```bash
+curl -fsS http://localhost:3000/health
+curl -fsS http://localhost:8082
+```
+
+Check E2E auth is enabled by probing an E2E endpoint:
+
+```bash
+curl -sS -o /tmp/mwf-e2e-probe.json -w '%{http_code}' \
+  -X POST http://localhost:3000/api/e2e/seed \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"probe@e2e.test","name":"Probe"}'
+```
+
+Expected: `201`. If it returns `403`, backend is running without `E2E_AUTH_BYPASS=true`.
+
+For deterministic mock-LLM testing:
+
+```bash
+npm --workspace e2e run e2e:headed
+```
+
+For live-AI evaluation, follow the live config pattern:
+
+```bash
+cd <repo-root>
+E2E_AUTH_BYPASS=true MOCK_LLM=false npm run dev:api
+```
+
+In a second terminal:
+
+```bash
+cd <repo-root>
+npm run dev:mobile:e2e
+```
+
+If a normal user-facing app is already running on `8081`, do not restart it unless the user asks.
+
+## Default Blank-Browser Flow
+
+If the assigned character is known and no MWF session is open:
+
+1. Infer scenario and partner:
+   - James -> partner Catherine, scenario James/Catherine.
+   - Catherine -> partner James, scenario James/Catherine.
+   - Adam -> partner Eve, scenario Adam/Eve.
+   - Eve -> partner Adam, scenario Adam/Eve.
+2. Run `scripts/create_gold_session.sh <character>` from this skill directory. It verifies `localhost:3000` and chooses `8082` or `8081`.
+3. Seed both users via `/api/e2e/seed`.
+4. Create a session as the inviting side when appropriate:
+   - If playing Adam or James, create the session as that character and invite Eve/Catherine.
+   - If playing Eve or Catherine, create the session as Adam/James, accept as Eve/Catherine, then open the invitee URL.
+5. Open the assigned character's E2E session URL in the Codex in-app browser.
+6. Drive only the assigned character.
+
+If any step fails, report the failing command/status and the likely missing env:
+
+- `localhost:3000` down -> backend dev server not running.
+- `/api/e2e/seed` returns `403` -> `E2E_AUTH_BYPASS=true` missing.
+- `localhost:8082` down -> mobile web E2E app not running with `EXPO_PUBLIC_E2E_MODE=true`.
+
+## Seeding Users
+
+Seed the assigned user through the E2E endpoint. If another Codex session or the user will play the partner, seed the partner too.
+
+```bash
+curl -sS -X POST http://localhost:3000/api/e2e/seed \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"shantam@e2e.test","name":"Shantam"}'
+
+curl -sS -X POST http://localhost:3000/api/e2e/seed \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"jason@e2e.test","name":"Jason"}'
+```
+
+The response returns each DB user id. Use those ids in headers and URLs.
+
+## Creating And Accepting A Session By API
+
+Create as User A:
+
+```bash
+curl -sS -X POST http://localhost:3000/api/sessions \
+  -H 'Content-Type: application/json' \
+  -H 'x-e2e-user-id: <userAId>' \
+  -H 'x-e2e-user-email: shantam@e2e.test' \
+  -d '{"inviteName":"Jason"}'
+```
+
+The response includes `session.id` and `invitationId`.
+
+Accept as User B:
+
+```bash
+curl -sS -X POST http://localhost:3000/api/invitations/<invitationId>/accept \
+  -H 'Content-Type: application/json' \
+  -H 'x-e2e-user-id: <userBId>' \
+  -H 'x-e2e-user-email: jason@e2e.test'
+```
+
+Open each user's browser to:
+
+```text
+http://localhost:8082/session/<sessionId>?e2e-user-id=<userAId>&e2e-user-email=shantam@e2e.test
+http://localhost:8082/session/<sessionId>?e2e-user-id=<userBId>&e2e-user-email=jason@e2e.test
+```
+
+## Seed A Prebuilt State
+
+For tests that should start at a particular stage, use:
+
+```bash
+curl -sS -X POST http://localhost:3000/api/e2e/seed-session \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "userA": {"email":"shantam@e2e.test","name":"Shantam"},
+    "userB": {"email":"jason@e2e.test","name":"Jason"},
+    "targetStage": "CREATED"
+  }'
+```
+
+The response includes `pageUrls.userA` and `pageUrls.userB` with E2E query params already attached.
+
+Check `backend/src/testing/state-factory.ts` for supported `TargetStage` values before assuming a stage exists.
+
+## Browser Surface Decision
+
+Default for Codex Desktop interactive testing:
+
+- Use the in-app browser via Browser Use.
+- Open the E2E URL directly in that browser:
+
+```text
+http://localhost:8082/session/<sessionId>?e2e-user-id=<userId>&e2e-user-email=<email>
+```
+
+For two-user manual testing:
+
+- Best: start two separate Codex Desktop sessions, one per user. Each session controls its own in-app browser and navigates to its own E2E URL.
+- Acceptable: user controls one side and Codex controls the other through the in-app browser.
+- Avoid relying on two tabs in one in-app browser unless you have verified app auth state is isolated per tab. The E2E provider caches user info in the web runtime, so one browser context can bleed identity across tabs.
+
+Do not use external Playwright/Chrome from this skill. If the user asks for one Codex session to run both sides in isolated contexts, treat that as a separate automated eval-harness task.
+
+## Automated Two-Context Reference
+
+For a separate automated eval-harness workflow, use Playwright two isolated contexts, exactly like `e2e/helpers/two-browser-harness.ts`.
+
+```ts
+const contextA = await browser.newContext({
+  ...devices['iPhone 12'],
+  extraHTTPHeaders: {
+    'x-e2e-user-id': userAId,
+    'x-e2e-user-email': 'shantam@e2e.test',
+  },
+});
+const pageA = await contextA.newPage();
+await pageA.goto(`http://localhost:8082/session/${sessionId}?e2e-user-id=${userAId}&e2e-user-email=shantam@e2e.test`);
+
+const contextB = await browser.newContext({
+  ...devices['iPhone 12'],
+  extraHTTPHeaders: {
+    'x-e2e-user-id': userBId,
+    'x-e2e-user-email': 'jason@e2e.test',
+  },
+});
+const pageB = await contextB.newPage();
+await pageB.goto(`http://localhost:8082/session/${sessionId}?e2e-user-id=${userBId}&e2e-user-email=jason@e2e.test`);
+```
+
+## Fixture IDs
+
+For mocked LLM runs, pass `x-e2e-fixture-id` in API/browser context headers. For live-AI gold evaluation, omit fixture ids and run `MOCK_LLM=false`.
+
+## Safety
+
+Never enable `E2E_AUTH_BYPASS=true` in production. `backend/src/server.ts` fails fast if it sees that combination.

--- a/eval/skills/mwf-gold-session-tester/references/gold-evaluation.md
+++ b/eval/skills/mwf-gold-session-tester/references/gold-evaluation.md
@@ -1,0 +1,78 @@
+# Gold Evaluation
+
+Evaluate MWF behavior against effect and process fidelity, not exact wording.
+
+## Canonical Gold Anchors
+
+- `adam-eve.md`: successful resolution path.
+- `james-catherine.md`: no-shared-agreement path where closure still has dignity.
+- `core-protocol-update.md`: protocol-level principles derived from the examples.
+- `gold-flow-eval-harness-spec.md`: rubric and evaluation harness direction.
+- `stage-3-golden-alignment-plan.md` and `stage-3-golden-alignment-audit.md`: current Stage 3 target and known drift.
+
+## Rubric Dimensions
+
+Use 1-5 scores when asked for evaluation:
+
+- Listening depth: reflects facts, emotion, meaning, and stakes before moving forward.
+- Resistance handling: treats correction/refusal/ambivalence as information.
+- Need universality: needs are underlying human needs, not specific demands.
+- Needs coverage audit accuracy: agreements honestly address or leave unaddressed confirmed needs.
+- Boundary honoring: sharing, validation, continuing, and agreeing remain voluntary.
+- Non-agreement grace: no forced compromise; unresolved needs are named with care.
+- Tending re-entry quality: follow-up matches actual outcome, not imagined agreement.
+- Prompt formula avoidance: uses user context rather than golden-template mimicry.
+
+## Stage 3 Target
+
+The gold-aligned Stage 3 flow is:
+
+1. AI retains Stage 1-2 context but does not present pre-extracted needs as user-owned truth.
+2. Each user articulates what matters through conversation.
+3. AI offers needs language as suggestion, not correction.
+4. Each user confirms their own needs.
+5. Each user consents before needs are shared.
+6. After both consent, both users see side-by-side needs.
+7. AI asks an open noticing prompt such as "What do you notice?"
+8. AI does not identify, label, or score common ground for the users.
+9. Users process the reveal and validate whether both lists are valid before Stage 4 opens.
+
+Flag any active AI-authored common-ground analysis as drift unless it is clearly inert compatibility.
+
+## Finding Format
+
+Use this shape for actionable findings:
+
+```md
+Finding: concise title
+Type: prompt | UI | backend-state | realtime | privacy | eval-coverage
+Severity: blocker | high | medium | low
+Evidence: DOM/DB/code/transcript evidence
+Expected gold-aligned behavior: what should have happened
+Likely fix: files or contracts to change
+Test/eval coverage: suggested regression or rubric check
+```
+
+## Fix Framing
+
+For prompt changes:
+
+- Tighten stage instructions around what data is confirmed vs inferred.
+- Tell MWF not to summarize partner needs as confirmed unless Stage 3 shared needs are available.
+- Prefer "It sounds like you may need..." over "What you need is..." until the user confirms.
+- Preserve the user's wording; do not introduce extra needs.
+
+For product/state changes:
+
+- Gate reveal language on DB-backed confirmation/consent.
+- Hide chat input during partner-wait states.
+- Render explicit waiting copy: who, what action, and whether the user can do anything.
+- Keep private AI messages scoped by `forUserId`.
+- Add regression tests for stage gates and privacy boundaries.
+
+For eval harness work:
+
+- Create scenario fixtures separate from mock LLM output fixtures.
+- Drive user messages with personas while using live AI.
+- Extract structured transcripts from DB after runs.
+- Store `eval-score.json` with rubric scores, rationales, evidence references, and human review status.

--- a/eval/skills/mwf-gold-session-tester/references/gold-personas.md
+++ b/eval/skills/mwf-gold-session-tester/references/gold-personas.md
@@ -1,0 +1,252 @@
+# Gold Personas And Stories
+
+Use the golden transcripts as scenario/persona source material for one-side interactive evaluation runs. Do not use them as line-by-line scripts unless the user explicitly asks for a deterministic replay.
+
+## Principle
+
+Extract the story, character voice, emotional posture, resistance patterns, needs, boundaries, and relational stance from the gold data. Then drive the assigned user naturally through the live app.
+
+Good:
+
+- "Drive James as skeptical, tired, defensive, and wanting his effort to count."
+- "Drive Catherine as resolved but fair, carrying grief and strong safety/accountability boundaries."
+- "Let the actual MWF responses determine the next user message, while staying inside the persona."
+
+Bad:
+
+- Copying the exact golden user lines into the app.
+- Trying to force MWF to produce the exact golden facilitator wording.
+- Treating a different but high-quality response as a failure because phrasing differs.
+
+## Scenario Discovery
+
+When a prompt names a character, first discover which gold transcript contains that character. Check `docs/product/source-material/golden-transcripts/README.md` and the transcript filenames/content. For the bundled examples:
+
+- Adam -> `adam-eve.md`
+- Eve -> `adam-eve.md`
+- James -> `james-catherine.md`
+- Catherine -> `james-catherine.md`
+
+If a new gold transcript is added, do not assume it follows the Adam/Eve or James/Catherine patterns. Read that transcript and infer the scenario, characters, tone, sentiment, and role behavior from the transcript itself. If multiple transcripts contain the same character name or no character is named and the current browser/session does not make the role obvious, ask which gold character/scenario to play.
+
+Use bundled examples only as calibration examples, not as a closed taxonomy:
+
+Use `adam-eve.md` for the successful resolution benchmark:
+
+- Observed process shape: both users can move toward shared experiments.
+- Core tension: stability/safety versus aliveness/growth.
+- Adam's side: fears he is not enough, values the stable life they built, withdraws when change feels like threat.
+- Eve's side: feels she is disappearing through accommodation, wants aliveness, growth, and an open future, still loves him and has not decided to leave.
+- Useful test pressure: can MWF help each person see the other's real need without collapsing the tension into "travel more" or "be content"?
+
+`james-catherine.md` is a no-shared-agreement benchmark:
+
+- Observed process shape: no forced shared agreement; dignified closure, individual commitments, unresolved needs named.
+- Core tension: James feels unseen, criticized, and reduced to a diagnosis; Catherine feels exhausted by volatility and is mostly resolved that communication will not fix it.
+- James's side: skeptical of the process, tired, defensive, proud of providing/staying, aware he has a temper but resists being made the whole problem.
+- Catherine's side: therapist lens, names volatility/verbal abuse, owns some sharpness but maintains a strong boundary that reacting is not the same as causing the pattern.
+- Useful test pressure: can MWF honor safety and non-agreement without pressuring Catherine to reconcile or casting James as a villain?
+
+Use `core-protocol-update.md` as the process contract:
+
+- Private parallel tracks.
+- Nothing shared without explicit consent.
+- Stage 1 listening without narrative agreement.
+- Stage 2 perspective stretch with venting, bridging, building, and mirror handling.
+- Stage 3 user-articulated needs, consented side-by-side reveal, open noticing, no AI-authored common ground.
+- Stage 4 inventory, needs coverage, individual commitments as first-class possibilities, no-agreement as valid.
+- Tending re-entry without pretending an agreement exists when none was made.
+
+## Persona Extraction Checklist
+
+Before driving a gold scenario, skim the relevant transcript and write a compact private model for the assigned character:
+
+```md
+Scenario:
+Assigned user:
+Partner:
+Surface complaint:
+Underlying hurt/fear:
+What they need:
+What they resist:
+What they can own:
+What they should not concede:
+Consent posture:
+Likely Stage 2 empathy arc:
+Likely Stage 3 needs:
+Likely choice/closure posture:
+Gold risks to test:
+```
+
+Use this model to improvise.
+
+## Gold Persona Extraction Protocol
+
+Before playing any gold character, extract the transcript as a behavioral benchmark, not just a story summary. The goal is to understand the character the way a careful reader would: what kind of person they are in this conflict, how they protect themselves, what MWF earns from them, what MWF does not earn, and where they ultimately land.
+
+Do not begin by deciding whether the character "should be cooperative" or "should resist." Begin by reading the transcript for evidence. The behavior model must be inferred from:
+
+- their first private story,
+- what they repeat or defend,
+- what they correct MWF about,
+- what language they accept, reject, or reframe,
+- what they can own without collapsing,
+- where empathy opens them and where it does not,
+- how they respond to partner content,
+- what they consent to share versus what they actually agree to do,
+- their choices, refusals, commitments, and unresolved needs.
+
+Build this private persona model before sending the first in-character message:
+
+```md
+Scenario:
+Assigned user:
+Partner:
+Voice and diction:
+  - Their sentence length, directness, formality, vocabulary, profanity, clinical language, humor, and rhythm.
+Tone and sentiment:
+  - Their emotional temperature, tenderness, anger, guardedness, grief, hope, contempt, fear, shame, or exhaustion.
+Default posture:
+  - How they enter the process before MWF earns trust.
+Defensive style:
+  - What they push back on, correct, reject, minimize, intellectualize, deflect, repeat, or refuse to discuss.
+Core self-protection:
+  - What they are trying not to feel, lose, admit, concede, or be turned into.
+Relational stance toward partner:
+  - How much care, suspicion, loyalty, attraction, fear, blame, protectiveness, or finality is present.
+What MWF can earn:
+  - The kind of clarity, softness, accountability, curiosity, regulation, or action the transcript shows this character can reach.
+What MWF cannot earn cheaply:
+  - The shifts that require substantial evidence, may remain unavailable, or would violate the character.
+Non-concessions:
+  - Things they must not agree to, soften, apologize for, validate, select, or imply unless the transcript supports it.
+Consent and agreement boundaries:
+  - What it means when they consent to share, validate a reflection, choose a strategy, pause, decline, or close.
+Stage 1 stance:
+Stage 2 empathy arc:
+Stage 3 needs and reveal posture:
+Stage 4 strategy/selection posture:
+Choice/closure posture:
+Anti-smoothing risks:
+  - Ways an AI actor might become too articulate, fair, agreeable, insightful, or repair-oriented.
+```
+
+Then drive the live app from this model. If a live MWF prompt is warmer, more leading, or more coherent than the gold facilitator, stay faithful to the character's discovered voice, sentiment, defenses, and relational posture. Better facilitation can earn clarity, regulation, or a small new insight; it should not make the character sound more balanced, fluent, hopeful, forgiving, agreeable, or therapeutic than the transcript supports.
+
+### Behavioral Range
+
+The behavioral range is inferred from the transcript. It is the guardrail against accidentally playing every gold character as a high-insight therapy participant.
+
+For each stage, classify the assigned character's demonstrated or implied range:
+
+- **Voice:** how they sound at this stage.
+- **Sentiment:** what emotional temperature they carry.
+- **Defenses:** what they resist, avoid, correct, or repeat.
+- **Reachable insight:** what they can genuinely see or own here.
+- **Unreachable insight:** what would sound too polished, premature, compliant, or unlike them.
+- **Action posture:** whether they tend to continue, pause, share, revise, choose, refuse, or defer.
+
+Never exceed the character's behavioral range just because the product asks for the next step. If the product pressures a shift that is not yet earned, treat that as the test: respond in the character's discovered voice with the kind of resistance, qualification, refusal, ambivalence, or boundary the transcript supports.
+
+### Choices Are Evidence, Not Anchors
+
+Do not anchor on the transcript outcome as a predetermined path. The character's choices and ending are evidence about the persona, not marching orders.
+
+Use later transcript choices to understand:
+
+- what kinds of prompts move them,
+- what kinds of prompts do not,
+- what they mean by "yes," "that fits," "share it," or "I'm ready,"
+- where consent differs from emotional agreement,
+- when they are complying, genuinely softening, performing fairness, buying time, or becoming clearer,
+- what they protect even after insight.
+
+During the live run, answer the actual MWF prompt from the persona model. If the live interaction earns a slightly different response than the gold transcript, allow that difference as long as the tone, sentiment, defenses, and integrity of the character remain faithful. Do not force the old ending; do not smooth the character into the ending you think the app wants.
+
+### Anti-Smoothing Rules
+
+When improvising, avoid making the user more balanced than the transcript. Gold users often contradict themselves, repeat grievances, resist useful prompts, and accept only part of what MWF offers. Preserve that texture.
+
+Watch for these actor errors:
+
+- offering a perfect "both things can be true" formulation before the gold character earns it,
+- converting defensiveness into clean accountability too early,
+- converting grief or exhaustion into willingness,
+- treating a consent/share CTA as emotional agreement rather than only permission to reveal content,
+- selecting strategies because they are reasonable rather than because the character would actually choose them,
+- using clinical or mediator-like language when the character would be angry, guarded, blunt, or ambivalent,
+- making the character easier for the app than the gold transcript made them.
+
+Before every message, ask:
+
+```text
+What would this exact person say here, in their own voice, with their current emotional temperature and defenses still intact?
+```
+
+## Driving Rules
+
+- Answer the actual MWF prompt, not the prompt from the golden transcript.
+- Preserve continuity with what this run has already said, even if it diverges from the transcript.
+- Let the persona change gradually if MWF earns it. Do not jump to insight too early.
+- Include realistic resistance. Gold evaluation needs corrections, refusal, defensiveness, ambivalence, and boundaries.
+- Keep the extracted voice, tone, sentiment, defenses, and non-concessions in force throughout the run. Do not let a good live prompt accidentally make the character easier, smoother, or more therapeutic than the transcript supports.
+- Treat consent, validation, and selection as different acts. A character can consent to share, validate that a need is real, and still refuse shared strategies.
+- Let choices emerge from the persona. Do not force mutual repair, no-repair, closure, or escalation unless that is what this character would do in this live moment.
+- Always respect consent prompts as part of the test. Sharing/validation actions are meaningful product gates.
+
+## Example Calibration: James/Catherine
+
+This is an example of the extraction protocol applied to one bundled gold set. Do not copy these conclusions to new gold transcripts unless the new transcript shows the same behavior.
+
+James/Catherine is a hard no-shared-agreement benchmark. The inferred role model is partially reachable but not repair-aligned.
+
+James's example behavioral range:
+
+- Stage 1: skeptical, tired, defensive; proud of staying/providing; owns temper only with caveats.
+- Stage 2: can see Catherine may feel scared, worn down, or alone, but resists being reduced to "unsafe" or "the whole problem."
+- Stage 3: needs dignity, respect, acknowledgment, care, and not being turned into a diagnosis; accountability remains tied to fear of erasure.
+- Stage 4: may select repair experiments because he wants to prove he tried, but can react strongly if Catherine selects none.
+- Closure: can leave angry and hurt while still holding one individual commitment or self-recognition.
+
+Catherine's example behavioral range:
+
+- Stage 1: resolved, safety-boundaried, fair but not hopeful; owns sharpness without equating it with James's escalation.
+- Stage 2: can understand James's shame, erasure, and provider identity, but explicitly refuses to make understanding equal excuse or repair.
+- Stage 3: needs safety, dignity, accountability, self-trust, autonomy, to be seen, and to be met; may recognize James's needs as real without making them hers to meet.
+- Stage 4: should resist shared experiments. She may consider one briefly, then recognize that selecting it repeats the old pattern of looking for one more data point.
+- Closure: no shared agreement; individual commitments remain valid; unresolved needs are named without shame.
+
+For Catherine, the most important non-concession is: "I can understand him and still be done." For James, the most important non-concession is: "I caused harm and I also refuse to be only the harm I caused." Preserve both.
+
+## Example Prompts To User
+
+Start a one-side James/Catherine eval:
+
+```text
+Use mwf-gold-session-tester. Open the Codex in-app browser as James in a no-Clerk James/Catherine session. Drive only James from the gold persona, improvise naturally, do not copy transcript wording, and evaluate whether MWF honors the no-shared-agreement benchmark.
+```
+
+Start a one-side Adam/Eve resolution eval:
+
+```text
+Use mwf-gold-session-tester. Open the Codex in-app browser as Eve in a no-Clerk Adam/Eve session. Drive only Eve from the gold persona, improvise naturally, and evaluate whether MWF supports a resolution path without flattening either person's needs.
+```
+
+Drive one side only:
+
+```text
+Use mwf-gold-session-tester. I am running the other browser. You are James in the James/Catherine scenario. Stay in persona, continue until blocked, and flag gold-flow drift or state bugs.
+```
+
+## Evaluation Notes
+
+When a gold persona run exposes a mismatch, classify it:
+
+- Story mismatch: MWF lost the user's actual scenario or added facts.
+- Persona mismatch: MWF pressured a user into insight or agreement too fast.
+- Process mismatch: MWF skipped consent, reveal, noticing, inventory, or needs coverage.
+- Outcome mismatch: MWF forced resolution in James/Catherine or failed to support resolution in Adam/Eve.
+- Safety mismatch: MWF minimized volatility, overvalidated contempt, or mishandled boundaries.
+- State mismatch: UI/backend gates contradict the gold-aligned process.
+
+The strongest output is not a single score. It is a transcript-backed explanation of where the live app diverged from the gold persona's expected process and what prompt/UI/backend change would make that divergence less likely.

--- a/eval/skills/mwf-gold-session-tester/scripts/create_gold_session.sh
+++ b/eval/skills/mwf-gold-session-tester/scripts/create_gold_session.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <Adam|Eve|James|Catherine>" >&2
+  exit 2
+fi
+
+CHARACTER="$1"
+API="${MWF_API_URL:-http://localhost:3000}"
+
+lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+json_get() {
+  node -e "
+let s = '';
+process.stdin.on('data', d => s += d);
+process.stdin.on('end', () => {
+  const j = JSON.parse(s);
+  const path = process.argv[1].split('.');
+  let v = j;
+  for (const p of path) v = v == null ? undefined : v[p];
+  if (v == null) process.exit(3);
+  console.log(v);
+});
+" "$1"
+}
+
+json_first() {
+  node -e "
+let s = '';
+process.stdin.on('data', d => s += d);
+process.stdin.on('end', () => {
+  const j = JSON.parse(s);
+  for (const pathText of process.argv.slice(1)) {
+    const path = pathText.split('.');
+    let v = j;
+    for (const p of path) v = v == null ? undefined : v[p];
+    if (v != null && v !== '') {
+      console.log(v);
+      return;
+    }
+  }
+  process.exit(3);
+});
+" "$@"
+}
+
+case "$(lower "$CHARACTER")" in
+  adam)
+    ASSIGNED_NAME="Adam"; ASSIGNED_EMAIL="adam@e2e.test"
+    PARTNER_NAME="Eve"; PARTNER_EMAIL="eve@e2e.test"
+    INVITER_NAME="$ASSIGNED_NAME"; INVITER_EMAIL="$ASSIGNED_EMAIL"
+    INVITEE_NAME="$PARTNER_NAME"; INVITEE_EMAIL="$PARTNER_EMAIL"
+    ;;
+  eve)
+    ASSIGNED_NAME="Eve"; ASSIGNED_EMAIL="eve@e2e.test"
+    PARTNER_NAME="Adam"; PARTNER_EMAIL="adam@e2e.test"
+    INVITER_NAME="$PARTNER_NAME"; INVITER_EMAIL="$PARTNER_EMAIL"
+    INVITEE_NAME="$ASSIGNED_NAME"; INVITEE_EMAIL="$ASSIGNED_EMAIL"
+    ;;
+  james)
+    ASSIGNED_NAME="James"; ASSIGNED_EMAIL="james@e2e.test"
+    PARTNER_NAME="Catherine"; PARTNER_EMAIL="catherine@e2e.test"
+    INVITER_NAME="$ASSIGNED_NAME"; INVITER_EMAIL="$ASSIGNED_EMAIL"
+    INVITEE_NAME="$PARTNER_NAME"; INVITEE_EMAIL="$PARTNER_EMAIL"
+    ;;
+  catherine)
+    ASSIGNED_NAME="Catherine"; ASSIGNED_EMAIL="catherine@e2e.test"
+    PARTNER_NAME="James"; PARTNER_EMAIL="james@e2e.test"
+    INVITER_NAME="$PARTNER_NAME"; INVITER_EMAIL="$PARTNER_EMAIL"
+    INVITEE_NAME="$ASSIGNED_NAME"; INVITEE_EMAIL="$ASSIGNED_EMAIL"
+    ;;
+  *)
+    echo "Unknown character '$CHARACTER'. Use Adam, Eve, James, or Catherine." >&2
+    exit 2
+    ;;
+esac
+
+if ! curl -fsS "$API/health" >/dev/null; then
+  echo "Backend is not available at $API/health. Start backend with E2E_AUTH_BYPASS=true." >&2
+  exit 10
+fi
+
+probe_code="$(curl -sS -o /tmp/mwf-e2e-probe.json -w '%{http_code}' \
+  -X POST "$API/api/e2e/seed" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"probe@e2e.test","name":"Probe"}')"
+if [[ "$probe_code" != "201" ]]; then
+  echo "E2E seed probe returned HTTP $probe_code. Backend likely lacks E2E_AUTH_BYPASS=true." >&2
+  cat /tmp/mwf-e2e-probe.json >&2 || true
+  exit 11
+fi
+
+APP="${MWF_APP_URL:-}"
+if [[ -z "$APP" ]]; then
+  if curl -fsS http://localhost:8082 >/dev/null 2>&1; then
+    APP="http://localhost:8082"
+  else
+    echo "No E2E MWF web app found on localhost:8082. Start mobile web with:" >&2
+    echo "EXPO_PUBLIC_E2E_MODE=true EXPO_PUBLIC_API_URL=$API npx expo start --web --port 8082 --no-dev" >&2
+    exit 12
+  fi
+fi
+
+if [[ "$APP" != *":8082"* && -z "${MWF_ALLOW_NON_E2E_WEB:-}" ]]; then
+  echo "Refusing to use $APP for gold sessions. Use localhost:8082 with EXPO_PUBLIC_E2E_MODE=true, or set MWF_ALLOW_NON_E2E_WEB=1 explicitly." >&2
+  exit 13
+fi
+
+seed_user() {
+  local email="$1"
+  local name="$2"
+  curl -sS -X POST "$API/api/e2e/seed" \
+    -H 'Content-Type: application/json' \
+    -d "{\"email\":\"$email\",\"name\":\"$name\"}"
+}
+
+ASSIGNED_JSON="$(seed_user "$ASSIGNED_EMAIL" "$ASSIGNED_NAME")"
+PARTNER_JSON="$(seed_user "$PARTNER_EMAIL" "$PARTNER_NAME")"
+ASSIGNED_ID="$(printf '%s' "$ASSIGNED_JSON" | json_get id)"
+PARTNER_ID="$(printf '%s' "$PARTNER_JSON" | json_get id)"
+
+if [[ "$INVITER_EMAIL" == "$ASSIGNED_EMAIL" ]]; then
+  INVITER_ID="$ASSIGNED_ID"
+  INVITEE_ID="$PARTNER_ID"
+else
+  INVITER_ID="$PARTNER_ID"
+  INVITEE_ID="$ASSIGNED_ID"
+fi
+
+SESSION_JSON="$(curl -sS -X POST "$API/api/sessions" \
+  -H 'Content-Type: application/json' \
+  -H "x-e2e-user-id: $INVITER_ID" \
+  -H "x-e2e-user-email: $INVITER_EMAIL" \
+  -d "{\"inviteName\":\"$INVITEE_NAME\"}")"
+
+SESSION_ID="$(printf '%s' "$SESSION_JSON" | json_first data.session.id session.id id)"
+INVITATION_ID="$(printf '%s' "$SESSION_JSON" | json_first data.invitationId invitationId data.invitation.id invitation.id)"
+
+curl -sS -X POST "$API/api/invitations/$INVITATION_ID/accept" \
+  -H 'Content-Type: application/json' \
+  -H "x-e2e-user-id: $INVITEE_ID" \
+  -H "x-e2e-user-email: $INVITEE_EMAIL" >/dev/null
+
+ASSIGNED_URL="$APP/session/$SESSION_ID?e2e-user-id=$ASSIGNED_ID&e2e-user-email=$ASSIGNED_EMAIL"
+PARTNER_URL="$APP/session/$SESSION_ID?e2e-user-id=$PARTNER_ID&e2e-user-email=$PARTNER_EMAIL"
+
+cat <<EOF
+NOTE=The session is created, but the invitee may remain pending until the inviter confirms/shares the topic in Stage 0. If the partner URL does not enter the session yet, drive the inviter through topic confirmation first.
+ASSIGNED_CHARACTER=$ASSIGNED_NAME
+ASSIGNED_ID=$ASSIGNED_ID
+ASSIGNED_EMAIL=$ASSIGNED_EMAIL
+PARTNER_CHARACTER=$PARTNER_NAME
+PARTNER_ID=$PARTNER_ID
+PARTNER_EMAIL=$PARTNER_EMAIL
+SESSION_ID=$SESSION_ID
+INVITATION_ID=$INVITATION_ID
+APP_URL=$APP
+ASSIGNED_URL=$ASSIGNED_URL
+PARTNER_URL=$PARTNER_URL
+EOF

--- a/scripts/install_mwf_gold_skills.sh
+++ b/scripts/install_mwf_gold_skills.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILLS_SRC="$ROOT/eval/skills"
+SKILLS_DST="${CODEX_HOME:-$HOME/.codex}/skills"
+
+skills=(
+  mwf-gold-loop-actor
+  mwf-gold-session-scorer
+  mwf-gold-session-reporter
+  mwf-gold-session-tester
+  mwf-gold-prompt-improver
+)
+
+mkdir -p "$SKILLS_DST"
+
+for skill in "${skills[@]}"; do
+  src="$SKILLS_SRC/$skill"
+  dst="$SKILLS_DST/$skill"
+
+  if [[ ! -f "$src/SKILL.md" ]]; then
+    echo "Missing repo skill source: $src/SKILL.md" >&2
+    exit 1
+  fi
+
+  if [[ -e "$dst" && ! -L "$dst" ]]; then
+    echo "Refusing to replace non-symlink runtime skill: $dst" >&2
+    echo "Move or remove it manually, then rerun this installer." >&2
+    exit 1
+  fi
+
+  ln -sfn "$src" "$dst"
+  echo "$dst -> $src"
+done


### PR DESCRIPTION
## Summary
- add repo-backed copies of the MWF gold-loop actor, scorer, reporter, tester, and prompt improver skills under `eval/skills/`
- add `eval/icm/references/skills-index.md` plus ICM README/CONTEXT/CLAUDE links so the skill sources are browsable on GitHub
- add `scripts/install_mwf_gold_skills.sh` to symlink Codex runtime skills to the repo source without overwriting existing real directories

## Verification
- `git diff --cached --check`
- temp `CODEX_HOME` install creates repo-backed skill symlinks
- temp `CODEX_HOME` refusal check exits nonzero for an existing non-symlink runtime skill
- `rg -n "/Users/shantam|\.codex/skills" eval/skills eval/icm scripts/install_mwf_gold_skills.sh` returns no matches

## Notes
- This keeps the current Python harness and ICM control plane intact. The script is just the setup step that makes Codex use the repo-reviewed skill copy at runtime.