### PR TITLE
[codex] Fix invitation app redirect URL

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -30,6 +30,7 @@ Required environment variables:
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk publishable key |
 | `CLERK_SECRET_KEY` | Clerk secret key |
 | `NEXT_PUBLIC_API_URL` | Backend API URL |
+| `NEXT_PUBLIC_APP_URL` | Hosted app URL |
 | `NEXT_PUBLIC_TESTFLIGHT_URL` | iOS TestFlight invitation URL |
 | `NEXT_PUBLIC_ANDROID_APK_URL` | Android APK download URL |
 
@@ -66,6 +67,7 @@ Set these in your Vercel project settings:
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
 - `CLERK_SECRET_KEY`
 - `NEXT_PUBLIC_API_URL` (e.g., `https://api.meetwithoutfear.com`)
+- `NEXT_PUBLIC_APP_URL` (e.g., `https://app.meetwithoutfear.com/`)
 - `NEXT_PUBLIC_TESTFLIGHT_URL`
 - `NEXT_PUBLIC_ANDROID_APK_URL`
 
@@ -76,7 +78,7 @@ When a user opens an invitation link (`/invitation/{id}`):
 1. The page fetches invitation details from the API
 2. If the invitation is valid and the user is not signed in, they see a sign-up/sign-in form
 3. After authentication, the invitation is automatically accepted
-4. The user is redirected to the app download page
+4. The user can open the hosted app or download the mobile app
 
 ## Project Structure
 

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -1,5 +1,10 @@
 import type { NextConfig } from "next";
 
+const defaultAppUrl =
+  process.env.NODE_ENV === "production"
+    ? "https://app.meetwithoutfear.com/"
+    : "http://localhost:3001";
+
 const nextConfig: NextConfig = {
   // Enable React strict mode for better development experience
   reactStrictMode: true,
@@ -9,8 +14,8 @@ const nextConfig: NextConfig = {
 
   // Configure environment variables that can be exposed to the browser
   env: {
-    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001',
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000',
+    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL || defaultAppUrl,
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000",
   },
 };
 


### PR DESCRIPTION
## Summary
- make the website production fallback for NEXT_PUBLIC_APP_URL point at https://app.meetwithoutfear.com/ instead of localhost
- document NEXT_PUBLIC_APP_URL as a Vercel setting for the website
- update the invitation flow docs to match the current hosted-app handoff

## Root cause
Next config injected NEXT_PUBLIC_APP_URL with a localhost default at build time, so production invitation success pages could compile a localhost Open Meet Without Fear link when the env var was absent.

## Validation
- npm run check
- npm run build

## Deployment note
I also added NEXT_PUBLIC_APP_URL=https://app.meetwithoutfear.com/ to the website Vercel project production environment.