### PR TITLE
Fix partner last seen and biometric lock overlay

### DIFF
--- a/backend/prisma/migrations/20260509000000_add_user_vessel_last_active_at/migration.sql
+++ b/backend/prisma/migrations/20260509000000_add_user_vessel_last_active_at/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "UserVessel"
+ADD COLUMN "lastActiveAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -366,6 +366,9 @@ model UserVessel {
   // When the user last viewed the Share/Partner tab
   // Used to determine "seen" status for shared content (empathy, context)
   lastViewedShareTabAt DateTime?
+  // When the user last actively did something in this session.
+  // Used for partner-facing presence details; distinct from read/view state.
+  lastActiveAt         DateTime?
   // When this user removed the session from their own conversation list.
   // The partner may still retain their own vessel and access.
   archivedAt           DateTime?

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -25,7 +25,7 @@ import {
 } from '@meet-without-fear/shared';
 import { notifyPartner, publishSessionEvent, notifySessionMembers, publishMessageAIResponse, publishMessageError, publishTopicFrameUpdated } from '../services/realtime';
 import { successResponse, errorResponse } from '../utils/response';
-import { getPartnerUserId, isSessionCreator } from '../utils/session';
+import { getPartnerUserId, isSessionCreator, touchUserSessionActivity } from '../utils/session';
 import { embedSessionContent } from '../services/embedding';
 import { updateSessionSummary, getSessionSummary } from '../services/conversation-summarizer';
 import { runReconcilerForDirection, getSharedContextForGuesser } from '../services/reconciler';
@@ -1288,6 +1288,12 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
         stage: currentStage,
       },
     });
+    await touchUserSessionActivity(sessionId, user.id, userMessage.timestamp);
+    publishSessionEvent(sessionId, 'partner.activity', {
+      activeAt: userMessage.timestamp.toISOString(),
+    }, user.id).catch((err) =>
+      logger.warn(`[sendMessageStream:${requestId}] Failed to publish partner activity:`, err)
+    );
     logger.info(`[sendMessageStream:${requestId}] User message created: ${userMessage.id}`);
 
     // Broadcast to Status Site

--- a/backend/src/controllers/session-state.ts
+++ b/backend/src/controllers/session-state.ts
@@ -33,6 +33,17 @@ interface CompactGates {
   signedAt?: string;
 }
 
+function latestDate(...values: Array<Date | null | undefined>): Date | null {
+  let latest: Date | null = null;
+  for (const value of values) {
+    if (!value) continue;
+    if (!latest || value > latest) {
+      latest = value;
+    }
+  }
+  return latest;
+}
+
 async function acceptPendingInvitationForE2ESession(sessionId: string, userId: string): Promise<boolean> {
   if (process.env.E2E_AUTH_BYPASS !== 'true' || process.env.NODE_ENV === 'production') {
     return false;
@@ -192,6 +203,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
         },
         select: {
           lastViewedAt: true,
+          lastActiveAt: true,
           lastSeenChatItemId: true,
         },
       }),
@@ -273,9 +285,40 @@ export async function getSessionState(req: Request, res: Response): Promise<void
           },
           select: {
             lastViewedAt: true,
+            lastActiveAt: true,
           },
         })
       : null;
+    const partnerLastMessage = partnerId
+      ? await prisma.message.findFirst({
+          where: {
+            sessionId,
+            senderId: partnerId,
+            role: 'USER',
+          },
+          orderBy: { timestamp: 'desc' },
+          select: { timestamp: true },
+        })
+      : null;
+    const partnerLastStageProgress = partnerId
+      ? await prisma.stageProgress.findFirst({
+          where: { sessionId, userId: partnerId },
+          orderBy: [
+            { completedAt: 'desc' },
+            { startedAt: 'desc' },
+          ],
+          select: {
+            startedAt: true,
+            completedAt: true,
+          },
+        })
+      : null;
+    const partnerLastActiveAt = latestDate(
+      partnerVessel?.lastActiveAt,
+      partnerLastMessage?.timestamp,
+      partnerLastStageProgress?.completedAt,
+      partnerLastStageProgress?.startedAt
+    );
 
     // Build messages response (reverse to chronological order)
     const hasMoreMessages = messages.length > 25;
