### PR TITLE
[codex] Polish mobile chat navigation and light mode

### DIFF
--- a/mobile/app/(auth)/(tabs)/index.tsx
+++ b/mobile/app/(auth)/(tabs)/index.tsx
@@ -11,8 +11,9 @@
  * - Self-Reflection, Needs Assessment, Gratitude, Meditation
  */
 
-import { useMemo, useState, useEffect, useCallback } from 'react';
+import { useMemo, useState, useEffect, useCallback, useRef } from 'react';
 import {
+  Animated,
   View,
   Text,
   TouchableOpacity,
@@ -25,7 +26,7 @@ import {
   TextInput,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { ArrowRight, Plus, Layers, UserPlus, Menu, Settings } from 'lucide-react-native';
+import { ArrowRight, ArrowUp, Plus, Layers, UserPlus, Menu, Settings } from 'lucide-react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useAuth } from '@/src/hooks/useAuth';
@@ -49,6 +50,13 @@ export default function HomeScreen() {
   const { isAvailable, isEnrolled, hasPrompted, isLoading: biometricLoading } = useBiometricAuth();
   const { openDrawer } = useSessionDrawer();
   const { count: unreadCount } = useUnreadSessionCount();
+  const [isComposerFocused, setIsComposerFocused] = useState(false);
+  const composerExtrasOpacity = useRef(new Animated.Value(1)).current;
+
+  const dismissHomeComposer = useCallback(() => {
+    Keyboard.dismiss();
+    setIsComposerFocused(false);
+  }, []);
 
   // Check for pending invitation from deep link
   const { pendingInvitation, isLoading: isPendingLoading, clearInvitation } = usePendingInvitation();
@@ -91,6 +99,29 @@ export default function HomeScreen() {
       return () => clearTimeout(timer);
     }
   }, [biometricLoading, isAvailable, isEnrolled, hasPrompted]);
+
+  useEffect(() => {
+    const subscription = Keyboard.addListener('keyboardDidHide', () => {
+      setIsComposerFocused(false);
+    });
+
+    return () => subscription.remove();
+  }, []);
+
+  useEffect(() => {
+    if (isComposerFocused) {
+      composerExtrasOpacity.stopAnimation();
+      composerExtrasOpacity.setValue(0);
+      return;
+    }
+
+    composerExtrasOpacity.setValue(0);
+    Animated.timing(composerExtrasOpacity, {
+      toValue: 1,
+      duration: 180,
+      useNativeDriver: true,
+    }).start();
+  }, [composerExtrasOpacity, isComposerFocused]);
 
   // Find the most recent session with a partner nickname
   const mostRecentSession = useMemo(() => {
@@ -156,42 +187,42 @@ export default function HomeScreen() {
     <SessionDrawer>
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
         {/* Header with hamburger and settings icons */}
-          <View style={styles.headerBar}>
-            <TouchableOpacity
-              style={styles.headerIconButton}
-              onPress={openDrawer}
-              accessibilityRole="button"
-              accessibilityLabel="Open session drawer"
-            >
-              <Menu color={palette.textMuted} size={22} />
-              {unreadCount > 0 && (
-                <View style={styles.badge}>
-                  <Text style={styles.badgeText}>
-                    {unreadCount > 99 ? '99+' : unreadCount}
-                  </Text>
-                </View>
-              )}
-            </TouchableOpacity>
-            <View style={styles.brandMark}>
-              <View style={styles.brandDot} />
-              <Text style={styles.brandText}>meet without fear</Text>
-            </View>
-            <TouchableOpacity
-              style={styles.headerIconButton}
-              onPress={handleSettings}
-              accessibilityRole="button"
-              accessibilityLabel="Open settings"
-            >
-              <Settings color={palette.textMuted} size={22} />
-            </TouchableOpacity>
+        <View style={styles.headerBar}>
+          <TouchableOpacity
+            style={styles.headerIconButton}
+            onPress={openDrawer}
+            accessibilityRole="button"
+            accessibilityLabel="Open session drawer"
+          >
+            <Menu color={palette.textMuted} size={22} />
+            {unreadCount > 0 && (
+              <View style={styles.badge}>
+                <Text style={styles.badgeText}>
+                  {unreadCount > 99 ? '99+' : unreadCount}
+                </Text>
+              </View>
+            )}
+          </TouchableOpacity>
+          <View style={styles.brandMark}>
+            <View style={styles.brandDot} />
+            <Text style={styles.brandText}>meet without fear</Text>
           </View>
+          <TouchableOpacity
+            style={styles.headerIconButton}
+            onPress={handleSettings}
+            accessibilityRole="button"
+            accessibilityLabel="Open settings"
+          >
+            <Settings color={palette.textMuted} size={22} />
+          </TouchableOpacity>
+        </View>
 
           <KeyboardAvoidingView
             style={styles.keyboardAvoid}
             behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-            keyboardVerticalOffset={90}
+            keyboardVerticalOffset={0}
           >
-            <Pressable style={styles.content} onPress={Keyboard.dismiss}>
+            <Pressable style={styles.content} onPress={dismissHomeComposer}>
               <View style={styles.greetingSection}>
                 <Text style={styles.timeGreet}>{getGreetingLabel()}</Text>
                 <Text style={styles.greeting}>
@@ -202,102 +233,110 @@ export default function HomeScreen() {
                 </Text>
               </View>
 
-              <View style={styles.actionsSection}>
-                {/* Accept pending invitation - shown first if there's a pending invitation */}
-                {hasPendingInvitation && (
-                  <TouchableOpacity
-                    style={[styles.actionCard, styles.primaryActionCard]}
-                    onPress={handleAcceptInvitation}
-                    accessibilityRole="button"
-                    accessibilityLabel={`Accept ${inviterName}'s invitation`}
-                    disabled={acceptInvitation.isPending}
-                  >
-                    {acceptInvitation.isPending ? (
-                      <ActivityIndicator size="small" color={palette.accent} />
-                    ) : (
-                      <View style={styles.actionIcon}>
-                        <UserPlus color={palette.textMuted} size={18} />
+              {!isComposerFocused && (
+                <Animated.View style={{ opacity: composerExtrasOpacity }}>
+                <View style={styles.actionsSection}>
+                  {/* Accept pending invitation - shown first if there's a pending invitation */}
+                  {hasPendingInvitation && (
+                    <TouchableOpacity
+                      style={[styles.actionCard, styles.primaryActionCard]}
+                      onPress={handleAcceptInvitation}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Accept ${inviterName}'s invitation`}
+                      disabled={acceptInvitation.isPending}
+                    >
+                      {acceptInvitation.isPending ? (
+                        <ActivityIndicator size="small" color={palette.accent} />
+                      ) : (
+                        <View style={styles.actionIcon}>
+                          <UserPlus color={palette.textMuted} size={18} />
+                        </View>
+                      )}
+                      <View style={styles.actionTextBlock}>
+                        <Text style={styles.actionEyebrow}>Invitation waiting</Text>
+                        <Text style={styles.actionTitle}>Accept {inviterName}&apos;s invitation</Text>
+                        <Text style={styles.actionSub}>Join the conversation when you are ready</Text>
                       </View>
-                    )}
-                    <View style={styles.actionTextBlock}>
-                      <Text style={styles.actionEyebrow}>Invitation waiting</Text>
-                      <Text style={styles.actionTitle}>Accept {inviterName}&apos;s invitation</Text>
-                      <Text style={styles.actionSub}>Join the conversation when you are ready</Text>
-                    </View>
-                    <ArrowRight color={palette.textFaint} size={16} />
-                  </TouchableOpacity>
-                )}
+                      <ArrowRight color={palette.textFaint} size={16} />
+                    </TouchableOpacity>
+                  )}
 
-                {/* Continue with partner - only show if there's a recent session and no pending invitation */}
-                {!hasPendingInvitation && mostRecentSession && partnerDisplayName && (
+                  {/* Continue with partner - only show if there's a recent session and no pending invitation */}
+                  {!hasPendingInvitation && mostRecentSession && partnerDisplayName && (
+                    <TouchableOpacity
+                      style={[styles.actionCard, styles.primaryActionCard]}
+                      onPress={handleContinueSession}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Continue with ${partnerDisplayName}`}
+                    >
+                      <View style={styles.actionAvatar}>
+                        <Text style={styles.actionAvatarText}>{partnerDisplayName.charAt(0).toUpperCase()}</Text>
+                        <View style={styles.actionPing} />
+                      </View>
+                      <View style={styles.actionTextBlock}>
+                        <Text style={styles.actionEyebrow}>Continue</Text>
+                        <Text style={styles.actionTitle}>A note for {partnerDisplayName}</Text>
+                        <Text style={styles.actionSub}>Pick up where you left off</Text>
+                      </View>
+                      <ArrowRight color={palette.textFaint} size={16} />
+                    </TouchableOpacity>
+                  )}
+
+                  {/* New Session */}
                   <TouchableOpacity
-                    style={[styles.actionCard, styles.primaryActionCard]}
-                    onPress={handleContinueSession}
+                    style={styles.actionCard}
+                    onPress={handleNewSession}
                     accessibilityRole="button"
-                    accessibilityLabel={`Continue with ${partnerDisplayName}`}
+                    accessibilityLabel="Start new session"
                   >
-                    <View style={styles.actionAvatar}>
-                      <Text style={styles.actionAvatarText}>{partnerDisplayName.charAt(0).toUpperCase()}</Text>
-                      <View style={styles.actionPing} />
+                    <View style={styles.actionIcon}>
+                      <Plus color={palette.textMuted} size={18} />
                     </View>
                     <View style={styles.actionTextBlock}>
-                      <Text style={styles.actionEyebrow}>Continue</Text>
-                      <Text style={styles.actionTitle}>A note for {partnerDisplayName}</Text>
-                      <Text style={styles.actionSub}>Pick up where you left off</Text>
+                      <Text style={styles.actionTitle}>New conversation</Text>
+                      <Text style={styles.actionSub}>Start with someone close to you</Text>
                     </View>
                     <ArrowRight color={palette.textFaint} size={16} />
                   </TouchableOpacity>
-                )}
 
-                {/* New Session */}
-                <TouchableOpacity
-                  style={styles.actionCard}
-                  onPress={handleNewSession}
-                  accessibilityRole="button"
-                  accessibilityLabel="Start new session"
-                >
-                  <View style={styles.actionIcon}>
-                    <Plus color={palette.textMuted} size={18} />
-                  </View>
-                  <View style={styles.actionTextBlock}>
-                    <Text style={styles.actionTitle}>New conversation</Text>
-                    <Text style={styles.actionSub}>Start with someone close to you</Text>
-                  </View>
-                  <ArrowRight color={palette.textFaint} size={16} />
-                </TouchableOpacity>
-
-                {/* Inner Work */}
-                <TouchableOpacity
-                  style={styles.actionCard}
-                  onPress={handleInnerWork}
-                  accessibilityRole="button"
-                  accessibilityLabel="Inner Work"
-                >
-                  <View style={styles.actionIcon}>
-                    <Layers color={palette.textMuted} size={18} />
-                  </View>
-                  <View style={styles.actionTextBlock}>
-                    <Text style={styles.actionTitle}>Inner work</Text>
-                    <Text style={styles.actionSub}>Sit with what came up, just for you</Text>
-                  </View>
-                  <ArrowRight color={palette.textFaint} size={16} />
-                </TouchableOpacity>
-              </View>
-
-              <View style={styles.whisper}>
-                <View style={styles.whisperRule}>
-                  <View style={styles.whisperDot} />
-                  <Text style={styles.whisperLabel}>Today</Text>
-                  <View style={styles.whisperLine} />
+                  {/* Inner Work */}
+                  <TouchableOpacity
+                    style={styles.actionCard}
+                    onPress={handleInnerWork}
+                    accessibilityRole="button"
+                    accessibilityLabel="Inner Work"
+                  >
+                    <View style={styles.actionIcon}>
+                      <Layers color={palette.textMuted} size={18} />
+                    </View>
+                    <View style={styles.actionTextBlock}>
+                      <Text style={styles.actionTitle}>Inner work</Text>
+                      <Text style={styles.actionSub}>Sit with what came up, just for you</Text>
+                    </View>
+                    <ArrowRight color={palette.textFaint} size={16} />
+                  </TouchableOpacity>
                 </View>
-                <Text style={styles.whisperQuote}>
-                  It is okay to take your time getting to the words. The right ones usually arrive after the rough ones.
-                </Text>
-              </View>
+
+                <View style={styles.whisper}>
+                  <View style={styles.whisperRule}>
+                    <View style={styles.whisperDot} />
+                    <Text style={styles.whisperLabel}>Today</Text>
+                    <View style={styles.whisperLine} />
+                  </View>
+                  <Text style={styles.whisperQuote}>
+                    It is okay to take your time getting to the words. The right ones usually arrive after the rough ones.
+                  </Text>
+                </View>
+                </Animated.View>
+              )}
             </Pressable>
 
             <View style={styles.chatInputSection}>
-              <HomeComposer onSend={handleHomeChat} palette={palette} />
+              <HomeComposer
+                onSend={handleHomeChat}
+                onFocusChange={setIsComposerFocused}
+                palette={palette}
+              />
             </View>
         </KeyboardAvoidingView>
 
@@ -315,14 +354,16 @@ export default function HomeScreen() {
 function getGreetingLabel() {
   const hour = new Date().getHours();
   const part = hour < 12 ? 'morning' : hour < 17 ? 'afternoon' : 'evening';
-  return `Today ${part}`;
+  return `This ${part}`;
 }
 
 function HomeComposer({
   onSend,
+  onFocusChange,
   palette,
 }: {
   onSend: (message: string) => void;
+  onFocusChange: (focused: boolean) => void;
   palette: ReturnType<typeof useAppAppearance>['palette'];
 }) {
   const [value, setValue] = useState('');
@@ -350,6 +391,8 @@ function HomeComposer({
             color: palette.text,
           },
         ]}
+        onFocus={() => onFocusChange(true)}
+        onBlur={() => onFocusChange(false)}
         onSubmitEditing={handleSend}
         returnKeyType="send"
       />
@@ -363,7 +406,7 @@ function HomeComposer({
         accessibilityRole="button"
         accessibilityLabel="Send"
       >
-        <ArrowRight color={canSend ? palette.bg : palette.textFaint} size={18} />
+        <ArrowUp color={canSend ? palette.bg : palette.textFaint} size={18} />
       </TouchableOpacity>
     </View>
   );

--- a/mobile/app/(auth)/_layout.tsx
+++ b/mobile/app/(auth)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Stack, Redirect } from 'expo-router';
 import { useAuth as useClerkAuth } from '@clerk/clerk-expo';
-import { colors } from '@/theme';
+import { useAppAppearance } from '@/src/theme';
 import { useUserSessionUpdates } from '@/src/hooks/useRealtime';
 import { isE2EMode } from '@/src/providers/E2EAuthProvider';
 import { useOTAUpdate } from '@/src/hooks/useOTAUpdate';
@@ -17,6 +17,7 @@ import { BiometricLockOverlay } from '@/src/components/BiometricLockOverlay';
  */
 export default function AuthLayout() {
   const { isSignedIn, isLoaded } = useClerkAuth();
+  const { palette } = useAppAppearance();
 
   // Subscribe to user-level session updates for real-time list refreshes
   // This is placed here (not in individual screens) to ensure only ONE Ably connection
@@ -43,20 +44,26 @@ export default function AuthLayout() {
       <Stack
         screenOptions={{
           headerShown: false,
+          gestureEnabled: false,
           headerStyle: {
-            backgroundColor: colors.bgPrimary,
+            backgroundColor: palette.bg,
           },
-          headerTintColor: colors.textPrimary,
+          headerTintColor: palette.text,
           headerTitleStyle: {
-            color: colors.textPrimary,
+            color: palette.text,
           },
           contentStyle: {
-            backgroundColor: colors.bgPrimary,
+            backgroundColor: palette.bg,
           },
         }}
       >
         {/* Main screens (Home, Settings) */}
-        <Stack.Screen name="(tabs)" />
+        <Stack.Screen
+          name="(tabs)"
+          options={{
+            animationTypeForReplace: 'pop',
+          }}
+        />
 
         {/* Inner Work - animation is handled at the screen level */}
         <Stack.Screen name="inner-work" />
@@ -66,6 +73,7 @@ export default function AuthLayout() {
           name="settings"
           options={{
             animation: 'slide_from_right',
+            gestureEnabled: true,
           }}
         />
 
@@ -77,9 +85,15 @@ export default function AuthLayout() {
             presentation: 'modal',
             headerShown: true,
             title: 'New Session',
+            gestureEnabled: true,
           }}
         />
-        <Stack.Screen name="session/[id]" />
+        <Stack.Screen
+          name="session/[id]"
+          options={{
+            gestureEnabled: true,
+          }}
+        />
 
         {/* Person detail */}
         <Stack.Screen
@@ -87,6 +101,7 @@ export default function AuthLayout() {
           options={{
             headerShown: true,
             title: 'Person',
+            gestureEnabled: true,
           }}
         />
       </Stack>

--- a/mobile/app/(auth)/inner-work/_layout.tsx
+++ b/mobile/app/(auth)/inner-work/_layout.tsx
@@ -10,24 +10,26 @@
  */
 
 import { Stack } from 'expo-router';
-import { colors } from '@/theme';
+import { useAppAppearance } from '@/src/theme';
 
 export default function InnerWorkLayout() {
+  const { palette } = useAppAppearance();
+
   return (
     <Stack
       screenOptions={{
         headerShown: true,
         headerBackTitle: 'Back',
         headerStyle: {
-          backgroundColor: colors.bgSecondary,
+          backgroundColor: palette.bg,
         },
-        headerTintColor: colors.textPrimary,
+        headerTintColor: palette.text,
         headerTitleStyle: {
-          color: colors.textPrimary,
+          color: palette.text,
         },
         headerShadowVisible: false,
         contentStyle: {
-          backgroundColor: colors.bgPrimary,
+          backgroundColor: palette.bg,
         },
       }}
     >

--- a/mobile/app/(auth)/inner-work/self-reflection/_layout.tsx
+++ b/mobile/app/(auth)/inner-work/self-reflection/_layout.tsx
@@ -8,24 +8,26 @@
  */
 
 import { Stack } from 'expo-router';
-import { colors } from '@/theme';
+import { useAppAppearance } from '@/src/theme';
 
 export default function SelfReflectionLayout() {
+  const { palette } = useAppAppearance();
+
   return (
     <Stack
       screenOptions={{
         headerShown: true,
         headerBackTitle: 'Back',
         headerStyle: {
-          backgroundColor: colors.bgSecondary,
+          backgroundColor: palette.bg,
         },
-        headerTintColor: colors.textPrimary,
+        headerTintColor: palette.text,
         headerTitleStyle: {
-          color: colors.textPrimary,
+          color: palette.text,
         },
         headerShadowVisible: false,
         contentStyle: {
-          backgroundColor: colors.bgPrimary,
+          backgroundColor: palette.bg,
         },
         // Allow swipe back gesture
         gestureEnabled: true,

--- a/mobile/app/(auth)/inner-work/self-reflection/index.tsx
+++ b/mobile/app/(auth)/inner-work/self-reflection/index.tsx
@@ -18,7 +18,7 @@ import { Swipeable } from 'react-native-gesture-handler';
 import { useInnerThoughtsSessionsInfinite, useCreateInnerThoughtsSession, useArchiveInnerThoughtsSession } from '@/src/hooks';
 import { ScreenHeader } from '@/src/components';
 import { createStyles } from '@/src/theme/styled';
-import { colors } from '@/src/theme';
+import { colors, useAppAppearance } from '@/src/theme';
 import { InnerWorkSessionSummaryDTO } from '@meet-without-fear/shared';
 
 // Animation types for delete
@@ -49,6 +49,7 @@ function formatTimeAgo(dateStr: string): string {
 
 export default function SelfReflectionListScreen() {
   const styles = useStyles();
+  const { palette } = useAppAppearance();
   const router = useRouter();
   const {
     data,
@@ -82,10 +83,10 @@ export default function SelfReflectionListScreen() {
     if (!isFetchingNextPage) return null;
     return (
       <View style={styles.footerLoader}>
-        <ActivityIndicator size="small" color={colors.accent} />
+        <ActivityIndicator size="small" color={palette.accent} />
       </View>
     );
-  }, [isFetchingNextPage, styles.footerLoader]);
+  }, [isFetchingNextPage, palette.accent, styles.footerLoader]);
 
   const handleStartNew = async () => {
     try {
@@ -266,7 +267,10 @@ export default function SelfReflectionListScreen() {
           <Pressable
             style={({ pressed }) => [
               styles.sessionCard,
-              pressed && styles.sessionCardPressed,
+              {
+                backgroundColor: pressed ? palette.chipBg : palette.bgElev,
+                borderColor: palette.border,
+              },
             ]}
             onPress={() => handleOpenSession(item.id)}
             disabled={isDeleting}
@@ -275,19 +279,19 @@ export default function SelfReflectionListScreen() {
           >
             <View style={styles.sessionContent}>
               <View style={styles.sessionTitleRow}>
-                <Text style={styles.sessionTitle} numberOfLines={1}>
+                <Text style={[styles.sessionTitle, { color: palette.text }]} numberOfLines={1}>
                   {displayTitle}
                 </Text>
                 {isLinked && (
-                  <Link color={colors.accent} size={14} />
+                  <Link color={palette.accent} size={14} />
                 )}
               </View>
-              <Text style={styles.sessionSummary} numberOfLines={2}>
+              <Text style={[styles.sessionSummary, { color: palette.textMuted }]} numberOfLines={2}>
                 {displaySummary}
               </Text>
-              <Text style={styles.sessionTime}>{timeAgo}</Text>
+              <Text style={[styles.sessionTime, { color: palette.textFaint }]}>{timeAgo}</Text>
             </View>
-            <ChevronRight color="#666" size={20} />
+            <ChevronRight color={palette.textFaint} size={20} />
           </Pressable>
         </Swipeable>
       </Animated.View>
@@ -298,9 +302,9 @@ export default function SelfReflectionListScreen() {
   // Header configuration
   const headerConfig = {
     title: 'Self-Reflection',
-    titleIcon: <MessageCircle color={colors.accent} size={18} />,
+    titleIcon: <MessageCircle color={palette.accent} size={18} />,
     rightAction: {
-      icon: <Plus color={colors.textPrimary} size={24} />,
+      icon: <Plus color={palette.text} size={24} />,
       onPress: handleStartNew,
       loading: createSession.isPending,
       accessibilityLabel: 'Start new self-reflection session',
@@ -309,25 +313,25 @@ export default function SelfReflectionListScreen() {
 
   if (isLoading) {
     return (
-      <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top', 'bottom']}>
         <ScreenHeader {...headerConfig} />
         <View style={styles.centerContainer}>
-          <ActivityIndicator size="large" color={colors.accent} />
-          <Text style={styles.loadingText}>Loading...</Text>
+          <ActivityIndicator size="large" color={palette.accent} />
+          <Text style={[styles.loadingText, { color: palette.textMuted }]}>Loading...</Text>
         </View>
       </SafeAreaView>
     );
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+    <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top', 'bottom']}>
       <ScreenHeader {...headerConfig} />
 
       {sessions.length === 0 && !isLoading ? (
         <View style={styles.emptyContainer}>
-          <MessageCircle color="#666" size={48} />
-          <Text style={styles.emptyTitle}>No sessions yet</Text>
-          <Text style={styles.emptySubtitle}>
+          <MessageCircle color={palette.textFaint} size={48} />
+          <Text style={[styles.emptyTitle, { color: palette.text }]}>No sessions yet</Text>
+          <Text style={[styles.emptySubtitle, { color: palette.textMuted }]}>
             Start a session to explore what's on your mind
           </Text>
         </View>
@@ -381,6 +385,7 @@ const useStyles = () =>
       backgroundColor: t.colors.bgSecondary,
       borderRadius: t.radius.lg,
       padding: t.spacing.lg,
+      borderWidth: 1,
     },
     sessionCardPressed: {
       backgroundColor: t.colors.bgTertiary,

--- a/mobile/app/(auth)/session/[id]/_layout.tsx
+++ b/mobile/app/(auth)/session/[id]/_layout.tsx
@@ -12,6 +12,7 @@ export default function SessionLayout() {
     <Stack
       screenOptions={{
         headerShown: false, // UnifiedSessionScreen has its own header
+        gestureEnabled: true,
         contentStyle: {
           backgroundColor: colors.bgPrimary,
         },
@@ -37,6 +38,7 @@ export default function SessionLayout() {
           },
           headerBackTitle: 'Chat',
           presentation: 'card',
+          gestureEnabled: true,
         }}
       />
       <Stack.Screen

--- a/mobile/app/(auth)/session/[id]/index.tsx
+++ b/mobile/app/(auth)/session/[id]/index.tsx
@@ -1,6 +1,5 @@
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
 import { UnifiedSessionScreen } from '@/src/screens/UnifiedSessionScreen';
-import { SessionDrawer } from '@/src/components';
 import { Stage } from '@meet-without-fear/shared';
 
 /**
@@ -44,15 +43,13 @@ export default function SessionScreen() {
           headerShown: false, // UnifiedSessionScreen has its own header
         }}
       />
-      <SessionDrawer>
-        <UnifiedSessionScreen
-          sessionId={id}
-          initialTendingEntryId={typeof tendingEntryId === 'string' ? tendingEntryId : null}
-          auditFixture={typeof auditFixture === 'string' ? auditFixture : null}
-          onNavigateBack={handleNavigateBack}
-          onStageComplete={handleStageComplete}
-        />
-      </SessionDrawer>
+      <UnifiedSessionScreen
+        sessionId={id}
+        initialTendingEntryId={typeof tendingEntryId === 'string' ? tendingEntryId : null}
+        auditFixture={typeof auditFixture === 'string' ? auditFixture : null}
+        onNavigateBack={handleNavigateBack}
+        onStageComplete={handleStageComplete}
+      />
     </>
   );
 }

--- a/mobile/app/(auth)/session/new.tsx
+++ b/mobile/app/(auth)/session/new.tsx
@@ -12,7 +12,7 @@
  * and pre-fills the partner name if available.
  */
 
-import { useState, useEffect } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -30,10 +30,10 @@ import { Send, User, UserPlus, Check, Layers } from 'lucide-react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useCreateSession } from '@/src/hooks/useSessions';
-import { usePeople } from '@/src/hooks/usePerson';
+import { dedupePeople, usePeople } from '@/src/hooks/usePerson';
 import { useGenerateContext } from '@/src/hooks/useInnerThoughts';
 import { NotificationPermissionDrawer } from '@/src/components/NotificationPermissionDrawer';
-import { colors } from '@/src/theme';
+import { useAppAppearance } from '@/src/theme';
 import { trackSessionCreated, trackPersonSelected } from '@/src/services/analytics';
 import {
   getNotificationPermissionStatus,
@@ -47,6 +47,8 @@ import type { PersonSummaryDTO, GenerateContextResponse } from '@meet-without-fe
 
 export default function NewSessionScreen() {
   const router = useRouter();
+  const { palette } = useAppAppearance();
+  const styles = useStyles();
   const { partnerName, innerThoughtsId } = useLocalSearchParams<{
     partnerName?: string;
     innerThoughtsId?: string;
@@ -62,7 +64,8 @@ export default function NewSessionScreen() {
   const [notificationLoading, setNotificationLoading] = useState(false);
   const [pendingSubmit, setPendingSubmit] = useState<(() => Promise<void>) | null>(null);
 
-  const { data: people = [], isLoading: peopleLoading } = usePeople();
+  const { data: rawPeople = [], isLoading: peopleLoading } = usePeople();
+  const people = useMemo(() => dedupePeople(rawPeople), [rawPeople]);
   const { mutateAsync: createSession, isPending } = useCreateSession();
   const { mutateAsync: generateContext, isPending: isGeneratingContext } = useGenerateContext();
 
@@ -239,12 +242,12 @@ export default function NewSessionScreen() {
             {innerThoughtsId && (
               <View style={styles.contextBanner}>
                 <View style={styles.contextBannerHeader}>
-                  <Layers size={16} color={colors.brandBlue} />
+                  <Layers size={16} color={palette.accent} />
                   <Text style={styles.contextBannerTitle}>From Inner Thoughts</Text>
                 </View>
                 {isGeneratingContext ? (
                   <View style={styles.contextLoading}>
-                    <ActivityIndicator size="small" color={colors.brandBlue} />
+                    <ActivityIndicator size="small" color={palette.accent} />
                     <Text style={styles.contextLoadingText}>Preparing context...</Text>
                   </View>
                 ) : innerThoughtsContext ? (
@@ -266,7 +269,7 @@ export default function NewSessionScreen() {
                 >
                   <User
                     size={18}
-                    color={mode === 'pick' ? colors.brandBlue : colors.textSecondary}
+                    color={mode === 'pick' ? palette.accent : palette.textMuted}
                   />
                   <Text
                     style={[styles.tabText, mode === 'pick' && styles.tabTextActive]}
@@ -282,7 +285,7 @@ export default function NewSessionScreen() {
                 >
                   <UserPlus
                     size={18}
-                    color={mode === 'new' ? colors.brandBlue : colors.textSecondary}
+                    color={mode === 'new' ? palette.accent : palette.textMuted}
                   />
                   <Text
                     style={[styles.tabText, mode === 'new' && styles.tabTextActive]}
@@ -297,7 +300,7 @@ export default function NewSessionScreen() {
             {effectiveMode === 'pick' && hasPeople && (
               <View style={styles.peopleList}>
                 {peopleLoading ? (
-                  <ActivityIndicator color={colors.brandBlue} />
+                  <ActivityIndicator color={palette.accent} />
                 ) : (
                   people.map((person) => (
                     <TouchableOpacity
@@ -333,7 +336,7 @@ export default function NewSessionScreen() {
                       </View>
                       {selectedPerson?.id === person.id && (
                         <View style={styles.checkIcon}>
-                          <Check size={20} color={colors.brandBlue} />
+                          <Check size={20} color={palette.accent} />
                         </View>
                       )}
                     </TouchableOpacity>
@@ -369,7 +372,7 @@ export default function NewSessionScreen() {
                   <TextInput
                     style={styles.input}
                     placeholder="Enter their first name"
-                    placeholderTextColor={colors.textMuted}
+                    placeholderTextColor={palette.textFaint}
                     value={firstName}
                     onChangeText={setFirstName}
                     autoCapitalize="words"
@@ -384,7 +387,7 @@ export default function NewSessionScreen() {
                   <TextInput
                     style={styles.input}
                     placeholder="Enter their last name"
-                    placeholderTextColor={colors.textMuted}
+                    placeholderTextColor={palette.textFaint}
                     value={lastName}
                     onChangeText={setLastName}
                     autoCapitalize="words"
@@ -410,11 +413,11 @@ export default function NewSessionScreen() {
               accessibilityLabel="Create session"
             >
               {isPending ? (
-                <ActivityIndicator color={colors.textPrimary} size="small" />
+                <ActivityIndicator color={palette.bg} size="small" />
               ) : (
                 <>
                   <Text style={styles.submitButtonText}>Create Session</Text>
-                  <Send color={colors.textPrimary} size={20} />
+                  <Send color={palette.bg} size={20} />
                 </>
               )}
             </TouchableOpacity>
@@ -449,223 +452,227 @@ function formatRelativeTime(dateString: string): string {
 // Styles
 // ============================================================================
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.bgPrimary,
-  },
-  keyboardView: {
-    flex: 1,
-  },
-  scrollView: {
-    flex: 1,
-  },
-  content: {
-    flexGrow: 1,
-    justifyContent: 'space-between',
-  },
-  form: {
-    padding: 16,
-    gap: 20,
-  },
-  heading: {
-    fontSize: 24,
-    fontWeight: '700',
-    color: colors.textPrimary,
-    marginBottom: 4,
-  },
-  subheading: {
-    fontSize: 16,
-    color: colors.textSecondary,
-    lineHeight: 24,
-    marginBottom: 8,
-  },
-  // Tabs
-  tabs: {
-    flexDirection: 'row',
-    backgroundColor: colors.bgSecondary,
-    borderRadius: 12,
-    padding: 4,
-  },
-  tab: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 8,
-    gap: 8,
-  },
-  tabActive: {
-    backgroundColor: colors.bgPrimary,
-  },
-  tabText: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: colors.textSecondary,
-  },
-  tabTextActive: {
-    color: colors.brandBlue,
-  },
-  // People list
-  peopleList: {
-    gap: 12,
-  },
-  personCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: colors.bgSecondary,
-    borderRadius: 12,
-    padding: 12,
-    borderWidth: 2,
-    borderColor: 'transparent',
-  },
-  personCardSelected: {
-    borderColor: colors.brandBlue,
-    backgroundColor: `${colors.brandBlue}10`,
-  },
-  personAvatar: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    backgroundColor: colors.bgTertiary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  personAvatarText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: colors.textPrimary,
-  },
-  personInfo: {
-    flex: 1,
-    marginLeft: 12,
-  },
-  personNameRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  personName: {
-    fontSize: 17,
-    fontWeight: '600',
-    color: colors.textPrimary,
-  },
-  activeBadge: {
-    backgroundColor: `${colors.brandBlue}20`,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 8,
-  },
-  activeBadgeText: {
-    fontSize: 11,
-    fontWeight: '600',
-    color: colors.brandBlue,
-  },
-  personMeta: {
-    fontSize: 13,
-    color: colors.textSecondary,
-    marginTop: 2,
-  },
-  checkIcon: {
-    marginLeft: 8,
-  },
-  activeWarningBanner: {
-    backgroundColor: `${colors.warning}15`,
-    borderRadius: 12,
-    padding: 16,
-    borderWidth: 1,
-    borderColor: `${colors.warning}30`,
-    gap: 12,
-  },
-  activeWarningText: {
-    fontSize: 15,
-    color: colors.textSecondary,
-    lineHeight: 22,
-  },
-  continueExistingButton: {
-    backgroundColor: colors.brandBlue,
-    borderRadius: 8,
-    paddingVertical: 10,
-    paddingHorizontal: 16,
-    alignItems: 'center',
-  },
-  continueExistingButtonText: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: colors.textPrimary,
-  },
-  // Input group
-  inputGroup: {
-    gap: 8,
-  },
-  label: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: colors.textSecondary,
-  },
-  input: {
-    backgroundColor: colors.bgSecondary,
-    borderRadius: 12,
-    padding: 16,
-    fontSize: 17,
-    borderWidth: 1,
-    borderColor: colors.border,
-    color: colors.textPrimary,
-  },
-  footer: {
-    padding: 16,
-    paddingBottom: 24,
-  },
-  submitButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.brandBlue,
-    borderRadius: 12,
-    padding: 16,
-    gap: 8,
-  },
-  submitButtonDisabled: {
-    backgroundColor: colors.bgTertiary,
-  },
-  submitButtonText: {
-    fontSize: 17,
-    fontWeight: '600',
-    color: colors.textPrimary,
-  },
-  // Context banner (from Inner Thoughts)
-  contextBanner: {
-    backgroundColor: `${colors.brandBlue}15`,
-    borderRadius: 12,
-    padding: 12,
-    borderWidth: 1,
-    borderColor: `${colors.brandBlue}30`,
-  },
-  contextBannerHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginBottom: 8,
-  },
-  contextBannerTitle: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: colors.brandBlue,
-  },
-  contextBannerText: {
-    fontSize: 14,
-    color: colors.textSecondary,
-    lineHeight: 20,
-  },
-  contextLoading: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  contextLoadingText: {
-    fontSize: 13,
-    color: colors.textMuted,
-  },
-});
+const useStyles = () => {
+  const { palette } = useAppAppearance();
+
+  return useMemo(() => StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: palette.bg,
+    },
+    keyboardView: {
+      flex: 1,
+    },
+    scrollView: {
+      flex: 1,
+    },
+    content: {
+      flexGrow: 1,
+      justifyContent: 'space-between',
+    },
+    form: {
+      padding: 16,
+      gap: 20,
+    },
+    heading: {
+      fontSize: 24,
+      fontWeight: '700',
+      color: palette.text,
+      marginBottom: 4,
+    },
+    subheading: {
+      fontSize: 16,
+      color: palette.textMuted,
+      lineHeight: 24,
+      marginBottom: 8,
+    },
+    // Tabs
+    tabs: {
+      flexDirection: 'row',
+      backgroundColor: palette.chipBg,
+      borderRadius: 12,
+      padding: 4,
+    },
+    tab: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: 12,
+      paddingHorizontal: 16,
+      borderRadius: 8,
+      gap: 8,
+    },
+    tabActive: {
+      backgroundColor: palette.bgElev,
+    },
+    tabText: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: palette.textMuted,
+    },
+    tabTextActive: {
+      color: palette.accent,
+    },
+    // People list
+    peopleList: {
+      gap: 12,
+    },
+    personCard: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: palette.bgElev,
+      borderRadius: 12,
+      padding: 12,
+      borderWidth: 2,
+      borderColor: palette.border,
+    },
+    personCardSelected: {
+      borderColor: palette.accent,
+      backgroundColor: palette.accentSoft,
+    },
+    personAvatar: {
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      backgroundColor: palette.chipBg,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    personAvatarText: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: palette.text,
+    },
+    personInfo: {
+      flex: 1,
+      marginLeft: 12,
+    },
+    personNameRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    personName: {
+      fontSize: 17,
+      fontWeight: '600',
+      color: palette.text,
+    },
+    activeBadge: {
+      backgroundColor: palette.accentSoft,
+      paddingHorizontal: 8,
+      paddingVertical: 2,
+      borderRadius: 8,
+    },
+    activeBadgeText: {
+      fontSize: 11,
+      fontWeight: '600',
+      color: palette.accentText,
+    },
+    personMeta: {
+      fontSize: 13,
+      color: palette.textMuted,
+      marginTop: 2,
+    },
+    checkIcon: {
+      marginLeft: 8,
+    },
+    activeWarningBanner: {
+      backgroundColor: palette.warningSoft,
+      borderRadius: 12,
+      padding: 16,
+      borderWidth: 1,
+      borderColor: palette.borderStrong,
+      gap: 12,
+    },
+    activeWarningText: {
+      fontSize: 15,
+      color: palette.textMuted,
+      lineHeight: 22,
+    },
+    continueExistingButton: {
+      backgroundColor: palette.accent,
+      borderRadius: 8,
+      paddingVertical: 10,
+      paddingHorizontal: 16,
+      alignItems: 'center',
+    },
+    continueExistingButtonText: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: palette.bg,
+    },
+    // Input group
+    inputGroup: {
+      gap: 8,
+    },
+    label: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: palette.textMuted,
+    },
+    input: {
+      backgroundColor: palette.bgElev,
+      borderRadius: 12,
+      padding: 16,
+      fontSize: 17,
+      borderWidth: 1,
+      borderColor: palette.border,
+      color: palette.text,
+    },
+    footer: {
+      padding: 16,
+      paddingBottom: 24,
+    },
+    submitButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: palette.accent,
+      borderRadius: 12,
+      padding: 16,
+      gap: 8,
+    },
+    submitButtonDisabled: {
+      backgroundColor: palette.chipBg,
+    },
+    submitButtonText: {
+      fontSize: 17,
+      fontWeight: '600',
+      color: palette.bg,
+    },
+    // Context banner (from Inner Thoughts)
+    contextBanner: {
+      backgroundColor: palette.accentSoft,
+      borderRadius: 12,
+      padding: 12,
+      borderWidth: 1,
+      borderColor: palette.borderStrong,
+    },
+    contextBannerHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      marginBottom: 8,
+    },
+    contextBannerTitle: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: palette.accentText,
+    },
+    contextBannerText: {
+      fontSize: 14,
+      color: palette.textMuted,
+      lineHeight: 20,
+    },
+    contextLoading: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    contextLoadingText: {
+      fontSize: 13,
+      color: palette.textFaint,
+    },
+  }), [palette]);
+};

--- a/mobile/app/(auth)/settings/_layout.tsx
+++ b/mobile/app/(auth)/settings/_layout.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Stack, useRouter } from 'expo-router';
-import { TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 import { ChevronLeft } from 'lucide-react-native';
 import { designFonts, useAppAppearance } from '@/theme';
 
@@ -19,8 +19,13 @@ function BackButton() {
   const router = useRouter();
   const { palette } = useAppAppearance();
   return (
-    <TouchableOpacity onPress={() => router.back()} style={{ marginLeft: -8, padding: 8 }}>
-      <ChevronLeft color={palette.text} size={28} />
+    <TouchableOpacity
+      onPress={() => router.back()}
+      style={[styles.backButton, { backgroundColor: palette.chipBg }]}
+      accessibilityRole="button"
+      accessibilityLabel="Go back"
+    >
+      <ChevronLeft color={palette.text} size={24} strokeWidth={2.4} />
     </TouchableOpacity>
   );
 }
@@ -33,9 +38,8 @@ export default function SettingsLayout() {
       screenOptions={{
         headerShown: true,
         headerBackTitle: 'Back',
-        headerTransparent: true,
         headerStyle: {
-          backgroundColor: 'transparent',
+          backgroundColor: palette.bg,
         },
         headerTintColor: palette.text,
         headerTitleStyle: {
@@ -89,3 +93,14 @@ export default function SettingsLayout() {
     </Stack>
   );
 }
+
+const styles = StyleSheet.create({
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: -4,
+  },
+});

--- a/mobile/app/(auth)/settings/index.tsx
+++ b/mobile/app/(auth)/settings/index.tsx
@@ -274,7 +274,7 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
   },
   content: {
     paddingHorizontal: 16,
-    paddingTop: 64,
+    paddingTop: 16,
     paddingBottom: 16,
     gap: 24,
   },

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -127,7 +127,7 @@ function AppShell({ includeMixpanel = true }: { includeMixpanel?: boolean }) {
             <SessionDrawerProvider>
               <ToastProvider>
                 {includeMixpanel && <MixpanelInitializer />}
-                <Stack screenOptions={{ headerShown: false }}>
+                <Stack screenOptions={{ headerShown: false, gestureEnabled: false }}>
                   <Stack.Screen name="(public)" />
                   <Stack.Screen name="(auth)" />
                   <Stack.Screen name="+not-found" options={{ headerShown: true }} />

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -43,6 +43,13 @@ const isE2EMode = process.env.EXPO_PUBLIC_E2E_MODE === 'true';
 const originalResolveRequest = config.resolver.resolveRequest;
 
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === 'react-native-reanimated' || moduleName.startsWith('react-native-reanimated/')) {
+    return {
+      filePath: require.resolve(moduleName, { paths: [projectRoot] }),
+      type: 'sourceFile',
+    };
+  }
+
   if (moduleName === '@meet-without-fear/shared') {
     return {
       filePath: path.resolve(workspaceRoot, 'shared/src/index.ts'),

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -66,7 +66,7 @@
     "react-native-audio-record": "^0.2.2",
     "react-native-drawer-layout": "^4.2.1",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-reanimated": "~4.1.1",
+    "react-native-reanimated": "4.1.6",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-sse": "^1.2.1",

--- a/mobile/src/components/ActivityDrawer.tsx
+++ b/mobile/src/components/ActivityDrawer.tsx
@@ -311,6 +311,7 @@ export function ActivityDrawer({
   // FlatList can be constrained to the visible area of the drawer.
   const [headerAreaHeight, setHeaderAreaHeight] = useState(0);
   const [snapPosition, setSnapPosition] = useState<'3q' | 'full'>('3q');
+  const [isMounted, setIsMounted] = useState(visible);
 
   // The visible height for the FlatList: screen minus snap offset minus header area
   const listHeight = useMemo(() => {
@@ -340,8 +341,10 @@ export function ActivityDrawer({
   const openDrawer = useCallback(() => {
     currentSnap.current = '3q';
     setSnapPosition('3q');
+    drawerTranslate.setValue(windowHeightRef.current);
+    backdropOpacity.setValue(0);
     snapTo(position3QRef.current, 0.4);
-  }, [snapTo]);
+  }, [backdropOpacity, drawerTranslate, snapTo]);
 
   const closeDrawer = useCallback(() => {
     Animated.parallel([
@@ -357,6 +360,7 @@ export function ActivityDrawer({
       }),
     ]).start(() => {
       currentSnap.current = '3q';
+      setIsMounted(false);
       onClose();
     });
   }, [drawerTranslate, backdropOpacity, onClose]);
@@ -365,20 +369,10 @@ export function ActivityDrawer({
   // The else branch is unnecessary since the component returns null when !visible.
   useEffect(() => {
     if (visible) {
+      setIsMounted(true);
       openDrawer();
     }
   }, [visible, openDrawer]);
-
-  useEffect(() => {
-    if (!visible) {
-      drawerTranslate.setValue(windowHeight);
-      return;
-    }
-
-    const position = currentSnap.current === 'full' ? positionFullRef.current : position3Q;
-    drawerTranslate.setValue(position);
-    setSnapPosition(currentSnap.current);
-  }, [visible, windowHeight, position3Q, drawerTranslate]);
 
   // -------------------------------------------------------------------------
   // Android back button
@@ -466,7 +460,7 @@ export function ActivityDrawer({
   // can override a parent's pointer-events:none with their own pointer-events:auto,
   // so the only reliable way to prevent the invisible backdrop from blocking clicks
   // is to remove it from the DOM entirely.
-  if (!visible) return null;
+  if (!isMounted) return null;
 
   return (
     <View
@@ -490,6 +484,7 @@ export function ActivityDrawer({
 
       {/* Drawer */}
       <Animated.View
+        pointerEvents={visible ? 'auto' : 'none'}
         style={[
           styles.drawer,
           appWidthStyle,
@@ -611,11 +606,11 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
     position: 'absolute',
     left: 0,
     right: 0,
-    backgroundColor: palette.bgPane,
-    borderWidth: 1,
+    backgroundColor: palette.bg,
+    borderTopWidth: 1,
     borderColor: palette.border,
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
+    borderTopLeftRadius: 14,
+    borderTopRightRadius: 14,
     overflow: 'hidden',
     elevation: 10,
   },
@@ -625,17 +620,19 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
     alignItems: 'center',
   },
   dragHandle: {
-    width: 36,
+    width: 38,
     height: 4,
     borderRadius: 2,
-    backgroundColor: palette.borderStrong,
+    backgroundColor: palette.textFaint,
+    opacity: 0.45,
   },
   header: {
-    fontSize: 16,
-    fontWeight: '600',
+    fontSize: 22,
+    fontWeight: '400',
     color: palette.text,
     paddingHorizontal: 16,
-    paddingBottom: 12,
+    paddingBottom: 14,
+    fontFamily: 'Lora',
   },
   sectionHeader: {
     fontSize: 11,
@@ -656,6 +653,11 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
   topicBlock: {
     marginTop: 4,
     marginBottom: 16,
+    padding: 14,
+    borderRadius: 10,
+    backgroundColor: palette.bgElev,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   topicLabel: {
     fontSize: 11,
@@ -670,22 +672,20 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
     lineHeight: 20,
   },
   topicShareButton: {
-    marginTop: 10,
+    marginTop: 12,
     alignSelf: 'flex-start',
-    backgroundColor: 'transparent',
-    borderRadius: 16,
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-    borderWidth: 1,
-    borderColor: palette.borderStrong,
+    backgroundColor: palette.accent,
+    borderRadius: 999,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
   },
   topicShareButtonPressed: {
     opacity: 0.6,
   },
   topicShareButtonText: {
-    color: palette.textMuted,
+    color: palette.bg,
     fontSize: 13,
-    fontWeight: '500',
+    fontWeight: '700',
   },
   emptyText: {
     fontSize: 14,

--- a/mobile/src/components/BiometricLockOverlay.tsx
+++ b/mobile/src/components/BiometricLockOverlay.tsx
@@ -1,34 +1,26 @@
 import { useEffect, useRef, useState } from 'react';
 import {
-  ActivityIndicator,
   Animated,
   InteractionManager,
   Modal,
+  Pressable,
   StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
 } from 'react-native';
-import { router } from 'expo-router';
-import { useAuth as useClerkAuth } from '@clerk/clerk-expo';
-import { Lock, LogOut, RefreshCw, ShieldCheck } from 'lucide-react-native';
 
 import { useBiometricLock } from '@/src/contexts/BiometricLockContext';
-import { colors } from '@/src/theme';
+import { Logo } from '@/src/components/Logo';
+import { useAppAppearance } from '@/src/theme';
 
-type LockState = 'locked' | 'authenticating' | 'failed' | 'unlocked';
+type LockState = 'locked' | 'authenticating' | 'unlocked';
 
 export function BiometricLockOverlay() {
-  const { isLocked, biometricName, unlock, shouldAutoTrigger, setShouldAutoTrigger } =
-    useBiometricLock();
-  const { signOut } = useClerkAuth();
+  const { isLocked, unlock, shouldAutoTrigger, setShouldAutoTrigger } = useBiometricLock();
+  const { palette } = useAppAppearance();
   const [lockState, setLockState] = useState<LockState>('unlocked');
-  const [error, setError] = useState('');
   const fadeAnim = useRef(new Animated.Value(0)).current;
 
   const handleBiometricAuth = async () => {
     setLockState('authenticating');
-    setError('');
 
     const result = await unlock();
     if (result.success) {
@@ -41,8 +33,7 @@ export function BiometricLockOverlay() {
       return;
     }
 
-    setLockState('failed');
-    setError(`Could not unlock with ${biometricName}. Try again or use your device passcode.`);
+    setLockState('locked');
   };
 
   useEffect(() => {
@@ -64,18 +55,9 @@ export function BiometricLockOverlay() {
     }
   }, [lockState, shouldAutoTrigger, setShouldAutoTrigger]);
 
-  const handleSignOut = async () => {
-    await signOut();
-    setLockState('unlocked');
-    router.replace('/(public)');
-  };
-
   if (!isLocked && lockState === 'unlocked') {
     return null;
   }
-
-  const isBusy = lockState === 'authenticating';
-  const isFailed = lockState === 'failed';
 
   return (
     <Modal
@@ -87,56 +69,17 @@ export function BiometricLockOverlay() {
       onRequestClose={() => {}}
     >
       <Animated.View
-        style={[styles.overlay, { opacity: fadeAnim }]}
+        style={[styles.overlay, { backgroundColor: palette.bg, opacity: fadeAnim }]}
         pointerEvents={isLocked ? 'auto' : 'none'}
       >
-        <View style={styles.content}>
-          <View style={styles.mark}>
-            {isFailed ? (
-              <Lock size={52} color={colors.brandOrange} strokeWidth={1.6} />
-            ) : (
-              <ShieldCheck size={58} color={colors.brandBlue} strokeWidth={1.5} />
-            )}
-          </View>
-
-          <Text style={styles.title}>
-            {isFailed ? 'Authentication failed' : 'Meet Without Fear is locked'}
-          </Text>
-          <Text style={styles.subtitle}>
-            {isFailed
-              ? error
-              : `Use ${biometricName} or your device passcode to continue.`}
-          </Text>
-
-          {isBusy ? (
-            <View style={styles.loadingRow}>
-              <ActivityIndicator color={colors.textPrimary} />
-              <Text style={styles.loadingText}>Authenticating...</Text>
-            </View>
-          ) : (
-            <TouchableOpacity
-              style={styles.primaryButton}
-              onPress={handleBiometricAuth}
-              accessibilityRole="button"
-            >
-              <RefreshCw size={18} color={colors.textOnAccent} />
-              <Text style={styles.primaryButtonText}>
-                {isFailed ? `Try ${biometricName} again` : `Unlock with ${biometricName}`}
-              </Text>
-            </TouchableOpacity>
-          )}
-
-          {isFailed && (
-            <TouchableOpacity
-              style={styles.signOutButton}
-              onPress={handleSignOut}
-              accessibilityRole="button"
-            >
-              <LogOut size={17} color={colors.error} />
-              <Text style={styles.signOutText}>Sign out</Text>
-            </TouchableOpacity>
-          )}
-        </View>
+        <Pressable
+          onPress={handleBiometricAuth}
+          disabled={lockState === 'authenticating'}
+          accessibilityRole="button"
+          accessibilityLabel="Unlock Meet Without Fear"
+        >
+          <Logo size={144} />
+        </Pressable>
       </Animated.View>
     </Modal>
   );
@@ -149,81 +92,7 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
     zIndex: 9999,
     elevation: 9999,
-    backgroundColor: colors.bgPage,
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 24,
-  },
-  content: {
-    width: '100%',
-    maxWidth: 380,
-    alignItems: 'center',
-  },
-  mark: {
-    width: 118,
-    height: 118,
-    borderRadius: 30,
-    borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.bgPrimary,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 28,
-  },
-  title: {
-    color: colors.textPrimary,
-    fontSize: 28,
-    lineHeight: 34,
-    fontWeight: '800',
-    textAlign: 'center',
-    letterSpacing: 0,
-    marginBottom: 10,
-  },
-  subtitle: {
-    color: colors.textSecondary,
-    fontSize: 16,
-    lineHeight: 23,
-    textAlign: 'center',
-    marginBottom: 28,
-  },
-  loadingRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    height: 52,
-  },
-  loadingText: {
-    color: colors.textSecondary,
-    fontSize: 15,
-    fontWeight: '600',
-  },
-  primaryButton: {
-    height: 52,
-    borderRadius: 8,
-    backgroundColor: colors.brandOrange,
-    paddingHorizontal: 20,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 10,
-    alignSelf: 'stretch',
-  },
-  primaryButtonText: {
-    color: colors.textOnAccent,
-    fontSize: 16,
-    fontWeight: '800',
-  },
-  signOutButton: {
-    marginTop: 16,
-    minHeight: 44,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-  },
-  signOutText: {
-    color: colors.error,
-    fontSize: 15,
-    fontWeight: '700',
   },
 });

--- a/mobile/src/components/ChatIndicator.tsx
+++ b/mobile/src/components/ChatIndicator.tsx
@@ -77,9 +77,9 @@ export function ChatIndicator({ type, timestamp, testID, onPress, metadata }: Ch
   const { palette } = useAppAppearance();
 
   const semanticColors = {
-    informational: { text: palette.accent, line: palette.warningSoft },
-    success: { text: palette.success, line: palette.successSoft },
-    warning: { text: palette.warning, line: palette.warningSoft },
+    informational: { text: palette.accentText, line: palette.borderStrong },
+    success: { text: palette.success, line: palette.borderStrong },
+    warning: { text: palette.accentText, line: palette.borderStrong },
   };
 
   const getIndicatorText = (): string => {
@@ -318,7 +318,7 @@ const useStyles = () => {
     },
     line: {
       flex: 1,
-      height: 1,
+      height: 1.5,
       backgroundColor: palette.border,
     },
     textContainer: {
@@ -329,9 +329,10 @@ const useStyles = () => {
     text: {
       fontSize: t.typography.fontSize.sm,
       fontFamily: designFonts.mono,
-      color: palette.textMuted,
+      color: palette.text,
       textTransform: 'uppercase',
       letterSpacing: 1,
+      fontWeight: '700',
     },
     arrow: {
       fontSize: 16,
@@ -339,34 +340,34 @@ const useStyles = () => {
     },
     // Invitation sent: yellow/amber tint - separate line and text styles
     invitationSentLine: {
-      backgroundColor: palette.warningSoft,
+      backgroundColor: palette.borderStrong,
     },
     invitationSentText: {
-      color: palette.warning,
+      color: palette.accentText,
     },
     // Feel heard: teal/green tint for completion feeling
     feelHeardLine: {
-      backgroundColor: palette.successSoft,
+      backgroundColor: palette.borderStrong,
     },
     feelHeardText: {
       color: palette.success,
     },
     // Compact signed: dark blue tint for commitment
     compactSignedLine: {
-      backgroundColor: palette.warningSoft,
+      backgroundColor: palette.borderStrong,
     },
     compactSignedText: {
-      color: palette.warning,
+      color: palette.accentText,
     },
     // Context shared: purple/accent tint for shared content
     contextSharedLine: {
-      backgroundColor: palette.warningSoft,
+      backgroundColor: palette.borderStrong,
     },
     contextSharedText: {
-      color: palette.warning,
+      color: palette.accentText,
     },
     defaultLine: {
-      backgroundColor: palette.border,
+      backgroundColor: palette.borderStrong,
     },
     defaultText: {
       color: palette.textMuted,

--- a/mobile/src/components/ChatInput.tsx
+++ b/mobile/src/components/ChatInput.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { View, TextInput, TouchableOpacity, Text, Platform, type TextInput as TextInputType } from 'react-native';
-import { ArrowRight, Mic } from 'lucide-react-native';
+import { ArrowUp, Mic } from 'lucide-react-native';
 import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
 
@@ -134,7 +134,7 @@ export function ChatInput({
         disabled={!canSend}
         activeOpacity={0.7}
       >
-        <ArrowRight color={canSend ? palette.bg : palette.textFaint} size={18} />
+        <ArrowUp color={canSend ? palette.bg : palette.textFaint} size={18} />
       </TouchableOpacity>
     </View>
   );

--- a/mobile/src/components/CompactChatItem.tsx
+++ b/mobile/src/components/CompactChatItem.tsx
@@ -5,9 +5,10 @@
  * Replaces the formal Curiosity Compact terms with a conversational welcome.
  */
 
-import { View } from 'react-native';
+import { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
 import { TypewriterText } from './TypewriterText';
-import { createStyles } from '../theme/styled';
+import { spacing, typography, useAppAppearance } from '../theme';
 
 // ============================================================================
 // Types
@@ -54,22 +55,25 @@ export function CompactChatItem({ testID, isFirstSession = true }: CompactChatIt
 // Styles
 // ============================================================================
 
-const useStyles = () =>
-  createStyles((t) => ({
+const useStyles = () => {
+  const { palette } = useAppAppearance();
+
+  return useMemo(() => StyleSheet.create({
     container: {
-      paddingTop: t.spacing.lg,
-      paddingBottom: t.spacing.md,
+      paddingTop: spacing.lg,
+      paddingBottom: spacing.md,
     },
     messageContainer: {
-      marginVertical: t.spacing.xs,
-      paddingHorizontal: t.spacing.lg,
+      marginVertical: spacing.xs,
+      paddingHorizontal: spacing.lg,
     },
     messageText: {
-      fontSize: t.typography.fontSize.md,
+      fontSize: typography.fontSize.md,
       lineHeight: 22,
-      color: t.colors.textPrimary,
-      fontFamily: t.typography.fontFamily.regular,
+      color: palette.text,
+      fontFamily: typography.fontFamily.regular,
     },
-  }));
+  }), [palette]);
+};
 
 export default CompactChatItem;

--- a/mobile/src/components/GuidedActionPanel.tsx
+++ b/mobile/src/components/GuidedActionPanel.tsx
@@ -108,11 +108,11 @@ export function GuidedActionPanel({
                   testID={action.testID}
                 >
                   {action.loading ? (
-                    <ActivityIndicator size="small" color={isPrimary ? palette.bg : accent} />
+                    <ActivityIndicator size="small" color={isPrimary ? '#fffaf0' : accent} />
                   ) : (
                     <Text style={[
                       styles.buttonText,
-                      isPrimary ? [styles.primaryButtonText, { color: palette.bg }] : [styles.secondaryButtonText, { color: accent }],
+                      isPrimary ? [styles.primaryButtonText, { color: '#fffaf0' }] : [styles.secondaryButtonText, { color: accent }],
                     ]}>
                       {action.label}
                     </Text>

--- a/mobile/src/components/InlineCompact.tsx
+++ b/mobile/src/components/InlineCompact.tsx
@@ -5,8 +5,9 @@
  * as an AI-triggered action. Shows a warm AI message with a "Ready" button.
  */
 
-import { View, Text, TouchableOpacity } from 'react-native';
-import { createStyles } from '../theme/styled';
+import { useMemo } from 'react';
+import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
+import { radius, spacing, typography, useAppAppearance } from '../theme';
 
 // ============================================================================
 // Types
@@ -71,35 +72,38 @@ export function InlineCompact({
 // Styles
 // ============================================================================
 
-const useStyles = () =>
-  createStyles((t) => ({
+const useStyles = () => {
+  const { palette } = useAppAppearance();
+
+  return useMemo(() => StyleSheet.create({
     container: {
-      backgroundColor: t.colors.bgSecondary,
-      borderRadius: t.radius.lg,
-      padding: t.spacing.xl,
-      marginVertical: t.spacing.md,
+      backgroundColor: palette.bgElev,
+      borderRadius: radius.lg,
+      padding: spacing.xl,
+      marginVertical: spacing.md,
       borderWidth: 1,
-      borderColor: t.colors.border,
+      borderColor: palette.border,
     },
     messageText: {
-      fontSize: t.typography.fontSize.md,
+      fontSize: typography.fontSize.md,
       lineHeight: 22,
-      color: t.colors.textPrimary,
-      marginBottom: t.spacing.lg,
+      color: palette.text,
+      marginBottom: spacing.lg,
     },
     readyButton: {
-      backgroundColor: 'rgb(59, 130, 246)',
-      paddingVertical: t.spacing.lg,
-      paddingHorizontal: t.spacing.xl,
-      borderRadius: t.radius.sm,
+      backgroundColor: palette.accent,
+      paddingVertical: spacing.lg,
+      paddingHorizontal: spacing.xl,
+      borderRadius: radius.sm,
       alignItems: 'center',
     },
     readyButtonDisabled: {
-      backgroundColor: t.colors.bgTertiary,
+      backgroundColor: palette.chipBg,
     },
     readyButtonText: {
-      color: 'white',
-      fontSize: t.typography.fontSize.md,
+      color: palette.bg,
+      fontSize: typography.fontSize.md,
       fontWeight: '600',
     },
-  }));
+  }), [palette]);
+};

--- a/mobile/src/components/NotificationPermissionDrawer.tsx
+++ b/mobile/src/components/NotificationPermissionDrawer.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import {
   ActivityIndicator,
   Modal,
@@ -9,7 +10,7 @@ import {
 import { Bell, BellRing, Clock, X } from 'lucide-react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { colors } from '@/src/theme';
+import { designFonts, useAppAppearance } from '@/src/theme';
 
 interface NotificationPermissionDrawerProps {
   visible: boolean;
@@ -24,6 +25,9 @@ export function NotificationPermissionDrawer({
   onEnable,
   onSkip,
 }: NotificationPermissionDrawerProps) {
+  const { palette } = useAppAppearance();
+  const styles = useStyles();
+
   return (
     <Modal visible={visible} animationType="slide" presentationStyle="fullScreen">
       <SafeAreaView style={styles.container}>
@@ -35,13 +39,13 @@ export function NotificationPermissionDrawer({
             accessibilityRole="button"
             accessibilityLabel="Not now"
           >
-            <X size={22} color={colors.textSecondary} />
+            <X size={22} color={palette.textMuted} />
           </TouchableOpacity>
         </View>
 
         <View style={styles.content}>
           <View style={styles.iconFrame}>
-            <BellRing size={44} color={colors.brandOrange} />
+            <BellRing size={44} color={palette.accent} />
           </View>
 
           <Text style={styles.eyebrow}>Session timing</Text>
@@ -52,13 +56,13 @@ export function NotificationPermissionDrawer({
 
           <View style={styles.preview}>
             <View style={styles.previewIcon}>
-              <Bell size={18} color={colors.brandBlue} />
+              <Bell size={18} color={palette.accentText} />
             </View>
             <View style={styles.previewText}>
               <Text style={styles.previewTitle}>Your partner is ready</Text>
               <Text style={styles.previewBody}>Open the session when you are ready.</Text>
             </View>
-            <Clock size={18} color={colors.textMuted} />
+            <Clock size={18} color={palette.textFaint} />
           </View>
         </View>
 
@@ -70,10 +74,10 @@ export function NotificationPermissionDrawer({
             accessibilityRole="button"
           >
             {loading ? (
-              <ActivityIndicator color={colors.textOnAccent} />
+              <ActivityIndicator color={palette.bg} />
             ) : (
               <>
-                <Bell size={18} color={colors.textOnAccent} />
+                <Bell size={18} color={palette.bg} />
                 <Text style={styles.primaryButtonText}>Turn on notifications</Text>
               </>
             )}
@@ -92,124 +96,130 @@ export function NotificationPermissionDrawer({
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.bgPage,
-  },
-  topBar: {
-    alignItems: 'flex-end',
-    paddingHorizontal: 20,
-    paddingTop: 10,
-  },
-  closeButton: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    backgroundColor: colors.bgSecondary,
-  },
-  content: {
-    flex: 1,
-    justifyContent: 'center',
-    paddingHorizontal: 28,
-  },
-  iconFrame: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 88,
-    height: 88,
-    borderRadius: 24,
-    backgroundColor: colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: colors.border,
-    marginBottom: 28,
-  },
-  eyebrow: {
-    color: colors.brandBlue,
-    fontSize: 13,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-    letterSpacing: 0,
-    marginBottom: 10,
-  },
-  title: {
-    color: colors.textPrimary,
-    fontSize: 34,
-    lineHeight: 39,
-    fontWeight: '800',
-    letterSpacing: 0,
-    marginBottom: 16,
-  },
-  body: {
-    color: colors.textSecondary,
-    fontSize: 17,
-    lineHeight: 25,
-    marginBottom: 28,
-  },
-  preview: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    padding: 16,
-    borderRadius: 8,
-    backgroundColor: colors.bgPrimary,
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  previewIcon: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: colors.bgSecondary,
-  },
-  previewText: {
-    flex: 1,
-  },
-  previewTitle: {
-    color: colors.textPrimary,
-    fontSize: 15,
-    fontWeight: '700',
-    marginBottom: 3,
-  },
-  previewBody: {
-    color: colors.textSecondary,
-    fontSize: 13,
-    lineHeight: 18,
-  },
-  actions: {
-    paddingHorizontal: 20,
-    paddingBottom: 24,
-    gap: 12,
-  },
-  primaryButton: {
-    height: 54,
-    borderRadius: 8,
-    backgroundColor: colors.brandOrange,
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'row',
-    gap: 10,
-  },
-  disabledButton: {
-    opacity: 0.7,
-  },
-  primaryButtonText: {
-    color: colors.textOnAccent,
-    fontSize: 16,
-    fontWeight: '800',
-  },
-  secondaryButton: {
-    height: 48,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  secondaryButtonText: {
-    color: colors.textSecondary,
-    fontSize: 15,
-    fontWeight: '700',
-  },
-});
+const useStyles = () => {
+  const { palette } = useAppAppearance();
+
+  return useMemo(() => StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: palette.bg,
+    },
+    topBar: {
+      alignItems: 'flex-end',
+      paddingHorizontal: 20,
+      paddingTop: 10,
+    },
+    closeButton: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      backgroundColor: palette.chipBg,
+    },
+    content: {
+      flex: 1,
+      justifyContent: 'center',
+      paddingHorizontal: 28,
+    },
+    iconFrame: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: 88,
+      height: 88,
+      borderRadius: 24,
+      backgroundColor: palette.bgElev,
+      borderWidth: 1,
+      borderColor: palette.border,
+      marginBottom: 28,
+    },
+    eyebrow: {
+      color: palette.accentText,
+      fontFamily: designFonts.mono,
+      fontSize: 13,
+      fontWeight: '700',
+      textTransform: 'uppercase',
+      letterSpacing: 0.8,
+      marginBottom: 10,
+    },
+    title: {
+      color: palette.text,
+      fontFamily: designFonts.serif,
+      fontSize: 40,
+      lineHeight: 43,
+      fontWeight: '400',
+      letterSpacing: -0.6,
+      marginBottom: 16,
+    },
+    body: {
+      color: palette.textMuted,
+      fontSize: 17,
+      lineHeight: 25,
+      marginBottom: 28,
+    },
+    preview: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      padding: 16,
+      borderRadius: 10,
+      backgroundColor: palette.bgElev,
+      borderWidth: 1,
+      borderColor: palette.border,
+    },
+    previewIcon: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      backgroundColor: palette.accentSoft,
+    },
+    previewText: {
+      flex: 1,
+    },
+    previewTitle: {
+      color: palette.text,
+      fontSize: 15,
+      fontWeight: '700',
+      marginBottom: 3,
+    },
+    previewBody: {
+      color: palette.textMuted,
+      fontSize: 13,
+      lineHeight: 18,
+    },
+    actions: {
+      paddingHorizontal: 20,
+      paddingBottom: 24,
+      gap: 12,
+    },
+    primaryButton: {
+      height: 54,
+      borderRadius: 999,
+      backgroundColor: palette.accent,
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'row',
+      gap: 10,
+    },
+    disabledButton: {
+      opacity: 0.7,
+    },
+    primaryButtonText: {
+      color: palette.bg,
+      fontSize: 16,
+      fontWeight: '800',
+    },
+    secondaryButton: {
+      height: 48,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    secondaryButtonText: {
+      color: palette.textMuted,
+      fontSize: 15,
+      fontWeight: '700',
+    },
+  }), [palette]);
+};

--- a/mobile/src/components/ScreenHeader.tsx
+++ b/mobile/src/components/ScreenHeader.tsx
@@ -9,12 +9,11 @@
  */
 
 import React, { ReactNode } from 'react';
-import { View, Text, Pressable, ActivityIndicator } from 'react-native';
+import { StyleSheet, View, Text, Pressable, ActivityIndicator } from 'react-native';
 import { ArrowLeft } from 'lucide-react-native';
 import { useRouter } from 'expo-router';
 
-import { createStyles } from '../theme/styled';
-import { colors } from '../theme';
+import { designFonts, useAppAppearance } from '../theme';
 
 // ============================================================================
 // Types
@@ -56,7 +55,7 @@ export function ScreenHeader({
   rightContent,
   testID = 'screen-header',
 }: ScreenHeaderProps) {
-  const styles = useStyles();
+  const { palette } = useAppAppearance();
   const router = useRouter();
 
   const handleBackPress = () => {
@@ -68,7 +67,16 @@ export function ScreenHeader({
   };
 
   return (
-    <View style={styles.header} testID={testID}>
+    <View
+      style={[
+        styles.header,
+        {
+          backgroundColor: palette.bg,
+          borderBottomColor: palette.divider,
+        },
+      ]}
+      testID={testID}
+    >
       {/* Left section */}
       <View style={styles.leftSection}>
         {showBackButton ? (
@@ -80,7 +88,7 @@ export function ScreenHeader({
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
             testID={`${testID}-back-button`}
           >
-            <ArrowLeft color={colors.textPrimary} size={24} />
+            <ArrowLeft color={palette.text} size={24} />
           </Pressable>
         ) : (
           <View style={styles.headerButtonSpacer} />
@@ -90,7 +98,7 @@ export function ScreenHeader({
       {/* Center section */}
       <View style={styles.titleContainer}>
         {titleIcon}
-        <Text style={styles.titleText} numberOfLines={1}>
+        <Text style={[styles.titleText, { color: palette.text }]} numberOfLines={1}>
           {title}
         </Text>
       </View>
@@ -107,7 +115,7 @@ export function ScreenHeader({
             testID={`${testID}-right-action`}
           >
             {rightAction.loading ? (
-              <ActivityIndicator size="small" color={colors.accent} />
+              <ActivityIndicator size="small" color={palette.accent} />
             ) : (
               rightAction.icon
             )}
@@ -126,47 +134,44 @@ export function ScreenHeader({
 // Styles
 // ============================================================================
 
-const useStyles = () =>
-  createStyles((t) => ({
-    header: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      paddingHorizontal: t.spacing.md,
-      paddingVertical: t.spacing.sm,
-      backgroundColor: t.colors.bgSecondary,
-      borderBottomWidth: 1,
-      borderBottomColor: t.colors.border,
-      minHeight: 56,
-    },
-    leftSection: {
-      width: 44,
-      alignItems: 'flex-start',
-    },
-    rightSection: {
-      width: 44,
-      alignItems: 'flex-end',
-    },
-    headerButton: {
-      padding: t.spacing.xs,
-    },
-    headerButtonSpacer: {
-      width: 24,
-      height: 24,
-    },
-    titleContainer: {
-      flex: 1,
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: t.spacing.sm,
-    },
-    titleText: {
-      fontSize: 17,
-      fontWeight: '600',
-      color: t.colors.textPrimary,
-    },
-  }));
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    minHeight: 56,
+  },
+  leftSection: {
+    width: 44,
+    alignItems: 'flex-start',
+  },
+  rightSection: {
+    width: 44,
+    alignItems: 'flex-end',
+  },
+  headerButton: {
+    padding: 4,
+  },
+  headerButtonSpacer: {
+    width: 24,
+    height: 24,
+  },
+  titleContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  titleText: {
+    fontSize: 17,
+    fontWeight: '600',
+    fontFamily: designFonts.sans,
+  },
+});
 
 // ============================================================================
 // Exports

--- a/mobile/src/components/SessionDrawer/index.tsx
+++ b/mobile/src/components/SessionDrawer/index.tsx
@@ -29,7 +29,7 @@ import {
 import { Drawer } from 'react-native-drawer-layout';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { X, Plus, Trash2, Search, MoreHorizontal, Home } from 'lucide-react-native';
+import { X, Plus, Trash2, Search, MoreHorizontal } from 'lucide-react-native';
 
 import { useSessionDrawer } from '../../hooks/useSessionDrawer';
 import { useSessions, useDeleteSession } from '../../hooks/useSessions';
@@ -87,7 +87,7 @@ function getBadgeLabel(session: SessionSummaryDTO): { label: string; kind: 'read
   if (session.status === SessionStatus.RESOLVED) return { label: 'Complete', kind: 'neutral' };
   if (session.status === SessionStatus.PAUSED) return { label: 'Paused', kind: 'neutral' };
   if (session.status === SessionStatus.CREATED || session.status === SessionStatus.INVITED) {
-    return { label: 'Invitation sent', kind: 'ready' };
+    return { label: 'Invite pending', kind: 'ready' };
   }
   if (session.selfActionNeeded.length > 0) return { label: 'Ready for you', kind: 'ready' };
   return { label: 'In progress', kind: 'neutral' };
@@ -144,7 +144,12 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
 
   const sessions = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
-    return (data?.items ?? []).filter((s) => {
+    const uniqueSessions = new Map<string, SessionSummaryDTO>();
+    for (const session of data?.items ?? []) {
+      uniqueSessions.set(session.id, session);
+    }
+
+    return Array.from(uniqueSessions.values()).filter((s) => {
       if (s.status === SessionStatus.ARCHIVED) return false;
       if (!normalizedQuery) return true;
       const haystack = `${getPartnerDisplayName(s)} ${getTopicLine(s)}`.toLowerCase();
@@ -520,11 +525,6 @@ export function SessionDrawer({ children }: SessionDrawerProps) {
     router.push('/session/new');
   }, [closeDrawer, router]);
 
-  const handleHomePress = useCallback(() => {
-    closeDrawer();
-    router.replace('/(auth)/(tabs)');
-  }, [closeDrawer, router]);
-
   const renderDrawerContent = () => (
     <View style={[styles.drawerContent, { paddingTop: insets.top + 16, paddingBottom: insets.bottom }]}>
       <View style={styles.header}>
@@ -532,14 +532,6 @@ export function SessionDrawer({ children }: SessionDrawerProps) {
           <Text style={styles.headerTitle}>Conversations</Text>
         </View>
         <View style={styles.headerActions}>
-          <TouchableOpacity
-            style={styles.headerButton}
-            onPress={handleHomePress}
-            accessibilityRole="button"
-            accessibilityLabel="Go to home"
-          >
-            <Home color={palette.textMuted} size={20} />
-          </TouchableOpacity>
           <TouchableOpacity
             style={styles.headerButton}
             onPress={handleNewSession}

--- a/mobile/src/components/chat/renderers/IndicatorRenderer.tsx
+++ b/mobile/src/components/chat/renderers/IndicatorRenderer.tsx
@@ -11,6 +11,7 @@ import { memo } from 'react';
 import { View, Text } from 'react-native';
 import { AnimationState, IndicatorItem, IndicatorType } from '@meet-without-fear/shared';
 import { createStyles } from '../../../theme/styled';
+import { designFonts, useAppAppearance } from '../../../theme';
 import type { ChatItemRendererProps } from './types';
 
 type IndicatorRendererProps = ChatItemRendererProps<IndicatorItem>;
@@ -20,6 +21,7 @@ function IndicatorRendererImpl({
   animationState,
 }: IndicatorRendererProps) {
   const styles = useStyles();
+  const { palette } = useAppAppearance();
 
   // Indicators typically don't animate but if hidden, don't render
   if (animationState === AnimationState.HIDDEN) {
@@ -76,9 +78,9 @@ function IndicatorRendererImpl({
   return (
     <View style={styles.container} testID={`indicator-${item.id}`}>
       <View style={styles.lineContainer}>
-        <View style={[styles.line, getLineStyle()]} />
-        <Text style={[styles.text, getTextStyle()]}>{getIndicatorText()}</Text>
-        <View style={[styles.line, getLineStyle()]} />
+        <View style={[styles.line, { backgroundColor: palette.borderStrong }, getLineStyle()]} />
+        <Text style={[styles.text, { color: palette.textMuted }, getTextStyle()]}>{getIndicatorText()}</Text>
+        <View style={[styles.line, { backgroundColor: palette.borderStrong }, getLineStyle()]} />
       </View>
     </View>
   );
@@ -113,36 +115,37 @@ const useStyles = () =>
     },
     line: {
       flex: 1,
-      height: 1,
+      height: 1.5,
       backgroundColor: t.colors.border,
     },
     text: {
       fontSize: t.typography.fontSize.sm,
-      fontFamily: t.typography.fontFamily.regular,
+      fontFamily: designFonts.mono,
       color: t.colors.textMuted,
       textTransform: 'uppercase',
       letterSpacing: 1,
+      fontWeight: '700',
     },
     // Invitation sent: yellow/amber tint
     invitationSentLine: {
-      backgroundColor: 'rgba(245, 158, 11, 0.3)',
+      backgroundColor: 'rgba(138, 79, 25, 0.28)',
     },
     invitationSentText: {
-      color: 'rgba(245, 158, 11, 0.9)',
+      color: '#8a4f19',
     },
     // Feel heard: teal/green tint for completion feeling
     feelHeardLine: {
-      backgroundColor: 'rgba(20, 184, 166, 0.3)',
+      backgroundColor: 'rgba(58, 139, 99, 0.28)',
     },
     feelHeardText: {
-      color: 'rgba(20, 184, 166, 0.9)',
+      color: '#3a8b63',
     },
     // Compact signed: dark blue tint for commitment
     compactSignedLine: {
-      backgroundColor: 'rgba(59, 130, 246, 0.3)',
+      backgroundColor: 'rgba(138, 79, 25, 0.28)',
     },
     compactSignedText: {
-      color: 'rgba(59, 130, 246, 0.9)',
+      color: '#8a4f19',
     },
     defaultLine: {
       backgroundColor: t.colors.border,

--- a/mobile/src/hooks/useNotifications.ts
+++ b/mobile/src/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import * as Notifications from 'expo-notifications';
-import { router, useGlobalSearchParams, usePathname } from 'expo-router';
+import { router } from 'expo-router';
 
 import {
   getNotificationPermissionStatus,
@@ -8,17 +8,7 @@ import {
   requestAndRegisterForPushNotifications,
 } from '@/src/services/notifications';
 
-function normalizeParam(value: string | string[] | undefined): string | undefined {
-  return Array.isArray(value) ? value[0] : value;
-}
-
 export function useNotifications() {
-  const pathname = usePathname();
-  const params = useGlobalSearchParams<{ id?: string | string[] }>();
-  const currentSessionId = pathname.startsWith('/session/')
-    ? normalizeParam(params.id)
-    : undefined;
-
   useEffect(() => {
     let cancelled = false;
 
@@ -43,11 +33,7 @@ export function useNotifications() {
 
       if (sessionId) {
         const sessionPath = `/session/${sessionId}` as const;
-        if (sessionId === currentSessionId) {
-          router.replace(sessionPath);
-        } else {
-          router.push(sessionPath);
-        }
+        router.replace(sessionPath);
       } else if (screen === 'home') {
         router.push('/(auth)/(tabs)');
       }
@@ -57,7 +43,7 @@ export function useNotifications() {
       cancelled = true;
       responseSubscription.remove();
     };
-  }, [currentSessionId]);
+  }, []);
 
   const shouldAskForSessionNotifications = useCallback(async () => {
     const status = await getNotificationPermissionStatus();

--- a/mobile/src/hooks/usePerson.ts
+++ b/mobile/src/hooks/usePerson.ts
@@ -67,6 +67,35 @@ export interface GetPastSessionsResponse {
   sessions: PastSessionDTO[];
 }
 
+function isAfter(left?: string, right?: string) {
+  if (!left) return false;
+  if (!right) return true;
+  return new Date(left).getTime() > new Date(right).getTime();
+}
+
+export function dedupePeople(people: PersonSummaryDTO[]) {
+  const byId = new Map<string, PersonSummaryDTO>();
+
+  for (const person of people) {
+    const existing = byId.get(person.id);
+    if (!existing) {
+      byId.set(person.id, person);
+      continue;
+    }
+
+    byId.set(person.id, {
+      ...existing,
+      ...person,
+      lastSession: isAfter(person.lastSession?.updatedAt, existing.lastSession?.updatedAt)
+        ? person.lastSession
+        : existing.lastSession,
+      activeSessionCount: Math.max(existing.activeSessionCount, person.activeSessionCount),
+    });
+  }
+
+  return Array.from(byId.values());
+}
+
 // ============================================================================
 // Get Person Hook
 // ============================================================================
@@ -148,7 +177,7 @@ export function usePeople(
     queryKey: personKeys.lists(),
     queryFn: async () => {
       const response = await get<ListPeopleResponse>('/people');
-      return response.people;
+      return dedupePeople(response.people);
     },
     staleTime: 30_000, // 30 seconds
     ...options,

--- a/mobile/src/screens/InnerThoughtsScreen.tsx
+++ b/mobile/src/screens/InnerThoughtsScreen.tsx
@@ -21,7 +21,7 @@ import { TranscriptionDrawer } from '../components/TranscriptionDrawer';
 import { useInnerThoughtsSession, useSendInnerThoughtsMessage } from '../hooks';
 import { useVoiceInput } from '../hooks/useVoiceInput';
 import { createStyles } from '../theme/styled';
-import { colors } from '../theme';
+import { colors, useAppAppearance } from '../theme';
 
 // ============================================================================
 // Types
@@ -62,6 +62,7 @@ export function InnerThoughtsScreen({
   auditFixture = null,
 }: InnerThoughtsScreenProps) {
   const styles = useStyles();
+  const { palette } = useAppAppearance();
   const router = useRouter();
 
   // Takeaways review sheet state
@@ -228,7 +229,7 @@ export function InnerThoughtsScreen({
   // Loading state - but NOT when creating (we show typing indicator instead)
   if (isLoading && !isCreating) {
     return (
-      <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top', 'bottom']}>
         <View style={styles.centerContainer}>
           <ActivityIndicator size="large" color={colors.accent} />
           <Text style={styles.loadingText}>Loading...</Text>
@@ -240,7 +241,7 @@ export function InnerThoughtsScreen({
   // Error state - but NOT when creating
   if (!isCreating && (error || !session)) {
     return (
-      <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top', 'bottom']}>
         <View style={styles.centerContainer}>
           <Text style={styles.errorText}>We couldn't load your reflection right now</Text>
           <TouchableOpacity style={styles.backButton} onPress={handleBack}>
@@ -255,9 +256,17 @@ export function InnerThoughtsScreen({
   const isLinked = !!linkedPartnerName;
 
   return (
-    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+    <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top', 'bottom']}>
       {/* Header - styled like the rest of the app */}
-      <View style={styles.header}>
+      <View
+        style={[
+          styles.header,
+          {
+            backgroundColor: palette.bg,
+            borderBottomColor: palette.border,
+          },
+        ]}
+      >
         <TouchableOpacity
           style={styles.headerBackButton}
           onPress={handleBack}
@@ -265,30 +274,30 @@ export function InnerThoughtsScreen({
           accessibilityLabel="Go back"
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
         >
-          <ArrowLeft color="#ececec" size={24} />
+          <ArrowLeft color={palette.text} size={24} />
         </TouchableOpacity>
 
         <View style={styles.headerContent}>
           <View style={styles.headerTitleRow}>
-            <Layers color={colors.brandBlue} size={16} />
-            <Text style={styles.headerTitle} numberOfLines={1}>
+            <Layers color={palette.accent} size={16} />
+            <Text style={[styles.headerTitle, { color: palette.text }]} numberOfLines={1}>
               {title}
             </Text>
-            <Lock size={12} color={colors.textMuted} />
+            <Lock size={12} color={palette.textMuted} />
           </View>
           {isLinked ? (
             <>
               <TouchableOpacity onPress={onNavigateToPartnerSession}>
-                <Text style={styles.linkedSubtitle} numberOfLines={1}>
+                <Text style={[styles.linkedSubtitle, { color: palette.accent }]} numberOfLines={1}>
                   ↩ Back to session with {linkedPartnerName}
                 </Text>
               </TouchableOpacity>
-              <Text style={styles.privacyNote}>
+              <Text style={[styles.privacyNote, { color: palette.textMuted }]}>
                 Private — {linkedPartnerName} cannot see this
               </Text>
             </>
           ) : !isCreating && session?.theme && session?.title ? (
-            <Text style={styles.headerSubtitle} numberOfLines={1}>
+            <Text style={[styles.headerSubtitle, { color: palette.textMuted }]} numberOfLines={1}>
               {session.theme}
             </Text>
           ) : null}
@@ -302,7 +311,7 @@ export function InnerThoughtsScreen({
             accessibilityRole="button"
             accessibilityLabel="View takeaways"
           >
-            <Sparkles color={colors.brandBlue} size={20} />
+            <Sparkles color={palette.accent} size={20} />
           </TouchableOpacity>
         )}
 
@@ -314,7 +323,7 @@ export function InnerThoughtsScreen({
             accessibilityRole="button"
             accessibilityLabel="End session"
           >
-            <MoreVertical color={colors.textMuted} size={20} />
+            <MoreVertical color={palette.textMuted} size={20} />
           </TouchableOpacity>
         )}
         {isCreating && <View style={{ width: 48 }} />}
@@ -328,6 +337,7 @@ export function InnerThoughtsScreen({
         disabled={isCreating || sendMessage.isPending}
         emptyStateTitle="Inner Thoughts"
         emptyStateMessage="A private space for reflection. Share what's on your mind."
+        keyboardVerticalOffset={0}
         onVoicePress={Platform.OS !== 'web' ? handleVoicePress : undefined}
       />
 

--- a/mobile/src/screens/InnerWorkHubScreen.tsx
+++ b/mobile/src/screens/InnerWorkHubScreen.tsx
@@ -19,7 +19,7 @@ import {
 import { useInnerThoughtsSessions } from '../hooks';
 import { InnerWorkSessionSummaryDTO } from '@meet-without-fear/shared';
 import { createStyles } from '../theme/styled';
-import { colors } from '../theme';
+import { colors, useAppAppearance } from '../theme';
 
 // ============================================================================
 // Types
@@ -40,6 +40,7 @@ interface SessionListItemProps {
 // ============================================================================
 
 function SessionListItem({ session, onPress }: SessionListItemProps) {
+  const { palette } = useAppAppearance();
   const formattedDate = new Date(session.createdAt).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
@@ -56,20 +57,30 @@ function SessionListItem({ session, onPress }: SessionListItemProps) {
   }
 
   return (
-    <TouchableOpacity style={styles.sessionItem} onPress={onPress} activeOpacity={0.7}>
+    <TouchableOpacity
+      style={[
+        styles.sessionItem,
+        {
+          backgroundColor: palette.bgElev,
+          borderColor: palette.border,
+        },
+      ]}
+      onPress={onPress}
+      activeOpacity={0.7}
+    >
       <View style={styles.sessionContent}>
-        <Text style={styles.sessionDate}>{formattedDate}</Text>
+        <Text style={[styles.sessionDate, { color: palette.text }]}>{formattedDate}</Text>
         {session.theme != null && (
           <View style={styles.sessionThemeTag}>
-            <Sparkles size={11} color={colors.brandPurple} />
-            <Text style={styles.sessionThemeText}>{session.theme}</Text>
+            <Sparkles size={11} color={palette.accent} />
+            <Text style={[styles.sessionThemeText, { color: palette.accent }]}>{session.theme}</Text>
           </View>
         )}
-        <Text style={styles.sessionSummary} numberOfLines={2}>
+        <Text style={[styles.sessionSummary, { color: palette.textMuted }]} numberOfLines={2}>
           {secondaryText}
         </Text>
       </View>
-      <ChevronRight size={20} color={colors.textMuted} />
+      <ChevronRight size={20} color={palette.textFaint} />
     </TouchableOpacity>
   );
 }
@@ -82,6 +93,7 @@ export function InnerWorkHubScreen({
   onBack,
   onNavigateToSelfReflection,
 }: InnerWorkHubScreenProps) {
+  const { palette } = useAppAppearance();
   const { data, isLoading, error, refetch } = useInnerThoughtsSessions();
 
   const handleBack = useCallback(() => {
@@ -101,10 +113,10 @@ export function InnerWorkHubScreen({
   // Loading state
   if (isLoading) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]}>
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.accent} />
-          <Text style={styles.loadingText}>Opening your space...</Text>
+          <ActivityIndicator size="large" color={palette.accent} />
+          <Text style={[styles.loadingText, { color: palette.textMuted }]}>Opening your space...</Text>
         </View>
       </SafeAreaView>
     );
@@ -113,39 +125,39 @@ export function InnerWorkHubScreen({
   // Error state
   if (error) {
     return (
-      <SafeAreaView style={styles.container} edges={['top']}>
-        <View style={styles.header}>
+      <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top']}>
+        <View style={[styles.header, { backgroundColor: palette.bg, borderBottomColor: palette.divider }]}>
           <TouchableOpacity
             onPress={handleBack}
             style={styles.backButton}
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >
-            <ArrowLeft size={24} color={colors.textPrimary} />
+            <ArrowLeft size={24} color={palette.text} />
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>Inner Work</Text>
+          <Text style={[styles.headerTitle, { color: palette.text }]}>Inner Work</Text>
           <View style={styles.headerRight} />
         </View>
         <View style={styles.errorContainer}>
-          <Text style={styles.errorText}>
+          <Text style={[styles.errorText, { color: palette.text }]}>
             We're having trouble loading your space right now.
           </Text>
-          <Text style={styles.errorSubtext}>
+          <Text style={[styles.errorSubtext, { color: palette.textMuted }]}>
             Your reflections are safe — please try again in a moment.
           </Text>
           <View style={styles.errorActions}>
             <TouchableOpacity
-              style={styles.errorRetryButton}
+              style={[styles.errorRetryButton, { backgroundColor: palette.accent }]}
               onPress={() => refetch()}
               activeOpacity={0.7}
             >
-              <Text style={styles.errorRetryText}>Try Again</Text>
+              <Text style={[styles.errorRetryText, { color: palette.bg }]}>Try Again</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={styles.errorHomeButton}
+              style={[styles.errorHomeButton, { backgroundColor: palette.bgElev }]}
               onPress={handleBack}
               activeOpacity={0.7}
             >
-              <Text style={styles.errorHomeText}>Go Home</Text>
+              <Text style={[styles.errorHomeText, { color: palette.text }]}>Go Home</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -154,21 +166,21 @@ export function InnerWorkHubScreen({
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={['top']}>
+    <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top']}>
       {/* Header */}
-      <View style={styles.header}>
+      <View style={[styles.header, { backgroundColor: palette.bg, borderBottomColor: palette.divider }]}>
         <TouchableOpacity
           onPress={handleBack}
           style={styles.backButton}
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
         >
-          <ArrowLeft size={24} color={colors.textPrimary} />
+          <ArrowLeft size={24} color={palette.text} />
         </TouchableOpacity>
         <View style={styles.headerTitleContainer}>
-          <Text style={styles.headerTitle}>Inner Work</Text>
+          <Text style={[styles.headerTitle, { color: palette.text }]}>Inner Work</Text>
           <View style={styles.privacyBadge}>
-            <Lock size={10} color={colors.textMuted} />
-            <Text style={styles.privacyText}>Your private space</Text>
+            <Lock size={10} color={palette.textMuted} />
+            <Text style={[styles.privacyText, { color: palette.textMuted }]}>Your private space</Text>
           </View>
         </View>
         <View style={styles.headerRight} />
@@ -181,15 +193,21 @@ export function InnerWorkHubScreen({
         showsVerticalScrollIndicator={false}
         ListHeaderComponent={
           <TouchableOpacity
-            style={styles.newSessionButton}
+            style={[
+              styles.newSessionButton,
+              {
+                backgroundColor: palette.bgElev,
+                borderColor: palette.border,
+              },
+            ]}
             onPress={handleNewSession}
             activeOpacity={0.8}
           >
-            <View style={styles.newSessionIconContainer}>
-              <MessageCircle size={22} color={colors.brandPurple} />
+            <View style={[styles.newSessionIconContainer, { backgroundColor: palette.accentSoft }]}>
+              <MessageCircle size={22} color={palette.accent} />
             </View>
-            <Text style={styles.newSessionText}>New Session</Text>
-            <ChevronRight size={20} color={colors.brandPurple} />
+            <Text style={[styles.newSessionText, { color: palette.text }]}>New Session</Text>
+            <ChevronRight size={20} color={palette.accent} />
           </TouchableOpacity>
         }
         renderItem={({ item }) => (
@@ -197,9 +215,9 @@ export function InnerWorkHubScreen({
         )}
         ListEmptyComponent={
           <View style={styles.emptyState}>
-            <MessageCircle size={40} color={colors.textMuted} />
-            <Text style={styles.emptyStateText}>Start your first session</Text>
-            <Text style={styles.emptyStateSubtext}>
+            <MessageCircle size={40} color={palette.textMuted} />
+            <Text style={[styles.emptyStateText, { color: palette.text }]}>Start your first session</Text>
+            <Text style={[styles.emptyStateSubtext, { color: palette.textMuted }]}>
               This is your private space to reflect and process your thoughts.
             </Text>
           </View>
@@ -351,6 +369,7 @@ const styles = createStyles((t) => ({
     borderRadius: t.radius.lg,
     padding: t.spacing.md,
     marginBottom: t.spacing.sm,
+    borderWidth: 1,
   },
   sessionContent: {
     flex: 1,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -62,7 +62,6 @@ import { TypewriterText } from '../components/TypewriterText';
 import { GuidedActionPanel } from '../components/GuidedActionPanel';
 
 import { useUnifiedSession, InlineChatCard } from '../hooks/useUnifiedSession';
-import { useSessionDrawer } from '../hooks/useSessionDrawer';
 import { useConfirmTopicFrame } from '../hooks/useSessions';
 import { useValidationFeedbackCoachChat } from '../hooks/useRefinementChat';
 import { useChatUIState } from '../hooks/useChatUIState';
@@ -250,6 +249,7 @@ function InviteeTopicIntroCard({
   onAnimationComplete?: () => void;
 }) {
   const styles = useStyles();
+  const { palette } = useAppAppearance();
   const [showTopic, setShowTopic] = useState(skipAnimation);
   const [showOutro, setShowOutro] = useState(skipAnimation);
   const topicOpacity = useRef(new Animated.Value(skipAnimation ? 1 : 0)).current;
@@ -293,7 +293,7 @@ function InviteeTopicIntroCard({
     <View style={styles.inviteeTopicAckBody} testID="invitee-topic-ack-body">
       <TypewriterText
         text={introText}
-        style={styles.inviteeTopicAckText}
+        style={[styles.inviteeTopicAckText, { color: palette.text }]}
         wordDelay={45}
         fadeDuration={120}
         skipAnimation={skipAnimation}
@@ -301,8 +301,17 @@ function InviteeTopicIntroCard({
       />
 
       {showTopic ? (
-        <Animated.View style={[styles.inviteeTopicAckFrameWrap, { opacity: topicOpacity }]}>
-          <Text style={styles.inviteeTopicAckFrame} testID="invitee-topic-text">
+        <Animated.View
+          style={[
+            styles.inviteeTopicAckFrameWrap,
+            {
+              opacity: topicOpacity,
+              backgroundColor: palette.bgElev,
+              borderColor: palette.border,
+            },
+          ]}
+        >
+          <Text style={[styles.inviteeTopicAckFrame, { color: palette.text }]} testID="invitee-topic-text">
             {topicFrame}
           </Text>
         </Animated.View>
@@ -311,7 +320,7 @@ function InviteeTopicIntroCard({
       {showOutro ? (
         <TypewriterText
           text={outroText}
-          style={styles.inviteeTopicAckText}
+          style={[styles.inviteeTopicAckText, { color: palette.textMuted }]}
           wordDelay={45}
           fadeDuration={120}
           skipAnimation={skipAnimation}
@@ -511,7 +520,6 @@ export function UnifiedSessionScreen({
   const insets = useSafeAreaInsets();
   const { user, updateUser } = useAuth();
   const { mutate: updateMood } = useUpdateMood();
-  const { openDrawer } = useSessionDrawer();
   const queryClient = useQueryClient();
   const { showError } = useToast();
 
@@ -3163,8 +3171,7 @@ export function UnifiedSessionScreen({
             partnerOnline={partnerOnline}
             connectionStatus={connectionStatus}
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
-            onBackPress={openDrawer}
-            leftActionIcon="menu"
+            onBackPress={onNavigateBack}
             onPress={() => setShowPartnerInfo(true)}
             stageName="Closed"
             testID="session-chat-header"
@@ -3200,8 +3207,7 @@ export function UnifiedSessionScreen({
           partnerOnline={partnerOnline}
           connectionStatus={connectionStatus}
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
-          onBackPress={openDrawer}
-          leftActionIcon="menu"
+          onBackPress={onNavigateBack}
           onPress={() => setShowPartnerInfo(true)}
           stageName="Closed"
           testID="session-chat-header"
@@ -3240,8 +3246,7 @@ export function UnifiedSessionScreen({
             partnerOnline={partnerOnline}
             connectionStatus={connectionStatus}
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
-            onBackPress={openDrawer}
-            leftActionIcon="menu"
+            onBackPress={onNavigateBack}
             onPress={() => setShowPartnerInfo(true)}
             stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
             testID="session-chat-header"
@@ -3278,8 +3283,7 @@ export function UnifiedSessionScreen({
             partnerOnline={partnerOnline}
             connectionStatus={connectionStatus}
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
-            onBackPress={openDrawer}
-            leftActionIcon="menu"
+            onBackPress={onNavigateBack}
             onPress={() => setShowPartnerInfo(true)}
             stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
             testID="session-chat-header"
@@ -3310,8 +3314,7 @@ export function UnifiedSessionScreen({
           partnerOnline={partnerOnline}
           connectionStatus={connectionStatus}
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
-          onBackPress={openDrawer}
-          leftActionIcon="menu"
+          onBackPress={onNavigateBack}
           onPress={() => setShowPartnerInfo(true)}
           stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
           testID="session-chat-header"
@@ -3348,8 +3351,7 @@ export function UnifiedSessionScreen({
           partnerOnline={partnerOnline}
           connectionStatus={connectionStatus}
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
-          onBackPress={openDrawer}
-          leftActionIcon="menu"
+          onBackPress={onNavigateBack}
           onPress={() => setShowPartnerInfo(true)}
           stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
           testID="session-chat-header"
@@ -3393,8 +3395,7 @@ export function UnifiedSessionScreen({
         connectionStatus={connectionStatus}
         briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
         hideOnlineStatus={isInvitationPhase}
-        onBackPress={openDrawer}
-        leftActionIcon="menu"
+        onBackPress={onNavigateBack}
         onBriefStatusPress={
           session?.status === SessionStatus.INVITED && invitation?.isInviter
             ? () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,7 +309,7 @@
         "react-native-audio-record": "^0.2.2",
         "react-native-drawer-layout": "^4.2.1",
         "react-native-gesture-handler": "~2.28.0",
-        "react-native-reanimated": "~4.1.1",
+        "react-native-reanimated": "4.1.6",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-sse": "^1.2.1",
@@ -552,6 +552,22 @@
         "react": "^19.2.5"
       }
     },
+    "mobile/node_modules/react-native-reanimated": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.6.tgz",
+      "integrity": "sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1",
+        "semver": "7.7.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": ">=0.5.0"
+      }
+    },
     "mobile/node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -559,6 +575,18 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "mobile/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.2.0",
@@ -42650,6 +42678,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"


### PR DESCRIPTION
## Summary

- Updates partner chat navigation so home is the base route and sessions sit above it with native back gestures.
- Removes the session drawer from partner chat, keeps the drawer on home, and removes the sidebar home shortcut.
- Fixes multiple light-mode/readability issues across chat indicators, invitee topic intro, inner work/self-reflection, settings, new session, and activity drawer surfaces.
- Tightens chat/home input behavior and icons, including up-arrow send buttons and home composer focus handling.
- Simplifies biometric lock UI and pins local Metro resolution to the matching Reanimated version for device crash stability.
- Dedupes people/sessions before rendering to avoid duplicate-key warnings.

## Validation

- `npm --prefix mobile run check`
