### PR TITLE
Add durable slam-bot midstream reply handling

### DIFF
--- a/scripts/ec2-bot/deploy.sh
+++ b/scripts/ec2-bot/deploy.sh
@@ -29,6 +29,10 @@ echo "Installing systemd service..."
 scp -q "$SCRIPT_DIR/slam-bot-socket.service" "$HOST":/tmp/slam-bot-socket.service
 ssh "$HOST" 'sudo mv /tmp/slam-bot-socket.service /etc/systemd/system/slam-bot-socket.service && sudo chown root:root /etc/systemd/system/slam-bot-socket.service && sudo systemctl daemon-reload && sudo systemctl enable slam-bot-socket'
 
+echo "Installing durable worker systemd service..."
+scp -q "$SCRIPT_DIR/slam-bot-worker.service" "$HOST":/tmp/slam-bot-worker.service
+ssh "$HOST" 'sudo mv /tmp/slam-bot-worker.service /etc/systemd/system/slam-bot-worker.service && sudo chown root:root /etc/systemd/system/slam-bot-worker.service && sudo systemctl daemon-reload && sudo systemctl enable slam-bot-worker && sudo systemctl restart slam-bot-worker'
+
 # Install systemd unit file for the github-state scanner daemon (Phase 1
 # of the GitHub API budget reduction plan). The daemon owns the
 # consolidated GraphQL state file under /opt/slam-bot/state/, which

--- a/scripts/ec2-bot/scripts/lib/bot_harness/__main__.py
+++ b/scripts/ec2-bot/scripts/lib/bot_harness/__main__.py
@@ -7,7 +7,7 @@ import sys
 
 from pathlib import Path
 
-from . import activity_journal, agent_runtime, dispatcher, github_check, queue, run
+from . import activity_journal, agent_runtime, dispatcher, github_check, jobs, queue, run
 from .processes import count_running_agents, count_running_workspace_agents
 from .shared_state import create_queue_entry
 
@@ -21,7 +21,7 @@ def exec_script(name: str, args: list[str]) -> int:
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("usage: python -m bot_harness <run|dispatch|queue|github-check|command>", file=sys.stderr)
+        print("usage: python -m bot_harness <run|dispatch|jobs|queue|github-check|command>", file=sys.stderr)
         return 2
     command = sys.argv[1]
     args = sys.argv[2:]
@@ -31,6 +31,8 @@ def main() -> int:
         return dispatcher.main(args)
     if command == "queue":
         return queue.main(args)
+    if command == "jobs":
+        return jobs.main(args)
     if command == "github-check":
         return github_check.main(args)
     if command == "activity-write":