@@ -368,6 +411,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
         resolvedAt: session.resolvedAt?.toISOString() ?? null,
         lastViewedAt: userVessel?.lastViewedAt?.toISOString() ?? null,
         partnerLastViewedAt: partnerVessel?.lastViewedAt?.toISOString() ?? null,
+        partnerLastActiveAt: partnerLastActiveAt?.toISOString() ?? null,
         lastSeenChatItemId: userVessel?.lastSeenChatItemId ?? null,
       },
 

--- a/backend/src/controllers/sessions.ts
+++ b/backend/src/controllers/sessions.ts
@@ -1091,12 +1091,14 @@ export async function markSessionViewed(req: Request, res: Response): Promise<vo
       },
       update: {
         lastViewedAt: now,
+        lastActiveAt: now,
         lastSeenChatItemId: lastSeenChatItemId ?? null,
       },
       create: {
         userId: user.id,
         sessionId,
         lastViewedAt: now,
+        lastActiveAt: now,
         lastSeenChatItemId: lastSeenChatItemId ?? null,
       },
     });
@@ -1109,6 +1111,7 @@ export async function markSessionViewed(req: Request, res: Response): Promise<vo
         const allStatuses = await buildEmpathyExchangeStatusForBothUsers(sessionId);
         await publishSessionEvent(sessionId, 'partner.session_viewed', {
           viewedAt: now.toISOString(),
+          activeAt: now.toISOString(),
           empathyStatuses: allStatuses,
         }, user.id);
       } catch (err) {
@@ -1156,11 +1159,13 @@ export async function markShareTabViewed(req: Request, res: Response): Promise<v
       },
       update: {
         lastViewedShareTabAt: now,
+        lastActiveAt: now,
       },
       create: {
         userId: user.id,
         sessionId,
         lastViewedShareTabAt: now,
+        lastActiveAt: now,
       },
     });
 
