### PR TITLE
Fix ActivityDrawer contrast and remove close button (#464)

### DIFF
--- a/mobile/src/components/ActivityDrawer.tsx
+++ b/mobile/src/components/ActivityDrawer.tsx
@@ -502,16 +502,6 @@ export function ActivityDrawer({
             <View style={styles.dragHandle} />
           </View>
 
-          <Pressable
-            style={styles.closeHistoryButton}
-            onPress={closeDrawer}
-            accessibilityRole="button"
-            accessibilityLabel="Close exchange history"
-            testID="activity-drawer-close"
-          >
-            <Text style={styles.closeHistoryText}>Close exchange history</Text>
-          </Pressable>
-
           {/* Header */}
           <Text
             style={styles.header}
@@ -618,7 +608,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     right: 0,
-    backgroundColor: colors.bgPrimary,
+    backgroundColor: colors.bgSecondary,
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
     overflow: 'hidden',
@@ -641,19 +631,6 @@ const styles = StyleSheet.create({
     color: colors.textPrimary,
     paddingHorizontal: 16,
     paddingBottom: 12,
-  },
-  closeHistoryButton: {
-    marginHorizontal: 16,
-    marginBottom: 10,
-    paddingVertical: 12,
-    alignItems: 'center',
-    borderRadius: 8,
-    backgroundColor: colors.bgSecondary,
-  },
-  closeHistoryText: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: colors.textPrimary,
   },
   sectionHeader: {
     fontSize: 11,


### PR DESCRIPTION
## Changes
- Fix: Changed ActivityDrawer background from `bgPrimary` to `bgSecondary` so the drawer is visually distinct from the chat screen behind it
- Fix: Removed the redundant "Close exchange history" text button — backdrop tap and drag handle already dismiss, matching PartnerInfoDrawer and NeedsDrawer patterns
- Cleanup: Removed unused `closeHistoryButton` and `closeHistoryText` styles

Related to #464

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam
- **Original message:** This drawer doesn't look good. The backgrounds color is the same as the chat so it's hard to see. Also that enormously close button is bad. You can click above it to dismiss anyway right? Look at other places we have a drawer to close and make it consistent.

## Docs updated
No doc changes needed — styling-only fix (background color and button removal).