### PR TITLE
docs: incremental audit 2026-05-09 — stage4 capture, scanner filter, UserVessel fields

### DIFF
--- a/docs/architecture/backend-overview.md
+++ b/docs/architecture/backend-overview.md
@@ -3,7 +3,7 @@ title: Architecture
 sidebar_position: 2
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-04-27
+updated: 2026-05-09
 status: living
 ---
 # Architecture
@@ -135,6 +135,7 @@ status: living
 - Triggers: `npm run dev:api` in development; PORT=3000 (default) in production
 - Responsibilities: Initializes Express app with middleware; mounts all route modules under both `/api` and `/api/v1` (dual-prefix for compatibility); attaches the `/realtime` WebSocket for real-time transcription via `attachRealtimeWebSocket(server)` (requires Clerk JWT via `?token=` query parameter on upgrade); handles errors consistently; graceful shutdown on SIGTERM/SIGINT (closes HTTP server, disconnects Prisma, flushes Sentry, force-exits after 10 s timeout)
 - Compression: the compression middleware is explicitly disabled for `/messages/stream` paths to prevent SSE buffering
+- **Scanner Filter:** `backend/src/middleware/scanner-filter.ts` sits early in the middleware chain (before logging) and silently returns a plain 404 for known vulnerability-scanner paths (`.php`, `.asp`, `.aspx`, `.jsp`, `.cgi` extensions; `/wp-admin`, `/wp-login`, `/phpmyadmin`, etc.). This keeps application logs clean of automated probe noise without incurring any logging overhead.
 
 **Mobile App Entry:**
 - Location: `mobile/app/_layout.tsx` (Expo Router file-based routing)
@@ -190,7 +191,8 @@ status: living
 ## Cross-Cutting Concerns
 
 **Logging:**
-- Backend: Winston structured logger (`backend/src/lib/logger.ts`) with JSON output in production, pretty-print in development; automatically injects request context (turnId, sessionId, userId, requestId); Sentry transport forwards error-level logs; PII fields stripped via `beforeSend` hook before transmission
+- Backend: Winston structured logger (`backend/src/lib/logger.ts`) with JSON output in production, pretty-print in development; automatically injects request context (turnId, sessionId, userId, requestId); PII fields stripped via `beforeSend` hook before transmission
+- **4xx vs 5xx split:** Client errors (4xx) are logged at `warn` level and do NOT trigger Sentry; only server errors (5xx) and unhandled async errors are logged at `error` level and forwarded to Sentry. This keeps Sentry focused on true server failures rather than client mistakes.
 - Mobile: Handled by error tracking provider (Sentry integration possible); development console logs
 
 **Validation:**

--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -3,7 +3,7 @@ title: Codebase Structure
 sidebar_position: 8
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-05-07
+updated: 2026-05-09
 status: living
 ---
 # Codebase Structure
@@ -151,6 +151,9 @@ project-root/
   - Stage 2 components are integrated into UnifiedSessionScreen.tsx and its sub-components in `components/sharing/`, `components/SessionDrawer/`, `AccuracyFeedbackDrawer.tsx`, `ViewEmpathyStatementDrawer.tsx`, and reusable guided chat modals like `GuidedDraftChatModal.tsx`
   - `NeedCard.tsx`, `StrategyCard.tsx` - Stage 3-4 components
   - `Stage4RedesignPanel.tsx` - Stage 4 redesign UI: proposal inventory, needs coverage audit, willingness selection, outcome display (678 lines)
+  - `BiometricLockOverlay.tsx` - Full-screen modal that locks the app after 5 s in background; requires biometric or device passcode to unlock. Context provided by `contexts/BiometricLockContext.tsx` (platform-specific: `.web.tsx` variant is a no-op).
+  - `NotificationPermissionDrawer.tsx` - Full-screen modal requesting push notification permissions ("Know when it is your turn again"). Paired with `hooks/useNotifications.ts`.
+  - `SessionChatHeader.tsx` - Chat header with configurable left action: `'back'` (navigate up) or `'menu'` (open SessionDrawer via `onMenuPress` callback)
   - `TendingPanel.tsx` - Post-resolution check-in UI: scheduled agreement check-ins and passive re-entry (490 lines)
   - `WaitingRoom.tsx`, `WaitingBanner.tsx` - Waiting state UI
   - Subdirectories: `chat/`, `sharing/`, `SessionDrawer/` for organized subsets