@@ -1172,6 +1177,7 @@ export async function markShareTabViewed(req: Request, res: Response): Promise<v
         const allStatuses = await buildEmpathyExchangeStatusForBothUsers(sessionId);
         await publishSessionEvent(sessionId, 'partner.share_tab_viewed', {
           viewedAt: now.toISOString(),
+          activeAt: now.toISOString(),
           empathyStatuses: allStatuses,
         }, user.id);
       } catch (err) {

--- a/backend/src/utils/session.ts
+++ b/backend/src/utils/session.ts
@@ -50,9 +50,39 @@ type SessionWithIncludes = {
   userVessels?: Array<{
     userId: string;
     lastViewedAt: Date | null;
+    lastActiveAt?: Date | null;
     lastSeenChatItemId: string | null;
   }>;
 };
+
+/**
+ * Records that a user actively did something in a session.
+ *
+ * This is intentionally separate from lastViewedAt, which is read-state used
+ * for unread indicators and chat animation boundaries.
+ */
+export async function touchUserSessionActivity(
+  sessionId: string,
+  userId: string,
+  at: Date = new Date()
+): Promise<void> {
+  await prisma.userVessel.upsert({
+    where: {
+      userId_sessionId: {
+        userId,
+        sessionId,
+      },
+    },
+    update: {
+      lastActiveAt: at,
+    },
+    create: {
+      userId,
+      sessionId,
+      lastActiveAt: at,
+    },
+  });
+}
 
 /**
  * Gets the partner's user ID from a session

--- a/mobile/src/components/BiometricLockOverlay.tsx
+++ b/mobile/src/components/BiometricLockOverlay.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   Animated,
   InteractionManager,
+  Modal,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -77,58 +78,67 @@ export function BiometricLockOverlay() {
   const isFailed = lockState === 'failed';
 
   return (
-    <Animated.View
-      style={[styles.overlay, { opacity: fadeAnim }]}
-      pointerEvents={isLocked ? 'auto' : 'none'}
+    <Modal
+      visible
+      transparent={false}
+      animationType="none"
+      presentationStyle="overFullScreen"
+      statusBarTranslucent
+      onRequestClose={() => {}}
     >
-      <View style={styles.content}>
-        <View style={styles.mark}>
-          {isFailed ? (
-            <Lock size={52} color={colors.brandOrange} strokeWidth={1.6} />
+      <Animated.View
+        style={[styles.overlay, { opacity: fadeAnim }]}
+        pointerEvents={isLocked ? 'auto' : 'none'}
+      >
+        <View style={styles.content}>
+          <View style={styles.mark}>
+            {isFailed ? (
+              <Lock size={52} color={colors.brandOrange} strokeWidth={1.6} />
+            ) : (
+              <ShieldCheck size={58} color={colors.brandBlue} strokeWidth={1.5} />
+            )}
+          </View>
+
+          <Text style={styles.title}>
+            {isFailed ? 'Authentication failed' : 'Meet Without Fear is locked'}
+          </Text>
+          <Text style={styles.subtitle}>
+            {isFailed
+              ? error
+              : `Use ${biometricName} or your device passcode to continue.`}
+          </Text>
+
+          {isBusy ? (
+            <View style={styles.loadingRow}>
+              <ActivityIndicator color={colors.textPrimary} />
+              <Text style={styles.loadingText}>Authenticating...</Text>
+            </View>
           ) : (
-            <ShieldCheck size={58} color={colors.brandBlue} strokeWidth={1.5} />
+            <TouchableOpacity
+              style={styles.primaryButton}
+              onPress={handleBiometricAuth}
+              accessibilityRole="button"
+            >
+              <RefreshCw size={18} color={colors.textOnAccent} />
+              <Text style={styles.primaryButtonText}>
+                {isFailed ? `Try ${biometricName} again` : `Unlock with ${biometricName}`}
+              </Text>
+            </TouchableOpacity>
+          )}
+
+          {isFailed && (
+            <TouchableOpacity
+              style={styles.signOutButton}
+              onPress={handleSignOut}
+              accessibilityRole="button"
+            >
+              <LogOut size={17} color={colors.error} />
+              <Text style={styles.signOutText}>Sign out</Text>
+            </TouchableOpacity>
           )}
         </View>
-
-        <Text style={styles.title}>
-          {isFailed ? 'Authentication failed' : 'Meet Without Fear is locked'}
-        </Text>
-        <Text style={styles.subtitle}>
-          {isFailed
-            ? error
-            : `Use ${biometricName} or your device passcode to continue.`}
-        </Text>
-
-        {isBusy ? (
-          <View style={styles.loadingRow}>
-            <ActivityIndicator color={colors.textPrimary} />
-            <Text style={styles.loadingText}>Authenticating...</Text>
-          </View>
-        ) : (
-          <TouchableOpacity
-            style={styles.primaryButton}
-            onPress={handleBiometricAuth}
-            accessibilityRole="button"
-          >
-            <RefreshCw size={18} color={colors.textOnAccent} />
-            <Text style={styles.primaryButtonText}>
-              {isFailed ? `Try ${biometricName} again` : `Unlock with ${biometricName}`}
-            </Text>
-          </TouchableOpacity>
-        )}
-
-        {isFailed && (
-          <TouchableOpacity
-            style={styles.signOutButton}
-            onPress={handleSignOut}
-            accessibilityRole="button"
-          >
-            <LogOut size={17} color={colors.error} />
-            <Text style={styles.signOutText}>Sign out</Text>
-          </TouchableOpacity>
-        )}
-      </View>
-    </Animated.View>
+      </Animated.View>
+    </Modal>
   );
 }
 

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -686,6 +686,27 @@ export function UnifiedSessionScreen({
     }
   }, [queryClient, refetchPersistedMessages, sessionId]);
 
+  const updatePartnerLastActiveAt = useCallback((activeAt: unknown, viewedAt?: unknown) => {
+    const activeAtString = typeof activeAt === 'string'
+      ? activeAt
+      : typeof viewedAt === 'string'
+        ? viewedAt
+        : null;
+    if (!activeAtString) return;
+
+    queryClient.setQueryData(sessionKeys.state(sessionId), (old: any) => {
+      if (!old?.session) return old;
+      return {
+        ...old,
+        session: {
+          ...old.session,
+          partnerLastActiveAt: activeAtString,
+          ...(typeof viewedAt === 'string' ? { partnerLastViewedAt: viewedAt } : {}),
+        },
+      };
+    });
+  }, [queryClient, sessionId]);
+
   useEffect(() => {
     const latestMessage = messages[messages.length - 1];
     if (
@@ -781,6 +802,7 @@ export function UnifiedSessionScreen({
       if (event === 'partner.session_viewed' && data.empathyStatuses && user?.id) {
         // Partner viewed the session - update delivery status
         console.log('[UnifiedSessionScreen] Partner viewed session, updating cache');
+        updatePartnerLastActiveAt(data.activeAt, data.viewedAt);
         const statuses = data.empathyStatuses as Record<string, unknown>;
         if (statuses[user.id]) {
           queryClient.setQueryData(stageKeys.empathyStatus(sessionId), statuses[user.id]);
@@ -790,10 +812,15 @@ export function UnifiedSessionScreen({
       if (event === 'partner.share_tab_viewed' && data.empathyStatuses && user?.id) {
         // Partner viewed the Share tab - update delivery status
         console.log('[UnifiedSessionScreen] Partner viewed Share tab, updating cache');
+        updatePartnerLastActiveAt(data.activeAt, data.viewedAt);
         const statuses = data.empathyStatuses as Record<string, unknown>;
         if (statuses[user.id]) {
           queryClient.setQueryData(stageKeys.empathyStatus(sessionId), statuses[user.id]);
         }
+      }
+
+      if (event === 'partner.activity') {
+        updatePartnerLastActiveAt(data.activeAt);
       }
 
       // Notification events - invalidate pending actions for activity menu badges
@@ -1248,13 +1275,19 @@ export function UnifiedSessionScreen({
     partnerProgress,
     session?.status
   );
-  const partnerLastViewedAt = (session as { partnerLastViewedAt?: string | null } | undefined)?.partnerLastViewedAt ?? null;
+  const partnerActivitySession = session as
+    | { partnerLastActiveAt?: string | null; partnerLastViewedAt?: string | null }
+    | undefined;
+  const partnerLastSeenAt =
+    partnerActivitySession?.partnerLastActiveAt ??
+    partnerActivitySession?.partnerLastViewedAt ??
+    null;
   const partnerInfoDrawer = (
     <PartnerInfoDrawer
       visible={showPartnerInfo}
       name={partnerInfoName}
       isOnline={partnerOnline}
-      lastSeenAt={partnerLastViewedAt}
+      lastSeenAt={partnerLastSeenAt}
       stageDescription={partnerStageDescription}
       topic={topicFrame}
       onClose={() => setShowPartnerInfo(false)}

--- a/shared/src/dto/realtime.ts
+++ b/shared/src/dto/realtime.ts
@@ -80,6 +80,7 @@ export type SessionEventType =
   | 'partner.empathy_revealed' // Reconciler: empathy statement was revealed to recipient
   | 'partner.session_viewed' // Partner viewed the session (for delivery status updates)
   | 'partner.share_tab_viewed' // Partner viewed the Share tab (for "seen" delivery status)
+  | 'partner.activity' // Partner actively did something in the session
   | 'partner.skipped_refinement' // Partner skipped refinement (agreement to disagree)
   // Empathy reconciler events
   | 'empathy.share_suggestion' // Subject receives suggestion to share context with guesser

--- a/shared/src/dto/session-state.ts
+++ b/shared/src/dto/session-state.ts
@@ -44,6 +44,8 @@ export interface SessionStateResponse {
     lastViewedAt: string | null;
     // When the other person last viewed this session (for presence details)
     partnerLastViewedAt: string | null;
+    // When the other person last actively did something in this session
+    partnerLastActiveAt: string | null;
     // ID of last chat item seen (for "new messages" line placement)
     lastSeenChatItemId: string | null;
   };


### PR DESCRIPTION
## Summary
- add `UserVessel.lastActiveAt` and return `partnerLastActiveAt` from session state
- update partner details to base Last seen on partner activity, with a fallback to the old viewed timestamp
- render the biometric lock as a top-level native modal so it covers drawers and other popups

## Root Cause
The partner details drawer used `partnerLastViewedAt`, which tracks read state rather than user activity. The biometric lock was an absolutely positioned view, so React Native modal drawers could render above it despite its high z-index.

## Validation
- `npm --workspace backend run prisma:generate`
- `npm --workspace backend run check`
- `npm --workspace mobile run check`