--- a/scripts/ec2-bot/scripts/lib/bot_harness/jobs.py
+++ b/scripts/ec2-bot/scripts/lib/bot_harness/jobs.py
@@ -1,0 +1,663 @@
+"""Durable interactive job queue for Slack-triggered bot runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib import request
+from urllib.parse import urlencode
+
+from .config import BotConfig
+from .github_state import GitHubState
+from .logging import append
+
+
+TERMINAL_STATUSES = {"succeeded", "failed", "cancelled"}
+RUNNING_REAP_GRACE_SECONDS = 300
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def db_path(config: BotConfig) -> Path:
+    return Path(os.environ.get("BOT_JOBS_DB", str(config.bot_state_dir / "jobs.sqlite")))
+
+
+def connect(config: BotConfig) -> sqlite3.Connection:
+    path = db_path(config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=30)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=30000")
+    init_db(conn)
+    return conn
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS jobs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            status TEXT NOT NULL DEFAULT 'pending',
+            priority TEXT NOT NULL DEFAULT 'normal',
+            channel TEXT NOT NULL DEFAULT '',
+            slack_channel TEXT NOT NULL DEFAULT '',
+            slack_ts TEXT NOT NULL DEFAULT '',
+            thread_ts TEXT NOT NULL DEFAULT '',
+            command_slug TEXT NOT NULL DEFAULT '',
+            workspace TEXT NOT NULL DEFAULT '',
+            session_key TEXT NOT NULL DEFAULT '',
+            prompt TEXT NOT NULL DEFAULT '',
+            prompt_file TEXT NOT NULL DEFAULT '',
+            msg_ts TEXT NOT NULL DEFAULT '',
+            provider TEXT NOT NULL DEFAULT '',
+            fallback_provider TEXT NOT NULL DEFAULT '',
+            review_provider TEXT NOT NULL DEFAULT '',
+            model TEXT NOT NULL DEFAULT '',
+            effort TEXT NOT NULL DEFAULT '',
+            provenance_channel TEXT NOT NULL DEFAULT '',
+            provenance_requester TEXT NOT NULL DEFAULT '',
+            provenance_message TEXT NOT NULL DEFAULT '',
+            log_name TEXT NOT NULL DEFAULT '',
+            issue_number TEXT NOT NULL DEFAULT '',
+            trigger_label TEXT NOT NULL DEFAULT '',
+            entry_stage TEXT NOT NULL DEFAULT '',
+            keep_label INTEGER NOT NULL DEFAULT 0,
+            claim_file TEXT NOT NULL DEFAULT '',
+            review_pr_number TEXT NOT NULL DEFAULT '',
+            review_pr_head_sha TEXT NOT NULL DEFAULT '',
+            review_pr_provider TEXT NOT NULL DEFAULT '',
+            review_pr_context_file TEXT NOT NULL DEFAULT '',
+            pid INTEGER,
+            exit_code INTEGER,
+            failure_reason TEXT NOT NULL DEFAULT '',
+            log_path TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            claimed_at TEXT,
+            started_at TEXT,
+            completed_at TEXT,
+            last_heartbeat_at TEXT,
+            retry_count INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_jobs_status_priority_created
+            ON jobs(status, priority, created_at);
+        CREATE INDEX IF NOT EXISTS idx_jobs_thread_running
+            ON jobs(thread_ts, status);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_slack_message
+            ON jobs(slack_channel, slack_ts)
+            WHERE slack_channel != '' AND slack_ts != '';
+        """
+    )
+    existing = {row["name"] for row in conn.execute("PRAGMA table_info(jobs)").fetchall()}
+    columns = {
+        "issue_number": "TEXT NOT NULL DEFAULT ''",
+        "trigger_label": "TEXT NOT NULL DEFAULT ''",
+        "entry_stage": "TEXT NOT NULL DEFAULT ''",
+        "keep_label": "INTEGER NOT NULL DEFAULT 0",
+        "claim_file": "TEXT NOT NULL DEFAULT ''",
+        "review_pr_number": "TEXT NOT NULL DEFAULT ''",
+        "review_pr_head_sha": "TEXT NOT NULL DEFAULT ''",
+        "review_pr_provider": "TEXT NOT NULL DEFAULT ''",
+        "review_pr_context_file": "TEXT NOT NULL DEFAULT ''",
+    }
+    for name, spec in columns.items():
+        if name not in existing:
+            try:
+                conn.execute(f"ALTER TABLE jobs ADD COLUMN {name} {spec}")
+            except sqlite3.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+    conn.commit()
+
+
+def priority_rank(priority: str) -> int:
+    return {"high": 0, "normal": 1, "low": 2}.get(priority, 1)
+
+
+def pid_alive(pid: int | None) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def active_agent_for_thread(config: BotConfig, channel: str, thread_ts: str) -> Path | None:
+    if not channel or not thread_ts or not config.active_dir.exists():
+        return None
+    for agent_dir in sorted(config.active_dir.glob("agent-*")):
+        suffix = agent_dir.name.removeprefix("agent-")
+        if not suffix.isdigit() or not pid_alive(int(suffix)):
+            continue
+        try:
+            meta = json.loads((agent_dir / "meta.json").read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if meta.get("channel") == channel and meta.get("messageTs") == thread_ts:
+            return agent_dir
+    return None
+
+
+def wait_active_agent_for_thread(config: BotConfig, channel: str, thread_ts: str, attempts: int = 10, delay: float = 0.5) -> Path | None:
+    for attempt in range(attempts):
+        agent_dir = active_agent_for_thread(config, channel, thread_ts)
+        if agent_dir is not None:
+            return agent_dir
+        if attempt < attempts - 1:
+            time.sleep(delay)
+    return None
+
+
+def active_message_text(payload: dict) -> str:
+    channel = str(payload.get("slack_channel") or payload.get("channel") or "")
+    slack_ts = str(payload.get("slack_ts") or payload.get("msg_ts") or "")
+    thread_ts = str(payload.get("thread_ts") or "")
+    requester = str(payload.get("provenance_requester") or "")
+    message = str(payload.get("provenance_message") or "").strip()
+    prompt_file = Path(str(payload.get("prompt_file") or ""))
+    if not message and prompt_file.exists():
+        try:
+            message = prompt_file.read_text(encoding="utf-8", errors="replace").strip()
+        except OSError:
+            message = ""
+    return "\n".join(
+        [
+            "[Slack thread reply delivered while this run was active]",
+            f"Channel: {channel}",
+            f"Thread: {thread_ts}",
+            f"Message timestamp: {slack_ts}",
+            f"Requester: {requester or 'unknown'}",
+            "",
+            message or "(no text)",
+        ]
+    )
+
+
+def deliver_to_active_agent(agent_dir: Path, payload: dict) -> Path:
+    inbox = agent_dir / "inbox" / "unread"
+    inbox.mkdir(parents=True, exist_ok=True)
+    message_id = uuid.uuid4().hex
+    path = inbox / f"slack-{message_id}.md"
+    path.write_text(active_message_text(payload), encoding="utf-8")
+    return path
+
+
+def parsed_utc_timestamp(value: str | None) -> float:
+    if not value:
+        return 0
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0
+
+
+def reap_dead_running_jobs(conn: sqlite3.Connection) -> None:
+    now = utc_now()
+    now_ts = time.time()
+    for row in conn.execute("SELECT id, pid, last_heartbeat_at, started_at, claimed_at FROM jobs WHERE status='running'").fetchall():
+        pid = int(row["pid"] or 0)
+        if pid_alive(pid):
+            continue
+        heartbeat_ts = parsed_utc_timestamp(str(row["last_heartbeat_at"] or row["started_at"] or row["claimed_at"] or ""))
+        if heartbeat_ts and now_ts - heartbeat_ts < RUNNING_REAP_GRACE_SECONDS:
+            continue
+        conn.execute(
+            """
+            UPDATE jobs
+            SET status='failed',
+                completed_at=?,
+                last_heartbeat_at=?,
+                failure_reason=?
+            WHERE id=? AND status='running'
+            """,
+            (now, now, f"worker recovered dead process pid={pid or 'missing'}", int(row["id"])),
+        )
+
+
+def enqueue(config: BotConfig, payload: dict) -> int:
+    now = utc_now()
+    fields = {
+        "status": "pending",
+        "priority": str(payload.get("priority") or "normal"),
+        "channel": str(payload.get("channel") or ""),
+        "slack_channel": str(payload.get("slack_channel") or payload.get("channel") or ""),
+        "slack_ts": str(payload.get("slack_ts") or payload.get("msg_ts") or ""),
+        "thread_ts": str(payload.get("thread_ts") or payload.get("slack_ts") or payload.get("msg_ts") or ""),
+        "command_slug": str(payload.get("command_slug") or ""),
+        "workspace": str(payload.get("workspace") or ""),
+        "session_key": str(payload.get("session_key") or ""),
+        "prompt": str(payload.get("prompt") or ""),
+        "prompt_file": str(payload.get("prompt_file") or ""),
+        "msg_ts": str(payload.get("msg_ts") or payload.get("slack_ts") or ""),
+        "provider": str(payload.get("provider") or ""),
+        "fallback_provider": str(payload.get("fallback_provider") or ""),
+        "review_provider": str(payload.get("review_provider") or ""),
+        "model": str(payload.get("model") or ""),
+        "effort": str(payload.get("effort") or ""),
+        "provenance_channel": str(payload.get("provenance_channel") or ""),
+        "provenance_requester": str(payload.get("provenance_requester") or ""),
+        "provenance_message": str(payload.get("provenance_message") or ""),
+        "log_name": str(payload.get("log_name") or ""),
+        "issue_number": str(payload.get("issue_number") or ""),
+        "trigger_label": str(payload.get("trigger_label") or ""),
+        "entry_stage": str(payload.get("entry_stage") or ""),
+        "keep_label": 1 if payload.get("keep_label") else 0,
+        "claim_file": str(payload.get("claim_file") or ""),
+        "review_pr_number": str(payload.get("review_pr_number") or ""),
+        "review_pr_head_sha": str(payload.get("review_pr_head_sha") or ""),
+        "review_pr_provider": str(payload.get("review_pr_provider") or ""),
+        "review_pr_context_file": str(payload.get("review_pr_context_file") or ""),
+        "created_at": now,
+        "last_heartbeat_at": now,
+    }
+    with connect(config) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        row = None
+        if fields["slack_channel"] and fields["slack_ts"]:
+            row = conn.execute(
+                "SELECT id, status, failure_reason FROM jobs WHERE slack_channel=? AND slack_ts=?",
+                (fields["slack_channel"], fields["slack_ts"]),
+            ).fetchone()
+        if row and row["status"] == "succeeded" and str(row["failure_reason"]).startswith("delivered_to_active_agent"):
+            conn.commit()
+            return int(row["id"])
+        if (
+            fields["slack_channel"]
+            and fields["slack_ts"]
+            and fields["thread_ts"]
+            and fields["slack_ts"] != fields["thread_ts"]
+            and thread_has_running_job(conn, fields["thread_ts"])
+        ):
+            agent_dir = wait_active_agent_for_thread(config, fields["slack_channel"], fields["thread_ts"])
+            if agent_dir is not None:
+                delivered_path = deliver_to_active_agent(agent_dir, payload)
+                delivered_fields = {
+                    **fields,
+                    "status": "succeeded",
+                    "completed_at": now,
+                    "failure_reason": f"delivered_to_active_agent {agent_dir.name} {delivered_path.name}",
+                }
+                if row:
+                    cols = ", ".join(f"{key}=?" for key in delivered_fields if key != "created_at")
+                    values = [value for key, value in delivered_fields.items() if key != "created_at"]
+                    conn.execute(f"UPDATE jobs SET {cols} WHERE id=?", [*values, int(row["id"])])
+                    job_id = int(row["id"])
+                else:
+                    cols = ", ".join(delivered_fields)
+                    placeholders = ", ".join("?" for _ in delivered_fields)
+                    cur = conn.execute(f"INSERT INTO jobs ({cols}) VALUES ({placeholders})", list(delivered_fields.values()))
+                    job_id = int(cur.lastrowid)
+                conn.commit()
+                slack_api(config, "reactions.remove", {"channel": fields["slack_channel"], "timestamp": fields["slack_ts"], "name": "hourglass_flowing_sand"})
+                slack_api(config, "reactions.add", {"channel": fields["slack_channel"], "timestamp": fields["slack_ts"], "name": "white_check_mark"})
+                return job_id
+        if row:
+            update_fields = {key: value for key, value in fields.items() if key != "created_at"}
+            cols = ", ".join(f"{key}=?" for key in update_fields)
+            conn.execute(f"UPDATE jobs SET {cols} WHERE id=?", [*update_fields.values(), int(row["id"])])
+            job_id = int(row["id"])
+        else:
+            cols = ", ".join(fields)
+            placeholders = ", ".join("?" for _ in fields)
+            cur = conn.execute(f"INSERT INTO jobs ({cols}) VALUES ({placeholders})", list(fields.values()))
+            job_id = int(cur.lastrowid)
+        conn.commit()
+        return job_id
+
+
+def thread_has_running_job(conn: sqlite3.Connection, thread_ts: str) -> bool:
+    if not thread_ts:
+        return False
+    row = conn.execute(
+        "SELECT 1 FROM jobs WHERE thread_ts=? AND status='running' LIMIT 1",
+        (thread_ts,),
+    ).fetchone()
+    return row is not None
+
+
+def claim_next(config: BotConfig) -> sqlite3.Row | None:
+    with connect(config) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        reap_dead_running_jobs(conn)
+        rows = conn.execute("SELECT * FROM jobs WHERE status='pending' ORDER BY created_at ASC").fetchall()
+        rows = sorted(rows, key=lambda row: (priority_rank(str(row["priority"])), str(row["created_at"])))
+        selected = None
+        for row in rows:
+            if not thread_has_running_job(conn, str(row["thread_ts"])):
+                selected = row
+                break
+        if selected is None:
+            conn.commit()
+            return None
+        now = utc_now()
+        conn.execute(
+            "UPDATE jobs SET status='running', claimed_at=?, started_at=?, last_heartbeat_at=? WHERE id=?",
+            (now, now, now, int(selected["id"])),
+        )
+        conn.commit()
+        return conn.execute("SELECT * FROM jobs WHERE id=?", (int(selected["id"]),)).fetchone()
+
+
+def update_job(config: BotConfig, job_id: int, **fields: object) -> None:
+    if not fields:
+        return
+    cols = ", ".join(f"{key}=?" for key in fields)
+    values = list(fields.values())
+    values.append(job_id)
+    with connect(config) as conn:
+        conn.execute(f"UPDATE jobs SET {cols} WHERE id=?", values)
+        conn.commit()
+
+
+def get_job(config: BotConfig, job_id: int) -> sqlite3.Row | None:
+    with connect(config) as conn:
+        return conn.execute("SELECT * FROM jobs WHERE id=?", (job_id,)).fetchone()
+
+
+def issue_has_active_job(config: BotConfig, issue_number: int) -> bool:
+    with connect(config) as conn:
+        row = conn.execute(
+            """
+            SELECT 1 FROM jobs
+            WHERE issue_number=?
+              AND status NOT IN ('succeeded','failed','cancelled')
+            LIMIT 1
+            """,
+            (str(issue_number),),
+        ).fetchone()
+        return row is not None
+
+
+def slack_api(config: BotConfig, endpoint: str, payload: dict) -> None:
+    if not config.slack_bot_token:
+        return
+    data = urlencode(payload).encode()
+    req = request.Request(
+        f"https://slack.com/api/{endpoint}",
+        data=data,
+        headers={"Authorization": f"Bearer {config.slack_bot_token}", "Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        request.urlopen(req, timeout=10).read()
+    except Exception:
+        return
+
+
+def remove_reaction(config: BotConfig, job: sqlite3.Row, name: str) -> None:
+    channel = str(job["slack_channel"])
+    ts = str(job["slack_ts"])
+    if channel and ts:
+        slack_api(config, "reactions.remove", {"channel": channel, "timestamp": ts, "name": name})
+
+
+def add_reaction(config: BotConfig, job: sqlite3.Row, name: str) -> None:
+    channel = str(job["slack_channel"])
+    ts = str(job["slack_ts"])
+    if channel and ts:
+        slack_api(config, "reactions.add", {"channel": channel, "timestamp": ts, "name": name})
+
+
+def build_run_args(job: sqlite3.Row) -> list[str]:
+    args: list[str] = []
+    workspace = str(job["workspace"] or "")
+    session_key = str(job["session_key"] or "")
+    provider = str(job["provider"] or "")
+    fallback_provider = str(job["fallback_provider"] or "")
+    review_provider = str(job["review_provider"] or "")
+    if workspace:
+        args += ["--workspace", workspace]
+    if session_key:
+        args += ["--session", session_key]
+    if provider:
+        args += ["--provider", provider]
+    if fallback_provider:
+        args += ["--fallback-provider", fallback_provider]
+    if review_provider:
+        args += ["--review-provider", review_provider]
+    if workspace:
+        args += [str(job["prompt"] or ""), str(job["prompt_file"] or ""), str(job["msg_ts"] or "")]
+    else:
+        args += [str(job["command_slug"] or ""), str(job["prompt"] or ""), str(job["prompt_file"] or ""), str(job["msg_ts"] or "")]
+    return args
+
+
+def worker_log(config: BotConfig) -> Path:
+    return config.bot_log_dir / "jobs-worker.log"
+
+
+def run_job(config: BotConfig, job: sqlite3.Row) -> int:
+    logfile = worker_log(config)
+    append(logfile, f"[{time.ctime()}] START job {job['id']} {job['command_slug']} channel={job['slack_channel']} ts={job['slack_ts']} provider={job['provider'] or 'default'}\n")
+    remove_reaction(config, job, "hourglass_flowing_sand")
+    remove_reaction(config, job, "zzz")
+    add_reaction(config, job, "eyes")
+
+    env = os.environ.copy()
+    lib_path = str(config.bot_scripts_dir / "lib")
+    env["PYTHONPATH"] = f"{lib_path}:{env.get('PYTHONPATH', '')}".rstrip(":")
+    env.update(
+        {
+            "BOT_SCRIPTS_DIR": str(config.bot_scripts_dir),
+            "SLAM_BOT": "1",
+            "PRIORITY": str(job["priority"] or "normal"),
+            "CHANNEL": str(job["channel"] or job["slack_channel"] or ""),
+            "THREAD_TS": str(job["thread_ts"] or ""),
+            "PROVENANCE_CHANNEL": str(job["provenance_channel"] or ""),
+            "PROVENANCE_REQUESTER": str(job["provenance_requester"] or ""),
+            "PROVENANCE_MESSAGE": str(job["provenance_message"] or ""),
+            "MODEL": str(job["model"] or ""),
+            "EFFORT": str(job["effort"] or ""),
+            "PROVIDER": str(job["provider"] or ""),
+            "FALLBACK_PROVIDER": str(job["fallback_provider"] or ""),
+            "REVIEW_PROVIDER": str(job["review_provider"] or ""),
+            "ISSUE_NUMBER": str(job["issue_number"] or ""),
+            "TRIGGER_LABEL": str(job["trigger_label"] or ""),
+            "ENTRY_STAGE": str(job["entry_stage"] or ""),
+            "REVIEW_PR_NUMBER": str(job["review_pr_number"] or ""),
+            "REVIEW_PR_HEAD_SHA": str(job["review_pr_head_sha"] or ""),
+            "REVIEW_PR_PROVIDER": str(job["review_pr_provider"] or ""),
+            "REVIEW_PR_CONTEXT_FILE": str(job["review_pr_context_file"] or ""),
+            "SLAM_BOT_JOB_ID": str(job["id"]),
+        }
+    )
+
+    args = [sys.executable, "-m", "bot_harness", "run", *build_run_args(job)]
+    with logfile.open("a", encoding="utf-8") as fh:
+        proc = subprocess.Popen(args, cwd=str(config.project_dir), env=env, stdout=fh, stderr=fh, start_new_session=True)
+    update_job(config, int(job["id"]), pid=proc.pid, log_path=str(logfile), last_heartbeat_at=utc_now())
+
+    cancelled = False
+    while True:
+        code = proc.poll()
+        if code is not None:
+            break
+        current = get_job(config, int(job["id"]))
+        if current and str(current["status"]) == "cancel_requested":
+            cancelled = True
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                code = proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                code = proc.wait()
+            break
+        update_job(config, int(job["id"]), last_heartbeat_at=utc_now())
+        time.sleep(15)
+
+    remove_reaction(config, job, "eyes")
+    if cancelled:
+        add_reaction(config, job, "x")
+        update_job(config, int(job["id"]), status="cancelled", exit_code=code, completed_at=utc_now(), last_heartbeat_at=utc_now(), failure_reason="cancelled")
+        append(logfile, f"[{time.ctime()}] CANCELLED job {job['id']} exit={code}\n")
+        return int(code or 1)
+    finish_github_job(config, job, int(code or 0), logfile)
+    if code == 0:
+        add_reaction(config, job, "white_check_mark")
+        status = "succeeded"
+        failure_reason = ""
+    elif code in {75, 76}:
+        add_reaction(config, job, "zzz")
+        status = "failed"
+        failure_reason = f"rate_limited exit_code={code}"
+    else:
+        add_reaction(config, job, "x")
+        status = "failed"
+        failure_reason = f"exit_code={code}"
+    update_job(config, int(job["id"]), status=status, exit_code=code, completed_at=utc_now(), last_heartbeat_at=utc_now(), failure_reason=failure_reason)
+    append(logfile, f"[{time.ctime()}] END job {job['id']} status={status} exit={code}\n")
+    return int(code or 0)
+
+
+def gh_json(config: BotConfig, args: list[str], *, mutate: bool = False) -> object | None:
+    if mutate and os.environ.get("BOT_HARNESS_NO_GH_MUTATION") == "1":
+        return None
+    proc = subprocess.run(["gh", *args], text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        return None
+    try:
+        return json.loads(proc.stdout) if proc.stdout.strip() else None
+    except json.JSONDecodeError:
+        return None
+
+
+def prs_fixing_count(config: BotConfig, issue_number: int) -> int:
+    state = GitHubState(Path(os.environ.get("GITHUB_STATE_FILE", str(config.bot_state_dir / "github-state.json"))))
+    if state.path.exists() and state.is_fresh():
+        return state.prs_fixing_issue_count(issue_number)
+    result = gh_json(config, ["pr", "list", "--repo", config.github_repo, "--search", f"Fixes #{issue_number}", "--state", "all", "--json", "number"])
+    return len(result) if isinstance(result, list) else 0
+
+
+def bot_commented(config: BotConfig, issue_number: int) -> bool:
+    comments = gh_json(config, ["api", f"repos/{config.github_repo}/issues/{issue_number}/comments?per_page=5&direction=desc"])
+    if not isinstance(comments, list):
+        return False
+    return any(
+        ((comment.get("user") or {}).get("login") in {"slam-bot", "slam-bot-app[bot]"})
+        for comment in comments
+        if isinstance(comment, dict)
+    )
+
+
+def finish_github_job(config: BotConfig, job: sqlite3.Row, exit_code: int, logfile: Path) -> None:
+    issue_raw = str(job["issue_number"] or "")
+    label = str(job["trigger_label"] or "")
+    if not issue_raw or not label:
+        return
+    try:
+        issue = int(issue_raw)
+    except ValueError:
+        return
+    claim_file = Path(str(job["claim_file"] or ""))
+    if str(claim_file):
+        claim_file.unlink(missing_ok=True)
+    gh_json(config, ["issue", "edit", str(issue), "--repo", config.github_repo, "--remove-label", "bot:in-progress"], mutate=True)
+    if bool(job["keep_label"]):
+        append(logfile, f"[{time.ctime()}] Preserving label {label} on #{issue} (keep_label=true)\n")
+        updated = gh_json(config, ["issue", "view", str(issue), "--repo", config.github_repo, "--json", "updatedAt"])
+        updated_at = updated.get("updatedAt", "") if isinstance(updated, dict) else ""
+        cooldown = config.claims_dir / f"cooldown-{issue}.txt"
+        cooldown.parent.mkdir(parents=True, exist_ok=True)
+        cooldown.write_text(f"{int(time.time())}\n{updated_at}\n", encoding="utf-8")
+    else:
+        gh_json(config, ["issue", "edit", str(issue), "--repo", config.github_repo, "--remove-label", label], mutate=True)
+    if exit_code == 0:
+        append(logfile, f"[{time.ctime()}] Completed GitHub job for #{issue}\n")
+        return
+    if prs_fixing_count(config, issue) > 0:
+        append(logfile, f"[{time.ctime()}] Agent exited {exit_code} but PR exists for #{issue} - treating as success\n")
+        return
+    if bot_commented(config, issue):
+        append(logfile, f"[{time.ctime()}] Agent exited {exit_code} but posted comments on #{issue} - treating as success\n")
+        return
+    append(logfile, f"[{time.ctime()}] Failed GitHub job for #{issue} (exit={exit_code}) - no PR or comments found\n")
+    gh_json(config, ["issue", "edit", str(issue), "--repo", config.github_repo, "--add-label", "bot:failed"], mutate=True)
+
+
+def request_cancel(config: BotConfig, channel: str, ts: str) -> int:
+    with connect(config) as conn:
+        row = conn.execute(
+            "SELECT * FROM jobs WHERE slack_channel=? AND slack_ts=? AND status NOT IN ('succeeded','failed','cancelled') ORDER BY id DESC LIMIT 1",
+            (channel, ts),
+        ).fetchone()
+        if not row:
+            return 0
+        status = "cancel_requested" if row["status"] == "running" else "cancelled"
+        conn.execute(
+            "UPDATE jobs SET status=?, completed_at=COALESCE(completed_at, ?), failure_reason=? WHERE id=?",
+            (status, utc_now(), "cancel requested by Slack reaction", int(row["id"])),
+        )
+        conn.commit()
+        if status == "cancelled":
+            remove_reaction(config, row, "hourglass_flowing_sand")
+        return int(row["id"])
+
+
+def worker_once(config: BotConfig) -> int:
+    job = claim_next(config)
+    if job is None:
+        return 0
+    return run_job(config, job)
+
+
+def worker_loop(config: BotConfig, idle_sleep: int) -> int:
+    while True:
+        code = worker_once(config)
+        if code == 0:
+            time.sleep(idle_sleep)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="bot_harness jobs")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("init")
+    sub.add_parser("enqueue")
+    sub.add_parser("worker-once")
+    worker = sub.add_parser("worker")
+    worker.add_argument("--idle-sleep", type=int, default=5)
+    cancel = sub.add_parser("cancel")
+    cancel.add_argument("channel")
+    cancel.add_argument("ts")
+    args = parser.parse_args([] if argv is None else argv)
+    config = BotConfig.from_env()
+    if args.command == "init":
+        connect(config).close()
+        return 0
+    if args.command == "enqueue":
+        payload = json.loads(sys.stdin.read() or "{}")
+        print(enqueue(config, payload))
+        return 0
+    if args.command == "worker-once":
+        return worker_once(config)
+    if args.command == "worker":
+        return worker_loop(config, args.idle_sleep)
+    if args.command == "cancel":
+        print(request_cancel(config, args.channel, args.ts))
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ec2-bot/scripts/lib/bot_harness/providers.py
+++ b/scripts/ec2-bot/scripts/lib/bot_harness/providers.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -202,6 +203,10 @@ class InvokeProvider:
 class ClaudeProvider(InvokeProvider):
     name = "claude"
 
+    @property
+    def settings_file(self) -> Path:
+        return self.ctx.agent_home / "claude-settings.json"
+
     def prepare_session(self) -> None:
         self.session_id = ""
         self.session_mode = "stateless"
@@ -209,6 +214,24 @@ class ClaudeProvider(InvokeProvider):
             self.session_id = str(uuid.uuid5(uuid.NAMESPACE_URL, self.ctx.session_key))
             exists = any(Path.home().glob(f".claude/projects/**/{self.session_id}.jsonl"))
             self.session_mode = "resume" if exists else "new"
+        hook = self.ctx.lib_dir.parent / "check-pending-messages.sh"
+        write_json(
+            self.settings_file,
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": str(hook),
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+        )
 
     def command(self) -> list[str]:
         cmd = ["claude"]
@@ -218,8 +241,135 @@ class ClaudeProvider(InvokeProvider):
             cmd += ["--effort", self.ctx.effort]
         if self.session_id:
             cmd += ["--resume" if self.session_mode == "resume" else "--session-id", self.session_id]
-        cmd += ["--dangerously-skip-permissions", "-p", "-", "--output-format", "stream-json", "--verbose"]
+        cmd += ["--settings", str(self.settings_file)]
+        cmd += ["--dangerously-skip-permissions", "-p", "--input-format", "stream-json", "--output-format", "stream-json", "--verbose"]
         return cmd
+
+    def stream_user_message(self, text: str) -> str:
+        return json.dumps({"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": text}]}}) + "\n"
+
+    def pending_context_after_tool(self, event: dict[str, Any]) -> str:
+        tool_result = event.get("message", {}).get("content", []) if event.get("type") == "user" else []
+        if not any(isinstance(part, dict) and part.get("type") == "tool_result" for part in tool_result):
+            return ""
+        hook = self.ctx.lib_dir.parent / "check-pending-messages.sh"
+        if not hook.exists():
+            return ""
+        env = os.environ.copy()
+        env["SLAM_BOT_AGENT_HOME"] = str(self.ctx.agent_home)
+        proc = subprocess.run(
+            [str(hook)],
+            input=json.dumps(event),
+            text=True,
+            capture_output=True,
+            check=False,
+            env=env,
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return ""
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return ""
+        return str(payload.get("hookSpecificOutput", {}).get("additionalContext", ""))
+
+    def run(self, input_file: Path, raw_stream: Path, stream_log: Path, stderr_file: Path) -> tuple[bool, str]:
+        self.prepare_session()
+        cmd = self.command()
+        if shutil.which(cmd[0]) is None:
+            return False, f"missing_binary: {cmd[0]}"
+        self.ctx.log(f"Provider={self.name} session_mode={self.session_mode}{(' session_id=' + self.session_id) if self.session_id else ''}")
+        raw_stream.write_text("", encoding="utf-8")
+        stream_log.write_text("", encoding="utf-8")
+        stderr_file.write_text("", encoding="utf-8")
+
+        stdin_lock = threading.Lock()
+        stdin_open = True
+        close_timer: threading.Timer | None = None
+
+        def close_stdin(proc: subprocess.Popen[bytes]) -> None:
+            nonlocal stdin_open
+            with stdin_lock:
+                if not stdin_open or proc.stdin is None:
+                    return
+                try:
+                    proc.stdin.close()
+                except OSError:
+                    pass
+                stdin_open = False
+
+        def schedule_close(proc: subprocess.Popen[bytes]) -> None:
+            nonlocal close_timer
+            if close_timer is not None:
+                close_timer.cancel()
+            close_timer = threading.Timer(1.0, close_stdin, args=(proc,))
+            close_timer.daemon = True
+            close_timer.start()
+
+        def cancel_close() -> None:
+            nonlocal close_timer
+            if close_timer is not None:
+                close_timer.cancel()
+                close_timer = None
+
+        with raw_stream.open("ab") as raw_out, stream_log.open("a", encoding="utf-8") as stream_out, stderr_file.open("wb") as stderr_out:
+            proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=stderr_out)
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            initial = input_file.read_text(encoding="utf-8", errors="replace")
+            proc.stdin.write(self.stream_user_message(initial).encode("utf-8"))
+            proc.stdin.flush()
+            for raw_line in proc.stdout:
+                raw_out.write(raw_line)
+                raw_out.flush()
+                try:
+                    event = json.loads(raw_line.decode("utf-8"))
+                except json.JSONDecodeError:
+                    continue
+
+                parts = event.get("message", {}).get("content", []) if isinstance(event.get("message"), dict) else []
+                has_tool_use = any(isinstance(part, dict) and part.get("type") == "tool_use" for part in parts)
+                has_text = bool(self.text_from_event(event))
+                if has_tool_use:
+                    cancel_close()
+
+                context = self.pending_context_after_tool(event)
+                if context:
+                    with stdin_lock:
+                        if stdin_open and proc.stdin is not None:
+                            proc.stdin.write(self.stream_user_message(context).encode("utf-8"))
+                            proc.stdin.flush()
+
+                text = self.text_from_event(event)
+                if text:
+                    stream_out.write(text + "\n")
+                    stream_out.flush()
+                    append(self.ctx.log_file, text + "\n")
+                if has_text and not has_tool_use:
+                    schedule_close(proc)
+            if close_timer is not None:
+                close_timer.cancel()
+            close_stdin(proc)
+            exit_code = proc.wait()
+
+        stderr = stderr_file.read_text(encoding="utf-8", errors="replace")
+        if stderr:
+            append(self.ctx.log_file, stderr)
+
+        reason = self.failure_reason(stderr, raw_stream)
+        if exit_code != 0:
+            detail = reason or stderr or f"exit_code={exit_code}"
+            return False, f"exit_code={exit_code}\n{detail}".strip()
+        if reason:
+            return False, reason
+
+        self.finalize_session(raw_stream)
+        for event in iter_jsonl(raw_stream):
+            usage = self.usage_from_event(event)
+            if usage:
+                self.ctx.update_meta(providerUsage=usage)
+                break
+        return True, ""
 
     def text_from_event(self, event: dict[str, Any]) -> str:
         if event.get("type") != "assistant":

