### PR TITLE
[codex] Add notification prompts and biometric app lock

### DIFF
--- a/backend/src/controllers/session-state.ts
+++ b/backend/src/controllers/session-state.ts
@@ -33,10 +33,7 @@ interface CompactGates {
   signedAt?: string;
 }
 
-async function acceptPendingInvitationForE2ESession(
-  sessionId: string,
-  userId: string
-): Promise<boolean> {
+async function acceptPendingInvitationForE2ESession(sessionId: string, userId: string): Promise<boolean> {
   if (process.env.E2E_AUTH_BYPASS !== 'true' || process.env.NODE_ENV === 'production') {
     return false;
   }
@@ -63,7 +60,7 @@ async function acceptPendingInvitationForE2ESession(
     return false;
   }
 
-  await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async tx => {
     await tx.relationshipMember.upsert({
       where: {
         relationshipId_userId: {
@@ -215,27 +212,19 @@ export async function getSessionState(req: Request, res: Response): Promise<void
     const partnerId = await getPartnerUserId(sessionId, user.id);
 
     // Get my membership (for nickname I use for partner)
-    const myMember = session.relationship.members.find(
-      (m) => m.userId === user.id
-    );
-    const partnerMember = session.relationship.members.find(
-      (m) => m.userId !== user.id
-    );
+    const myMember = session.relationship.members.find(m => m.userId === user.id);
+    const partnerMember = session.relationship.members.find(m => m.userId !== user.id);
 
     // Build progress response
     const myProgressRecord = session.stageProgress
-      .filter((sp) => sp.userId === user.id)
+      .filter(sp => sp.userId === user.id)
       .sort((a, b) => b.stage - a.stage)[0];
     const partnerProgressRecord = partnerId
-      ? session.stageProgress
-          .filter((sp) => sp.userId === partnerId)
-          .sort((a, b) => b.stage - a.stage)[0]
+      ? session.stageProgress.filter(sp => sp.userId === partnerId).sort((a, b) => b.stage - a.stage)[0]
       : null;
 
     // Get Stage 1 record for milestones
-    const myStage1Record = session.stageProgress.find(
-      (sp) => sp.userId === user.id && sp.stage === 1
-    );
+    const myStage1Record = session.stageProgress.find(sp => sp.userId === user.id && sp.stage === 1);
 
     const defaultProgress = {
       stage: 0,
@@ -273,17 +262,26 @@ export async function getSessionState(req: Request, res: Response): Promise<void
     };
 
     // Partner display name
-    const partnerDisplayName =
-      myMember?.nickname ||
-      partnerMember?.user.firstName ||
-      partnerMember?.user.name ||
-      null;
+    const partnerDisplayName = myMember?.nickname || partnerMember?.user.firstName || partnerMember?.user.name || null;
+    const partnerVessel = partnerId
+      ? await prisma.userVessel.findUnique({
+          where: {
+            userId_sessionId: {
+              userId: partnerId,
+              sessionId,
+            },
+          },
+          select: {
+            lastViewedAt: true,
+          },
+        })
+      : null;
 
     // Build messages response (reverse to chronological order)
     const hasMoreMessages = messages.length > 25;
     const messageSlice = hasMoreMessages ? messages.slice(0, 25) : messages;
     const messagesResponse = {
-      messages: messageSlice.reverse().map((m) => ({
+      messages: messageSlice.reverse().map(m => ({
         id: m.id,
         sessionId: m.sessionId,
         senderId: m.senderId,
@@ -320,13 +318,9 @@ export async function getSessionState(req: Request, res: Response): Promise<void
       : null;
 
     // Build compact status from Stage 0 progress gatesSatisfied
-    const myStage0Record = session.stageProgress.find(
-      (sp) => sp.userId === user.id && sp.stage === 0
-    );
+    const myStage0Record = session.stageProgress.find(sp => sp.userId === user.id && sp.stage === 0);
     const partnerStage0Record = partnerId
-      ? session.stageProgress.find(
-          (sp) => sp.userId === partnerId && sp.stage === 0
-        )
+      ? session.stageProgress.find(sp => sp.userId === partnerId && sp.stage === 0)
       : null;
 
     const myGates = myStage0Record?.gatesSatisfied as CompactGates | null;
@@ -373,6 +367,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
         createdAt: session.createdAt.toISOString(),
         resolvedAt: session.resolvedAt?.toISOString() ?? null,
         lastViewedAt: userVessel?.lastViewedAt?.toISOString() ?? null,
+        partnerLastViewedAt: partnerVessel?.lastViewedAt?.toISOString() ?? null,
         lastSeenChatItemId: userVessel?.lastSeenChatItemId ?? null,
       },
 

--- a/backend/src/services/__tests__/push.test.ts
+++ b/backend/src/services/__tests__/push.test.ts
@@ -1,16 +1,9 @@
-import {
-  sendPushNotification,
-  sendPushNotifications,
-  isValidPushToken,
-  PUSH_MESSAGES,
-  resetExpoClient,
-} from '../push';
+import { sendPushNotification, sendPushNotifications, isValidPushToken, PUSH_MESSAGES, resetExpoClient } from '../push';
 import { prisma } from '../../lib/prisma';
 import type { SessionEvent } from '../realtime';
 
 // Mock Prisma
 jest.mock('../../lib/prisma');
-
 
 // Mock Expo SDK
 const mockSendPushNotificationsAsync = jest.fn();
@@ -35,7 +28,7 @@ describe('Push Notification Service', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetExpoClient();
-    ((Expo as unknown as { isExpoPushToken: jest.Mock }).isExpoPushToken).mockReturnValue(true);
+    (Expo as unknown as { isExpoPushToken: jest.Mock }).isExpoPushToken.mockReturnValue(true);
   });
 
   describe('PUSH_MESSAGES', () => {
@@ -63,12 +56,12 @@ describe('Push Notification Service', () => {
 
     it('has appropriate messages for partner events', () => {
       expect(PUSH_MESSAGES['partner.signed_compact'].title).toContain('ready');
-      expect(PUSH_MESSAGES['partner.empathy_shared'].title).toContain('Empathy');
+      expect(PUSH_MESSAGES['partner.empathy_shared'].title).toContain('empathy');
     });
 
     it('has appropriate messages for agreement events', () => {
-      expect(PUSH_MESSAGES['agreement.proposed'].title).toContain('proposed');
-      expect(PUSH_MESSAGES['agreement.confirmed'].title).toContain('review');
+      expect(PUSH_MESSAGES['agreement.proposed'].title).toContain('review');
+      expect(PUSH_MESSAGES['agreement.confirmed'].title).toContain('confirmed');
     });
 
     it('has appropriate messages for session events', () => {
@@ -82,12 +75,7 @@ describe('Push Notification Service', () => {
     it('returns false when user has no push token', async () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({ pushToken: null });
 
-      const result = await sendPushNotification(
-        testUserId,
-        'partner.signed_compact',
-        {},
-        testSessionId
-      );
+      const result = await sendPushNotification(testUserId, 'partner.signed_compact', {}, testSessionId);
 
       expect(result).toBe(false);
       expect(mockSendPushNotificationsAsync).not.toHaveBeenCalled();
@@ -96,12 +84,7 @@ describe('Push Notification Service', () => {
     it('returns false when user is not found', async () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
 
-      const result = await sendPushNotification(
-        testUserId,
-        'partner.signed_compact',
-        {},
-        testSessionId
-      );
+      const result = await sendPushNotification(testUserId, 'partner.signed_compact', {}, testSessionId);
 
       expect(result).toBe(false);
     });
@@ -110,14 +93,9 @@ describe('Push Notification Service', () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({
         pushToken: 'invalid-token',
       });
-      ((Expo as unknown as { isExpoPushToken: jest.Mock }).isExpoPushToken).mockReturnValue(false);
+      (Expo as unknown as { isExpoPushToken: jest.Mock }).isExpoPushToken.mockReturnValue(false);
 
-      const result = await sendPushNotification(
-        testUserId,
-        'partner.signed_compact',
-        {},
-        testSessionId
-      );
+      const result = await sendPushNotification(testUserId, 'partner.signed_compact', {}, testSessionId);
 
       expect(result).toBe(false);
     });
@@ -128,24 +106,57 @@ describe('Push Notification Service', () => {
       });
       mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok' }]);
 
-      await sendPushNotification(
-        testUserId,
-        'partner.empathy_shared',
-        { empathyId: 'emp-1' },
-        testSessionId
-      );
+      await sendPushNotification(testUserId, 'partner.empathy_shared', { empathyId: 'emp-1' }, testSessionId);
 
       expect(mockSendPushNotificationsAsync).toHaveBeenCalledWith([
         expect.objectContaining({
           to: validPushToken,
           sound: 'default',
-          title: PUSH_MESSAGES['partner.empathy_shared'].title,
-          body: PUSH_MESSAGES['partner.empathy_shared'].body,
+          title: 'Their empathy is ready',
+          body: 'Read what They understood about your experience.',
           data: expect.objectContaining({
+            screen: 'session',
             sessionId: testSessionId,
             event: 'partner.empathy_shared',
             empathyId: 'emp-1',
           }),
+        }),
+      ]);
+    });
+
+    it('uses the recipient nickname for the other person when available', async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        pushToken: validPushToken,
+      });
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+        relationship: {
+          members: [
+            {
+              userId: testUserId,
+              nickname: 'Sammy',
+              user: { firstName: 'Recipient', name: 'Recipient User' },
+            },
+            {
+              userId: 'actor-123',
+              nickname: null,
+              user: { firstName: 'Sam', name: 'Sam Person' },
+            },
+          ],
+        },
+      });
+      mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok' }]);
+
+      await sendPushNotification(
+        testUserId,
+        'partner.stage_completed',
+        { completedBy: 'actor-123', stage: 1 },
+        testSessionId,
+      );
+
+      expect(mockSendPushNotificationsAsync).toHaveBeenCalledWith([
+        expect.objectContaining({
+          title: 'Sammy finished Your Story',
+          body: 'It is your turn to continue.',
         }),
       ]);
     });
@@ -156,12 +167,7 @@ describe('Push Notification Service', () => {
       });
       mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok' }]);
 
-      const result = await sendPushNotification(
-        testUserId,
-        'session.resolved',
-        {},
-        testSessionId
-      );
+      const result = await sendPushNotification(testUserId, 'session.resolved', {}, testSessionId);
 
       expect(result).toBe(true);
     });
@@ -170,16 +176,9 @@ describe('Push Notification Service', () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({
         pushToken: validPushToken,
       });
-      mockSendPushNotificationsAsync.mockResolvedValue([
-        { status: 'error', message: 'Push failed' },
-      ]);
+      mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'error', message: 'Push failed' }]);
 
-      const result = await sendPushNotification(
-        testUserId,
-        'session.paused',
-        {},
-        testSessionId
-      );
+      const result = await sendPushNotification(testUserId, 'session.paused', {}, testSessionId);
 
       expect(result).toBe(false);
     });
@@ -210,12 +209,7 @@ describe('Push Notification Service', () => {
       });
       mockSendPushNotificationsAsync.mockRejectedValue(new Error('Network error'));
 
-      const result = await sendPushNotification(
-        testUserId,
-        'partner.advanced',
-        {},
-        testSessionId
-      );
+      const result = await sendPushNotification(testUserId, 'partner.advanced', {}, testSessionId);
 
       expect(result).toBe(false);
     });
@@ -229,12 +223,7 @@ describe('Push Notification Service', () => {
       mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok' }]);
 
       const userIds = ['user-1', 'user-2', 'user-3'];
-      const result = await sendPushNotifications(
-        userIds,
-        'agreement.confirmed',
-        {},
-        testSessionId
-      );
+      const result = await sendPushNotifications(userIds, 'agreement.confirmed', {}, testSessionId);
 
       expect(result).toBe(3);
       expect(mockSendPushNotificationsAsync).toHaveBeenCalledTimes(3);
@@ -252,12 +241,7 @@ describe('Push Notification Service', () => {
       mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok' }]);
 
       const userIds = ['user-1', 'user-2', 'user-3'];
-      const result = await sendPushNotifications(
-        userIds,
-        'partner.ranking_submitted',
-        {},
-        testSessionId
-      );
+      const result = await sendPushNotifications(userIds, 'partner.ranking_submitted', {}, testSessionId);
 
       expect(result).toBe(2); // Only 2 successful sends
     });
@@ -266,12 +250,7 @@ describe('Push Notification Service', () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({ pushToken: null });
 
       const userIds = ['user-1', 'user-2'];
-      const result = await sendPushNotifications(
-        userIds,
-        'partner.needs_shared',
-        {},
-        testSessionId
-      );
+      const result = await sendPushNotifications(userIds, 'partner.needs_shared', {}, testSessionId);
 
       expect(result).toBe(0);
     });
@@ -279,12 +258,12 @@ describe('Push Notification Service', () => {
 
   describe('isValidPushToken', () => {
     it('returns true for valid Expo push token', () => {
-      ((Expo as unknown as { isExpoPushToken: jest.Mock }).isExpoPushToken).mockReturnValue(true);
+      (Expo as unknown as { isExpoPushToken: jest.Mock }).isExpoPushToken.mockReturnValue(true);
       expect(isValidPushToken(validPushToken)).toBe(true);
     });
 
     it('returns false for invalid token', () => {
-      ((Expo as unknown as { isExpoPushToken: jest.Mock }).isExpoPushToken).mockReturnValue(false);
+      (Expo as unknown as { isExpoPushToken: jest.Mock }).isExpoPushToken.mockReturnValue(false);
       expect(isValidPushToken('invalid')).toBe(false);
     });
   });

--- a/backend/src/services/push.ts
+++ b/backend/src/services/push.ts
@@ -2,6 +2,7 @@ import { Expo, ExpoPushMessage } from 'expo-server-sdk';
 import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
 import type { SessionEvent } from './realtime';
+import { Stage, STAGE_FRIENDLY_NAMES } from '@meet-without-fear/shared';
 
 /**
  * Expo SDK instance for sending push notifications.
@@ -23,127 +24,139 @@ export function resetExpoClient(): void {
   expoClient = null;
 }
 
+interface PushMessageTemplate {
+  title: string;
+  body: string;
+}
+
+interface PushMessageContext {
+  actorName: string;
+  actorNamePossessive: string;
+  stageName: string;
+}
+
 /**
  * Push notification message templates for each session event type.
- * Each event has a user-friendly title and body message.
+ * Use {actor} for the other person's display name. The send path resolves it
+ * from the recipient's relationship nickname when available.
  */
-export const PUSH_MESSAGES: Record<SessionEvent, { title: string; body: string }> = {
+export const PUSH_MESSAGES: Record<SessionEvent, PushMessageTemplate> = {
   'partner.signed_compact': {
-    title: 'Partner is ready',
-    body: 'They signed the Curiosity Compact. Your turn!',
+    title: '{actor} is ready',
+    body: 'You can begin the session when you are ready.',
   },
   'partner.stage_completed': {
-    title: 'Partner finished a stage',
-    body: 'They completed their work. Check in when ready.',
+    title: '{actor} finished {stageName}',
+    body: 'It is your turn to continue.',
   },
   'partner.advanced': {
-    title: 'Partner moved forward',
-    body: 'Your partner is ready for the next step.',
+    title: 'Next step is ready',
+    body: '{actor} is ready for the next step with you.',
   },
   'partner.empathy_shared': {
-    title: 'Empathy received',
-    body: 'Your partner shared their understanding of your experience.',
+    title: '{actorPossessive} empathy is ready',
+    body: 'Read what {actor} understood about your experience.',
   },
   'partner.additional_context_shared': {
     title: 'More context shared',
-    body: 'Your partner shared additional context to help you understand them better.',
+    body: '{actor} added context to help you understand them better.',
   },
   'partner.needs_confirmed': {
-    title: 'Needs confirmed',
-    body: 'Your partner has confirmed their identified needs.',
+    title: '{actor} confirmed needs',
+    body: 'You can continue the needs step.',
   },
   'partner.needs_validated': {
-    title: 'Needs validated',
-    body: 'Your partner validated the revealed needs.',
+    title: '{actor} checked the needs list',
+    body: 'Open the session to continue the repair process.',
   },
   'partner.needs_shared': {
-    title: 'Needs shared',
-    body: 'Your partner shared their identified needs.',
+    title: '{actorPossessive} needs are ready',
+    body: 'Open the session to review the needs list.',
   },
   'session.strategies_updated': {
-    title: 'Ideas updated',
-    body: 'There are new ideas to review.',
+    title: 'Repair ideas are ready',
+    body: 'There are new repair ideas to review together.',
   },
   'partner.ranking_submitted': {
-    title: 'Ranking submitted',
-    body: 'Your partner submitted their strategy rankings.',
+    title: '{actor} ranked repair ideas',
+    body: 'Open the session to compare rankings.',
   },
   'partner.ready_to_rank': {
-    title: 'Ready to rank',
-    body: 'Your partner is ready to rank strategies.',
+    title: '{actor} is ready to rank',
+    body: 'You can start ranking repair ideas.',
   },
   'partner.consent_granted': {
     title: 'Content shared',
-    body: 'Your partner has shared some content with you.',
+    body: '{actor} shared content for this session.',
   },
   'partner.consent_revoked': {
     title: 'Content withdrawn',
-    body: 'Your partner has withdrawn some shared content.',
+    body: '{actor} withdrew shared content from this session.',
   },
   'agreement.proposed': {
-    title: 'Agreement proposed',
-    body: 'A new agreement has been proposed. Review it together.',
+    title: 'Agreement ready to review',
+    body: '{actor} proposed a new agreement.',
   },
   'agreement.confirmed': {
-    title: 'Agreement ready for review',
-    body: 'Your partner has confirmed. Take a look when you\'re ready.',
+    title: '{actor} confirmed an agreement',
+    body: "Take a look when you're ready.",
   },
   'session.paused': {
     title: 'Session paused',
-    body: 'Your partner needs a moment. The session is paused.',
+    body: '{actor} needs a moment. The session is paused.',
   },
   'session.resumed': {
     title: 'Session resumed',
-    body: 'Your partner is back. Ready to continue?',
+    body: '{actor} is back. Ready to continue?',
   },
   'session.resolved': {
     title: 'Session complete',
     body: 'Your conversation has been resolved.',
   },
   'session.joined': {
-    title: 'Partner joined',
-    body: 'Your partner has joined the session.',
+    title: '{actor} joined',
+    body: 'Open the session to continue together.',
   },
   'session.needs_reveal_ready': {
     title: 'Ready to reveal',
-    body: 'Both partners are ready. Time to share your needs side by side.',
+    body: 'You are both ready to reveal needs side by side.',
   },
   'invitation.declined': {
     title: 'Invitation declined',
-    body: 'Your partner has declined the session invitation.',
+    body: '{actor} has declined the session invitation.',
   },
   'invitation.confirmed': {
     title: 'Invitation confirmed',
-    body: 'Your partner confirmed the invitation message.',
+    body: '{actor} confirmed the invitation message.',
   },
   // Empathy reconciler events
   'partner.empathy_revealed': {
-    title: 'Empathy revealed',
-    body: "Your partner's empathy statement is now visible.",
+    title: '{actorPossessive} empathy is visible',
+    body: 'Open the session to read it.',
   },
   'partner.skipped_refinement': {
-    title: 'Ready to move on',
-    body: 'Your partner has accepted the current understanding.',
+    title: '{actor} accepted the current understanding',
+    body: 'You can move to the next step.',
   },
   'empathy.share_suggestion': {
-    title: 'Share suggestion available',
-    body: 'You can share additional context to help your partner understand you better.',
+    title: 'Help {actor} understand',
+    body: 'You can share a little more context when you are ready.',
   },
   'empathy.context_shared': {
-    title: 'Additional context shared',
-    body: 'Your partner shared additional context to help you understand them better.',
+    title: '{actor} shared more context',
+    body: 'It is your turn to refine your empathy.',
   },
   'empathy.revealed': {
     title: 'Your empathy is revealed',
-    body: 'Your empathy statement has been shared with your partner.',
+    body: 'Your empathy statement has been shared with {actor}.',
   },
   'empathy.refining': {
     title: 'New context to consider',
-    body: 'Your partner shared something to help you understand them better. Time to refine your empathy.',
+    body: '{actor} shared something to help you refine your empathy.',
   },
   'empathy.status_updated': {
-    title: 'Partner update',
-    body: 'Your partner is considering sharing more context.',
+    title: 'Empathy step updated',
+    body: 'Open the session to see what is ready now.',
   },
   'notification.pending_action': {
     title: 'Action needed',
@@ -151,9 +164,111 @@ export const PUSH_MESSAGES: Record<SessionEvent, { title: string; body: string }
   },
   'empathy.resubmitted': {
     title: 'Updated empathy',
-    body: 'Your partner has refined their understanding of your experience.',
+    body: '{actor} refined their understanding of your experience.',
   },
 };
+
+function possessive(name: string): string {
+  if (name === 'They') {
+    return 'Their';
+  }
+  return name.endsWith('s') ? `${name}'` : `${name}'s`;
+}
+
+function getActorUserId(data: Record<string, unknown>): string | null {
+  const candidate =
+    data.triggeredByUserId ??
+    data.signedBy ??
+    data.completedBy ??
+    data.sharedBy ??
+    data.confirmedBy ??
+    data.validatedBy ??
+    data.submittedBy ??
+    data.readyBy ??
+    data.pausedBy ??
+    data.resumedBy ??
+    data.resolvedBy ??
+    data.proposedBy;
+
+  return typeof candidate === 'string' ? candidate : null;
+}
+
+function getStageName(data: Record<string, unknown>): string {
+  switch (data.stage) {
+    case Stage.ONBOARDING:
+      return STAGE_FRIENDLY_NAMES[Stage.ONBOARDING];
+    case Stage.WITNESS:
+      return STAGE_FRIENDLY_NAMES[Stage.WITNESS];
+    case Stage.PERSPECTIVE_STRETCH:
+      return STAGE_FRIENDLY_NAMES[Stage.PERSPECTIVE_STRETCH];
+    case Stage.NEED_MAPPING:
+      return STAGE_FRIENDLY_NAMES[Stage.NEED_MAPPING];
+    case Stage.STRATEGIC_REPAIR:
+      return STAGE_FRIENDLY_NAMES[Stage.STRATEGIC_REPAIR];
+    case Stage.INFORMED_EMPATHY:
+      return STAGE_FRIENDLY_NAMES[Stage.INFORMED_EMPATHY];
+    default:
+      return 'the current step';
+  }
+}
+
+async function getNotificationActorName(
+  recipientUserId: string,
+  sessionId: string,
+  data: Record<string, unknown>,
+): Promise<string> {
+  const actorUserId = getActorUserId(data);
+  if (!actorUserId || actorUserId === recipientUserId) {
+    return 'They';
+  }
+
+  try {
+    const session = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: {
+        relationship: {
+          select: {
+            members: {
+              where: { userId: { in: [recipientUserId, actorUserId] } },
+              select: {
+                userId: true,
+                nickname: true,
+                user: {
+                  select: {
+                    firstName: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const members = session?.relationship.members ?? [];
+    const recipientMember = members.find(member => member.userId === recipientUserId);
+    const actorMember = members.find(member => member.userId === actorUserId);
+
+    return recipientMember?.nickname || actorMember?.user.firstName || actorMember?.user.name || 'They';
+  } catch (error) {
+    logger.warn(`[Push] Failed to resolve notification actor name for session ${sessionId}:`, error);
+    return 'They';
+  }
+}
+
+function renderPushMessage(template: PushMessageTemplate, context: PushMessageContext): PushMessageTemplate {
+  const render = (value: string) =>
+    value
+      .replace(/\{actor\}/g, context.actorName)
+      .replace(/\{actorPossessive\}/g, context.actorNamePossessive)
+      .replace(/\{stageName\}/g, context.stageName);
+
+  return {
+    title: render(template.title),
+    body: render(template.body),
+  };
+}
 
 /**
  * Sends a push notification to a user.
@@ -169,7 +284,7 @@ export async function sendPushNotification(
   userId: string,
   event: SessionEvent,
   data: Record<string, unknown>,
-  sessionId: string
+  sessionId: string,
 ): Promise<boolean> {
   try {
     // Fetch user's push token from database
@@ -190,10 +305,16 @@ export async function sendPushNotification(
     }
 
     // Get message template for this event type
-    const message = PUSH_MESSAGES[event] || {
+    const template = PUSH_MESSAGES[event] || {
       title: 'Meet Without Fear',
       body: 'You have an update',
     };
+    const actorName = await getNotificationActorName(userId, sessionId, data);
+    const message = renderPushMessage(template, {
+      actorName,
+      actorNamePossessive: possessive(actorName),
+      stageName: getStageName(data),
+    });
 
     // Construct the push notification
     const pushMessage: ExpoPushMessage = {
@@ -202,6 +323,7 @@ export async function sendPushNotification(
       title: message.title,
       body: message.body,
       data: {
+        screen: 'session',
         sessionId,
         event,
         ...data,
@@ -223,10 +345,7 @@ export async function sendPushNotification(
         logger.error(`[Push] Failed to send notification to user ${userId}:`, ticket.message);
 
         // If token is invalid, we could clean it up here
-        if (
-          ticket.details?.error === 'DeviceNotRegistered' ||
-          ticket.details?.error === 'InvalidCredentials'
-        ) {
+        if (ticket.details?.error === 'DeviceNotRegistered' || ticket.details?.error === 'InvalidCredentials') {
           logger.info(`[Push] Clearing invalid token for user ${userId}`);
           await prisma.user.update({
             where: { id: userId },
@@ -255,11 +374,9 @@ export async function sendPushNotifications(
   userIds: string[],
   event: SessionEvent,
   data: Record<string, unknown>,
-  sessionId: string
+  sessionId: string,
 ): Promise<number> {
-  const results = await Promise.all(
-    userIds.map((userId) => sendPushNotification(userId, event, data, sessionId))
-  );
+  const results = await Promise.all(userIds.map(userId => sendPushNotification(userId, event, data, sessionId)));
   return results.filter(Boolean).length;
 }
 

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -19,7 +19,8 @@
       "buildNumber": "38",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
-        "NSMicrophoneUsageDescription": "This app needs access to your microphone to record audio sessions."
+        "NSMicrophoneUsageDescription": "This app needs access to your microphone to record audio sessions.",
+        "NSFaceIDUsageDescription": "Meet Without Fear uses Face ID to protect your private sessions."
       },
       "appleTeamId": "446P429C8Q",
       "associatedDomains": [
@@ -79,6 +80,12 @@
           "image": "./assets/images/icon.png",
           "resizeMode": "contain",
           "backgroundColor": "#F7F6F3"
+        }
+      ],
+      [
+        "expo-local-authentication",
+        {
+          "faceIDPermission": "Meet Without Fear uses Face ID to protect your private sessions."
         }
       ]
     ],

--- a/mobile/app/(auth)/_layout.tsx
+++ b/mobile/app/(auth)/_layout.tsx
@@ -5,6 +5,9 @@ import { useUserSessionUpdates } from '@/src/hooks/useRealtime';
 import { isE2EMode } from '@/src/providers/E2EAuthProvider';
 import { useOTAUpdate } from '@/src/hooks/useOTAUpdate';
 import { UpdateBanner } from '@/src/components/UpdateBanner';
+import { useNotifications } from '@/src/hooks/useNotifications';
+import { BiometricLockProvider } from '@/src/contexts/BiometricLockContext';
+import { BiometricLockOverlay } from '@/src/components/BiometricLockOverlay';
 
 /**
  * Auth group layout
@@ -19,6 +22,7 @@ export default function AuthLayout() {
   // This is placed here (not in individual screens) to ensure only ONE Ably connection
   // Skip in E2E mode to avoid token/capability cache issues with the user notification channel
   useUserSessionUpdates({ enabled: !isE2EMode() });
+  useNotifications();
 
   // OTA update banner
   const { showUpdateBanner, applyUpdate, dismissUpdate } = useOTAUpdate();
@@ -35,7 +39,7 @@ export default function AuthLayout() {
 
   // Render the app - backend profile sync happens in useAuth hook
   return (
-    <>
+    <BiometricLockProvider>
       <Stack
         screenOptions={{
           headerShown: false,
@@ -88,6 +92,7 @@ export default function AuthLayout() {
       {showUpdateBanner && (
         <UpdateBanner onApply={applyUpdate} onDismiss={dismissUpdate} />
       )}
-    </>
+      <BiometricLockOverlay />
+    </BiometricLockProvider>
   );
 }

--- a/mobile/app/(auth)/session/new.tsx
+++ b/mobile/app/(auth)/session/new.tsx
@@ -32,8 +32,13 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useCreateSession } from '@/src/hooks/useSessions';
 import { usePeople } from '@/src/hooks/usePerson';
 import { useGenerateContext } from '@/src/hooks/useInnerThoughts';
+import { NotificationPermissionDrawer } from '@/src/components/NotificationPermissionDrawer';
 import { colors } from '@/src/theme';
 import { trackSessionCreated, trackPersonSelected } from '@/src/services/analytics';
+import {
+  getNotificationPermissionStatus,
+  requestAndRegisterForPushNotifications,
+} from '@/src/services/notifications';
 import type { PersonSummaryDTO, GenerateContextResponse } from '@meet-without-fear/shared';
 
 // ============================================================================
@@ -53,6 +58,9 @@ export default function NewSessionScreen() {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [innerThoughtsContext, setInnerThoughtsContext] = useState<GenerateContextResponse | null>(null);
+  const [showNotificationDrawer, setShowNotificationDrawer] = useState(false);
+  const [notificationLoading, setNotificationLoading] = useState(false);
+  const [pendingSubmit, setPendingSubmit] = useState<(() => Promise<void>) | null>(null);
 
   const { data: people = [], isLoading: peopleLoading } = usePeople();
   const { mutateAsync: createSession, isPending } = useCreateSession();
@@ -94,7 +102,7 @@ export default function NewSessionScreen() {
   // Effective mode: if no people exist, treat as 'new' regardless of state
   const effectiveMode = hasPeople ? mode : 'new';
 
-  const handleSubmit = async () => {
+  const createSessionFromForm = async () => {
     // Build optional context and innerThoughtsId for session creation
     const context = innerThoughtsContext?.contextSummary;
     const linkedInnerThoughtsId = innerThoughtsId;
@@ -167,10 +175,49 @@ export default function NewSessionScreen() {
     }
   };
 
+  const handleSubmit = async () => {
+    try {
+      if ((await getNotificationPermissionStatus()) === 'undetermined') {
+        setPendingSubmit(() => createSessionFromForm);
+        setShowNotificationDrawer(true);
+        return;
+      }
+    } catch (error) {
+      console.warn('Failed to check notification permission:', error);
+    }
+
+    await createSessionFromForm();
+  };
+
+  const continueAfterNotificationChoice = async () => {
+    const submit = pendingSubmit;
+    setPendingSubmit(null);
+    setShowNotificationDrawer(false);
+    if (submit) {
+      await submit();
+    }
+  };
+
+  const handleEnableNotifications = async () => {
+    setNotificationLoading(true);
+    try {
+      await requestAndRegisterForPushNotifications();
+    } finally {
+      setNotificationLoading(false);
+    }
+    await continueAfterNotificationChoice();
+  };
+
   const canSubmit = effectiveMode === 'pick' ? !!selectedPerson : !!firstName.trim();
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
+      <NotificationPermissionDrawer
+        visible={showNotificationDrawer}
+        loading={notificationLoading}
+        onEnable={handleEnableNotifications}
+        onSkip={continueAfterNotificationChoice}
+      />
       <KeyboardAvoidingView
         style={styles.keyboardView}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}

--- a/mobile/src/components/BiometricLockOverlay.tsx
+++ b/mobile/src/components/BiometricLockOverlay.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Animated,
+  InteractionManager,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { router } from 'expo-router';
+import { useAuth as useClerkAuth } from '@clerk/clerk-expo';
+import { Lock, LogOut, RefreshCw, ShieldCheck } from 'lucide-react-native';
+
+import { useBiometricLock } from '@/src/contexts/BiometricLockContext';
+import { colors } from '@/src/theme';
+
+type LockState = 'locked' | 'authenticating' | 'failed' | 'unlocked';
+
+export function BiometricLockOverlay() {
+  const { isLocked, biometricName, unlock, shouldAutoTrigger, setShouldAutoTrigger } =
+    useBiometricLock();
+  const { signOut } = useClerkAuth();
+  const [lockState, setLockState] = useState<LockState>('unlocked');
+  const [error, setError] = useState('');
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  const handleBiometricAuth = async () => {
+    setLockState('authenticating');
+    setError('');
+
+    const result = await unlock();
+    if (result.success) {
+      setLockState('unlocked');
+      Animated.timing(fadeAnim, {
+        toValue: 0,
+        duration: 220,
+        useNativeDriver: true,
+      }).start();
+      return;
+    }
+
+    setLockState('failed');
+    setError(`Could not unlock with ${biometricName}. Try again or use your device passcode.`);
+  };
+
+  useEffect(() => {
+    if (isLocked) {
+      setLockState('locked');
+      fadeAnim.setValue(1);
+    } else {
+      setLockState('unlocked');
+      fadeAnim.setValue(0);
+    }
+  }, [fadeAnim, isLocked]);
+
+  useEffect(() => {
+    if (lockState === 'locked' && shouldAutoTrigger) {
+      setShouldAutoTrigger(false);
+      InteractionManager.runAfterInteractions(() => {
+        void handleBiometricAuth();
+      });
+    }
+  }, [lockState, shouldAutoTrigger, setShouldAutoTrigger]);
+
+  const handleSignOut = async () => {
+    await signOut();
+    setLockState('unlocked');
+    router.replace('/(public)');
+  };
+
+  if (!isLocked && lockState === 'unlocked') {
+    return null;
+  }
+
+  const isBusy = lockState === 'authenticating';
+  const isFailed = lockState === 'failed';
+
+  return (
+    <Animated.View
+      style={[styles.overlay, { opacity: fadeAnim }]}
+      pointerEvents={isLocked ? 'auto' : 'none'}
+    >
+      <View style={styles.content}>
+        <View style={styles.mark}>
+          {isFailed ? (
+            <Lock size={52} color={colors.brandOrange} strokeWidth={1.6} />
+          ) : (
+            <ShieldCheck size={58} color={colors.brandBlue} strokeWidth={1.5} />
+          )}
+        </View>
+
+        <Text style={styles.title}>
+          {isFailed ? 'Authentication failed' : 'Meet Without Fear is locked'}
+        </Text>
+        <Text style={styles.subtitle}>
+          {isFailed
+            ? error
+            : `Use ${biometricName} or your device passcode to continue.`}
+        </Text>
+
+        {isBusy ? (
+          <View style={styles.loadingRow}>
+            <ActivityIndicator color={colors.textPrimary} />
+            <Text style={styles.loadingText}>Authenticating...</Text>
+          </View>
+        ) : (
+          <TouchableOpacity
+            style={styles.primaryButton}
+            onPress={handleBiometricAuth}
+            accessibilityRole="button"
+          >
+            <RefreshCw size={18} color={colors.textOnAccent} />
+            <Text style={styles.primaryButtonText}>
+              {isFailed ? `Try ${biometricName} again` : `Unlock with ${biometricName}`}
+            </Text>
+          </TouchableOpacity>
+        )}
+
+        {isFailed && (
+          <TouchableOpacity
+            style={styles.signOutButton}
+            onPress={handleSignOut}
+            accessibilityRole="button"
+          >
+            <LogOut size={17} color={colors.error} />
+            <Text style={styles.signOutText}>Sign out</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </Animated.View>
+  );
+}
+
+export default BiometricLockOverlay;
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 9999,
+    elevation: 9999,
+    backgroundColor: colors.bgPage,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  content: {
+    width: '100%',
+    maxWidth: 380,
+    alignItems: 'center',
+  },
+  mark: {
+    width: 118,
+    height: 118,
+    borderRadius: 30,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bgPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 28,
+  },
+  title: {
+    color: colors.textPrimary,
+    fontSize: 28,
+    lineHeight: 34,
+    fontWeight: '800',
+    textAlign: 'center',
+    letterSpacing: 0,
+    marginBottom: 10,
+  },
+  subtitle: {
+    color: colors.textSecondary,
+    fontSize: 16,
+    lineHeight: 23,
+    textAlign: 'center',
+    marginBottom: 28,
+  },
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    height: 52,
+  },
+  loadingText: {
+    color: colors.textSecondary,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  primaryButton: {
+    height: 52,
+    borderRadius: 8,
+    backgroundColor: colors.brandOrange,
+    paddingHorizontal: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    alignSelf: 'stretch',
+  },
+  primaryButtonText: {
+    color: colors.textOnAccent,
+    fontSize: 16,
+    fontWeight: '800',
+  },
+  signOutButton: {
+    marginTop: 16,
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  signOutText: {
+    color: colors.error,
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/mobile/src/components/NotificationPermissionDrawer.tsx
+++ b/mobile/src/components/NotificationPermissionDrawer.tsx
@@ -1,0 +1,215 @@
+import {
+  ActivityIndicator,
+  Modal,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Bell, BellRing, Clock, X } from 'lucide-react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { colors } from '@/src/theme';
+
+interface NotificationPermissionDrawerProps {
+  visible: boolean;
+  loading?: boolean;
+  onEnable: () => void;
+  onSkip: () => void;
+}
+
+export function NotificationPermissionDrawer({
+  visible,
+  loading = false,
+  onEnable,
+  onSkip,
+}: NotificationPermissionDrawerProps) {
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="fullScreen">
+      <SafeAreaView style={styles.container}>
+        <View style={styles.topBar}>
+          <TouchableOpacity
+            style={styles.closeButton}
+            onPress={onSkip}
+            disabled={loading}
+            accessibilityRole="button"
+            accessibilityLabel="Not now"
+          >
+            <X size={22} color={colors.textSecondary} />
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.content}>
+          <View style={styles.iconFrame}>
+            <BellRing size={44} color={colors.brandOrange} />
+          </View>
+
+          <Text style={styles.eyebrow}>Session timing</Text>
+          <Text style={styles.title}>Know when it is your turn again</Text>
+          <Text style={styles.body}>
+            Sometimes this process includes waiting for the other person. A notification can let you know when it is your turn to engage again.
+          </Text>
+
+          <View style={styles.preview}>
+            <View style={styles.previewIcon}>
+              <Bell size={18} color={colors.brandBlue} />
+            </View>
+            <View style={styles.previewText}>
+              <Text style={styles.previewTitle}>Your partner is ready</Text>
+              <Text style={styles.previewBody}>Open the session when you are ready.</Text>
+            </View>
+            <Clock size={18} color={colors.textMuted} />
+          </View>
+        </View>
+
+        <View style={styles.actions}>
+          <TouchableOpacity
+            style={[styles.primaryButton, loading && styles.disabledButton]}
+            onPress={onEnable}
+            disabled={loading}
+            accessibilityRole="button"
+          >
+            {loading ? (
+              <ActivityIndicator color={colors.textOnAccent} />
+            ) : (
+              <>
+                <Bell size={18} color={colors.textOnAccent} />
+                <Text style={styles.primaryButtonText}>Turn on notifications</Text>
+              </>
+            )}
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.secondaryButton}
+            onPress={onSkip}
+            disabled={loading}
+            accessibilityRole="button"
+          >
+            <Text style={styles.secondaryButtonText}>Not now</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgPage,
+  },
+  topBar: {
+    alignItems: 'flex-end',
+    paddingHorizontal: 20,
+    paddingTop: 10,
+  },
+  closeButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: colors.bgSecondary,
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 28,
+  },
+  iconFrame: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 88,
+    height: 88,
+    borderRadius: 24,
+    backgroundColor: colors.bgSecondary,
+    borderWidth: 1,
+    borderColor: colors.border,
+    marginBottom: 28,
+  },
+  eyebrow: {
+    color: colors.brandBlue,
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0,
+    marginBottom: 10,
+  },
+  title: {
+    color: colors.textPrimary,
+    fontSize: 34,
+    lineHeight: 39,
+    fontWeight: '800',
+    letterSpacing: 0,
+    marginBottom: 16,
+  },
+  body: {
+    color: colors.textSecondary,
+    fontSize: 17,
+    lineHeight: 25,
+    marginBottom: 28,
+  },
+  preview: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: colors.bgPrimary,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  previewIcon: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: colors.bgSecondary,
+  },
+  previewText: {
+    flex: 1,
+  },
+  previewTitle: {
+    color: colors.textPrimary,
+    fontSize: 15,
+    fontWeight: '700',
+    marginBottom: 3,
+  },
+  previewBody: {
+    color: colors.textSecondary,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  actions: {
+    paddingHorizontal: 20,
+    paddingBottom: 24,
+    gap: 12,
+  },
+  primaryButton: {
+    height: 54,
+    borderRadius: 8,
+    backgroundColor: colors.brandOrange,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: 10,
+  },
+  disabledButton: {
+    opacity: 0.7,
+  },
+  primaryButtonText: {
+    color: colors.textOnAccent,
+    fontSize: 16,
+    fontWeight: '800',
+  },
+  secondaryButton: {
+    height: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryButtonText: {
+    color: colors.textSecondary,
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/mobile/src/components/PartnerInfoDrawer.tsx
+++ b/mobile/src/components/PartnerInfoDrawer.tsx
@@ -1,0 +1,209 @@
+import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { X } from 'lucide-react-native';
+
+import { colors } from '@/src/theme';
+
+interface PartnerInfoDrawerProps {
+  visible: boolean;
+  name: string;
+  isOnline: boolean;
+  lastSeenAt?: string | null;
+  stageDescription: string;
+  topic?: string | null;
+  onClose: () => void;
+}
+
+function formatTimeAgo(value?: string | null): string | null {
+  if (!value) return null;
+
+  const then = new Date(value).getTime();
+  if (Number.isNaN(then)) return null;
+
+  const diffMs = Math.max(0, Date.now() - then);
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes === 1) return '1 minute ago';
+  if (diffMinutes < 60) return `${diffMinutes} minutes ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours === 1) return '1 hour ago';
+  if (diffHours < 24) return `${diffHours} hours ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays === 1) return '1 day ago';
+  if (diffDays < 30) return `${diffDays} days ago`;
+
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths === 1) return '1 month ago';
+  if (diffMonths < 12) return `${diffMonths} months ago`;
+
+  const diffYears = Math.floor(diffDays / 365);
+  return diffYears === 1 ? '1 year ago' : `${diffYears} years ago`;
+}
+
+export function PartnerInfoDrawer({
+  visible,
+  name,
+  isOnline,
+  lastSeenAt,
+  stageDescription,
+  topic,
+  onClose,
+}: PartnerInfoDrawerProps) {
+  const lastSeenText = formatTimeAgo(lastSeenAt);
+  const statusText = isOnline ? 'Online now' : lastSeenText ? `Last seen ${lastSeenText}` : 'Not online right now';
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <TouchableOpacity
+          style={styles.backdropPressable}
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close person details"
+        />
+        <SafeAreaView style={styles.drawer} edges={['bottom']}>
+          <View style={styles.handle} />
+          <View style={styles.header}>
+            <View style={styles.titleBlock}>
+              <Text style={styles.name} numberOfLines={1}>
+                {name}
+              </Text>
+              <View style={styles.statusRow}>
+                <View style={[styles.statusDot, isOnline && styles.statusDotOnline]} />
+                <Text style={[styles.statusText, isOnline && styles.statusTextOnline]}>{statusText}</Text>
+              </View>
+            </View>
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close person details"
+            >
+              <X size={20} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.bodyText}>{stageDescription}</Text>
+          </View>
+
+          {topic ? (
+            <View style={styles.topicBox}>
+              <Text style={styles.topicLabel}>Conversation topic</Text>
+              <Text style={styles.topicText}>{topic}</Text>
+            </View>
+          ) : null}
+        </SafeAreaView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(2, 6, 23, 0.62)',
+  },
+  backdropPressable: {
+    flex: 1,
+  },
+  drawer: {
+    backgroundColor: colors.bgPrimary,
+    borderTopLeftRadius: 18,
+    borderTopRightRadius: 18,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    borderColor: colors.border,
+    paddingHorizontal: 20,
+    paddingBottom: 18,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 42,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.bgTertiary,
+    marginTop: 10,
+    marginBottom: 18,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 14,
+  },
+  titleBlock: {
+    flex: 1,
+  },
+  name: {
+    color: colors.textPrimary,
+    fontSize: 26,
+    lineHeight: 31,
+    fontWeight: '800',
+    letterSpacing: 0,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 7,
+    marginTop: 8,
+  },
+  statusDot: {
+    width: 9,
+    height: 9,
+    borderRadius: 4.5,
+    backgroundColor: colors.textMuted,
+  },
+  statusDotOnline: {
+    backgroundColor: colors.success,
+  },
+  statusText: {
+    color: colors.textSecondary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  statusTextOnline: {
+    color: colors.success,
+  },
+  closeButton: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgSecondary,
+  },
+  section: {
+    marginTop: 24,
+  },
+  bodyText: {
+    color: colors.textPrimary,
+    fontSize: 17,
+    lineHeight: 25,
+  },
+  topicBox: {
+    marginTop: 22,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bgSecondary,
+    padding: 16,
+  },
+  topicLabel: {
+    color: colors.brandBlue,
+    fontSize: 12,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0,
+    marginBottom: 8,
+  },
+  topicText: {
+    color: colors.textPrimary,
+    fontSize: 16,
+    lineHeight: 23,
+  },
+});
+
+export default PartnerInfoDrawer;

--- a/mobile/src/components/SessionChatHeader.tsx
+++ b/mobile/src/components/SessionChatHeader.tsx
@@ -122,13 +122,16 @@ export function SessionChatHeader({
   // Center content - always partner name + status (whether tabs or not)
   const centerContent = (
     <View style={styles.centerSection}>
-      <Text
-        style={styles.partnerName}
-        numberOfLines={1}
-        testID={`${testID}-partner-name`}
-      >
-        {displayName}
-      </Text>
+      <View style={styles.nameRow}>
+        {!hideOnlineStatus && <StatusDot isOnline={isOnline} />}
+        <Text
+          style={styles.partnerName}
+          numberOfLines={1}
+          testID={`${testID}-partner-name`}
+        >
+          {displayName}
+        </Text>
+      </View>
       {stageName ? (
         <Text
           style={styles.stageNameText}
@@ -302,6 +305,15 @@ const useStyles = () =>
       fontWeight: '600',
       color: t.colors.textPrimary,
       textAlign: 'center',
+      flexShrink: 1,
+      minWidth: 0,
+    },
+    nameRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 7,
+      maxWidth: '100%',
     },
     statusRow: {
       flexDirection: 'row',

--- a/mobile/src/contexts/BiometricLockContext.tsx
+++ b/mobile/src/contexts/BiometricLockContext.tsx
@@ -1,0 +1,132 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+import { useAuth as useClerkAuth } from '@clerk/clerk-expo';
+
+import { useBiometricAuth } from '@/src/hooks/useBiometricAuth';
+
+interface BiometricLockContextValue {
+  isLocked: boolean;
+  biometricName: string;
+  shouldAutoTrigger: boolean;
+  setShouldAutoTrigger: (value: boolean) => void;
+  unlock: () => Promise<{ success: boolean; error?: string }>;
+}
+
+const BiometricLockContext = createContext<BiometricLockContextValue | undefined>(undefined);
+
+const BACKGROUND_TIMEOUT_MS = 5000;
+
+export function BiometricLockProvider({ children }: { children: ReactNode }) {
+  const { isSignedIn } = useClerkAuth();
+  const {
+    isAvailable,
+    isEnrolled,
+    isEnabled,
+    isLoading,
+    biometricName,
+    authenticate,
+  } = useBiometricAuth();
+  const [isLocked, setIsLocked] = useState(false);
+  const [shouldAutoTrigger, setShouldAutoTrigger] = useState(false);
+  const appState = useRef(AppState.currentState);
+  const lastBackgroundTime = useRef<number | null>(null);
+
+  const shouldLock = Boolean(isSignedIn && isAvailable && isEnrolled && isEnabled && !isLoading);
+
+  const unlock = useCallback(async () => {
+    const success = await authenticate(`Unlock Meet Without Fear`);
+    if (success) {
+      setIsLocked(false);
+      return { success: true };
+    }
+
+    return { success: false, error: 'authentication_failed' };
+  }, [authenticate]);
+
+  const checkLockOnForeground = useCallback(async () => {
+    if (!shouldLock) {
+      setIsLocked(false);
+      setShouldAutoTrigger(false);
+      return;
+    }
+
+    if (lastBackgroundTime.current) {
+      const timeAway = Date.now() - lastBackgroundTime.current;
+      if (timeAway < BACKGROUND_TIMEOUT_MS) {
+        setIsLocked(false);
+        setShouldAutoTrigger(false);
+        return;
+      }
+    }
+
+    setIsLocked(true);
+    setShouldAutoTrigger(true);
+  }, [shouldLock]);
+
+  useEffect(() => {
+    if (!shouldLock) {
+      setIsLocked(false);
+      setShouldAutoTrigger(false);
+    }
+  }, [shouldLock]);
+
+  useEffect(() => {
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      const previousState = appState.current;
+      appState.current = nextAppState;
+
+      if (
+        previousState === 'active' &&
+        (nextAppState === 'inactive' || nextAppState === 'background')
+      ) {
+        lastBackgroundTime.current = Date.now();
+        if (shouldLock) {
+          setIsLocked(true);
+          setShouldAutoTrigger(false);
+        }
+      }
+
+      if (
+        (previousState === 'inactive' || previousState === 'background') &&
+        nextAppState === 'active'
+      ) {
+        void checkLockOnForeground();
+      }
+    };
+
+    const subscription = AppState.addEventListener('change', handleAppStateChange);
+    return () => {
+      subscription.remove();
+    };
+  }, [checkLockOnForeground, shouldLock]);
+
+  return (
+    <BiometricLockContext.Provider
+      value={{
+        isLocked,
+        biometricName: biometricName ?? 'Biometrics',
+        shouldAutoTrigger,
+        setShouldAutoTrigger,
+        unlock,
+      }}
+    >
+      {children}
+    </BiometricLockContext.Provider>
+  );
+}
+
+export function useBiometricLock() {
+  const context = useContext(BiometricLockContext);
+  if (!context) {
+    throw new Error('useBiometricLock must be used within BiometricLockProvider');
+  }
+  return context;
+}

--- a/mobile/src/contexts/BiometricLockContext.web.tsx
+++ b/mobile/src/contexts/BiometricLockContext.web.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+interface BiometricLockContextValue {
+  isLocked: boolean;
+  biometricName: string;
+  shouldAutoTrigger: boolean;
+  setShouldAutoTrigger: (value: boolean) => void;
+  unlock: () => Promise<{ success: boolean; error?: string }>;
+}
+
+const BiometricLockContext = createContext<BiometricLockContextValue | undefined>(undefined);
+
+export function BiometricLockProvider({ children }: { children: ReactNode }) {
+  return (
+    <BiometricLockContext.Provider
+      value={{
+        isLocked: false,
+        biometricName: 'Biometrics',
+        shouldAutoTrigger: false,
+        setShouldAutoTrigger: () => {},
+        unlock: async () => ({ success: false }),
+      }}
+    >
+      {children}
+    </BiometricLockContext.Provider>
+  );
+}
+
+export function useBiometricLock() {
+  const context = useContext(BiometricLockContext);
+  if (!context) {
+    throw new Error('useBiometricLock must be used within BiometricLockProvider');
+  }
+  return context;
+}

--- a/mobile/src/hooks/useNotifications.ts
+++ b/mobile/src/hooks/useNotifications.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect } from 'react';
+import * as Notifications from 'expo-notifications';
+import { router } from 'expo-router';
+
+import {
+  getNotificationPermissionStatus,
+  registerForPushNotifications,
+  requestAndRegisterForPushNotifications,
+} from '@/src/services/notifications';
+
+export function useNotifications() {
+  useEffect(() => {
+    let cancelled = false;
+
+    getNotificationPermissionStatus()
+      .then((status) => {
+        if (cancelled || status !== 'granted') {
+          return;
+        }
+        return registerForPushNotifications();
+      })
+      .catch((error) => {
+        console.warn('[notifications] Failed to register existing push permission:', error);
+      });
+
+    const responseSubscription = Notifications.addNotificationResponseReceivedListener((response) => {
+      const data = response.notification.request.content.data as
+        | Record<string, unknown>
+        | undefined;
+
+      const sessionId = typeof data?.sessionId === 'string' ? data.sessionId : undefined;
+      const screen = typeof data?.screen === 'string' ? data.screen : undefined;
+
+      if (sessionId) {
+        router.push(`/session/${sessionId}`);
+      } else if (screen === 'home') {
+        router.push('/(auth)/(tabs)');
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      responseSubscription.remove();
+    };
+  }, []);
+
+  const shouldAskForSessionNotifications = useCallback(async () => {
+    const status = await getNotificationPermissionStatus();
+    return status === 'undetermined';
+  }, []);
+
+  const requestSessionNotifications = useCallback(async () => {
+    try {
+      return await requestAndRegisterForPushNotifications();
+    } catch (error) {
+      console.warn('[notifications] Failed to request push notifications:', error);
+      return false;
+    }
+  }, []);
+
+  return {
+    shouldAskForSessionNotifications,
+    requestSessionNotifications,
+  };
+}

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -54,6 +54,7 @@ import { ViewEmpathyStatementDrawer } from '../components/ViewEmpathyStatementDr
 import { MemorySuggestionCard } from '../components/MemorySuggestionCard';
 // SegmentedControl removed - tabs are now integrated in SessionChatHeader
 import { ActivityDrawer } from '../components/ActivityDrawer';
+import { PartnerInfoDrawer } from '../components/PartnerInfoDrawer';
 import { NeedsDrawer, NeedsDrawerMode } from '../components/NeedsDrawer';
 import { RefinementModalScreen } from './RefinementModalScreen';
 import { GuidedDraftChatModal } from '../components/GuidedDraftChatModal';
@@ -151,6 +152,45 @@ const STAGE_FRIENDLY_NAMES: Record<number, string> = {
   [Stage.STRATEGIC_REPAIR]: 'What Comes Next',
   [Stage.INFORMED_EMPATHY]: 'Deeper Understanding',
 };
+
+function getPartnerStageDescription(
+  name: string,
+  progress: { stage?: number; status?: string } | null | undefined,
+  sessionStatus?: SessionStatus
+): string {
+  if (sessionStatus === SessionStatus.RESOLVED) {
+    return `${name} has completed this session with you.`;
+  }
+
+  const stageName = progress?.stage !== undefined
+    ? STAGE_FRIENDLY_NAMES[progress.stage]
+    : 'this step';
+
+  if (progress?.status === 'COMPLETED' || progress?.status === 'GATE_PENDING') {
+    return `${name} has finished ${stageName}.`;
+  }
+
+  if (progress?.status === 'NOT_STARTED') {
+    return `${name} is ready to begin ${stageName} when they are.`;
+  }
+
+  switch (progress?.stage) {
+    case Stage.ONBOARDING:
+      return `${name} is now getting ready to begin the session.`;
+    case Stage.WITNESS:
+      return `${name} is now sharing their story.`;
+    case Stage.PERSPECTIVE_STRETCH:
+      return `${name} is now working to understand your experience more clearly.`;
+    case Stage.NEED_MAPPING:
+      return `${name} is now exploring what matters most to them.`;
+    case Stage.STRATEGIC_REPAIR:
+      return `${name} is now considering what could come next.`;
+    case Stage.INFORMED_EMPATHY:
+      return `${name} is now working through deeper understanding.`;
+    default:
+      return `${name} is moving through the session with you.`;
+  }
+}
 
 /** Stages that should NOT generate chapter markers */
 const SUPPRESSED_CHAPTER_STAGES = new Set([Stage.ONBOARDING, Stage.INFORMED_EMPATHY]);
@@ -1187,6 +1227,7 @@ export function UnifiedSessionScreen({
   // Activity Menu Modal
   // -------------------------------------------------------------------------
   const [showActivityMenu, setShowActivityMenu] = useState(false);
+  const [showPartnerInfo, setShowPartnerInfo] = useState(false);
   const topicFrame = invitation && 'topicFrame' in invitation
     ? (invitation.topicFrame as string | null)
     : null;
@@ -1200,6 +1241,24 @@ export function UnifiedSessionScreen({
   // for the current proposed value. As soon as the AI emits a new <draft>
   // (topicFrame changes), the latch resets and the panel reappears.
   const topicProposalDismissed = false;
+  const partnerInfoName = partnerName || 'Meet Without Fear';
+  const partnerStageDescription = getPartnerStageDescription(
+    partnerInfoName,
+    partnerProgress,
+    session?.status
+  );
+  const partnerLastViewedAt = (session as { partnerLastViewedAt?: string | null } | undefined)?.partnerLastViewedAt ?? null;
+  const partnerInfoDrawer = (
+    <PartnerInfoDrawer
+      visible={showPartnerInfo}
+      name={partnerInfoName}
+      isOnline={partnerOnline}
+      lastSeenAt={partnerLastViewedAt}
+      stageDescription={partnerStageDescription}
+      topic={topicFrame}
+      onClose={() => setShowPartnerInfo(false)}
+    />
+  );
 
   const { mutate: confirmTopicFrame, isPending: isConfirmingTopicFrame } = useConfirmTopicFrame({
     onError: (error) => {
@@ -3022,9 +3081,11 @@ export function UnifiedSessionScreen({
             connectionStatus={connectionStatus}
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
             onBackPress={onNavigateBack}
+            onPress={() => setShowPartnerInfo(true)}
             stageName="Closed"
             testID="session-chat-header"
           />
+          {partnerInfoDrawer}
           <View style={styles.content}>
             <Stage4RedesignPanel
               state={stage4State}
@@ -3056,9 +3117,11 @@ export function UnifiedSessionScreen({
           connectionStatus={connectionStatus}
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
           onBackPress={onNavigateBack}
+          onPress={() => setShowPartnerInfo(true)}
           stageName="Closed"
           testID="session-chat-header"
         />
+        {partnerInfoDrawer}
         <SessionCompletionScreen
           partnerName={partnerName}
           agreements={agreements.map((a) => ({
@@ -3093,9 +3156,11 @@ export function UnifiedSessionScreen({
             connectionStatus={connectionStatus}
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
             onBackPress={onNavigateBack}
+            onPress={() => setShowPartnerInfo(true)}
             stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
             testID="session-chat-header"
           />
+          {partnerInfoDrawer}
           <AgreementCard
             agreement={{
               experiment: unconfirmedAgreement.description,
@@ -3128,9 +3193,11 @@ export function UnifiedSessionScreen({
             connectionStatus={connectionStatus}
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
             onBackPress={onNavigateBack}
+            onPress={() => setShowPartnerInfo(true)}
             stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
             testID="session-chat-header"
           />
+          {partnerInfoDrawer}
           <WaitingRoom
             message={`You've proposed the agreement. Waiting for ${partnerName || 'your partner'} to confirm.`}
             partnerName={partnerName || undefined}
@@ -3157,9 +3224,11 @@ export function UnifiedSessionScreen({
           connectionStatus={connectionStatus}
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
           onBackPress={onNavigateBack}
+          onPress={() => setShowPartnerInfo(true)}
           stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
           testID="session-chat-header"
         />
+        {partnerInfoDrawer}
         <StrategyRanking
           strategies={strategies.map((s) => ({
             id: s.id,
@@ -3192,9 +3261,11 @@ export function UnifiedSessionScreen({
           connectionStatus={connectionStatus}
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
           onBackPress={onNavigateBack}
+          onPress={() => setShowPartnerInfo(true)}
           stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
           testID="session-chat-header"
         />
+        {partnerInfoDrawer}
         {waitingForRankingReveal ? (
           <WaitingRoom
             message="Waiting for your partner to submit their ranking"
@@ -3251,9 +3322,11 @@ export function UnifiedSessionScreen({
               }
             : undefined
         }
+        onPress={() => setShowPartnerInfo(true)}
         stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
         testID="session-chat-header"
       />
+      {partnerInfoDrawer}
       {/* Chat content - Share is now a separate route */}
       {(
       <View style={styles.content}>

--- a/mobile/src/services/notifications.ts
+++ b/mobile/src/services/notifications.ts
@@ -1,0 +1,85 @@
+import { Platform } from 'react-native';
+import Constants from 'expo-constants';
+import * as Device from 'expo-device';
+import * as Notifications from 'expo-notifications';
+
+import { post } from '@/src/lib/api';
+import type { UpdatePushTokenRequest, UpdatePushTokenResponse } from '@meet-without-fear/shared';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: true,
+    shouldShowBanner: true,
+    shouldShowList: true,
+  }),
+});
+
+export type NotificationPermissionStatus = Notifications.PermissionStatus | 'unavailable';
+
+export function canUsePushNotifications(): boolean {
+  return Platform.OS === 'ios' || Platform.OS === 'android';
+}
+
+export async function getNotificationPermissionStatus(): Promise<NotificationPermissionStatus> {
+  if (!canUsePushNotifications() || !Device.isDevice) {
+    return 'unavailable';
+  }
+
+  const permission = await Notifications.getPermissionsAsync();
+  return permission.status;
+}
+
+export async function requestNotificationPermission(): Promise<boolean> {
+  if (!canUsePushNotifications() || !Device.isDevice) {
+    return false;
+  }
+
+  const { status } = await Notifications.requestPermissionsAsync();
+  return status === 'granted';
+}
+
+export async function registerForPushNotifications(): Promise<boolean> {
+  if (!canUsePushNotifications() || !Device.isDevice) {
+    return false;
+  }
+
+  const permission = await Notifications.getPermissionsAsync();
+  if (permission.status !== 'granted') {
+    return false;
+  }
+
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('default', {
+      name: 'default',
+      importance: Notifications.AndroidImportance.MAX,
+    });
+  }
+
+  const projectId =
+    Constants.expoConfig?.extra?.eas?.projectId ??
+    Constants.easConfig?.projectId;
+
+  const token = await Notifications.getExpoPushTokenAsync({ projectId });
+  const platform = Platform.OS === 'android' ? 'android' : 'ios';
+
+  const response = await post<UpdatePushTokenResponse, UpdatePushTokenRequest>(
+    '/auth/push-token',
+    {
+      pushToken: token.data,
+      platform,
+    }
+  );
+
+  return response.registered;
+}
+
+export async function requestAndRegisterForPushNotifications(): Promise<boolean> {
+  const granted = await requestNotificationPermission();
+  if (!granted) {
+    return false;
+  }
+
+  return registerForPushNotifications();
+}

--- a/shared/src/dto/session-state.ts
+++ b/shared/src/dto/session-state.ts
@@ -42,6 +42,8 @@ export interface SessionStateResponse {
     resolvedAt: string | null;
     // When the user last viewed this session (for cross-device animation/read boundaries)
     lastViewedAt: string | null;
+    // When the other person last viewed this session (for presence details)
+    partnerLastViewedAt: string | null;
     // ID of last chat item seen (for "new messages" line placement)
     lastSeenChatItemId: string | null;
   };


### PR DESCRIPTION
## Summary
- wire Expo push notification registration and notification tap routing in the authenticated mobile app
- ask for notification permission with a full-screen drawer before starting a session when permission is still undecided
- personalize push notification copy with the recipient's nickname for the other person, avoid “partner” wording in notification text, and make each notification clearer about what changed
- add a global biometric privacy shield for signed-in users who enabled biometrics, plus Face ID usage config
- restore the online presence dot beside the session header name while preserving the current stage subtitle
- add a tap target on the session header name that opens a person details drawer with online/last-seen status, plain-English stage context, and the conversation topic

## Notes
- Most notification and biometric overlay behavior is OTA-able JS. The new Face ID usage string / expo-local-authentication config in app.json requires a native build to be guaranteed in iOS metadata.
- Existing unrelated dirty files were not included: .claude/scheduled_tasks.lock and slam-bot-midstream-parity-goal.md.

## Validation
- mobile: npm run check
- mobile: targeted eslint on changed session drawer/header files
- shared: npm run check
- backend: npm run check
- backend: npx eslint src/services/push.ts src/controllers/session-state.ts --quiet
- backend: npm test -- --runTestsByPath src/services/__tests__/push.test.ts --runInBand
