### PR TITLE
docs: incremental audit — Stage 2 gates, GuidedActionPanel, ICM, python-eval CI

### DIFF
--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -3,7 +3,7 @@ title: Codebase Structure
 sidebar_position: 8
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-05-07
 status: living
 ---
 # Codebase Structure
@@ -145,7 +145,8 @@ project-root/
 - Contains: 90 component files organized by feature
 - Key components:
   - `ChatInterface.tsx` - Main chat UI (29KB; messages, input, streaming)
-  - `ChatBubble.tsx` - Single message bubble (20KB, handles AI streaming animation)
+  - `ChatBubble.tsx` - Single message bubble (20KB, handles AI streaming animation with queue-based hiding: bubbles return `null` until their animation turn to prevent premature rendering)
+  - `GuidedActionPanel.tsx` - Unified action surface component (added #446); replaces six separate inline panels with a single `tone`-driven pattern (tones: `topic`, `review`, `share`, `success`, `needs`)
   - `EmotionalBarometer.tsx` - Emotion slider UI
   - Stage 2 components are integrated into UnifiedSessionScreen.tsx and its sub-components in `components/sharing/`, `components/SessionDrawer/`, `AccuracyFeedbackDrawer.tsx`, `ViewEmpathyStatementDrawer.tsx`, and reusable guided chat modals like `GuidedDraftChatModal.tsx`
   - `NeedCard.tsx`, `StrategyCard.tsx` - Stage 3-4 components

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -3,7 +3,7 @@ title: Testing Patterns
 sidebar_position: 9
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-04-28
+updated: 2026-05-07
 status: living
 ---
 # Testing Patterns
@@ -619,6 +619,7 @@ npm run e2e
 
 **CI Pipeline:**
 - GitHub Actions workflows in `.github/workflows/` run `npm run check` and `npm run test` on each PR
+- A separate `python-eval` CI job runs when eval files change (`scripts/mwf_*.py`, `eval/gold-scenarios.json`, `eval/icm/**`, `eval/moments/**`, etc.): runs `py_compile` syntax checks across all gold-loop scripts and executes `scripts/test_mwf_moment_eval.py`
 - E2E tests run on merge to main (slower, separate job)
 - Live AI tests optional (manual trigger)
 

--- a/docs/backend/api/stage-2.md
+++ b/docs/backend/api/stage-2.md
@@ -3,6 +3,8 @@ title: "Stage 2 API: Perspective Stretch"
 sidebar_position: 7
 description: Endpoints for building and exchanging empathy attempts.
 slug: /backend/api/stage-2
+updated: 2026-05-07
+status: living
 ---
 # Stage 2 API: Perspective Stretch
 
@@ -209,7 +211,7 @@ Besides the Phase-1 / Phase-2 core above, the routes file exposes these controll
 | `POST` | `/api/v1/sessions/:id/empathy/refine` | Run AI refinement on the caller's current draft (used by the validation feedback / coach loop) |
 | `POST` | `/api/v1/sessions/:id/empathy/resubmit` | After refinement, resubmit an updated `EmpathyAttempt` on top of an existing validation request |
 | `POST` | `/api/v1/sessions/:id/empathy/skip-refinement` | Accept or decline the current gap as a "willing-to-accept" difference and advance without further refinement; updates `skippedRefinement`, `willingToAccept`, `skipReason` on the caller's StageProgress |
-| `GET`  | `/api/v1/sessions/:id/empathy/share-suggestion` | Asymmetric reconciler: fetch a suggestion to help the caller close an empathy gap for the partner |
+| `GET`  | `/api/v1/sessions/:id/empathy/share-suggestion` | Asymmetric reconciler: fetch a suggestion to help the caller close an empathy gap for the partner. The mobile client only surfaces this panel after the caller has consented to share their own empathy attempt (`alreadyConsented === true` on the `EmpathyDraftDTO`). |
 | `POST` | `/api/v1/sessions/:id/empathy/share-suggestion/respond` | Accept or decline a share suggestion |
 | `POST` | `/api/v1/sessions/:id/empathy/validation-feedback/draft` | Draft feedback via the "Feedback Coach" AI flow |
 | `POST` | `/api/v1/sessions/:id/empathy/validation-feedback/refine` | Iterate on feedback-coach output |

--- a/docs/code-to-docs-mapping.json
+++ b/docs/code-to-docs-mapping.json
@@ -64,6 +64,8 @@
     { "code": "scripts/ec2-bot/**",                      "label": "scripts/ec2-bot",               "docs": ["docs/infrastructure/index.md"] },
     { "code": "bot-workspaces/**",                       "label": "bot-workspaces",                "docs": ["docs/infrastructure/index.md"] },
     { "code": ".github/workflows/**",                    "label": ".github/workflows",             "docs": ["docs/infrastructure/index.md"] },
-    { "code": "tools/test-dashboard/**",                 "label": "tools/test-dashboard",           "docs": ["docs/e2e-testing/architecture.md", "docs/infrastructure/index.md"] }
+    { "code": "tools/test-dashboard/**",                 "label": "tools/test-dashboard",           "docs": ["docs/e2e-testing/architecture.md", "docs/infrastructure/index.md"] },
+    { "code": "eval/**",                                  "label": "eval",                           "docs": ["docs/e2e-testing/gold-loop-icm.md"] },
+    { "code": "scripts/mwf_*.py",                         "label": "scripts/mwf_*.py",               "docs": ["docs/e2e-testing/gold-loop-icm.md"] }
   ]
 }

