### PR TITLE
Simplify guided action panels to title-only

### DIFF
--- a/mobile/src/components/CompactAgreementBar.tsx
+++ b/mobile/src/components/CompactAgreementBar.tsx
@@ -40,9 +40,7 @@ export function CompactAgreementBar({
   return (
     <GuidedActionPanel
       tone="topic"
-      eyebrow="Curiosity compact"
       title="Ready to begin?"
-      subtitle={isFirstSession ? 'Start with the compact, then name the conversation topic.' : undefined}
       primaryAction={{
         label,
         onPress: onSign,

--- a/mobile/src/components/FeelHeardConfirmation.tsx
+++ b/mobile/src/components/FeelHeardConfirmation.tsx
@@ -29,9 +29,7 @@ export function FeelHeardConfirmation({
   return (
     <GuidedActionPanel
       tone="success"
-      eyebrow="Ready check"
       title="Do you feel heard enough to continue?"
-      subtitle="You can keep talking, or move into the next part when this feels complete."
       secondaryAction={onContinue ? {
         label: 'Not yet',
         onPress: onContinue,

--- a/mobile/src/components/ShareTopicPanel.tsx
+++ b/mobile/src/components/ShareTopicPanel.tsx
@@ -41,9 +41,7 @@ export function ShareTopicPanel({
   return (
     <GuidedActionPanel
       tone={action === 'OFFER_SHARING' ? 'share' : 'review'}
-      eyebrow="Share suggestion"
-      title={`Help ${partnerName} understand you better`}
-      subtitle="Review the suggested context before deciding whether to share it."
+      title={`Share this with ${partnerName}?`}
       primaryAction={{ label: 'Review', onPress }}
       testID="share-topic-panel"
     />

--- a/mobile/src/components/__tests__/ShareTopicPanel.test.tsx
+++ b/mobile/src/components/__tests__/ShareTopicPanel.test.tsx
@@ -36,12 +36,12 @@ describe('ShareTopicPanel', () => {
   describe('content', () => {
     it('displays the suggestion text with partner name', () => {
       render(<ShareTopicPanel {...defaultProps} />);
-      expect(screen.getByText('Help Partner understand you better')).toBeTruthy();
+      expect(screen.getByText('Share this with Partner?')).toBeTruthy();
     });
 
     it('displays correct name when partnerName changes', () => {
       render(<ShareTopicPanel {...defaultProps} partnerName="Alex" />);
-      expect(screen.getByText('Help Alex understand you better')).toBeTruthy();
+      expect(screen.getByText('Share this with Alex?')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Summary
- Drop eyebrow + subtitle from the three `GuidedActionPanel` callers in the chat input area. The "Curiosity compact" eyebrow is dead product terminology, and the subtitles restated info already on screen.
- `CompactAgreementBar` → just **"Ready to begin?"**
- `FeelHeardConfirmation` → just **"Do you feel heard enough to continue?"**
- `ShareTopicPanel` → **"Share this with {partner}?"** (replaces "Help {partner} understand you better" + review subtitle)

## Test plan
- [ ] Stage 0 onboarding panel renders cleanly with just the title + Ready button
- [ ] Stage 1 feel-heard gate renders without the "Ready check" eyebrow
- [ ] Stage 2 share suggestion panel shows "Share this with {partner}?"
- [ ] `ShareTopicPanel` unit tests pass (updated to new copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)