### PR TITLE
Fix AI messages re-animating after streaming completes

### DIFF
--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -20,6 +20,7 @@ import { ChatIndicator, ChatIndicatorType } from './ChatIndicator';
 import { EmpathyValidationCard } from './EmpathyValidationCard';
 import { createStyles } from '../theme/styled';
 import { useSpeech, useAutoSpeech } from '../hooks/useSpeech';
+import { isPreRegisteredAnimatedId } from '../utils/animationBridge';
 
 // ============================================================================
 // Types
@@ -461,6 +462,7 @@ export function ChatInterface({
     if (isIndicator(item) || isValidationCard(item) || isCustomEmptyState(item)) return false;
     if (animatedItemIdsRef.current.has(item.id)) return false;
     if (seenAnimatedItemIdsRef.current.has(item.id)) return false;
+    if (isPreRegisteredAnimatedId(item.id)) return false;
     if (isAtOrBeforeSeenBoundary(item, index)) return false;
 
     if (isCustomCard(item)) {

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -19,6 +19,7 @@ import {
 } from '@meet-without-fear/shared';
 import { messageKeys, sessionKeys, stageKeys, timelineKeys } from './queryKeys';
 import { getPersistedMessageRefreshQueryKeys } from '../utils/realtimeInvalidation';
+import { preRegisterAnimatedId } from '../utils/animationBridge';
 
 // ============================================================================
 // Types
@@ -144,6 +145,8 @@ export function useStreamingMessage(
   // Ref to track optimistic user message ID for replacement
   const optimisticUserIdRef = useRef<string>('');
   const activeUserMessageIdRef = useRef<string>('');
+  // Real server ID received from the user_message event, used for ID bridging
+  const realUserIdRef = useRef<string>('');
 
   // Refs for throttled cache updates (reduces stuttering)
   const lastCacheUpdateRef = useRef<number>(0);
@@ -291,6 +294,49 @@ export function useStreamingMessage(
         queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
           messageKeys.infinite(sessionId, stage),
           updateInfiniteCache
+        );
+      }
+    },
+    [queryClient]
+  );
+
+  /**
+   * Replace a message ID in cache. Used to bridge temporary streaming/optimistic
+   * IDs to real server UUIDs before reconciliation, so refetch matches by ID
+   * instead of treating messages as new.
+   */
+  const replaceMessageIdInCache = useCallback(
+    (sessionId: string, oldId: string, newId: string, stage?: Stage) => {
+      const replaceInPage = (page: GetMessagesResponse): GetMessagesResponse => ({
+        ...page,
+        messages: (page.messages || []).map((m) =>
+          m.id === oldId ? { ...m, id: newId } : m
+        ),
+      });
+
+      queryClient.setQueryData<GetMessagesResponse>(
+        messageKeys.list(sessionId),
+        (old) => old ? replaceInPage(old) : old
+      );
+      queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
+        messageKeys.infinite(sessionId),
+        (old) => {
+          if (!old) return old;
+          return { ...old, pages: old.pages.map(replaceInPage) };
+        }
+      );
+
+      if (stage !== undefined) {
+        queryClient.setQueryData<GetMessagesResponse>(
+          messageKeys.list(sessionId, stage),
+          (old) => old ? replaceInPage(old) : old
+        );
+        queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
+          messageKeys.infinite(sessionId, stage),
+          (old) => {
+            if (!old) return old;
+            return { ...old, pages: old.pages.map(replaceInPage) };
+          }
         );
       }
     },
@@ -505,6 +551,7 @@ export function useStreamingMessage(
       aiMessageIdRef.current = `streaming-${Date.now()}`;
       optimisticUserIdRef.current = `optimistic-user-${Date.now()}`;
       activeUserMessageIdRef.current = optimisticUserIdRef.current;
+      realUserIdRef.current = '';
       textCompleteReceivedRef.current = false;
 
       // Create optimistic user message
@@ -598,6 +645,7 @@ export function useStreamingMessage(
           if (!event.data) return;
           try {
             const data = JSON.parse(event.data) as UserMessageEvent;
+            realUserIdRef.current = data.id; // Store for ID bridging at completion
             // Update optimistic message with server timestamp (keep same ID for React key stability)
             if (optimisticUserIdRef.current) {
               activeUserMessageIdRef.current = optimisticUserIdRef.current;
@@ -771,6 +819,20 @@ export function useStreamingMessage(
               if (data.metadata) {
                 handleMetadata(sessionId, data.metadata);
               }
+
+              // Bridge temporary IDs to real server IDs before reconciliation.
+              // This prevents ChatInterface from re-animating messages whose IDs
+              // change from streaming placeholders to real UUIDs during refetch.
+              if (data.messageId && aiMessageIdRef.current.startsWith('streaming-')) {
+                replaceMessageIdInCache(sessionId, aiMessageIdRef.current, data.messageId, currentStage);
+                preRegisterAnimatedId(data.messageId);
+                aiMessageIdRef.current = data.messageId;
+              }
+              if (realUserIdRef.current && activeUserMessageIdRef.current.startsWith('optimistic-user-')) {
+                replaceMessageIdInCache(sessionId, activeUserMessageIdRef.current, realUserIdRef.current, currentStage);
+                activeUserMessageIdRef.current = realUserIdRef.current;
+              }
+
               reconcilePersistedMessages(sessionId);
 
               // If text_complete wasn't received (fallback), handle completion here

--- a/mobile/src/utils/animationBridge.ts
+++ b/mobile/src/utils/animationBridge.ts
@@ -1,0 +1,18 @@
+/**
+ * Animation Bridge
+ *
+ * Allows useStreamingMessage to pre-register message IDs that should
+ * skip typewriter animation in ChatInterface. This bridges the gap
+ * when streaming placeholder IDs (e.g. "streaming-*") are replaced
+ * with real server UUIDs before cache reconciliation.
+ */
+
+const preRegisteredIds = new Set<string>();
+
+export function preRegisterAnimatedId(id: string): void {
+  preRegisteredIds.add(id);
+}
+
+export function isPreRegisteredAnimatedId(id: string): boolean {
+  return preRegisteredIds.has(id);
+}


### PR DESCRIPTION
## Changes
- Fix: Bridge streaming placeholder IDs (`streaming-*`, `optimistic-user-*`) to real server UUIDs before cache reconciliation
- Fix: Pre-register real AI message IDs in animation tracking to prevent ChatInterface from re-animating already-completed messages
- Add: `animationBridge.ts` utility for cross-module animation ID pre-registration

## How it works

When SSE streaming completes, the `complete` event now:
1. Replaces temporary IDs in the React Query cache with real server UUIDs (via new `replaceMessageIdInCache` helper)
2. Pre-registers the real AI message ID so `shouldAnimateItem` returns `false`
3. Then triggers reconciliation — the refetch now matches by ID instead of treating messages as new

This eliminates the visible jump where the AI message would vanish and re-render with a fresh typewriter animation.

Related to #462

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "Whenever a message comes in from MWF it seems like maybe it is rendering twice? I see a jump part way through the message animating in."

## Docs updated
No doc changes needed — bug fix only, no architectural changes. Mapped doc (`docs/architecture/structure.md`) describes file layout, not streaming internals.