### PR TITLE
[codex] Fix needs drawer footer height

### DIFF
--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -19,6 +19,7 @@ import {
   StyleSheet,
   BackHandler,
   useWindowDimensions,
+  LayoutChangeEvent,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { appWidthStyle, colors } from '@/theme';
@@ -85,29 +86,41 @@ export function NeedsDrawer({
 }: NeedsDrawerProps) {
   const insets = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
-  const position3Q = windowHeight * 0.25;
-  const windowHeightRef = useRef(windowHeight);
+  const [containerHeight, setContainerHeight] = useState<number | null>(null);
+  const drawerHeight = containerHeight ?? windowHeight;
+  const position3Q = drawerHeight * 0.25;
+  const drawerHeightRef = useRef(drawerHeight);
   const position3QRef = useRef(position3Q);
   const positionFullRef = useRef(insets.top);
-  windowHeightRef.current = windowHeight;
+  drawerHeightRef.current = drawerHeight;
   position3QRef.current = position3Q;
   positionFullRef.current = insets.top;
 
   // -------------------------------------------------------------------------
   // Animation refs
   // -------------------------------------------------------------------------
-  const drawerTranslate = useRef(new Animated.Value(windowHeight)).current;
+  const drawerTranslate = useRef(new Animated.Value(drawerHeight)).current;
   const backdropOpacity = useRef(new Animated.Value(0)).current;
   const isDragging = useRef(false);
   const currentSnap = useRef<'3q' | 'full'>('3q');
-  const [contentHeight, setContentHeight] = useState(windowHeight - position3Q);
+  const [contentHeight, setContentHeight] = useState(drawerHeight - position3Q);
+
+  const handleContainerLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = Math.ceil(event.nativeEvent.layout.height);
+    if (nextHeight <= 0) return;
+    setContainerHeight((currentHeight) => (
+      currentHeight === null || Math.abs(currentHeight - nextHeight) > 1
+        ? nextHeight
+        : currentHeight
+    ));
+  }, []);
 
   // -------------------------------------------------------------------------
   // Open / Close / Snap animations
   // -------------------------------------------------------------------------
   const snapTo = useCallback(
     (position: number, backdrop: number) => {
-      setContentHeight(windowHeightRef.current - position);
+      setContentHeight(drawerHeightRef.current - position);
       Animated.parallel([
         Animated.spring(drawerTranslate, {
           toValue: position,
@@ -133,7 +146,7 @@ export function NeedsDrawer({
   const closeDrawer = useCallback(() => {
     Animated.parallel([
       Animated.timing(drawerTranslate, {
-        toValue: windowHeightRef.current,
+        toValue: drawerHeightRef.current,
         duration: 200,
         useNativeDriver: true,
       }),
@@ -156,14 +169,14 @@ export function NeedsDrawer({
 
   useEffect(() => {
     if (!visible) {
-      drawerTranslate.setValue(windowHeight);
+      drawerTranslate.setValue(drawerHeight);
       return;
     }
 
     const position = currentSnap.current === 'full' ? positionFullRef.current : position3Q;
     drawerTranslate.setValue(position);
-    setContentHeight(windowHeight - position);
-  }, [visible, windowHeight, position3Q, drawerTranslate]);
+    setContentHeight(drawerHeight - position);
+  }, [visible, drawerHeight, position3Q, drawerTranslate]);
 
   // -------------------------------------------------------------------------
   // Android back button
@@ -191,7 +204,7 @@ export function NeedsDrawer({
         const pFull = positionFullRef.current;
         const base = currentSnap.current === 'full' ? pFull : position3QRef.current;
         const newPos = base + gestureState.dy;
-        const clamped = Math.max(pFull, Math.min(newPos, windowHeightRef.current));
+        const clamped = Math.max(pFull, Math.min(newPos, drawerHeightRef.current));
         drawerTranslate.setValue(clamped);
       },
       onPanResponderRelease: (_, gestureState) => {
@@ -377,6 +390,7 @@ export function NeedsDrawer({
   return (
     <View
       style={[StyleSheet.absoluteFill, { zIndex: 100, elevation: 100 }]}
+      onLayout={handleContainerLayout}
       pointerEvents="auto"
       testID={testID}
     >
@@ -400,7 +414,7 @@ export function NeedsDrawer({
           styles.drawer,
           appWidthStyle,
           {
-            height: windowHeight,
+            height: drawerHeight,
             transform: [{ translateY: drawerTranslate }],
           },
         ]}


### PR DESCRIPTION
## Summary
- Measure the rendered `NeedsDrawer` container height and use it for snap positions, close position, drawer height, and content height.
- Keep `useWindowDimensions()` as the fallback before layout measurement completes.

## Root Cause
On web, the native-app banner renders above the app root inside a clipped phone-width frame. The drawer was sizing from full browser `windowHeight`, so its fixed footer could be laid out below the actual clipped app area when the banner was visible.

## Validation
- `npm test -- NeedsDrawer.test.tsx --runInBand`
- `npm run check`

Note: installing dependencies in this fresh worktree produced npm engine/audit warnings because this shell is on Node 25.2.1 while the repo expects Node 20.x; the validation commands still passed after install.