@@ -187,6 +190,7 @@ project-root/
   - `useSessionDrawer.tsx` - Provides `SessionDrawerContext` for the hamburger drawer (open/close state, selected tab between Inner Thoughts and Partner Sessions).
   - Inner Work feature hooks: `useGratitude.ts`, `useMeditation.ts`, `useNeedsAssessment.ts`. Hooks exist in-code but the matching product pathways are deferred per v1.2 scope (see note on `InnerWorkHubScreen.tsx`).
   - Auth: `useAuth.ts` (user auth + `useUpdateMood` for persisting the user's default mood intensity), `useAuthProviderClerk.ts`, `useBiometricAuth.ts`
+  - `useNotifications.ts` - Push notification helpers: `shouldAskForSessionNotifications()` determines prompt timing; `requestSessionNotifications()` triggers the OS permission dialog and registers the Expo push token
   - Timeline: `useTimeline.ts` (13KB)
 
 **`services/`**

--- a/docs/backend/api/sessions.md
+++ b/docs/backend/api/sessions.md
@@ -172,7 +172,7 @@ interface SessionDetailDTO {
 | Code | When |
 |------|------|
 | `UNAUTHORIZED` (401) | No auth token |
-| `NOT_FOUND` (404) | Session doesn't exist, or the authenticated user isn't a participant (non-participants see 404, not 403, to avoid disclosing session IDs) |
+| `NOT_FOUND` (404) | Session doesn't exist, or the authenticated user isn't a participant (non-participants see 404, not 403, to avoid disclosing session IDs). The mobile client implements a circuit-breaker on 404: child queries wait for `/sessions/:id` state to resolve, pending-actions polling stops when access is denied, and Ably subscriptions tear down — preventing cascading error bursts. |
 
 ---
 

--- a/docs/backend/api/stage-4.md
+++ b/docs/backend/api/stage-4.md
@@ -3,7 +3,7 @@ title: "Stage 4 API: Strategic Repair"
 sidebar_position: 11
 description: Endpoints for collaborative strategy proposal, willingness selection, agreement documentation, and Tending check-ins.
 slug: /backend/api/stage-4
-updated: 2026-05-06
+updated: 2026-05-09
 ---
 # Stage 4 API: Strategic Repair
 
@@ -203,6 +203,53 @@ interface GetAgreementsResponse {
   agreements: AgreementDTO[];
 }
 ```
+
+---
+
+---
+
+## Proposal Capture: Typed Structured Input
+
+The AI populates a hidden `<stage4_proposals>` block in its response when it identifies proposals in the conversation. The capture service reads this block to extract typed proposals before falling back to free-text inference.
+
+### Stage4StructuredProposalInput shape
+
+```typescript
+interface Stage4StructuredProposalInput {
+  action:          'ADD' | 'REVISE' | 'REMOVE' | 'IGNORE';
+  classification:  'PROPOSAL' | 'REFLECTION' | 'SUCCESS_MARKER' | 'PROCESS';
+  kind?:           Stage4ProposalKind;    // authoritative if set; bypasses inferProposalKind()
+  description:     string;
+  ownerUserId?:    string;               // explicit ownership (INDIVIDUAL_COMMITMENT only)
+  targetProposalId?: string;             // required for REVISE / REMOVE actions
+}
+```
+
+When `structuredProposals` are present the capture service uses them directly and assigns a confidence score of **0.92**. When absent it falls back to free-text heuristics (`inferProposalKind()`) with a confidence of **0.78**.
+
+### inferProposalKind() fallback rules
+
+When no typed kind is supplied the heuristic defaults to **INDIVIDUAL_COMMITMENT** on ambiguity (safer than auto-promoting to shared):
+- Keywords "we", "together", "let's" → `SHARED_PROPOSAL`
+- First-person commitment ("I can", "I'll", "I will") → `INDIVIDUAL_COMMITMENT`
+- Explicit signals ("mine alone", "just for me") → `INDIVIDUAL_COMMITMENT`
+- Uncertain → `INDIVIDUAL_COMMITMENT` (safe default)
+
+---
+
+## Auto-Closure
+
+`applyStage4AutoClosureFromSignal()` (`backend/src/services/stage4-auto-closure.service.ts`) closes Stage 4 automatically when the AI emits a `Stage4ClosureSignalDTO` in its response micro-tags.
+
+### Closure paths
+
+| Signal | Condition | Result |
+|--------|-----------|--------|
+| `readyToClose: true` + `kind: NO_SHARED_AGREEMENT` | Always | Closes immediately with `NO_SHARED_AGREEMENT` |
+| `readyToClose: true` + `kind: SHARED_AGREEMENT` | Both partners have WILLING selection on ≥1 SHARED_PROPOSAL | Closes with `SHARED_AGREEMENT` |
+| `readyToClose: true` + `kind: SHARED_AGREEMENT` | Mutual WILLING not satisfied | Signal ignored; manual close required |
+
+Both auto-closure and manual `POST /stage4/close` filter needs using **OPEN and PARTIAL** coverage status when computing `openNeedIds` for the closure record.
 
 ---
 

--- a/docs/backend/api/stage-4.md
+++ b/docs/backend/api/stage-4.md
@@ -246,8 +246,9 @@ When no typed kind is supplied the heuristic defaults to **INDIVIDUAL_COMMITMENT
 | Signal | Condition | Result |
 |--------|-----------|--------|
 | `readyToClose: true` + `kind: NO_SHARED_AGREEMENT` | Always | Closes immediately with `NO_SHARED_AGREEMENT` |
-| `readyToClose: true` + `kind: SHARED_AGREEMENT` | Both partners have WILLING selection on ≥1 SHARED_PROPOSAL | Closes with `SHARED_AGREEMENT` |
-| `readyToClose: true` + `kind: SHARED_AGREEMENT` | Mutual WILLING not satisfied | Signal ignored; manual close required |
+| Any other signal | — | Returns `{closed: false, reason: 'no_explicit_no_shared_closure_signal'}` — signal ignored |
+
+> **Note:** `SHARED_AGREEMENT` closures are not handled by this function. They require the manual `POST /stage4/close` endpoint, which evaluates mutual WILLING selections and creates agreement records.
 
 Both auto-closure and manual `POST /stage4/close` filter needs using **OPEN and PARTIAL** coverage status when computing `openNeedIds` for the closure record.
 

--- a/docs/backend/data-model/prisma-schema.md
+++ b/docs/backend/data-model/prisma-schema.md
@@ -3,7 +3,7 @@ title: Prisma Schema
 sidebar_position: 1
 description: Core Vessel Architecture tables plus pointers to the rest of the Prisma schema (Inner Work, reconciler, memory, needs/people, telemetry).
 slug: /backend/data-model/prisma-schema
-updated: "2026-05-06"
+updated: "2026-05-09"
 ---
 # Prisma Schema
 
@@ -167,14 +167,30 @@ model UserVessel {
   updatedAt DateTime @updatedAt
 
   // Private content
-  events           UserEvent[]
+  events            UserEvent[]
   emotionalReadings EmotionalReading[]
-  identifiedNeeds  IdentifiedNeed[]
-  boundaries       Boundary[]
-  documents        UserDocument[]
+  identifiedNeeds   IdentifiedNeed[]
+  boundaries        Boundary[]
+  documents         UserDocument[]
 
-  // Embedding for semantic search within user's own content
-  embedding        Unsupported("vector(1536)")?
+  // Rolling conversation summary for long sessions
+  // Stores JSON: { text, keyThemes, emotionalJourney, unresolvedTopics }
+  conversationSummary String? @db.Text
+
+  // Session-level content embedding (vector(1024)) for semantic search
+  // Embeds combined facts + summary; replaces message-level embedding
+  contentEmbedding Unsupported("vector(1024)")?
+
+  // === Session Read State ===
+  lastViewedAt         DateTime?  // When user last opened this session's chat
+  lastSeenChatItemId   String?    // ID of last chat item seen (for "new messages" line)
+  lastViewedShareTabAt DateTime?  // When user last viewed the Share/Partner tab
+  lastActiveAt         DateTime?  // When user last actively did something (presence indicator)
+  archivedAt           DateTime?  // When user removed session from their conversation list
+
+  // AI-extracted structured facts: [{ category: string, fact: string }]
+  // Updated by Haiku after each message; reduces chat history in prompts
+  notableFacts Json?
 
   @@unique([userId, sessionId])
 }

--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -2,7 +2,7 @@
 title: Chat Interface
 sidebar_position: 3
 description: The primary conversation interface where users interact with the AI.
-updated: 2026-05-07
+updated: 2026-05-09
 status: living
 ---
 # Chat Interface
@@ -206,6 +206,16 @@ flowchart TB
 ## Session entry flow
 
 Before the chat list renders, `UnifiedSessionScreen` can swap in a full-screen mood check (`SessionEntryMoodCheck`) — this is the default entry when `shouldShowMoodCheck` is true. Only after the user submits (or dismisses) the mood reading does the usual chat layout show.
+
+## App-level overlays
+
+### Biometric Lock (`BiometricLockOverlay`)
+
+When the app returns from background after ≥5 seconds, `BiometricLockOverlay` covers the entire screen and prompts the user for biometric or device passcode authentication. On success the overlay dismisses. The context (`BiometricLockContext`) tracks lock state; the web variant is a no-op.
+
+### Notification Permission (`NotificationPermissionDrawer`)
+
+After a session turn completes, `useNotifications.ts` evaluates `shouldAskForSessionNotifications()`. When conditions are met the app shows a full-screen `NotificationPermissionDrawer` with the copy: *"Know when it is your turn again"* and a preview of the notification ("Your partner is ready"). Accepting calls `requestSessionNotifications()` which triggers the OS permission dialog and registers the Expo push token.
 
 ## Empty States
 


### PR DESCRIPTION
## Changes
- Add: Stage 4 typed structured proposal capture section to `stage-4.md` (Stage4StructuredProposalInput shape, confidence scoring, inferProposalKind fallback rules)
- Add: Auto-closure service documentation to `stage-4.md` (applyStage4AutoClosureFromSignal, closure paths table, OPEN+PARTIAL filter note)
- Add: Scanner filter middleware entry to `backend-overview.md` (blocks PHP/WP vulnerability probe paths before logging)
- Fix: 4xx→warn / 5xx→error logging split clarified in `backend-overview.md` (Sentry only receives error-level logs)
- Fix: UserVessel model in `prisma-schema.md` — add all read-state fields (lastViewedAt, lastSeenChatItemId, lastViewedShareTabAt, lastActiveAt, archivedAt, notableFacts, conversationSummary); fix contentEmbedding vector size 1536→1024
- Add: BiometricLockOverlay, NotificationPermissionDrawer, SessionChatHeader components to `structure.md`; add useNotifications hook
- Add: Biometric lock overlay and notification permission drawer flows to `chat-interface.md`
- Add: Circuit-breaker behavior note to sessions.md 404 error table

## Provenance
- **Channel:** cron / audit-docs
- **Requested by:** nightly incremental docs audit
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs workspace, stages/incremental/CONTEXT.md

## Docs updated
- `docs/backend/api/stage-4.md`
- `docs/architecture/backend-overview.md`
- `docs/backend/data-model/prisma-schema.md`
- `docs/architecture/structure.md`
- `docs/mobile/wireframes/chat-interface.md`
- `docs/backend/api/sessions.md`