### PR TITLE
[codex] Fix invitee start push copy

### DIFF
--- a/backend/src/controllers/invitations.ts
+++ b/backend/src/controllers/invitations.ts
@@ -680,6 +680,7 @@ export async function acceptInvitation(req: Request, res: Response): Promise<voi
     // Use notifyPartnerWithFallback to ensure Ably message is always published
     // and push is sent if user is offline
     await notifyPartnerWithFallback(invitation.sessionId, invitation.invitedById, 'session.joined', {
+      joinedBy: user.id,
       userId: user.id,
       userName: user.name,
     });

--- a/backend/src/services/__tests__/push.test.ts
+++ b/backend/src/services/__tests__/push.test.ts
@@ -161,6 +161,83 @@ describe('Push Notification Service', () => {
       ]);
     });
 
+    it('uses invitation acceptance copy when the invitee starts their side', async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        pushToken: validPushToken,
+      });
+      (prisma.invitation.findFirst as jest.Mock).mockResolvedValue({
+        invitedById: testUserId,
+      });
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+        relationship: {
+          members: [
+            {
+              userId: testUserId,
+              nickname: null,
+              user: { firstName: 'Jason', name: 'Jason Person' },
+            },
+            {
+              userId: 'actor-123',
+              nickname: null,
+              user: { firstName: 'Shantam', name: 'Shantam Person' },
+            },
+          ],
+        },
+      });
+      mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok' }]);
+
+      await sendPushNotification(
+        testUserId,
+        'partner.signed_compact',
+        { signedBy: 'actor-123' },
+        testSessionId,
+      );
+
+      expect(mockSendPushNotificationsAsync).toHaveBeenCalledWith([
+        expect.objectContaining({
+          title: 'Shantam accepted your invitation',
+          body: 'Shantam has started their side of the session. Open it to continue.',
+        }),
+      ]);
+    });
+
+    it('resolves the invitee name for session joined notifications', async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        pushToken: validPushToken,
+      });
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+        relationship: {
+          members: [
+            {
+              userId: testUserId,
+              nickname: null,
+              user: { firstName: 'Jason', name: 'Jason Person' },
+            },
+            {
+              userId: 'actor-123',
+              nickname: null,
+              user: { firstName: 'Shantam', name: 'Shantam Person' },
+            },
+          ],
+        },
+      });
+      mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok' }]);
+
+      await sendPushNotification(
+        testUserId,
+        'session.joined',
+        { joinedBy: 'actor-123' },
+        testSessionId,
+      );
+
+      expect(mockSendPushNotificationsAsync).toHaveBeenCalledWith([
+        expect.objectContaining({
+          title: 'Shantam joined',
+          body: 'Shantam accepted your invitation. Open the session to continue together.',
+        }),
+      ]);
+    });
+
     it('returns true on successful send', async () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({
         pushToken: validPushToken,

--- a/backend/src/services/push.ts
+++ b/backend/src/services/push.ts
@@ -115,7 +115,7 @@ export const PUSH_MESSAGES: Record<SessionEvent, PushMessageTemplate> = {
   },
   'session.joined': {
     title: '{actor} joined',
-    body: 'Open the session to continue together.',
+    body: '{actor} accepted your invitation. Open the session to continue together.',
   },
   'session.needs_reveal_ready': {
     title: 'Ready to reveal',
@@ -188,7 +188,8 @@ function getActorUserId(data: Record<string, unknown>): string | null {
     data.pausedBy ??
     data.resumedBy ??
     data.resolvedBy ??
-    data.proposedBy;
+    data.proposedBy ??
+    data.joinedBy;
 
   return typeof candidate === 'string' ? candidate : null;
 }
@@ -210,6 +211,42 @@ function getStageName(data: Record<string, unknown>): string {
     default:
       return 'the current step';
   }
+}
+
+async function getPushMessageTemplate(
+  userId: string,
+  event: SessionEvent,
+  data: Record<string, unknown>,
+  sessionId: string,
+): Promise<PushMessageTemplate> {
+  if (event === 'partner.signed_compact') {
+    const actorUserId = getActorUserId(data);
+
+    if (actorUserId && actorUserId !== userId) {
+      const invitation = await prisma.invitation.findFirst({
+        where: {
+          sessionId,
+          invitedById: userId,
+          status: 'ACCEPTED',
+        },
+        select: {
+          invitedById: true,
+        },
+      });
+
+      if (invitation) {
+        return {
+          title: '{actor} accepted your invitation',
+          body: '{actor} has started their side of the session. Open it to continue.',
+        };
+      }
+    }
+  }
+
+  return PUSH_MESSAGES[event] || {
+    title: 'Meet Without Fear',
+    body: 'You have an update',
+  };
 }
 
 async function getNotificationActorName(
@@ -304,11 +341,7 @@ export async function sendPushNotification(
       return false;
     }
 
-    // Get message template for this event type
-    const template = PUSH_MESSAGES[event] || {
-      title: 'Meet Without Fear',
-      body: 'You have an update',
-    };
+    const template = await getPushMessageTemplate(userId, event, data, sessionId);
     const actorName = await getNotificationActorName(userId, sessionId, data);
     const message = renderPushMessage(template, {
       actorName,


### PR DESCRIPTION
## Summary
- Fix invitation acceptance push actor resolution by sending `joinedBy` on `session.joined`.
- Update `session.joined` push copy to explicitly say the invitation was accepted.
- Override compact-sign push copy for the invitee-starts-after-acceptance case so the inviter does not get stale “begin when ready” language.

## Root Cause
When an invitee accepted and started their side, the later `partner.signed_compact` push reused the generic compact-ready message. For the inviter, that incorrectly implied they could begin the session, even though they were already in progress.

## Validation
- `npm test --workspace backend -- push.test.ts`