--- a/docs/e2e-testing/gold-loop-icm.md
+++ b/docs/e2e-testing/gold-loop-icm.md
@@ -1,0 +1,69 @@
+---
+title: Gold Loop ICM
+sidebar_position: 4
+description: Control plane for the MWF autonomous gold-loop self-improvement system.
+created: 2026-05-07
+updated: 2026-05-07
+status: living
+---
+# Gold Loop ICM
+
+The `eval/icm/` directory is the control plane for the MWF gold-loop self-improvement system. It owns durable routing, governance, completion criteria, failure taxonomy, stage contracts, regression records, and cycle reporting. The underlying scripts (`mwf_gold_loop.py`, `mwf_moment_eval.py`, etc.) and repo-backed specialist skills (`eval/skills/mwf-gold-*/`) remain the execution layer.
+
+## What It Is
+
+ICM (Iterative Calibration Machine) is an autonomous 9-stage pipeline that ingests a failing gold-loop result, triages the failure category, plans and implements a fix, verifies it, reruns the evaluation, judges the outcome, reports it, and optionally queues a self-improvement proposal.
+
+## Stages
+
+| Stage | Directory | Purpose |
+|---|---|---|
+| 01 Intake | `eval/icm/stages/01-intake/` | Receive a failing test result or regression report |
+| 02 Triage | `eval/icm/stages/02-triage/` | Classify failure type (actor, eval-machine, product, prompt) |
+| 03 Repair Plan | `eval/icm/stages/03-repair-plan/` | Select fix strategy |
+| 04 Implement | `eval/icm/stages/04-implement/` | Apply the fix |
+| 05 Verify | `eval/icm/stages/05-verify/` | Verify fix compiles / passes syntax checks |
+| 06 Rerun | `eval/icm/stages/06-rerun/` | Re-run the gold-loop evaluation |
+| 07 Judge | `eval/icm/stages/07-judge/` | Compare before/after scores |
+| 08 Report | `eval/icm/stages/08-report/` | Write a cycle report to `eval/icm/cycles/` |
+| 09 Self-Improve | `eval/icm/stages/09-self-improve/` | Queue a proposal to backlog if systemic issue found |
+
+## Canonical Inputs
+
+- `docs/product/source-material/golden-transcripts/` — Ground-truth session transcripts
+- `eval/gold-profiles/` — Persona profiles (adam-eve, james-catherine) with per-stage moments
+- `eval/gold-scenarios.json` — Scenario definitions driving gold-loop runs
+- `eval/gold-snapshot-registry.json` — Registry of saved session snapshots for replay
+- `eval/moments/` — Individual moment fixtures used in moment-level evaluation
+- `eval/baselines/` — Baseline scores for regression detection
+- `eval/scorer/` — Scoring rubrics and judge configurations
+- `eval/skills/` — Repo-backed versions of MWF gold specialist skills
+- `eval/prompt-versions/` — Versioned prompt artifacts for the gold loop
+
+## Governance
+
+Key policies live in `eval/icm/references/`:
+
+| Policy | File |
+|---|---|
+| What counts as a regression | `regression-policy.md` |
+| What changes are allowed per failure type | `product-change-policy.md`, `prompt-change-policy.md`, `eval-machine-change-policy.md` |
+| How to version prompts | `prompt-versioning-policy.md` |
+| Budget per cycle | `cycle-budget-policy.md` |
+| When to use real LLM calls | `real-llm-policy.md` |
+| Snapshot replay rules | `snapshot-replay-policy.md` |
+
+## Running the Loop
+
+- **Autonomous run**: Start with `eval/icm/RUN_SELF_IMPROVEMENT_LOOP.md`
+- **Manual inspection / resume**: Start with `eval/icm/CONTEXT.md`
+- **Skills install**: Run `scripts/install_mwf_gold_skills.sh` to install repo-backed skills for Codex
+
+## CI Integration
+
+The `python-eval` CI job in `.github/workflows/ci.yml` runs syntax checks and `scripts/test_mwf_moment_eval.py` whenever eval files change. See [CI Pipeline](../architecture/testing.md#ci-pipeline).
+
+## Related
+
+- [E2E Testing Architecture](./architecture.md)
+- [Architecture: Testing](../architecture/testing.md)

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -3,7 +3,7 @@ title: Infrastructure
 sidebar_position: 1
 description: Slam bot (EC2), Render hosting, Vercel deploys, GitHub automation.
 created: 2026-03-11
-updated: 2026-04-28
+updated: 2026-05-07
 status: living
 ---
 
@@ -123,7 +123,7 @@ See [deployment](../deployment/index.md) for release procedures and env var refe
 ## GitHub workflows
 
 - `.github/workflows/docs-impact.yml` — PR-time check that code changes and their mapped docs are updated together. Mapping rules in `docs/code-to-docs-mapping.json`.
-- `.github/workflows/ci.yml` — PR-time CI: spins up a Postgres 15 service container, installs deps (`npm ci`), generates the Prisma client, runs `npm run check`, migrates the test DB, and runs `npm run test`. Skipped for docs-only changes via `dorny/paths-filter`. A `ci-success` gate job is the single required status check for branch protection.
+- `.github/workflows/ci.yml` — PR-time CI: spins up a Postgres 15 service container, installs deps (`npm ci`), generates the Prisma client, runs `npm run check`, migrates the test DB, and runs `npm run test`. Also runs a `python-eval` job (syntax checks + `test_mwf_moment_eval.py`) when eval files change (`scripts/mwf_*.py`, `eval/gold-scenarios.json`, `eval/icm/**`, `eval/moments/**`, etc.). Skipped for docs-only changes via `dorny/paths-filter`. A `ci-success` gate job (requiring both `ci` and `python-eval`) is the single required status check for branch protection.
 - `.github/workflows/render-deploy.yml` — Push-to-`main` backend deploy: filters to pushes that touch `backend/`, `shared/`, the lockfile, `render.yaml`, or the workflow itself, then POSTs the Render deploy hook (stored in repo secret `RENDER_DEPLOY_HOOK`). Render's built-in auto-deploy must be **off** — this workflow is the sole deploy trigger.
 - `.github/workflows/vercel-deploy-app.yml` — Push-to-`main` Expo Web deploy: filters to pushes touching `mobile/**` or `shared/**`, builds the Expo Web bundle, and deploys to `app.meetwithoutfear.com` via Vercel (`mwf-app` project). Also supports `workflow_dispatch`.
 - `.github/workflows/vercel-deploy-website.yml` — Push-to-`main` marketing site deploy: filters to pushes touching `website/**`, deploys to Vercel.

--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -2,7 +2,7 @@
 title: Chat Interface
 sidebar_position: 3
 description: The primary conversation interface where users interact with the AI.
-updated: 2026-05-02
+updated: 2026-05-07
 status: living
 ---
 # Chat Interface
@@ -274,6 +274,20 @@ Not implemented. The message input accepts text only (`sendMessage(message: stri
 ## Integrated emotional barometer
 
 The chat input hosts an inline emotion slider (`barometerValue` / `handleBarometerChange`). Readings ≥9 automatically open the `support-options` overlay to surface coping exercises before the user continues typing.
+
+## Guided Action Panel
+
+`GuidedActionPanel` is a unified component (added in #446) that replaced six separate inline action surfaces with a single consistent pattern. It accepts a `tone` prop that controls color/icon and a `primaryAction` (and optional secondary). Current tones:
+
+| Tone | Used for |
+|---|---|
+| `topic` | Stage 0 — topic-frame confirmation above the input |
+| `review` | Stage 2 — empathy draft review / revisit |
+| `share` | Stage 2 — share suggestion |
+| `success` | Stage 1 — feel-heard confirmation |
+| `needs` | Stage 3 — needs reveal / validate |
+
+Each panel shows an eyebrow label, title, optional subtitle, and one or two action buttons. The input field remains visible while any `GuidedActionPanel` is displayed — it is not hidden by the panel (this is intentional: users can continue the conversation even while an action is pending).
 
 ## Typewriter + inline Stage 2 cards
 

--- a/docs/product/stages/stage-2-perspective-stretch.md
+++ b/docs/product/stages/stage-2-perspective-stretch.md
@@ -2,6 +2,8 @@
 title: "Stage 2: Perspective Stretch"
 sidebar_position: 5
 description: Build genuine empathy by helping each user understand the other persons perspective, needs, and experience.
+updated: 2026-05-07
+status: living
 ---
 # Stage 2: Perspective Stretch
 
@@ -117,6 +119,18 @@ If a user is stuck, the AI may offer a hint about the partner's perspective.
 - Hints inform AI questions - partner content is never quoted directly
 
 See [Hint System](../mechanisms/hint-system.md) for the full design.
+
+### Share Suggestions (Reconciler-Driven)
+
+Separately from hints, the reconciler may surface a share suggestion — a prompt for the user to share their empathy attempt with their partner in order to close an identified empathy gap.
+
+**Key gate:** The share suggestion panel is intentionally held until the user has consented to share their own empathy attempt (`alreadyConsented === true`). This prevents the suggestion from appearing before the user has completed their own perspective-taking work, which would risk interrupting that process.
+
+**Flow:**
+1. User builds and consents to share their empathy attempt
+2. Reconciler detects an empathy gap for the partner
+3. Share suggestion panel appears in the chat UI
+4. User can accept (share) or decline the suggestion
 
 ## Mirror Intervention
 


### PR DESCRIPTION
## Changes
- Add: `docs/e2e-testing/gold-loop-icm.md` — new living doc for the eval/icm control plane (9-stage ICM, governance policies, canonical inputs)
- Fix: `docs/product/stages/stage-2-perspective-stretch.md` — document share suggestion gating (held until user consents to share own empathy attempt)
- Fix: `docs/backend/api/stage-2.md` — add `alreadyConsented` gate note to share-suggestion endpoint row
- Fix: `docs/mobile/wireframes/chat-interface.md` — document GuidedActionPanel unified action surface (tones, input-stays-visible behaviour)
- Fix: `docs/architecture/structure.md` — add GuidedActionPanel and ChatBubble queue-hiding to component list
- Fix: `docs/infrastructure/index.md` — document new python-eval CI job
- Fix: `docs/architecture/testing.md` — add Python eval tests to CI Pipeline section
- Fix: `docs/code-to-docs-mapping.json` — add `eval/**` and `scripts/mwf_*.py` mappings pointing to gold-loop-icm.md

## Provenance
- **Channel:** cron / nightly incremental audit
- **Requested by:** automated (audit-docs job)
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs → docs-audit/stages/incremental/CONTEXT.md

## Docs updated
- `docs/e2e-testing/gold-loop-icm.md` (created)
- `docs/product/stages/stage-2-perspective-stretch.md`
- `docs/backend/api/stage-2.md`
- `docs/mobile/wireframes/chat-interface.md`
- `docs/architecture/structure.md`
- `docs/infrastructure/index.md`
- `docs/architecture/testing.md`
- `docs/code-to-docs-mapping.json`