### PR TITLE
Fix slack-triage image fetching docs

### DIFF
--- a/bot-workspaces/slack-triage/CLAUDE.md
+++ b/bot-workspaces/slack-triage/CLAUDE.md
@@ -77,17 +77,24 @@ Adapt tone based on the source channel:
 
 ## Image Handling
 
-The Slack MCP server cannot see file attachments at all. Always scan for them in parallel with message fetch:
+The Slack MCP server cannot see file attachments at all. When a message has `[Attached files: ...]`, download the images directly via the Slack API using `SLACK_BOT_TOKEN` (NOT `SLACK_MCP_XOXB_TOKEN` which is not set):
 
 ```bash
-# Scan (fast, no download -- always run alongside MCP fetch)
-SLACK_MCP_XOXB_TOKEN="$SLACK_MCP_XOXB_TOKEN" node scripts/slack-get-images.mjs C0A3FF86FB7 --scan
+# 1. Fetch the message to get file URLs
+FILE_INFO=$(curl -s -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  "https://slack.com/api/conversations.history?channel=CHANNEL_ID&latest=MSG_TS_PLUS_ONE&oldest=MSG_TS_MINUS_ONE&inclusive=true&limit=1" \
+  | jq -r '.messages[0].files[0].url_private')
 
-# Download specific message's images
-SLACK_MCP_XOXB_TOKEN="$SLACK_MCP_XOXB_TOKEN" node scripts/slack-get-images.mjs C0A3FF86FB7 --ts <message_ts>
+# 2. Download the image
+mkdir -p /tmp/slack-images
+curl -s -o /tmp/slack-images/image.png \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  "$FILE_INFO"
 ```
 
 Images save to `/tmp/slack-images/`. View with the Read tool.
+
+**Important:** The old `scripts/slack-get-images.mjs` script does not exist. Always use the curl approach above.
 
 ## GitHub API Budget (Policy #1649)
 

--- a/bot-workspaces/slack-triage/references/dispatch-bug.md
+++ b/bot-workspaces/slack-triage/references/dispatch-bug.md
@@ -5,9 +5,7 @@
 ## Steps
 
 1. **Download images** (if `has_images`):
-   ```bash
-   SLACK_MCP_XOXB_TOKEN="$SLACK_MCP_XOXB_TOKEN" node scripts/slack-get-images.mjs C0A3FF86FB7 --ts <message_ts>
-   ```
+   Use the curl-based approach from workspace CLAUDE.md "Image Handling" section (uses `SLACK_BOT_TOKEN`).
    View downloaded images from `/tmp/slack-images/` with the Read tool.
 
 2. **Check for duplicates:**

--- a/bot-workspaces/slack-triage/stages/1-fetch-and-classify/CONTEXT.md
+++ b/bot-workspaces/slack-triage/stages/1-fetch-and-classify/CONTEXT.md
@@ -7,7 +7,7 @@
 | Prompt | The specific message to handle (provided by socket-listener) | Contains channel context + message text |
 | `.claude/config/services.json` | Bot user ID `U0ALQHDUVSM` | Filter self |
 | `references/classification-guide.md` | Classification criteria and examples | Accurate message typing |
-| `scripts/slack-get-images.mjs` | Image scanner | Detect file attachments MCP cannot see |
+| Slack API via `curl` + `SLACK_BOT_TOKEN` | Image downloader | Fetch file attachments MCP cannot see |
 
 ## Process
 
@@ -21,10 +21,7 @@ The socket-listener provides the message in the prompt under "## Message to hand
 - Message text
 - Whether the message has file attachments (check `[Attached files: ...]` in the formatted message)
 
-If the message mentions attached files, scan for images:
-```bash
-SLACK_MCP_XOXB_TOKEN="$SLACK_MCP_XOXB_TOKEN" node scripts/slack-get-images.mjs <CHANNEL_ID> --ts <message_ts>
-```
+If the message mentions attached files, download images via Slack API (see workspace CLAUDE.md "Image Handling" section for the curl commands using `SLACK_BOT_TOKEN`).
 
 ### Step 2: Filter non-actionable messages
 


### PR DESCRIPTION
## Summary

The slack-triage workspace docs referenced a nonexistent script (`slack-get-images.mjs`) and an unset env var (`SLACK_MCP_XOXB_TOKEN`). This caused image fetching to silently fail, leading to misidentified bug reports (e.g. fixing the wrong drawer component in #464).

- Replace with working `curl` commands using `SLACK_BOT_TOKEN` (which is actually available)
- Update all three docs that referenced the old approach: workspace CLAUDE.md, stage 1 CONTEXT.md, dispatch-bug.md

## Provenance

- **Channel:** #bugs-and-requests
- **Requester:** Shantam (U0AD3TF2U7L)
- **Original message:** Ugh that's disappointing. Seems like you have had that issue before with seeing images. Also the message you just sent has strange formatting. Are you feeling ok? It was the exchange history drawer. So now we have to fix that, but also I want you to try to get the image until you finally figure it out and then do what you can to identify why it wasn't working before and make sure whatever skill you have for getting slack messages included that info.

## Test plan

- [ ] Future slack-triage runs with image attachments should successfully download and view images
- [ ] Verify `SLACK_BOT_TOKEN` is available in the bot environment (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)