--- a/scripts/ec2-bot/scripts/tests/harness-integration-test.sh
+++ b/scripts/ec2-bot/scripts/tests/harness-integration-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Broad Python harness tests. Uses fake state and never calls real Slack/GitHub/model CLIs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB_DIR="$(cd "$SCRIPT_DIR/../lib" && pwd)"
+
+PYTHONPATH="$LIB_DIR" python3 -m unittest \
+  "$SCRIPT_DIR/test_invoke_provider.py" \
+  "$SCRIPT_DIR/test_bot_harness.py"

--- a/scripts/ec2-bot/scripts/tests/provider-integration-test.sh
+++ b/scripts/ec2-bot/scripts/tests/provider-integration-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+export PYTHONPATH="$SCRIPT_DIR/lib${PYTHONPATH:+:$PYTHONPATH}"
+python3 "$SCRIPT_DIR/tests/test_invoke_provider.py"
+
+export BOT_HOME="$TMP_DIR/bot-home"
+export BOT_LOG_DIR="$TMP_DIR/logs"
+export BOT_STATE_DIR="$TMP_DIR/state"
+export BOT_QUEUE_DIR="$TMP_DIR/queue"
+export REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+export PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+export WORKSPACES_DIR="$PROJECT_DIR/bot-workspaces"
+export ACTIVE_DIR="$TMP_DIR/active"
+export BOT_SCRIPTS_DIR="$SCRIPT_DIR"
+export LOCK_PREFIX="$TMP_DIR/slam-bot"
+export SLACK_BOT_TOKEN=""
+export PATH="$TMP_DIR/bin:$PATH"
+mkdir -p "$TMP_DIR/bin" "$BOT_LOG_DIR" "$BOT_STATE_DIR" "$ACTIVE_DIR"
+
+cat > "$TMP_DIR/bin/codex" <<'FAKE_CODEX'
+#!/bin/bash
+cat >/dev/null
+printf '%s\n' '{"type":"error","message":"controlled fake codex failure"}'
+exit 1
+FAKE_CODEX
+chmod +x "$TMP_DIR/bin/codex"
+
+cat > "$TMP_DIR/bin/claude" <<'FAKE_CLAUDE'
+#!/bin/bash
+read -r _initial_message
+printf '%s\n' '{"type":"system","session_id":"fake-claude-session"}'
+printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"fallback ok"}],"usage":{"input_tokens":1,"output_tokens":2}}}'
+FAKE_CLAUDE
+chmod +x "$TMP_DIR/bin/claude"
+
+"$SCRIPT_DIR/run-claude.sh" --no-worktree --provider codex --fallback-provider claude fallback-test "Return fallback ok"
+
+ARCHIVED=$(find "$ACTIVE_DIR/_archived" -mindepth 1 -maxdepth 1 -type d | sort | tail -1)
+grep -q "fallback ok" "$ARCHIVED/stream.log"
+grep -q '"provider": "claude"' "$ARCHIVED/meta.json"
+grep -q 'primaryProviderFailure' "$ARCHIVED/meta.json"
+[ -f "$ARCHIVED/raw-stream.codex.failed.jsonl" ]
+
+echo "provider-integration-test: ok"

