### PR TITLE
Pin empathy-validated divider to revealedAt (stop per-turn drift)

### DIFF
--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -81,7 +81,7 @@ import {
   useSubmitTendingResponse,
   useTendingEntries,
 } from '../hooks/useStages';
-import { deriveIndicators, SessionIndicatorData } from '../utils/chatListSelector';
+import { deriveEmpathyValidatedIndicator, deriveIndicators, SessionIndicatorData } from '../utils/chatListSelector';
 import { canInsertRealtimeMessageForCurrentUser, isRealtimePayloadAddressedToCurrentUser } from '../utils/realtimePrivacy';
 import {
   getPersistedMessageRefreshQueryKeys,
@@ -1719,15 +1719,17 @@ export function UnifiedSessionScreen({
     const allIndicators: ChatIndicatorItem[] = [...baseIndicators, ...sharedContentIndicators];
 
     // --- Empathy validated indicator ---
-    if (empathyStatusData?.myAttempt?.status === 'VALIDATED') {
-      allIndicators.push({
-        type: 'indicator' as const,
-        indicatorType: 'empathy-validated' as const,
-        id: 'empathy-validated',
-        timestamp: empathyStatusData.myAttempt.revealedAt
-          || new Date().toISOString(),
-        metadata: { partnerName: partnerName || 'Partner' },
-      });
+    // Pin to the attempt's revealedAt timestamp (stable, set once when partner saw it).
+    // If revealedAt is missing we intentionally skip the indicator rather than fall back
+    // to `new Date()`, which would re-anchor the divider on every render and cause it to
+    // visually slide just above the most-recent AI message on every turn.
+    const empathyValidatedIndicator = deriveEmpathyValidatedIndicator(
+      empathyStatusData?.myAttempt?.status ?? null,
+      empathyStatusData?.myAttempt?.revealedAt ?? null,
+      partnerName || 'Partner'
+    );
+    if (empathyValidatedIndicator) {
+      allIndicators.push(empathyValidatedIndicator);
     }
 
     // --- Stage chapter markers ---

--- a/mobile/src/utils/__tests__/chatListSelector.test.ts
+++ b/mobile/src/utils/__tests__/chatListSelector.test.ts
@@ -1,0 +1,41 @@
+import { deriveEmpathyValidatedIndicator } from '../chatListSelector';
+
+describe('deriveEmpathyValidatedIndicator', () => {
+  it('returns null when status is not VALIDATED', () => {
+    expect(deriveEmpathyValidatedIndicator('REVEALED', '2026-01-01T00:00:00Z', 'Catherine')).toBeNull();
+    expect(deriveEmpathyValidatedIndicator(null, '2026-01-01T00:00:00Z', 'Catherine')).toBeNull();
+  });
+
+  it('returns null when revealedAt is missing, even if VALIDATED (no Date.now() fallback)', () => {
+    // This guards the milestone-divider-position bug: a `new Date()` fallback
+    // would re-anchor the indicator on every render and the divider would
+    // visually slide just above the most-recent AI message each turn.
+    expect(deriveEmpathyValidatedIndicator('VALIDATED', null, 'Catherine')).toBeNull();
+  });
+
+  it('pins the indicator to revealedAt when validated', () => {
+    const indicator = deriveEmpathyValidatedIndicator(
+      'VALIDATED',
+      '2026-05-08T12:00:00.000Z',
+      'Catherine'
+    );
+    expect(indicator).toEqual({
+      type: 'indicator',
+      indicatorType: 'empathy-validated',
+      id: 'empathy-validated',
+      timestamp: '2026-05-08T12:00:00.000Z',
+      metadata: { partnerName: 'Catherine' },
+    });
+  });
+
+  it('returns the same stable timestamp across many invocations (no drift)', () => {
+    // Simulates the indicator being rederived on every render after every
+    // new message arrives. The timestamp must not change.
+    const calls = Array.from({ length: 10 }, () =>
+      deriveEmpathyValidatedIndicator('VALIDATED', '2026-05-08T12:00:00.000Z', 'Catherine')
+    );
+    const timestamps = new Set(calls.map((c) => c?.timestamp));
+    expect(timestamps.size).toBe(1);
+    expect([...timestamps][0]).toBe('2026-05-08T12:00:00.000Z');
+  });
+});

--- a/mobile/src/utils/chatListSelector.ts
+++ b/mobile/src/utils/chatListSelector.ts
@@ -249,6 +249,42 @@ export function deriveIndicators(data: SessionIndicatorData): IndicatorItem[] {
 }
 
 /**
+ * Derive the "empathy-validated" indicator (the green
+ * "— {Partner} CONFIRMED YOUR UNDERSTANDING —" divider).
+ *
+ * This is a one-shot milestone: once the partner has validated the empathy
+ * attempt, the divider should pin to the timestamp of that event and stay
+ * there for the rest of the session.
+ *
+ * Critical: never fall back to `Date.now()` / `new Date()`. The caller invokes
+ * this on every render of the message list (deps include `messages`), so a
+ * "now" fallback would re-anchor the indicator on every turn and the divider
+ * would visually slide just above the most-recent AI message each turn — the
+ * exact bug this helper exists to prevent.
+ *
+ * @param status - Current status of the user's empathy attempt.
+ * @param revealedAt - When the attempt was revealed to the partner. Stable
+ *   server timestamp; null if the attempt has not yet been revealed.
+ * @param partnerName - Display name to show in the indicator metadata.
+ * @returns The indicator item, or null if it shouldn't be shown.
+ */
+export function deriveEmpathyValidatedIndicator(
+  status: string | null,
+  revealedAt: string | null,
+  partnerName: string
+): IndicatorItem | null {
+  if (status !== 'VALIDATED') return null;
+  if (!revealedAt) return null;
+  return {
+    type: 'indicator',
+    indicatorType: 'empathy-validated',
+    id: 'empathy-validated',
+    timestamp: revealedAt,
+    metadata: { partnerName },
+  };
+}
+
+/**
  * Interleaves messages with indicator items, sorted by timestamp.
  *
  * The indicators are inserted at their appropriate positions based on timestamps,


### PR DESCRIPTION
## Bug

In Stage 4 of an active Catherine session, the milestone divider \`— CATHERINE CONFIRMED YOUR UNDERSTANDING —\` (the green hairline-rule divider) was visually sliding just above the most-recent AI message on every new turn instead of staying pinned at the moment confirmation actually happened. Across consecutive turns, the divider sat between most-recent user message and most-recent AI message, then between the *new* most-recent user message and the *new* AI message, etc.

## Root cause

\`mobile/src/screens/UnifiedSessionScreen.tsx\` built the \`empathy-validated\` indicator inside a \`useMemo\` whose dependency array includes \`messages\`. The indicator's \`timestamp\` was:

\`\`\`ts
timestamp: empathyStatusData.myAttempt.revealedAt || new Date().toISOString()
\`\`\`

When \`revealedAt\` was null, the fallback produced a fresh "now" on every render. Each turn the user message's timestamp was older-than-now and the just-arrived AI message's timestamp was newer-than-now, so the sort placed the divider between them. Next turn: same thing, new position.

## Fix

Extract a pure \`deriveEmpathyValidatedIndicator(status, revealedAt, partnerName)\` helper into \`mobile/src/utils/chatListSelector.ts\`. It pins to \`revealedAt\` and returns \`null\` if either \`status !== 'VALIDATED'\` or \`revealedAt\` is missing — no \`Date.now()\` fallback. The screen now calls this helper and only pushes the indicator when the helper returns one.

This matches the architecture rule from CLAUDE.md: indicators are derived data anchored on stable cache timestamps. Other one-shot milestones (\`feel-heard\`, \`needs-identified\`, \`common-ground-found\`, \`strategies-ready\`, \`overlap-revealed\`, \`agreement-reached\`, invitation-sent/accepted) all already pin to stable \`*At\` timestamps in \`deriveIndicators\`; \`empathy-validated\` was the outlier.

## Test

\`mobile/src/utils/__tests__/chatListSelector.test.ts\` (new) covers:
- Returns null when status isn't VALIDATED.
- Returns null when revealedAt is missing even if VALIDATED (guards the regression directly).
- Pins to the provided revealedAt.
- Returns the same stable timestamp across many invocations (simulates repeated re-renders after every new message).

\`npm run check\` is clean for the mobile workspace. Backend has 10 pre-existing \`state-factory.ts\` TS errors on main (Property does not exist on type 'never') unrelated to this PR. Mobile test suite has known pre-existing failures (stale copy expectations, Axios/Expo, Sentry ESM) per CLAUDE.md guidance — not introduced here.

## Test plan
- [ ] Live session: open a Stage 4 conversation where partner has confirmed empathy. Verify the divider appears once, pinned, and does not move when new turns arrive.
- [ ] Reload session: divider remains in the same position.
- [ ] Sessions where revealedAt is null (legacy / mid-flow): divider does not appear (preferable to a moving "now" anchor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)