### PR TITLE
Fix failed message text disappearing from input on send error

### DIFF
--- a/mobile/src/components/ChatInput.tsx
+++ b/mobile/src/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { View, TextInput, TouchableOpacity, Text, Platform, type TextInput as TextInputType } from 'react-native';
 import { Send, Mic } from 'lucide-react-native';
 import { createStyles } from '../theme/styled';
@@ -16,6 +16,8 @@ interface ChatInputProps {
   showCharacterCount?: boolean;
   /** Optional voice press handler -- when provided, renders a mic button */
   onVoicePress?: () => void;
+  /** Content of a failed message to restore to the input field */
+  failedMessage?: string | null;
 }
 
 // ============================================================================
@@ -36,12 +38,21 @@ export function ChatInput({
   maxLength = DEFAULT_MAX_LENGTH,
   showCharacterCount = false,
   onVoicePress,
+  failedMessage,
 }: ChatInputProps) {
   const styles = useStyles();
   const [input, setInput] = useState('');
   const inputRef = useRef<TextInputType>(null);
   // Flag to ignore onChangeText events right after sending (prevents autocorrect race condition)
   const justSentRef = useRef(false);
+
+  // Restore text from a failed send attempt
+  useEffect(() => {
+    if (failedMessage && input.length === 0) {
+      justSentRef.current = false;
+      setInput(failedMessage);
+    }
+  }, [failedMessage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const canSend = input.trim().length > 0 && !disabled;
   const characterRatio = input.length / maxLength;

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -153,6 +153,8 @@ interface ChatInterfaceProps {
   partnerName?: string;
   /** Optional voice press handler -- passed through to ChatInput; renders mic button when provided */
   onVoicePress?: () => void;
+  /** Content of a failed message to restore to the input field */
+  failedMessage?: string | null;
   /** ID of the last chat item the user has seen - used to show "New messages" separator */
   lastSeenChatItemId?: string | null;
   /** Server-backed timestamp from before this screen marked the session viewed. */
@@ -231,6 +233,7 @@ export function ChatInterface({
   onValidateAccurate,
   onValidateNotQuite,
   onVoicePress,
+  failedMessage,
 }: ChatInterfaceProps) {
   const styles = useStyles();
   const flatListRef = useRef<FlatList<ChatListItem>>(null);
@@ -867,6 +870,7 @@ export function ChatInterface({
             onSend={onSendMessage}
             disabled={disabled || isInputDisabled || isLoading}
             onVoicePress={onVoicePress}
+            failedMessage={failedMessage}
           />
         )}
         {renderAboveInput?.()}

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -94,6 +94,8 @@ export interface UseStreamingMessageResult {
   cancel: () => void;
   /** Error message if status is 'error' */
   errorMessage: string | null;
+  /** The content of the last failed message (for restoring to the input field) */
+  failedMessageContent: string | null;
   /** Retry the last failed message */
   retry: () => void;
 }
@@ -893,6 +895,8 @@ export function useStreamingMessage(
     }
   }, [sendMessage]);
 
+  const failedMessageContent = status === 'error' ? lastParamsRef.current?.content ?? null : null;
+
   return {
     status,
     isStreaming: status === 'streaming',
@@ -900,6 +904,7 @@ export function useStreamingMessage(
     sendMessage,
     cancel,
     errorMessage,
+    failedMessageContent,
     retry,
   };
 }

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -421,6 +421,7 @@ export function useUnifiedSession(
     sendMessage: streamingSendMessage,
     isSending,
     isStreaming,
+    failedMessageContent,
   } = useStreamingMessage({
     onMetadata: handleStreamMetadata,
     onError: handleStreamError,
@@ -1210,6 +1211,7 @@ export function useUnifiedSession(
     inlineCards,
     isSending,
     isStreaming,
+    failedMessageContent,
     isSigningCompact,
     isConfirmingFeelHeard,
     isConfirmingInvitation,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -534,6 +534,7 @@ export function UnifiedSessionScreen({
     messages,
     inlineCards,
     isSending,
+    failedMessageContent,
     isSigningCompact,
     isConfirmingFeelHeard,
     isConfirmingInvitation,
@@ -3335,6 +3336,7 @@ export function UnifiedSessionScreen({
           messages={displayMessages}
           indicators={indicators}
           onSendMessage={sendMessageWithTracking}
+          failedMessage={failedMessageContent}
           // Cache-First: Ghost dots are derived from last message role in ChatInterface
           // isSending is still needed for brief moment during API call before optimistic message appears
           // isFetchingInitialMessage shows dots while fetching first AI message


### PR DESCRIPTION
## Changes
- Fix: Restore user's typed text to the input field when a message send fails (e.g., offline/network error)
- Add: `failedMessageContent` field to `useStreamingMessage` return value, derived from existing `lastParamsRef` when status is `'error'`
- Thread: `failedMessage` prop through `useUnifiedSession` → `UnifiedSessionScreen` → `ChatInterface` → `ChatInput`
- Add: `useEffect` in `ChatInput` that restores text when `failedMessage` transitions to a non-null value (only if input is currently empty)

Related to #463

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "I was out of service for a moment and when I tried to send a message, I got a good error message but the message disappeared. This is bad. It should either put the text back into the input for me (easiest) or have an indicator that it was not sent and a button to retry."

## Docs updated
No doc changes needed — bug fix in existing components with no doc mappings.