### PR TITLE
Fix three mobile UI bugs (#462, #463, #464)

### DIFF
--- a/mobile/src/components/ChatInput.tsx
+++ b/mobile/src/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { View, TextInput, TouchableOpacity, Text, Platform, type TextInput as TextInputType } from 'react-native';
 import { Send, Mic } from 'lucide-react-native';
 import { createStyles } from '../theme/styled';
@@ -16,6 +16,8 @@ interface ChatInputProps {
   showCharacterCount?: boolean;
   /** Optional voice press handler -- when provided, renders a mic button */
   onVoicePress?: () => void;
+  /** Content of a failed message to restore to the input field */
+  failedMessage?: string | null;
 }
 
 // ============================================================================
@@ -36,12 +38,21 @@ export function ChatInput({
   maxLength = DEFAULT_MAX_LENGTH,
   showCharacterCount = false,
   onVoicePress,
+  failedMessage,
 }: ChatInputProps) {
   const styles = useStyles();
   const [input, setInput] = useState('');
   const inputRef = useRef<TextInputType>(null);
   // Flag to ignore onChangeText events right after sending (prevents autocorrect race condition)
   const justSentRef = useRef(false);
+
+  // Restore text from a failed send attempt
+  useEffect(() => {
+    if (failedMessage && input.length === 0) {
+      justSentRef.current = false;
+      setInput(failedMessage);
+    }
+  }, [failedMessage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const canSend = input.trim().length > 0 && !disabled;
   const characterRatio = input.length / maxLength;

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -153,6 +153,8 @@ interface ChatInterfaceProps {
   partnerName?: string;
   /** Optional voice press handler -- passed through to ChatInput; renders mic button when provided */
   onVoicePress?: () => void;
+  /** Content of a failed message to restore to the input field */
+  failedMessage?: string | null;
   /** ID of the last chat item the user has seen - used to show "New messages" separator */
   lastSeenChatItemId?: string | null;
   /** Server-backed timestamp from before this screen marked the session viewed. */
@@ -231,6 +233,7 @@ export function ChatInterface({
   onValidateAccurate,
   onValidateNotQuite,
   onVoicePress,
+  failedMessage,
 }: ChatInterfaceProps) {
   const styles = useStyles();
   const flatListRef = useRef<FlatList<ChatListItem>>(null);
@@ -867,6 +870,7 @@ export function ChatInterface({
             onSend={onSendMessage}
             disabled={disabled || isInputDisabled || isLoading}
             onVoicePress={onVoicePress}
+            failedMessage={failedMessage}
           />
         )}
         {renderAboveInput?.()}

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -20,6 +20,7 @@ import { ChatIndicator, ChatIndicatorType } from './ChatIndicator';
 import { EmpathyValidationCard } from './EmpathyValidationCard';
 import { createStyles } from '../theme/styled';
 import { useSpeech, useAutoSpeech } from '../hooks/useSpeech';
+import { isPreRegisteredAnimatedId } from '../utils/animationBridge';
 
 // ============================================================================
 // Types
@@ -464,6 +465,7 @@ export function ChatInterface({
     if (isIndicator(item) || isValidationCard(item) || isCustomEmptyState(item)) return false;
     if (animatedItemIdsRef.current.has(item.id)) return false;
     if (seenAnimatedItemIdsRef.current.has(item.id)) return false;
+    if (isPreRegisteredAnimatedId(item.id)) return false;
     if (isAtOrBeforeSeenBoundary(item, index)) return false;
 
     if (isCustomCard(item)) {

--- a/mobile/src/components/PartnerInfoDrawer.tsx
+++ b/mobile/src/components/PartnerInfoDrawer.tsx
@@ -1,6 +1,5 @@
 import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { X } from 'lucide-react-native';
 
 import { colors } from '@/src/theme';
 
@@ -65,24 +64,12 @@ export function PartnerInfoDrawer({
         />
         <SafeAreaView style={styles.drawer} edges={['bottom']}>
           <View style={styles.handle} />
-          <View style={styles.header}>
-            <View style={styles.titleBlock}>
-              <Text style={styles.name} numberOfLines={1}>
-                {name}
-              </Text>
-              <View style={styles.statusRow}>
-                <View style={[styles.statusDot, isOnline && styles.statusDotOnline]} />
-                <Text style={[styles.statusText, isOnline && styles.statusTextOnline]}>{statusText}</Text>
-              </View>
-            </View>
-            <TouchableOpacity
-              style={styles.closeButton}
-              onPress={onClose}
-              accessibilityRole="button"
-              accessibilityLabel="Close person details"
-            >
-              <X size={20} color={colors.textSecondary} />
-            </TouchableOpacity>
+          <Text style={styles.name} numberOfLines={1}>
+            {name}
+          </Text>
+          <View style={styles.statusRow}>
+            <View style={[styles.statusDot, isOnline && styles.statusDotOnline]} />
+            <Text style={[styles.statusText, isOnline && styles.statusTextOnline]}>{statusText}</Text>
           </View>
 
           <View style={styles.section}>
@@ -111,7 +98,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   drawer: {
-    backgroundColor: colors.bgPrimary,
+    backgroundColor: colors.bgSecondary,
     borderTopLeftRadius: 18,
     borderTopRightRadius: 18,
     borderWidth: 1,
@@ -128,14 +115,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bgTertiary,
     marginTop: 10,
     marginBottom: 18,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: 14,
-  },
-  titleBlock: {
-    flex: 1,
   },
   name: {
     color: colors.textPrimary,
@@ -167,14 +146,6 @@ const styles = StyleSheet.create({
   statusTextOnline: {
     color: colors.success,
   },
-  closeButton: {
-    width: 38,
-    height: 38,
-    borderRadius: 19,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.bgSecondary,
-  },
   section: {
     marginTop: 24,
   },
@@ -188,7 +159,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     borderWidth: 1,
     borderColor: colors.border,
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: colors.bgPrimary,
     padding: 16,
   },
   topicLabel: {

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -94,6 +94,8 @@ export interface UseStreamingMessageResult {
   cancel: () => void;
   /** Error message if status is 'error' */
   errorMessage: string | null;
+  /** The content of the last failed message (for restoring to the input field) */
+  failedMessageContent: string | null;
   /** Retry the last failed message */
   retry: () => void;
 }
@@ -893,6 +895,8 @@ export function useStreamingMessage(
     }
   }, [sendMessage]);
 
+  const failedMessageContent = status === 'error' ? lastParamsRef.current?.content ?? null : null;
+
   return {
     status,
     isStreaming: status === 'streaming',
@@ -900,6 +904,7 @@ export function useStreamingMessage(
     sendMessage,
     cancel,
     errorMessage,
+    failedMessageContent,
     retry,
   };
 }

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -19,6 +19,7 @@ import {
 } from '@meet-without-fear/shared';
 import { messageKeys, sessionKeys, stageKeys, timelineKeys } from './queryKeys';
 import { getPersistedMessageRefreshQueryKeys } from '../utils/realtimeInvalidation';
+import { preRegisterAnimatedId } from '../utils/animationBridge';
 
 // ============================================================================
 // Types
@@ -146,6 +147,8 @@ export function useStreamingMessage(
   // Ref to track optimistic user message ID for replacement
   const optimisticUserIdRef = useRef<string>('');
   const activeUserMessageIdRef = useRef<string>('');
+  // Real server ID received from the user_message event, used for ID bridging
+  const realUserIdRef = useRef<string>('');
 
   // Refs for throttled cache updates (reduces stuttering)
   const lastCacheUpdateRef = useRef<number>(0);
@@ -293,6 +296,49 @@ export function useStreamingMessage(
         queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
           messageKeys.infinite(sessionId, stage),
           updateInfiniteCache
+        );
+      }
+    },
+    [queryClient]
+  );
+
+  /**
+   * Replace a message ID in cache. Used to bridge temporary streaming/optimistic
+   * IDs to real server UUIDs before reconciliation, so refetch matches by ID
+   * instead of treating messages as new.
+   */
+  const replaceMessageIdInCache = useCallback(
+    (sessionId: string, oldId: string, newId: string, stage?: Stage) => {
+      const replaceInPage = (page: GetMessagesResponse): GetMessagesResponse => ({
+        ...page,
+        messages: (page.messages || []).map((m) =>
+          m.id === oldId ? { ...m, id: newId } : m
+        ),
+      });
+
+      queryClient.setQueryData<GetMessagesResponse>(
+        messageKeys.list(sessionId),
+        (old) => old ? replaceInPage(old) : old
+      );
+      queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
+        messageKeys.infinite(sessionId),
+        (old) => {
+          if (!old) return old;
+          return { ...old, pages: old.pages.map(replaceInPage) };
+        }
+      );
+
+      if (stage !== undefined) {
+        queryClient.setQueryData<GetMessagesResponse>(
+          messageKeys.list(sessionId, stage),
+          (old) => old ? replaceInPage(old) : old
+        );
+        queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
+          messageKeys.infinite(sessionId, stage),
+          (old) => {
+            if (!old) return old;
+            return { ...old, pages: old.pages.map(replaceInPage) };
+          }
         );
       }
     },
@@ -507,6 +553,7 @@ export function useStreamingMessage(
       aiMessageIdRef.current = `streaming-${Date.now()}`;
       optimisticUserIdRef.current = `optimistic-user-${Date.now()}`;
       activeUserMessageIdRef.current = optimisticUserIdRef.current;
+      realUserIdRef.current = '';
       textCompleteReceivedRef.current = false;
 
       // Create optimistic user message
@@ -600,6 +647,7 @@ export function useStreamingMessage(
           if (!event.data) return;
           try {
             const data = JSON.parse(event.data) as UserMessageEvent;
+            realUserIdRef.current = data.id; // Store for ID bridging at completion
             // Update optimistic message with server timestamp (keep same ID for React key stability)
             if (optimisticUserIdRef.current) {
               activeUserMessageIdRef.current = optimisticUserIdRef.current;
@@ -773,6 +821,20 @@ export function useStreamingMessage(
               if (data.metadata) {
                 handleMetadata(sessionId, data.metadata);
               }
+
+              // Bridge temporary IDs to real server IDs before reconciliation.
+              // This prevents ChatInterface from re-animating messages whose IDs
+              // change from streaming placeholders to real UUIDs during refetch.
+              if (data.messageId && aiMessageIdRef.current.startsWith('streaming-')) {
+                replaceMessageIdInCache(sessionId, aiMessageIdRef.current, data.messageId, currentStage);
+                preRegisterAnimatedId(data.messageId);
+                aiMessageIdRef.current = data.messageId;
+              }
+              if (realUserIdRef.current && activeUserMessageIdRef.current.startsWith('optimistic-user-')) {
+                replaceMessageIdInCache(sessionId, activeUserMessageIdRef.current, realUserIdRef.current, currentStage);
+                activeUserMessageIdRef.current = realUserIdRef.current;
+              }
+
               reconcilePersistedMessages(sessionId);
 
               // If text_complete wasn't received (fallback), handle completion here

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -421,6 +421,7 @@ export function useUnifiedSession(
     sendMessage: streamingSendMessage,
     isSending,
     isStreaming,
+    failedMessageContent,
   } = useStreamingMessage({
     onMetadata: handleStreamMetadata,
     onError: handleStreamError,
@@ -1210,6 +1211,7 @@ export function useUnifiedSession(
     inlineCards,
     isSending,
     isStreaming,
+    failedMessageContent,
     isSigningCompact,
     isConfirmingFeelHeard,
     isConfirmingInvitation,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -534,6 +534,7 @@ export function UnifiedSessionScreen({
     messages,
     inlineCards,
     isSending,
+    failedMessageContent,
     isSigningCompact,
     isConfirmingFeelHeard,
     isConfirmingInvitation,
@@ -3335,6 +3336,7 @@ export function UnifiedSessionScreen({
           messages={displayMessages}
           indicators={indicators}
           onSendMessage={sendMessageWithTracking}
+          failedMessage={failedMessageContent}
           // Cache-First: Ghost dots are derived from last message role in ChatInterface
           // isSending is still needed for brief moment during API call before optimistic message appears
           // isFetchingInitialMessage shows dots while fetching first AI message

--- a/mobile/src/utils/animationBridge.ts
+++ b/mobile/src/utils/animationBridge.ts
@@ -1,0 +1,18 @@
+/**
+ * Animation Bridge
+ *
+ * Allows useStreamingMessage to pre-register message IDs that should
+ * skip typewriter animation in ChatInterface. This bridges the gap
+ * when streaming placeholder IDs (e.g. "streaming-*") are replaced
+ * with real server UUIDs before cache reconciliation.
+ */
+
+const preRegisteredIds = new Set<string>();
+
+export function preRegisterAnimatedId(id: string): void {
+  preRegisteredIds.add(id);
+}
+
+export function isPreRegisteredAnimatedId(id: string): boolean {
+  return preRegisteredIds.has(id);
+}


### PR DESCRIPTION
## Summary

Combined PR for three mobile bug fixes from #bugs-and-requests:

• **Fix failed message text disappearing on send error** (#463) — When a message fails to send (e.g. no network), the text now restores to the input field instead of vanishing
• **Fix AI messages re-animating after streaming completes** (#462) — Prevents the visual "jump" where messages appeared to render twice mid-animation
• **Fix PartnerInfoDrawer contrast and oversized close button** (#464) — Drawer background now uses distinct color from chat, removed oversized close button for consistency with other drawers

Replaces individual PRs #465, #466, #467.

## Test plan

- [ ] Send a message while offline — verify text restores to input on error
- [ ] Receive an AI message — verify no double-render jump
- [ ] Open PartnerInfoDrawer — verify distinct background and no oversized close button
- [ ] Tap above drawer to dismiss — verify still works

## Provenance

- **Channel:** #bugs-and-requests
- **Requester:** Shantam (U0AD3TF2U7L)
- **Original message:** Can you make a new branch for this and the other two PRs from the previous thread and point them all to it, merge them together into one PR so I can approve and merge in one go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)