--- a/scripts/ec2-bot/scripts/tests/test_bot_harness.py
+++ b/scripts/ec2-bot/scripts/tests/test_bot_harness.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
-from bot_harness import github_check, run
+from bot_harness import github_check, jobs, run
 from bot_harness.activity_journal import render_recent
 from bot_harness.agent_runtime import cleanup, setup_agent
 from bot_harness.config import BotConfig
@@ -255,6 +255,90 @@ class HarnessTests(unittest.TestCase):
                 self.assertFalse((Path(env["BOT_LOG_DIR"]) / "run-claude.calls").exists())
                 log_text = (Path(env["BOT_LOG_DIR"]) / "workspace-dispatcher.log").read_text(encoding="utf-8")
                 self.assertIn("duplicate detected by check-duplicates.sh", log_text)
+
+    def test_enqueue_thread_reply_delivers_to_running_agent_inbox(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            env = self.env(tmp)
+            with patch.dict(os.environ, env, clear=False):
+                config = BotConfig.from_env()
+                agent_home = Path(env["ACTIVE_DIR"]) / f"agent-{os.getpid()}"
+                (agent_home / "inbox" / "unread").mkdir(parents=True)
+                write_json(agent_home / "meta.json", {"channel": "C1", "messageTs": "111.000"})
+                now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+                with jobs.connect(config) as conn:
+                    conn.execute(
+                        """
+                        INSERT INTO jobs (status, thread_ts, command_slug, prompt, pid, created_at, last_heartbeat_at)
+                        VALUES ('running', '111.000', 'active', 'prompt', ?, ?, ?)
+                        """,
+                        (os.getpid(), now, now),
+                    )
+                    conn.commit()
+
+                payload = {
+                    "channel": "C1",
+                    "slack_channel": "C1",
+                    "slack_ts": "222.000",
+                    "thread_ts": "111.000",
+                    "command_slug": "reply",
+                    "provenance_requester": "Shantam (U1)",
+                    "provenance_message": "can you include this while you are still working?",
+                }
+                job_id = jobs.enqueue(config, payload)
+                self.assertEqual(jobs.enqueue(config, payload), job_id)
+
+                delivered = list((agent_home / "inbox" / "unread").glob("slack-*.md"))
+                self.assertEqual(len(delivered), 1)
+                self.assertIn("can you include this", delivered[0].read_text(encoding="utf-8"))
+                with jobs.connect(config) as conn:
+                    row = conn.execute("SELECT status, failure_reason FROM jobs WHERE id=?", (job_id,)).fetchone()
+                self.assertEqual(row["status"], "succeeded")
+                self.assertIn("delivered_to_active_agent", row["failure_reason"])
+
+    def test_enqueue_thread_reply_waits_for_active_agent_race(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            env = self.env(tmp)
+            with patch.dict(os.environ, env, clear=False):
+                config = BotConfig.from_env()
+                agent_home = Path(env["ACTIVE_DIR"]) / f"agent-{os.getpid()}"
+                (agent_home / "inbox" / "unread").mkdir(parents=True)
+                write_json(agent_home / "meta.json", {"channel": "C1", "messageTs": "111.000"})
+                now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+                with jobs.connect(config) as conn:
+                    conn.execute(
+                        """
+                        INSERT INTO jobs (status, thread_ts, command_slug, prompt, pid, created_at, last_heartbeat_at)
+                        VALUES ('running', '111.000', 'active', 'prompt', ?, ?, ?)
+                        """,
+                        (os.getpid(), now, now),
+                    )
+                    conn.commit()
+
+                with (
+                    patch("bot_harness.jobs.active_agent_for_thread", side_effect=[None, agent_home]),
+                    patch("bot_harness.jobs.time.sleep", return_value=None),
+                ):
+                    job_id = jobs.enqueue(
+                        config,
+                        {
+                            "channel": "C1",
+                            "slack_channel": "C1",
+                            "slack_ts": "222.000",
+                            "thread_ts": "111.000",
+                            "command_slug": "reply",
+                            "provenance_message": "arrived before active dir was visible",
+                        },
+                    )
+
+                delivered = list((agent_home / "inbox" / "unread").glob("slack-*.md"))
+                self.assertEqual(len(delivered), 1)
+                self.assertIn("arrived before active dir", delivered[0].read_text(encoding="utf-8"))
+                with jobs.connect(config) as conn:
+                    row = conn.execute("SELECT status, failure_reason FROM jobs WHERE id=?", (job_id,)).fetchone()
+                self.assertEqual(row["status"], "succeeded")
+                self.assertIn("delivered_to_active_agent", row["failure_reason"])
 
     def test_agent_metadata_cleanup_and_journal_render(self):
         with tempfile.TemporaryDirectory() as td:

--- a/scripts/ec2-bot/scripts/tests/test_invoke_provider.py
+++ b/scripts/ec2-bot/scripts/tests/test_invoke_provider.py
@@ -75,6 +75,30 @@ class ProviderParsingTests(unittest.TestCase):
             self.assertEqual(text, "Claude hello")
             self.assertEqual(usage, {"input_tokens": 12, "output_tokens": 3})
 
+    def test_claude_command_uses_bot_hook_settings(self):
+        with tempfile.TemporaryDirectory() as td:
+            ctx = self.context(Path(td))
+            provider = ClaudeProvider(ctx)
+            provider.prepare_session()
+            cmd = provider.command()
+            self.assertIn("--settings", cmd)
+            self.assertIn("--input-format", cmd)
+            self.assertEqual(cmd[cmd.index("--input-format") + 1], "stream-json")
+            settings_path = Path(cmd[cmd.index("--settings") + 1])
+            self.assertEqual(settings_path, ctx.agent_home / "claude-settings.json")
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+            hook = settings["hooks"]["PostToolUse"][0]["hooks"][0]
+            self.assertEqual(hook["type"], "command")
+            self.assertTrue(hook["command"].endswith("check-pending-messages.sh"))
+
+    def test_claude_stream_user_message_shape(self):
+        with tempfile.TemporaryDirectory() as td:
+            provider = ClaudeProvider(self.context(Path(td)))
+            payload = json.loads(provider.stream_user_message("hello"))
+            self.assertEqual(payload["type"], "user")
+            self.assertEqual(payload["message"]["role"], "user")
+            self.assertEqual(payload["message"]["content"][0]["text"], "hello")
+
     def test_codex_text_usage_and_session_map(self):
         with tempfile.TemporaryDirectory() as td:
             ctx = self.context(Path(td))

--- a/scripts/ec2-bot/slam-bot-worker.service
+++ b/scripts/ec2-bot/slam-bot-worker.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Slam Paws Bot Durable Agent Worker
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/meet-without-fear
+ExecStartPre=+/bin/bash -c "mkdir -p /var/log/slam-bot && touch /var/log/slam-bot/jobs-worker.log && chown ubuntu:ubuntu /var/log/slam-bot/jobs-worker.log"
+ExecStart=/bin/bash -c "source /opt/slam-bot/.env && for i in $(seq 1 ${BOT_WORKER_CONCURRENCY:-5}); do PYTHONPATH=/opt/slam-bot/scripts/lib BOT_SCRIPTS_DIR=/opt/slam-bot/scripts python3 -m bot_harness jobs worker & done; wait"
+Restart=always
+RestartSec=5
+TimeoutStopSec=300
+StandardOutput=append:/var/log/slam-bot/jobs-worker.log
+StandardError=append:/var/log/slam-bot/jobs-worker.log
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ec2-bot/socket-mode/socket-listener.mjs
+++ b/scripts/ec2-bot/socket-mode/socket-listener.mjs
@@ -11,9 +11,8 @@
  *   3. Claim message (atomic file creation)
  *   4. Add :eyes: reaction
  *   5. Build prompt (context + message + template/prompt file)
- *   6. Spawn run-claude.sh as background process
- *   7. On completion: remove :eyes:, add :white_check_mark:
- *      - Exit code 75/76: rate limited → add :zzz: instead of :white_check_mark:
+ *   6. Enqueue a durable Python harness job
+ *   7. Worker updates reactions on completion
  *
  * Environment variables (from /opt/slam-bot/.env):
  *   SLACK_APP_TOKEN       — App-level token (xapp-...) for Socket Mode
@@ -29,7 +28,7 @@
 
 import { SocketModeClient } from '@slack/socket-mode';
 import { WebClient } from '@slack/web-api';
-import { spawn, execSync } from 'node:child_process';
+import { spawn, execSync, spawnSync } from 'node:child_process';
 import { writeFileSync, readFileSync, mkdirSync, existsSync, readdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
@@ -74,22 +73,15 @@ const HEARTBEAT_FILE = join(STATE_DIR, 'socket-mode-heartbeat.txt');
 mkdirSync(CLAIMS_DIR, { recursive: true });
 
 // ---------------------------------------------------------------------------
-// Thread-aware queuing — thread replies wait for parent agent
+// Priority bypass — channels that should skip resource gates in the worker
 // ---------------------------------------------------------------------------
 
-/**
- * Tracks active agents by thread. Key = "channel:thread_ts".
- * Value = { channel, ts, config, child } of the running agent.
- * @type {Map<string, object>}
- */
-const activeThreadAgents = new Map();
-
-/**
- * Queued thread replies waiting for the active agent to finish.
- * Key = "channel:thread_ts". Value = array of { event, config } objects.
- * @type {Map<string, Array<{event: object, config: object}>>}
- */
-const threadQueue = new Map();
+function isPriorityChannel(channel) {
+  if (!channel) return false;
+  if (channel.startsWith('D')) return true;
+  if (channel === AGENTIC_DEVS_CHANNEL) return true;
+  return false;
+}
 
 /**
  * Get the thread key for an event. A top-level message starts a thread
@@ -114,7 +106,7 @@ const socketClient = new SocketModeClient({ appToken: APP_TOKEN });
  *
  * Each channel can be dispatched in one of two modes:
  *   1. Command-slug mode (legacy): uses `commandSlug` + optional `promptFile`/`inlineTemplate`
- *   2. Workspace mode (new): uses `workspace` — run-claude.sh cds into bot-workspaces/<name>/
+ *   2. Workspace mode (new): uses `workspace` — the harness cds into bot-workspaces/<name>/
  *      and Claude's native CLAUDE.md auto-loading handles context routing.
  *
  * When `workspace` is set, the prompt content (context + message + template) is still built
@@ -442,7 +434,7 @@ async function resolveUserName(userId) {
 }
 
 // ---------------------------------------------------------------------------
-// Agent dispatch (spawns run-claude.sh as background process)
+// Agent dispatch (durably enqueues work for the independent worker service)
 // ---------------------------------------------------------------------------
 
 function dispatchAgent(channel, ts, config, promptContent, provenance = {}, tKey = null, { providerOverride = '' } = {}) {
@@ -450,128 +442,51 @@ function dispatchAgent(channel, ts, config, promptContent, provenance = {}, tKey
   const promptFile = join(tmpdir(), `slam-bot-prompt-${ts.replace('.', '_')}.md`);
   writeFileSync(promptFile, promptContent);
 
-  // Build args based on mode: workspace or command-slug (legacy)
-  // Thread replies get --session for continuity (same thread = same Claude session)
-  let args;
-  const sessionArgs = [];
-  if (tKey) {
-    const [sessionChannel, sessionThreadTs] = tKey.split(':');
-    sessionArgs.push('--session', `slack-${sessionChannel}-${sessionThreadTs}`);
-  }
-  const providerArgs = providerOverride ? ['--provider', providerOverride] : [];
-
-  if (config.workspace) {
-    // Workspace mode: --workspace <name> [--session <key>] <PROMPT> <PROMPT_FILE> <MSG_TS>
-    args = ['--workspace', config.workspace, ...sessionArgs, ...providerArgs, '', promptFile, ts];
-  } else {
-    // Command-slug mode (legacy): [--session <key>] <COMMAND_SLUG> <PROMPT> <PROMPT_FILE> <MSG_TS>
-    args = [...sessionArgs, ...providerArgs, config.commandSlug, '', promptFile, ts];
-  }
-
-  // Extract thread_ts from tKey so run-claude.sh can pass it to the queue.
-  // Without this, queued thread replies have no thread_ts and the
-  // process-queue cancellation check uses conversations.history (which
-  // doesn't return threaded replies), falsely concluding the message was
-  // deleted and cancelling the job (#562 follow-up).
-  const threadTs = tKey ? (tKey.split(':')[1] || '') : '';
-
-  const env = {
-    ...process.env,
-    SLAM_BOT: '1',
-    PRIORITY: 'high',
-    CHANNEL: channel,
-    THREAD_TS: threadTs,
-    PROVENANCE_CHANNEL: provenance.channel || '',
-    PROVENANCE_REQUESTER: provenance.requester || '',
-    PROVENANCE_MESSAGE: provenance.message || '',
+  const mode = config.workspace ? `workspace=${config.workspace}` : `slug=${config.commandSlug}`;
+  const payload = {
+    channel,
+    slack_channel: channel,
+    slack_ts: ts,
+    thread_ts: tKey ? tKey.split(':')[1] : ts,
+    command_slug: config.commandSlug,
+    workspace: config.workspace || '',
+    session_key: tKey ? `slack-${tKey.replace(':', '-')}` : '',
+    prompt: '',
+    prompt_file: promptFile,
+    msg_ts: ts,
+    priority: isPriorityChannel(channel) ? 'high' : 'normal',
+    provider: providerOverride || '',
+    fallback_provider: '',
+    review_provider: '',
+    model: '',
+    effort: '',
+    provenance_channel: provenance.channel || '',
+    provenance_requester: provenance.requester || '',
+    provenance_message: provenance.message || '',
+    log_name: config.logName,
   };
 
-  const child = spawn(
-    join(SCRIPTS_DIR, 'run-claude.sh'),
-    args,
-    {
-      cwd: MWF_APP_DIR,
-      stdio: 'ignore',
-      detached: true,
-      env,
-    }
-  );
-
-  child.unref();
-
-  // Track this agent as active for its thread
-  if (tKey) {
-    activeThreadAgents.set(tKey, { channel, ts, config, pid: child.pid });
-  }
-
-  const mode = config.workspace ? `workspace=${config.workspace}` : `slug=${config.commandSlug}`;
-  child.on('exit', async (code) => {
-    log(config.logName, `Agent for ${ts} (${mode}${providerOverride ? `, provider=${providerOverride}` : ''}) exited with code ${code}`);
-    await removeReaction(channel, ts, 'eyes');
-
-    if (code === 0) {
-      await addReaction(channel, ts, 'white_check_mark');
-    } else if (code === 75 || code === 76) {
-      await addReaction(channel, ts, 'zzz');
-    } else {
-      await addReaction(channel, ts, 'x');
-    }
-
-    // Thread queue drain: when this agent finishes, dispatch the next
-    // queued reply for the same thread (if any).
-    if (tKey) {
-      activeThreadAgents.delete(tKey);
-      drainThreadQueue(tKey);
-    }
+  const proc = spawnSync('/usr/bin/python3', ['-m', 'bot_harness', 'jobs', 'enqueue'], {
+    cwd: MWF_APP_DIR,
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PYTHONPATH: [join(SCRIPTS_DIR, 'lib'), process.env.PYTHONPATH].filter(Boolean).join(':'),
+      BOT_SCRIPTS_DIR: SCRIPTS_DIR,
+      SLAM_BOT: '1',
+      PRIORITY: payload.priority,
+      CHANNEL: channel,
+    },
   });
 
-  log(config.logName, `Dispatched agent for ${ts} (PID ${child.pid}, ${mode}${providerOverride ? `, provider=${providerOverride}` : ''})`);
-}
-
-/**
- * Drain the next queued thread reply for the given thread key.
- * Called when an agent exits for that thread.
- */
-async function drainThreadQueue(tKey) {
-  const queue = threadQueue.get(tKey);
-  if (!queue || queue.length === 0) {
-    threadQueue.delete(tKey);
-    return;
+  if (proc.status !== 0) {
+    const detail = (proc.stderr || proc.stdout || '').trim();
+    throw new Error(`failed to enqueue job for ${ts}: ${detail || `exit ${proc.status}`}`);
   }
 
-  const next = queue.shift();
-  if (queue.length === 0) {
-    threadQueue.delete(tKey);
-  }
-
-  const { event, config } = next;
-  const channel = event.channel;
-  const ts = event.ts;
-
-  logMain(`Draining thread queue for ${tKey}: dispatching queued reply ${ts} (${queue?.length || 0} remaining)`);
-
-  // Add :eyes: reaction (the :hourglass_flowing_sand: was added when queued)
-  await removeReaction(channel, ts, 'hourglass_flowing_sand');
-  await addReaction(channel, ts, 'eyes');
-
-  // Build prompt and provenance for the queued message
-  const [promptContent, requesterName] = await Promise.all([
-    buildPrompt(channel, config, event),
-    event.user ? resolveUserName(event.user) : Promise.resolve('unknown'),
-  ]);
-
-  const provenance = {
-    channel: config.channelName || channel,
-    requester: requesterName,
-    message: event.text || '(no text)',
-  };
-
-  const providerOverride = providerOverrideForMessage(event);
-  if (providerOverride) {
-    logMain(`Provider override: routing ${ts} through ${providerOverride} because message contains "codex"`);
-  }
-
-  dispatchAgent(channel, ts, config, promptContent, provenance, tKey, { providerOverride });
+  const jobId = (proc.stdout || '').trim();
+  log(config.logName, `Enqueued agent job ${jobId || '(unknown)'} for ${ts} (${mode}${providerOverride ? `, provider=${providerOverride}` : ''})`);
 }
 
 // ---------------------------------------------------------------------------
@@ -727,32 +642,10 @@ async function handleMessageEvent(event) {
 
   logMain(`Claimed message ${ts} in ${config.logName} from user=${user}`);
 
-  // Thread-aware queuing: if an agent is already working on this thread,
-  // queue this message instead of dispatching immediately.
   const tKey = threadKey(channel, event);
-  if (activeThreadAgents.has(tKey)) {
-    logMain(`Thread ${tKey} has active agent — queuing reply ${ts}`);
-    if (!threadQueue.has(tKey)) {
-      threadQueue.set(tKey, []);
-    }
-    threadQueue.get(tKey).push({ event, config });
 
-    // Add :hourglass_flowing_sand: to indicate the message is queued
-    await addReaction(channel, ts, 'hourglass_flowing_sand');
-
-    // Update heartbeat
-    writeFileSync(HEARTBEAT_FILE, new Date().toISOString());
-    return;
-  }
-
-  // Mark thread as active IMMEDIATELY (synchronously) to prevent race conditions.
-  // Without this, rapid-fire messages can slip through the activeThreadAgents check
-  // because buildPrompt/resolveUserName are async and the map isn't set until
-  // dispatchAgent completes.
-  activeThreadAgents.set(tKey, { channel, ts, config, pid: null });
-
-  // Add :eyes: reaction
-  await addReaction(channel, ts, 'eyes');
+  // Add :hourglass_flowing_sand: while the durable worker owns scheduling.
+  await addReaction(channel, ts, 'hourglass_flowing_sand');
 
   // Resolve provenance in parallel with prompt building
   const [promptContent, requesterName] = await Promise.all([
@@ -771,8 +664,13 @@ async function handleMessageEvent(event) {
     logMain(`Provider override: routing ${ts} through ${providerOverride} because message contains "codex"`);
   }
 
-  // Dispatch provider agent (tracked by thread key — updates the pid set above)
-  dispatchAgent(channel, ts, config, promptContent, provenance, tKey, { providerOverride });
+  try {
+    dispatchAgent(channel, ts, config, promptContent, provenance, tKey, { providerOverride });
+  } catch (err) {
+    log(config.logName, `Failed to enqueue agent for ${ts}: ${err.message}`);
+    await removeReaction(channel, ts, 'hourglass_flowing_sand');
+    await addReaction(channel, ts, 'x');
+  }
 
   // Update heartbeat
   writeFileSync(HEARTBEAT_FILE, new Date().toISOString());
@@ -809,8 +707,28 @@ async function handleReactionAdded(event) {
     return;
   }
 
-  // Find and remove matching queue file(s)
+  // Find and cancel matching durable job and legacy queue file(s)
   let removed = 0;
+  let cancelledJob = '';
+  try {
+    const proc = spawnSync('/usr/bin/python3', ['-m', 'bot_harness', 'jobs', 'cancel', channel, ts], {
+      cwd: MWF_APP_DIR,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PYTHONPATH: [join(SCRIPTS_DIR, 'lib'), process.env.PYTHONPATH].filter(Boolean).join(':'),
+        BOT_SCRIPTS_DIR: SCRIPTS_DIR,
+      },
+    });
+    if (proc.status === 0) {
+      cancelledJob = (proc.stdout || '').trim();
+    } else {
+      logMain(`Cancel: durable job cancel failed for ${ts}: ${(proc.stderr || proc.stdout || '').trim()}`);
+    }
+  } catch (err) {
+    logMain(`Cancel: durable job cancel threw for ${ts}: ${err.message}`);
+  }
+
   try {
     if (existsSync(QUEUE_DIR)) {
       const files = readdirSync(QUEUE_DIR).filter((f) => f.startsWith('queue-') && f.endsWith('.json'));
@@ -835,7 +753,7 @@ async function handleReactionAdded(event) {
   // Remove the hourglass emoji
   await removeReaction(channel, ts, 'hourglass_flowing_sand');
 
-  logMain(`Cancel: ❌ reaction on ${ts} in ${channel} — removed ${removed} queue file(s)`);
+  logMain(`Cancel: ❌ reaction on ${ts} in ${channel} — durable job ${cancelledJob || 'none'}, removed ${removed} legacy queue file(s)`);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add durable SQLite jobs worker and systemd/deploy wiring for slam-bot Slack dispatches
- route Socket Mode messages through jobs enqueue while preserving test-trigger handling and Codex queued/resume behavior
- add Claude stream-json input handling with pending-message injection after tool results
- add unit and integration coverage for stream-json settings plus active-thread inbox delivery

## Tests
- PYTHONPATH=scripts/ec2-bot/scripts/lib python3 -m unittest scripts/ec2-bot/scripts/tests/test_invoke_provider.py
- PYTHONPATH=scripts/ec2-bot/scripts/lib python3 -m unittest scripts/ec2-bot/scripts/tests/test_bot_harness.py
- scripts/ec2-bot/scripts/tests/provider-integration-test.sh
- scripts/ec2-bot/scripts/tests/harness-integration-test.sh
- node --check scripts/ec2-bot/socket-mode/socket-listener.mjs