### PR TITLE
[codex] Polish home chat, drawers, and privacy settings

### DIFF
--- a/backend/prisma/migrations/20260509102000_add_user_privacy_preferences/migration.sql
+++ b/backend/prisma/migrations/20260509102000_add_user_privacy_preferences/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "privacyPreferences" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   biometricEnrolledAt     DateTime?
   memoryPreferences       Json? // MemoryPreferencesDTO - AI memory settings
   notificationPreferences Json? // NotificationPreferencesDTO - notification settings
+  privacyPreferences      Json? // PrivacyPreferencesDTO - visibility and invitation settings
   lastMoodIntensity       Int? // Last mood intensity (1-10) for session entry default
   createdAt               DateTime  @default(now())
   updatedAt               DateTime  @updatedAt

--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -21,16 +21,21 @@ import {
   UpdateMemoryPreferencesResponse,
   GetNotificationPreferencesResponse,
   UpdateNotificationPreferencesResponse,
+  GetPrivacyPreferencesResponse,
+  UpdatePrivacyPreferencesResponse,
   DeleteAccountResponse,
   MemoryPreferencesDTO,
   NotificationPreferencesDTO,
+  PrivacyPreferencesDTO,
   DEFAULT_MEMORY_PREFERENCES,
   DEFAULT_NOTIFICATION_PREFERENCES,
+  DEFAULT_PRIVACY_PREFERENCES,
   updateProfileRequestSchema,
   updatePushTokenRequestSchema,
   updateBiometricPreferenceRequestSchema,
   updateMemoryPreferencesRequestSchema,
   updateNotificationPreferencesRequestSchema,
+  updatePrivacyPreferencesRequestSchema,
 } from '@meet-without-fear/shared';
 import { deleteAccountWithNotifications } from '../services/account-deletion';
 
@@ -532,6 +537,68 @@ export const updateNotificationPreferences = asyncHandler(async (req: Request, r
     data: {
       preferences: newPreferences,
     },
+  };
+
+  res.json(response);
+});
+
+// ============================================================================
+// GET /auth/me/privacy-preferences
+// ============================================================================
+
+export const getPrivacyPreferences = asyncHandler(async (req: Request, res: Response): Promise<void> => {
+  const user = getUser(req);
+
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { privacyPreferences: true } as any,
+  });
+
+  const storedPrefs = (dbUser as { privacyPreferences?: unknown } | null)?.privacyPreferences as PrivacyPreferencesDTO | null;
+  const preferences: PrivacyPreferencesDTO = storedPrefs ?? DEFAULT_PRIVACY_PREFERENCES;
+
+  const response: ApiResponse<GetPrivacyPreferencesResponse> = {
+    success: true,
+    data: { preferences },
+  };
+
+  res.json(response);
+});
+
+// ============================================================================
+// PATCH /auth/me/privacy-preferences
+// ============================================================================
+
+export const updatePrivacyPreferences = asyncHandler(async (req: Request, res: Response): Promise<void> => {
+  const user = getUser(req);
+
+  const parseResult = updatePrivacyPreferencesRequestSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    throw new ValidationError('Invalid privacy preferences data', {
+      errors: parseResult.error.flatten().fieldErrors,
+    });
+  }
+
+  const updates = parseResult.data;
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { privacyPreferences: true } as any,
+  });
+
+  const currentPrefs = ((dbUser as { privacyPreferences?: unknown } | null)?.privacyPreferences as PrivacyPreferencesDTO | null) ?? DEFAULT_PRIVACY_PREFERENCES;
+  const newPreferences: PrivacyPreferencesDTO = {
+    showActivityStatus: updates.showActivityStatus ?? currentPrefs.showActivityStatus,
+    allowSessionInvites: updates.allowSessionInvites ?? currentPrefs.allowSessionInvites,
+  };
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { privacyPreferences: newPreferences as object } as any,
+  });
+
+  const response: ApiResponse<UpdatePrivacyPreferencesResponse> = {
+    success: true,
+    data: { preferences: newPreferences },
   };
 
   res.json(response);

--- a/backend/src/controllers/invitations.ts
+++ b/backend/src/controllers/invitations.ts
@@ -3,7 +3,15 @@ import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
 import { notifyPartner, notifyPartnerWithFallback, publishSessionCreated } from '../services/realtime';
 import { z } from 'zod';
-import { ApiResponse, ErrorCode, SessionStatus, StageStatus, Stage } from '@meet-without-fear/shared';
+import {
+  ApiResponse,
+  DEFAULT_PRIVACY_PREFERENCES,
+  ErrorCode,
+  PrivacyPreferencesDTO,
+  SessionStatus,
+  StageStatus,
+  Stage,
+} from '@meet-without-fear/shared';
 import { successResponse, errorResponse } from '../utils/response';
 import { generateSessionStatusSummary } from '../utils/session';
 import { createInvitationUrl } from '../utils/urls';
@@ -597,6 +605,16 @@ export async function acceptInvitation(req: Request, res: Response): Promise<voi
       !invitation.session.topicFrameConfirmedAt
     ) {
       errorResponse(res, 'VALIDATION_ERROR', 'Invitation is not ready to accept', 400);
+      return;
+    }
+
+    const acceptingUser = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { privacyPreferences: true } as any,
+    });
+    const privacyPreferences = ((acceptingUser as { privacyPreferences?: unknown } | null)?.privacyPreferences as PrivacyPreferencesDTO | null) ?? DEFAULT_PRIVACY_PREFERENCES;
+    if (!privacyPreferences.allowSessionInvites) {
+      errorResponse(res, 'VALIDATION_ERROR', 'You have disabled session invitations in Privacy settings', 403);
       return;
     }
 

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -22,6 +22,8 @@ import {
   feelHeardRequestSchema,
   getMessagesQuerySchema,
   MessageRole,
+  DEFAULT_PRIVACY_PREFERENCES,
+  PrivacyPreferencesDTO,
 } from '@meet-without-fear/shared';
 import { notifyPartner, publishSessionEvent, notifySessionMembers, publishMessageAIResponse, publishMessageError, publishTopicFrameUpdated } from '../services/realtime';
 import { successResponse, errorResponse } from '../utils/response';
@@ -46,6 +48,15 @@ import { applyStage4AutoClosureFromSignal } from '../services/stage4-auto-closur
 // ============================================================================
 // Helpers
 // ============================================================================
+
+async function getShowActivityStatus(userId: string): Promise<boolean> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { privacyPreferences: true } as any,
+  });
+  const preferences = ((user as { privacyPreferences?: unknown } | null)?.privacyPreferences as PrivacyPreferencesDTO | null) ?? DEFAULT_PRIVACY_PREFERENCES;
+  return preferences.showActivityStatus;
+}
 
 /**
  * Check if partner has completed stage 1 "feel heard"
@@ -1289,11 +1300,16 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       },
     });
     await touchUserSessionActivity(sessionId, user.id, userMessage.timestamp);
-    publishSessionEvent(sessionId, 'partner.activity', {
-      activeAt: userMessage.timestamp.toISOString(),
-    }, user.id).catch((err) =>
-      logger.warn(`[sendMessageStream:${requestId}] Failed to publish partner activity:`, err)
-    );
+    getShowActivityStatus(user.id)
+      .then((showActivityStatus) => {
+        if (!showActivityStatus) return;
+        return publishSessionEvent(sessionId, 'partner.activity', {
+          activeAt: userMessage.timestamp.toISOString(),
+        }, user.id);
+      })
+      .catch((err) =>
+        logger.warn(`[sendMessageStream:${requestId}] Failed to publish partner activity:`, err)
+      );
     logger.info(`[sendMessageStream:${requestId}] User message created: ${userMessage.id}`);
 
     // Broadcast to Status Site

--- a/backend/src/controllers/session-state.ts
+++ b/backend/src/controllers/session-state.ts
@@ -20,7 +20,7 @@
 import { Request, Response } from 'express';
 import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
-import { ErrorCode } from '@meet-without-fear/shared';
+import { DEFAULT_PRIVACY_PREFERENCES, ErrorCode, PrivacyPreferencesDTO } from '@meet-without-fear/shared';
 import { successResponse, errorResponse } from '../utils/response';
 import { getPartnerUserId } from '../utils/session';
 
@@ -313,12 +313,20 @@ export async function getSessionState(req: Request, res: Response): Promise<void
           },
         })
       : null;
-    const partnerLastActiveAt = latestDate(
+    const partnerPrivacyUser = partnerId
+      ? await prisma.user.findUnique({
+          where: { id: partnerId },
+          select: { privacyPreferences: true } as any,
+        })
+      : null;
+    const partnerPrivacyPreferences = (partnerPrivacyUser as { privacyPreferences?: unknown } | null)?.privacyPreferences as PrivacyPreferencesDTO | null;
+    const partnerShowsActivity = (partnerPrivacyPreferences ?? DEFAULT_PRIVACY_PREFERENCES).showActivityStatus;
+    const partnerLastActiveAt = partnerShowsActivity ? latestDate(
       partnerVessel?.lastActiveAt,
       partnerLastMessage?.timestamp,
       partnerLastStageProgress?.completedAt,
       partnerLastStageProgress?.startedAt
-    );
+    ) : null;
 
     // Build messages response (reverse to chronological order)
     const hasMoreMessages = messages.length > 25;
@@ -410,7 +418,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
         createdAt: session.createdAt.toISOString(),
         resolvedAt: session.resolvedAt?.toISOString() ?? null,
         lastViewedAt: userVessel?.lastViewedAt?.toISOString() ?? null,
-        partnerLastViewedAt: partnerVessel?.lastViewedAt?.toISOString() ?? null,
+        partnerLastViewedAt: partnerShowsActivity ? partnerVessel?.lastViewedAt?.toISOString() ?? null : null,
         partnerLastActiveAt: partnerLastActiveAt?.toISOString() ?? null,
         lastSeenChatItemId: userVessel?.lastSeenChatItemId ?? null,
       },

--- a/backend/src/controllers/sessions.ts
+++ b/backend/src/controllers/sessions.ts
@@ -15,7 +15,7 @@
 import { Request, Response } from 'express';
 import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
-import { ApiResponse, ErrorCode, MessageRole, Stage } from '@meet-without-fear/shared';
+import { ApiResponse, DEFAULT_PRIVACY_PREFERENCES, ErrorCode, MessageRole, PrivacyPreferencesDTO, Stage } from '@meet-without-fear/shared';
 import { notifyPartner, publishSessionEvent, publishMessageAIResponse, publishMessageError } from '../services/realtime';
 import { successResponse, errorResponse } from '../utils/response';
 import { getPartnerUserId, isSessionCreator } from '../utils/session';
@@ -23,6 +23,15 @@ import { getOrchestratedResponse, type FullAIContext } from '../services/ai';
 import { embedSessionContent } from '../services/embedding';
 import { updateSessionSummary, getSessionSummary } from '../services/conversation-summarizer';
 import { updateContext } from '../lib/request-context';
+
+async function getShowActivityStatus(userId: string): Promise<boolean> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { privacyPreferences: true } as any,
+  });
+  const preferences = ((user as { privacyPreferences?: unknown } | null)?.privacyPreferences as PrivacyPreferencesDTO | null) ?? DEFAULT_PRIVACY_PREFERENCES;
+  return preferences.showActivityStatus;
+}
 
 // ============================================================================
 // Controllers
@@ -1109,9 +1118,11 @@ export async function markSessionViewed(req: Request, res: Response): Promise<vo
       try {
         const { buildEmpathyExchangeStatusForBothUsers } = await import('../services/empathy-status');
         const allStatuses = await buildEmpathyExchangeStatusForBothUsers(sessionId);
+        const showActivityStatus = await getShowActivityStatus(user.id);
         await publishSessionEvent(sessionId, 'partner.session_viewed', {
-          viewedAt: now.toISOString(),
-          activeAt: now.toISOString(),
+          viewedAt: showActivityStatus ? now.toISOString() : null,
+          activeAt: showActivityStatus ? now.toISOString() : null,
+          presenceVisible: showActivityStatus,
           empathyStatuses: allStatuses,
         }, user.id);
       } catch (err) {
@@ -1175,9 +1186,11 @@ export async function markShareTabViewed(req: Request, res: Response): Promise<v
       try {
         const { buildEmpathyExchangeStatusForBothUsers } = await import('../services/empathy-status');
         const allStatuses = await buildEmpathyExchangeStatusForBothUsers(sessionId);
+        const showActivityStatus = await getShowActivityStatus(user.id);
         await publishSessionEvent(sessionId, 'partner.share_tab_viewed', {
-          viewedAt: now.toISOString(),
-          activeAt: now.toISOString(),
+          viewedAt: showActivityStatus ? now.toISOString() : null,
+          activeAt: showActivityStatus ? now.toISOString() : null,
+          presenceVisible: showActivityStatus,
           empathyStatuses: allStatuses,
         }, user.id);
       } catch (err) {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -20,6 +20,8 @@ import {
   updateMemoryPreferences,
   getNotificationPreferences,
   updateNotificationPreferences,
+  getPrivacyPreferences,
+  updatePrivacyPreferences,
   updateMood,
   deleteAccount,
 } from '../controllers/auth';
@@ -155,6 +157,30 @@ router.get('/me/notification-preferences', getNotificationPreferences);
  * - preferences: NotificationPreferencesDTO
  */
 router.patch('/me/notification-preferences', updateNotificationPreferences);
+
+/**
+ * GET /auth/me/privacy-preferences
+ *
+ * Get current privacy preferences.
+ *
+ * Response: GetPrivacyPreferencesResponse
+ * - preferences: PrivacyPreferencesDTO
+ */
+router.get('/me/privacy-preferences', getPrivacyPreferences);
+
+/**
+ * PATCH /auth/me/privacy-preferences
+ *
+ * Update privacy preferences.
+ *
+ * Request: UpdatePrivacyPreferencesRequest
+ * - showActivityStatus?: boolean
+ * - allowSessionInvites?: boolean
+ *
+ * Response: UpdatePrivacyPreferencesResponse
+ * - preferences: PrivacyPreferencesDTO
+ */
+router.patch('/me/privacy-preferences', updatePrivacyPreferences);
 
 /**
  * PATCH /auth/me/mood

--- a/mobile/app/(auth)/(tabs)/__tests__/index.test.tsx
+++ b/mobile/app/(auth)/(tabs)/__tests__/index.test.tsx
@@ -21,6 +21,7 @@ jest.mock('expo-router', () => ({
 // Mock lucide-react-native
 jest.mock('lucide-react-native', () => ({
   ArrowRight: () => 'ArrowRightIcon',
+  ArrowUp: () => 'ArrowUpIcon',
   Plus: () => 'PlusIcon',
   Heart: () => 'HeartIcon',
   UserPlus: () => 'UserPlusIcon',
@@ -182,6 +183,15 @@ function renderWithProviders(component: React.ReactElement) {
 }
 
 describe('HomeScreen', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-09T09:00:00-07:00'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(() => {
     mockPush.mockClear();
     mockUseSessions.mockClear();
@@ -250,7 +260,7 @@ describe('HomeScreen', () => {
 
     renderWithProviders(<HomeScreen />);
 
-    expect(screen.getByText('Hello, Test')).toBeTruthy();
+    expect(screen.getByText('Good morning, Test')).toBeTruthy();
   });
 
   it('shows main question', () => {
@@ -264,7 +274,7 @@ describe('HomeScreen', () => {
     expect(screen.getByText('What would you like to work through?')).toBeTruthy();
   });
 
-  it('shows New Conversation and Inner Work buttons', () => {
+  it('shows New Conversation and hides Inner Work while unavailable', () => {
     mockUseSessions.mockReturnValue({
       data: { items: [], hasMore: false },
       isLoading: false,
@@ -273,7 +283,7 @@ describe('HomeScreen', () => {
     renderWithProviders(<HomeScreen />);
 
     expect(screen.getByText('New conversation')).toBeTruthy();
-    expect(screen.getByText('Inner work')).toBeTruthy();
+    expect(screen.queryByText('Inner work')).toBeNull();
   });
 
   it('shows Continue button when there is a recent session with partner nickname', () => {
@@ -332,19 +342,6 @@ describe('HomeScreen', () => {
     expect(mockPush).toHaveBeenCalledWith('/session/new');
   });
 
-  it('navigates to inner thoughts when Inner Thoughts pressed', () => {
-    mockUseSessions.mockReturnValue({
-      data: { items: [], hasMore: false },
-      isLoading: false,
-    });
-
-    renderWithProviders(<HomeScreen />);
-
-    fireEvent.press(screen.getByLabelText('Inner Work'));
-
-    expect(mockPush).toHaveBeenCalledWith('/inner-work');
-  });
-
   it('navigates to session when Continue pressed', () => {
     const session = createMockSession({
       id: 'recent-session',
@@ -361,6 +358,32 @@ describe('HomeScreen', () => {
     fireEvent.press(screen.getByLabelText('Continue with Jane'));
 
     expect(mockPush).toHaveBeenCalledWith('/session/recent-session');
+  });
+
+  it('routes home composer to the inner work coming-soon chat', () => {
+    const session = createMockSession({
+      id: 'recent-session',
+      partner: { id: 'user-2', name: 'Jane', nickname: 'Jane' },
+    });
+
+    mockUseSessions.mockReturnValue({
+      data: { items: [session], hasMore: false },
+      isLoading: false,
+    });
+
+    renderWithProviders(<HomeScreen />);
+
+    fireEvent.changeText(screen.getByPlaceholderText("What's on your mind?"), 'I feel stuck');
+    fireEvent.press(screen.getByLabelText('Send'));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: '/inner-work/self-reflection/[id]',
+      params: {
+        id: 'new',
+        comingSoon: '1',
+        initialMessage: 'Doing inner work by yourself is a feature coming soon.',
+      },
+    });
   });
 
   it('shows the most recently updated session for Continue button', () => {

--- a/mobile/app/(auth)/(tabs)/_layout.tsx
+++ b/mobile/app/(auth)/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack } from 'expo-router';
-import { colors } from '@/src/theme';
+import { useAppAppearance } from '@/src/theme';
 
 /**
  * Main navigation layout
@@ -11,12 +11,14 @@ import { colors } from '@/src/theme';
  * - Home screen is the main landing page
  */
 export default function MainLayout() {
+  const { palette } = useAppAppearance();
+
   return (
     <Stack
       screenOptions={{
         headerShown: false,
         contentStyle: {
-          backgroundColor: colors.bgPrimary,
+          backgroundColor: palette.bg,
         },
       }}
     >
@@ -28,9 +30,12 @@ export default function MainLayout() {
           headerShown: true,
           headerTitle: 'My Sessions',
           headerStyle: {
-            backgroundColor: colors.bgSecondary,
+            backgroundColor: palette.bg,
           },
-          headerTintColor: colors.textPrimary,
+          headerTintColor: palette.text,
+          headerTitleStyle: {
+            color: palette.text,
+          },
         }}
       />
     </Stack>

--- a/mobile/app/(auth)/(tabs)/index.tsx
+++ b/mobile/app/(auth)/(tabs)/index.tsx
@@ -21,12 +21,13 @@ import {
   KeyboardAvoidingView,
   Platform,
   Keyboard,
+  Modal,
   Pressable,
   StyleSheet,
   TextInput,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { ArrowRight, ArrowUp, Plus, Layers, UserPlus, Menu, Settings } from 'lucide-react-native';
+import { ArrowRight, ArrowUp, Plus, Layers, UserPlus, Menu, Settings, X } from 'lucide-react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useAuth } from '@/src/hooks/useAuth';
@@ -36,6 +37,8 @@ import { useSessions, useAcceptInvitation } from '../../../src/hooks/useSessions
 import { useUnreadSessionCount } from '@/src/hooks/useUnreadSessionCount';
 import { BiometricPrompt, SessionDrawer } from '../../../src/components';
 import { designFonts, useAppAppearance } from '@/src/theme';
+
+const SHOW_INNER_WORK_BUTTON = false;
 
 // ============================================================================
 // Component
@@ -51,6 +54,7 @@ export default function HomeScreen() {
   const { openDrawer } = useSessionDrawer();
   const { count: unreadCount } = useUnreadSessionCount();
   const [isComposerFocused, setIsComposerFocused] = useState(false);
+  const [showProcessDrawer, setShowProcessDrawer] = useState(false);
   const composerExtrasOpacity = useRef(new Animated.Value(1)).current;
 
   const dismissHomeComposer = useCallback(() => {
@@ -73,16 +77,6 @@ export default function HomeScreen() {
       await clearInvitation();
     },
   });
-
-  // Handle sending a message from home page chat input
-  // Navigate to inner thoughts - Expo Router handles the fade transition
-  const handleHomeChat = useCallback((message: string) => {
-    Keyboard.dismiss();
-    router.push({
-      pathname: '/inner-work/self-reflection/[id]',
-      params: { id: 'new', initialMessage: message },
-    });
-  }, [router]);
 
   // Wait for auth, sessions, and pending invitation check to load
   const isLoading = isAuthLoading || isSessionsLoading || isPendingLoading;
@@ -139,6 +133,27 @@ export default function HomeScreen() {
   // Get the partner's nickname or name for the continue button
   const partnerDisplayName = mostRecentSession?.partner?.nickname || mostRecentSession?.partner?.name;
 
+  // Handle sending a message from home page chat input.
+  // Inner work is temporarily unavailable, but we still route into the chat shell
+  // so the transition and layout stay familiar.
+  const handleHomeChat = useCallback(() => {
+    Keyboard.dismiss();
+    const params: {
+      id: string;
+      comingSoon: string;
+      initialMessage: string;
+    } = {
+      id: 'new',
+      comingSoon: '1',
+      initialMessage: 'Doing inner work by yourself is a feature coming soon.',
+    };
+
+    router.push({
+      pathname: '/inner-work/self-reflection/[id]',
+      params,
+    });
+  }, [router]);
+
   // Get inviter's name for pending invitation
   const inviterName = invitation?.invitedBy?.name || 'Someone';
   const hasPendingInvitation = pendingInvitation && invitation && invitation.status === 'PENDING';
@@ -167,6 +182,14 @@ export default function HomeScreen() {
   const handleSettings = useCallback(() => {
     router.push('/settings');
   }, [router]);
+
+  const handleOpenProcessDrawer = useCallback(() => {
+    setShowProcessDrawer(true);
+  }, []);
+
+  const handleCloseProcessDrawer = useCallback(() => {
+    setShowProcessDrawer(false);
+  }, []);
 
   // Get the user's display name
   const userName = user?.firstName || user?.name?.split(' ')[0] || 'there';
@@ -224,9 +247,8 @@ export default function HomeScreen() {
           >
             <Pressable style={styles.content} onPress={dismissHomeComposer}>
               <View style={styles.greetingSection}>
-                <Text style={styles.timeGreet}>{getGreetingLabel()}</Text>
                 <Text style={styles.greeting}>
-                  Hello, <Text style={styles.greetingEm}>{userName}</Text>
+                  {getGreetingLabel()}, <Text style={styles.greetingEm}>{userName}</Text>
                 </Text>
                 <Text style={styles.question}>
                   What would you like to work through?
@@ -299,22 +321,23 @@ export default function HomeScreen() {
                     <ArrowRight color={palette.textFaint} size={16} />
                   </TouchableOpacity>
 
-                  {/* Inner Work */}
-                  <TouchableOpacity
-                    style={styles.actionCard}
-                    onPress={handleInnerWork}
-                    accessibilityRole="button"
-                    accessibilityLabel="Inner Work"
-                  >
-                    <View style={styles.actionIcon}>
-                      <Layers color={palette.textMuted} size={18} />
-                    </View>
-                    <View style={styles.actionTextBlock}>
-                      <Text style={styles.actionTitle}>Inner work</Text>
-                      <Text style={styles.actionSub}>Sit with what came up, just for you</Text>
-                    </View>
-                    <ArrowRight color={palette.textFaint} size={16} />
-                  </TouchableOpacity>
+                  {SHOW_INNER_WORK_BUTTON && (
+                    <TouchableOpacity
+                      style={styles.actionCard}
+                      onPress={handleInnerWork}
+                      accessibilityRole="button"
+                      accessibilityLabel="Inner Work"
+                    >
+                      <View style={styles.actionIcon}>
+                        <Layers color={palette.textMuted} size={18} />
+                      </View>
+                      <View style={styles.actionTextBlock}>
+                        <Text style={styles.actionTitle}>Inner work</Text>
+                        <Text style={styles.actionSub}>Sit with what came up, just for you</Text>
+                      </View>
+                      <ArrowRight color={palette.textFaint} size={16} />
+                    </TouchableOpacity>
+                  )}
                 </View>
 
                 <View style={styles.whisper}>
@@ -327,6 +350,15 @@ export default function HomeScreen() {
                     It is okay to take your time getting to the words. The right ones usually arrive after the rough ones.
                   </Text>
                 </View>
+
+                <TouchableOpacity
+                  style={styles.processLink}
+                  onPress={handleOpenProcessDrawer}
+                  accessibilityRole="button"
+                  accessibilityLabel="How does this work?"
+                >
+                  <Text style={styles.processLinkText}>How does this work?</Text>
+                </TouchableOpacity>
                 </Animated.View>
               )}
             </Pressable>
@@ -346,6 +378,12 @@ export default function HomeScreen() {
           onDismiss={() => setShowBiometricPrompt(false)}
           testID="biometric-prompt"
         />
+
+        <ProcessDrawer
+          visible={showProcessDrawer}
+          onClose={handleCloseProcessDrawer}
+          palette={palette}
+        />
       </SafeAreaView>
     </SessionDrawer>
   );
@@ -353,8 +391,9 @@ export default function HomeScreen() {
 
 function getGreetingLabel() {
   const hour = new Date().getHours();
-  const part = hour < 12 ? 'morning' : hour < 17 ? 'afternoon' : 'evening';
-  return `This ${part}`;
+  if (hour < 12) return 'Good morning';
+  if (hour < 17) return 'Good afternoon';
+  return 'Good evening';
 }
 
 function HomeComposer({
@@ -409,6 +448,90 @@ function HomeComposer({
         <ArrowUp color={canSend ? palette.bg : palette.textFaint} size={18} />
       </TouchableOpacity>
     </View>
+  );
+}
+
+const PROCESS_STEPS = [
+  {
+    title: 'Start in private',
+    body: 'Each person works with the AI separately. The app slows things down before anyone is asked to respond directly.',
+  },
+  {
+    title: 'Be fully heard',
+    body: 'You first tell your side without interruption. The AI reflects it back until you feel accurately understood.',
+  },
+  {
+    title: 'Practice understanding',
+    body: 'When both people are ready, the process helps each of you understand the other person without excusing or debating what happened.',
+  },
+  {
+    title: 'Name what matters',
+    body: 'You clarify the needs underneath the conflict, choose what to share, and only reveal it when both people have consented.',
+  },
+  {
+    title: 'Try a small repair',
+    body: 'The final step looks for small, reversible experiments both people are willing to try, then turns overlap into a clear next step.',
+  },
+];
+
+function ProcessDrawer({
+  visible,
+  onClose,
+  palette,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  palette: ReturnType<typeof useAppAppearance>['palette'];
+}) {
+  const styles = useMemo(() => makeProcessDrawerStyles(palette), [palette]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable style={styles.sheet} onPress={(event) => event.stopPropagation()}>
+          <View style={styles.handle} />
+          <View style={styles.drawerHeader}>
+            <View style={styles.drawerTitleBlock}>
+              <Text style={styles.drawerEyebrow}>A guided conversation</Text>
+              <Text style={styles.drawerTitle}>How it works</Text>
+            </View>
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+            >
+              <X color={palette.textMuted} size={18} />
+            </TouchableOpacity>
+          </View>
+
+          <Text style={styles.intro}>
+            Meet Without Fear works like a buffer between two people. It helps
+            each side settle, be heard, and move toward a next step without
+            rushing into a reactive conversation.
+          </Text>
+
+          <View style={styles.steps}>
+            {PROCESS_STEPS.map((step, index) => (
+              <View key={step.title} style={styles.stepRow}>
+                <View style={styles.stepNumber}>
+                  <Text style={styles.stepNumberText}>{index + 1}</Text>
+                </View>
+                <View style={styles.stepTextBlock}>
+                  <Text style={styles.stepTitle}>{step.title}</Text>
+                  <Text style={styles.stepBody}>{step.body}</Text>
+                </View>
+              </View>
+            ))}
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
   );
 }
 
@@ -520,6 +643,18 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) =>
     content: {
       flex: 1,
       paddingHorizontal: 16,
+    },
+    processLink: {
+      alignSelf: 'flex-start',
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      marginTop: 18,
+      marginLeft: 0,
+    },
+    processLinkText: {
+      color: palette.accentText,
+      fontSize: 15,
+      fontFamily: designFonts.serifItalic,
     },
     greetingSection: {
       paddingTop: 36,
@@ -673,5 +808,118 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) =>
       fontSize: 17,
       lineHeight: 24,
       fontFamily: designFonts.serifItalic,
+    },
+  });
+
+const makeProcessDrawerStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      justifyContent: 'flex-end',
+      backgroundColor: 'transparent',
+    },
+    sheet: {
+      backgroundColor: palette.bg,
+      borderTopLeftRadius: 28,
+      borderTopRightRadius: 28,
+      borderWidth: 1,
+      borderBottomWidth: 0,
+      borderColor: palette.border,
+      paddingHorizontal: 22,
+      paddingTop: 10,
+      paddingBottom: 28,
+    },
+    handle: {
+      alignSelf: 'center',
+      width: 44,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: palette.divider,
+      marginBottom: 22,
+    },
+    drawerHeader: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      justifyContent: 'space-between',
+      gap: 16,
+      marginBottom: 16,
+    },
+    drawerTitleBlock: {
+      flex: 1,
+      minWidth: 0,
+    },
+    drawerEyebrow: {
+      color: palette.accentText,
+      fontSize: 10,
+      letterSpacing: 1.2,
+      textTransform: 'uppercase',
+      fontWeight: '700',
+      fontFamily: designFonts.mono,
+      marginBottom: 8,
+    },
+    drawerTitle: {
+      color: palette.text,
+      fontSize: 32,
+      lineHeight: 36,
+      fontFamily: designFonts.serif,
+    },
+    closeButton: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: palette.chipBg,
+      borderWidth: 1,
+      borderColor: palette.border,
+    },
+    intro: {
+      color: palette.textMuted,
+      fontSize: 15,
+      lineHeight: 22,
+      fontFamily: designFonts.sans,
+      marginBottom: 22,
+    },
+    steps: {
+      gap: 16,
+    },
+    stepRow: {
+      flexDirection: 'row',
+      gap: 12,
+    },
+    stepNumber: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: palette.chipBg,
+      borderWidth: 1,
+      borderColor: palette.border,
+    },
+    stepNumberText: {
+      color: palette.accentText,
+      fontSize: 11,
+      fontWeight: '700',
+      fontFamily: designFonts.mono,
+    },
+    stepTextBlock: {
+      flex: 1,
+      minWidth: 0,
+      paddingBottom: 2,
+    },
+    stepTitle: {
+      color: palette.text,
+      fontSize: 15,
+      lineHeight: 20,
+      fontWeight: '700',
+      fontFamily: designFonts.sans,
+      marginBottom: 4,
+    },
+    stepBody: {
+      color: palette.textMuted,
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: designFonts.sans,
     },
   });

--- a/mobile/app/(auth)/_layout.tsx
+++ b/mobile/app/(auth)/_layout.tsx
@@ -66,7 +66,13 @@ export default function AuthLayout() {
         />
 
         {/* Inner Work - animation is handled at the screen level */}
-        <Stack.Screen name="inner-work" />
+        <Stack.Screen
+          name="inner-work"
+          options={{
+            animation: 'slide_from_right',
+            gestureEnabled: true,
+          }}
+        />
 
         {/* Settings - slide from right */}
         <Stack.Screen

--- a/mobile/app/(auth)/inner-work/self-reflection/[id].tsx
+++ b/mobile/app/(auth)/inner-work/self-reflection/[id].tsx
@@ -25,15 +25,24 @@ const FADE_DURATION = 300; // Match the fade animation duration
 
 export default function SelfReflectionChatScreen() {
   const router = useRouter();
-  const { id, partnerSessionId, partnerName, linkedTrigger, initialMessage } = useLocalSearchParams<{
+  const {
+    id,
+    partnerSessionId,
+    partnerName,
+    linkedTrigger,
+    initialMessage,
+    comingSoon,
+  } = useLocalSearchParams<{
     id: string;
     partnerSessionId?: string;
     partnerName?: string;
     linkedTrigger?: string;
     initialMessage?: string;
+    comingSoon?: string;
   }>();
 
   const isNewSession = id === 'new';
+  const isComingSoon = comingSoon === '1';
 
   // Track the created session ID in state to avoid route replacement remounting
   const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
@@ -56,7 +65,7 @@ export default function SelfReflectionChatScreen() {
 
   // Handle creating a new session when id="new"
   useEffect(() => {
-    if (id === 'new' && !hasStartedCreation.current) {
+    if (id === 'new' && !isComingSoon && !hasStartedCreation.current) {
       hasStartedCreation.current = true;
       createSession.mutate(
         {
@@ -89,11 +98,13 @@ export default function SelfReflectionChatScreen() {
         }
       );
     }
-  }, [id, partnerSessionId, linkedTrigger, initialMessage, createSession, router]);
+  }, [id, isComingSoon, partnerSessionId, linkedTrigger, initialMessage, createSession, router]);
 
   // Use created session ID if available, otherwise use URL id
-  const effectiveSessionId = createdSessionId || (id === 'new' ? '' : (id || ''));
-  const isCreating = id === 'new' && !createdSessionId;
+  const effectiveSessionId = isComingSoon
+    ? 'inner-work-coming-soon'
+    : createdSessionId || (id === 'new' ? '' : (id || ''));
+  const isCreating = id === 'new' && !isComingSoon && !createdSessionId;
 
   return (
     <>
@@ -101,7 +112,7 @@ export default function SelfReflectionChatScreen() {
         options={{
           headerShown: false,
           // Use fade for new sessions, slide for existing
-          animation: isNewSession ? 'fade' : 'slide_from_right',
+          animation: isComingSoon ? 'slide_from_right' : isNewSession ? 'fade' : 'slide_from_right',
           // Ensure swipe back works
           gestureEnabled: true,
         }}
@@ -118,7 +129,8 @@ export default function SelfReflectionChatScreen() {
         isCreating={isCreating}
         initialMessage={initialMessage}
         initialSuggestedActions={initialSuggestedActions}
-        hideContentUntilReady={!transitionComplete}
+        hideContentUntilReady={!isComingSoon && !transitionComplete}
+        comingSoonMode={isComingSoon}
       />
     </>
   );

--- a/mobile/app/(auth)/session/[id]/_layout.tsx
+++ b/mobile/app/(auth)/session/[id]/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack } from 'expo-router';
-import { colors } from '@/src/theme';
+import { useAppAppearance } from '@/src/theme';
 
 /**
  * Session detail layout
@@ -8,13 +8,15 @@ import { colors } from '@/src/theme';
  * The UnifiedSessionScreen handles all stage transitions internally.
  */
 export default function SessionLayout() {
+  const { palette } = useAppAppearance();
+
   return (
     <Stack
       screenOptions={{
         headerShown: false, // UnifiedSessionScreen has its own header
         gestureEnabled: true,
         contentStyle: {
-          backgroundColor: colors.bgPrimary,
+          backgroundColor: palette.bg,
         },
       }}
     >
@@ -30,10 +32,11 @@ export default function SessionLayout() {
           title: 'Sharing Status',
           headerShown: true,
           headerStyle: {
-            backgroundColor: colors.bgSecondary,
+            backgroundColor: palette.bg,
           },
-          headerTintColor: colors.textPrimary,
+          headerTintColor: palette.text,
           headerTitleStyle: {
+            color: palette.text,
             fontWeight: '600',
           },
           headerBackTitle: 'Chat',

--- a/mobile/app/(auth)/settings/_layout.tsx
+++ b/mobile/app/(auth)/settings/_layout.tsx
@@ -11,23 +11,12 @@
  */
 
 import { Stack, useRouter } from 'expo-router';
-import { StyleSheet, TouchableOpacity } from 'react-native';
-import { ChevronLeft } from 'lucide-react-native';
 import { designFonts, useAppAppearance } from '@/theme';
+import { HeaderBackButton } from '@/src/components/HeaderBackButton';
 
 function BackButton() {
   const router = useRouter();
-  const { palette } = useAppAppearance();
-  return (
-    <TouchableOpacity
-      onPress={() => router.back()}
-      style={[styles.backButton, { backgroundColor: palette.chipBg }]}
-      accessibilityRole="button"
-      accessibilityLabel="Go back"
-    >
-      <ChevronLeft color={palette.text} size={24} strokeWidth={2.4} />
-    </TouchableOpacity>
-  );
+  return <HeaderBackButton onPress={() => router.back()} />;
 }
 
 export default function SettingsLayout() {
@@ -93,14 +82,3 @@ export default function SettingsLayout() {
     </Stack>
   );
 }
-
-const styles = StyleSheet.create({
-  backButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginLeft: -4,
-  },
-});

--- a/mobile/app/(auth)/settings/account.tsx
+++ b/mobile/app/(auth)/settings/account.tsx
@@ -4,7 +4,7 @@
  * Allows users to manage their profile: edit profile, export data, delete account.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   View,
   Text,
@@ -18,11 +18,13 @@ import {
 import { Stack, useRouter } from 'expo-router';
 import { User, Trash2, Save } from 'lucide-react-native';
 import { useClerk } from '@clerk/clerk-expo';
-import { colors } from '@/src/theme';
+import { designFonts, useAppAppearance } from '@/src/theme';
 import { useProfile, useUpdateProfile, useDeleteAccount } from '@/src/hooks/useProfile';
 import { useAuth } from '@/src/hooks/useAuth';
 
 export default function AccountSettingsScreen() {
+  const { palette } = useAppAppearance();
+  const styles = useMemo(() => makeStyles(palette), [palette]);
   const { data: profileData } = useProfile();
   const user = profileData?.user;
   const updateProfile = useUpdateProfile();
@@ -117,12 +119,13 @@ export default function AccountSettingsScreen() {
           headerShown: true,
           headerBackTitle: 'Back',
           headerStyle: {
-            backgroundColor: colors.bgPrimary,
+            backgroundColor: palette.bg,
           },
-          headerTintColor: colors.textPrimary,
+          headerTintColor: palette.text,
           headerTitleStyle: {
             fontWeight: '600',
-            color: colors.textPrimary,
+            color: palette.text,
+            fontFamily: designFonts.sans,
           },
         }}
       />
@@ -133,7 +136,7 @@ export default function AccountSettingsScreen() {
           <Text style={styles.sectionTitle}>Profile</Text>
           <View style={styles.card}>
             <View style={styles.avatarContainer}>
-              <User color={colors.textPrimary} size={32} />
+              <User color={palette.bg} size={32} />
             </View>
             <View style={styles.profileInfo}>
               {isEditing ? (
@@ -144,7 +147,7 @@ export default function AccountSettingsScreen() {
                     value={firstName}
                     onChangeText={setFirstName}
                     placeholder="First name"
-                    placeholderTextColor={colors.textMuted}
+                    placeholderTextColor={palette.textFaint}
                     autoFocus
                   />
                   <Text style={styles.label}>Last Name</Text>
@@ -153,7 +156,7 @@ export default function AccountSettingsScreen() {
                     value={lastName}
                     onChangeText={setLastName}
                     placeholder="Last name (optional)"
-                    placeholderTextColor={colors.textMuted}
+                    placeholderTextColor={palette.textFaint}
                   />
                 </>
               ) : (
@@ -186,10 +189,10 @@ export default function AccountSettingsScreen() {
                 disabled={updateProfile.isPending}
               >
                 {updateProfile.isPending ? (
-                  <ActivityIndicator color={colors.textPrimary} size="small" />
+                  <ActivityIndicator color={palette.bg} size="small" />
                 ) : (
                   <>
-                    <Save color={colors.textPrimary} size={18} />
+                    <Save color={palette.bg} size={18} />
                     <Text style={styles.saveButtonText}>Save</Text>
                   </>
                 )}
@@ -213,7 +216,7 @@ export default function AccountSettingsScreen() {
             onPress={handleDeleteAccount}
           >
             <View style={styles.menuItemLeft}>
-              <Trash2 color={colors.error} size={22} />
+              <Trash2 color={palette.danger} size={22} />
               <View>
                 <Text style={[styles.menuItemLabel, styles.dangerLabel]}>
                   Delete Account
@@ -230,10 +233,10 @@ export default function AccountSettingsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.bgPage,
+    backgroundColor: palette.bg,
   },
   content: {
     padding: 16,
@@ -246,26 +249,29 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 13,
     fontWeight: '600',
-    color: colors.textSecondary,
+    color: palette.textMuted,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
     marginLeft: 4,
+    fontFamily: designFonts.sans,
   },
   dangerTitle: {
-    color: colors.error,
+    color: palette.danger,
   },
   card: {
     flexDirection: 'row',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
     gap: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   avatarContainer: {
     width: 64,
     height: 64,
     borderRadius: 32,
-    backgroundColor: colors.accent,
+    backgroundColor: palette.accent,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -275,54 +281,63 @@ const styles = StyleSheet.create({
   },
   label: {
     fontSize: 12,
-    color: colors.textMuted,
+    color: palette.textMuted,
     marginTop: 8,
+    fontFamily: designFonts.sans,
   },
   value: {
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.text,
+    fontFamily: designFonts.sans,
   },
   input: {
     fontSize: 16,
-    color: colors.textPrimary,
-    backgroundColor: colors.bgTertiary,
+    color: palette.text,
+    backgroundColor: palette.bgPane,
     borderRadius: 8,
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderWidth: 1,
-    borderColor: colors.accent,
+    borderColor: palette.borderStrong,
+    fontFamily: designFonts.sans,
   },
   buttonRow: {
     flexDirection: 'row',
     gap: 12,
   },
   editButton: {
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 8,
     paddingVertical: 12,
     alignItems: 'center',
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   editButtonText: {
     fontSize: 16,
-    color: colors.accent,
+    color: palette.accentText,
     fontWeight: '600',
+    fontFamily: designFonts.sans,
   },
   cancelButton: {
     flex: 1,
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 8,
     paddingVertical: 12,
     alignItems: 'center',
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   cancelButtonText: {
     fontSize: 16,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     fontWeight: '600',
+    fontFamily: designFonts.sans,
   },
   saveButton: {
     flex: 1,
     flexDirection: 'row',
-    backgroundColor: colors.accent,
+    backgroundColor: palette.accent,
     borderRadius: 8,
     paddingVertical: 12,
     alignItems: 'center',
@@ -331,20 +346,23 @@ const styles = StyleSheet.create({
   },
   saveButtonText: {
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.bg,
     fontWeight: '600',
+    fontFamily: designFonts.sans,
   },
   menuItem: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   dangerItem: {
     borderWidth: 1,
-    borderColor: colors.error,
+    borderColor: palette.danger,
   },
   menuItemLeft: {
     flexDirection: 'row',
@@ -354,15 +372,17 @@ const styles = StyleSheet.create({
   },
   menuItemLabel: {
     fontSize: 17,
-    color: colors.textPrimary,
+    color: palette.text,
     fontWeight: '500',
+    fontFamily: designFonts.sans,
   },
   dangerLabel: {
-    color: colors.error,
+    color: palette.danger,
   },
   menuItemDescription: {
     fontSize: 13,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     marginTop: 2,
+    fontFamily: designFonts.sans,
   },
 });

--- a/mobile/app/(auth)/settings/help.tsx
+++ b/mobile/app/(auth)/settings/help.tsx
@@ -13,6 +13,7 @@ import {
   Linking,
   Alert,
 } from 'react-native';
+import { useMemo } from 'react';
 import { Stack } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import {
@@ -24,7 +25,7 @@ import {
   ExternalLink,
   Heart,
 } from 'lucide-react-native';
-import { colors } from '@/src/theme';
+import { designFonts, useAppAppearance } from '@/src/theme';
 
 interface FAQItem {
   question: string;
@@ -55,6 +56,9 @@ const faqItems: FAQItem[] = [
 ];
 
 export default function HelpSupportScreen() {
+  const { palette } = useAppAppearance();
+  const styles = useMemo(() => makeStyles(palette), [palette]);
+
   const handleEmailSupport = () => {
     Linking.openURL('mailto:support@meetwithoutfear.com?subject=Support Request').catch(() => {
       Alert.alert('Error', 'Could not open email app');
@@ -81,12 +85,13 @@ export default function HelpSupportScreen() {
           headerShown: true,
           headerBackTitle: 'Back',
           headerStyle: {
-            backgroundColor: colors.bgPrimary,
+            backgroundColor: palette.bg,
           },
-          headerTintColor: colors.textPrimary,
+          headerTintColor: palette.text,
           headerTitleStyle: {
             fontWeight: '600',
-            color: colors.textPrimary,
+            color: palette.text,
+            fontFamily: designFonts.sans,
           },
         }}
       />
@@ -94,7 +99,7 @@ export default function HelpSupportScreen() {
       <ScrollView style={styles.container} contentContainerStyle={styles.content}>
         {/* Welcome Message */}
         <View style={styles.welcomeCard}>
-          <HelpCircle color={colors.accent} size={28} />
+          <HelpCircle color={palette.accent} size={28} />
           <View style={styles.welcomeText}>
             <Text style={styles.welcomeTitle}>How can we help?</Text>
             <Text style={styles.welcomeSubtitle}>
@@ -110,7 +115,7 @@ export default function HelpSupportScreen() {
           <TouchableOpacity style={styles.contactItem} onPress={handleEmailSupport}>
             <View style={styles.contactItemLeft}>
               <View style={styles.iconCircle}>
-                <Mail color={colors.textPrimary} size={20} />
+                <Mail color={palette.bg} size={20} />
               </View>
               <View>
                 <Text style={styles.contactItemLabel}>Email Support</Text>
@@ -119,13 +124,13 @@ export default function HelpSupportScreen() {
                 </Text>
               </View>
             </View>
-            <ChevronRight color={colors.textSecondary} size={20} />
+            <ChevronRight color={palette.textMuted} size={20} />
           </TouchableOpacity>
 
           <TouchableOpacity style={styles.contactItem} onPress={handleOpenDocs}>
             <View style={styles.contactItemLeft}>
               <View style={styles.iconCircle}>
-                <BookOpen color={colors.textPrimary} size={20} />
+                <BookOpen color={palette.bg} size={20} />
               </View>
               <View>
                 <Text style={styles.contactItemLabel}>Documentation</Text>
@@ -134,13 +139,13 @@ export default function HelpSupportScreen() {
                 </Text>
               </View>
             </View>
-            <ExternalLink color={colors.textSecondary} size={18} />
+            <ExternalLink color={palette.textMuted} size={18} />
           </TouchableOpacity>
 
           <TouchableOpacity style={styles.contactItem} onPress={handleFeedback}>
             <View style={styles.contactItemLeft}>
               <View style={styles.iconCircle}>
-                <MessageCircle color={colors.textPrimary} size={20} />
+                <MessageCircle color={palette.bg} size={20} />
               </View>
               <View>
                 <Text style={styles.contactItemLabel}>Send Feedback</Text>
@@ -149,7 +154,7 @@ export default function HelpSupportScreen() {
                 </Text>
               </View>
             </View>
-            <ChevronRight color={colors.textSecondary} size={20} />
+            <ChevronRight color={palette.textMuted} size={20} />
           </TouchableOpacity>
         </View>
 
@@ -167,7 +172,7 @@ export default function HelpSupportScreen() {
 
         {/* Made with Love */}
         <View style={styles.footer}>
-          <Heart color={colors.error} size={16} fill={colors.error} />
+          <Heart color={palette.danger} size={16} fill={palette.danger} />
           <Text style={styles.footerText}>Made with love for better relationships</Text>
         </View>
       </ScrollView>
@@ -175,10 +180,10 @@ export default function HelpSupportScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.bgPage,
+    backgroundColor: palette.bg,
   },
   content: {
     padding: 16,
@@ -187,11 +192,13 @@ const styles = StyleSheet.create({
   },
   welcomeCard: {
     flexDirection: 'row',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
     gap: 16,
     alignItems: 'flex-start',
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   welcomeText: {
     flex: 1,
@@ -199,13 +206,15 @@ const styles = StyleSheet.create({
   welcomeTitle: {
     fontSize: 18,
     fontWeight: '600',
-    color: colors.textPrimary,
+    color: palette.text,
     marginBottom: 4,
+    fontFamily: designFonts.sans,
   },
   welcomeSubtitle: {
     fontSize: 14,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     lineHeight: 20,
+    fontFamily: designFonts.sans,
   },
   section: {
     gap: 12,
@@ -213,18 +222,21 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 13,
     fontWeight: '600',
-    color: colors.textSecondary,
+    color: palette.textMuted,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
     marginLeft: 4,
+    fontFamily: designFonts.sans,
   },
   contactItem: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   contactItemLeft: {
     flexDirection: 'row',
@@ -235,35 +247,41 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: colors.accent,
+    backgroundColor: palette.accent,
     justifyContent: 'center',
     alignItems: 'center',
   },
   contactItemLabel: {
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.text,
     fontWeight: '500',
+    fontFamily: designFonts.sans,
   },
   contactItemDescription: {
     fontSize: 13,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     marginTop: 2,
+    fontFamily: designFonts.sans,
   },
   faqItem: {
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   faqQuestion: {
     fontSize: 15,
     fontWeight: '600',
-    color: colors.textPrimary,
+    color: palette.text,
     marginBottom: 8,
+    fontFamily: designFonts.sans,
   },
   faqAnswer: {
     fontSize: 14,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     lineHeight: 20,
+    fontFamily: designFonts.sans,
   },
   footer: {
     flexDirection: 'row',
@@ -274,6 +292,7 @@ const styles = StyleSheet.create({
   },
   footerText: {
     fontSize: 13,
-    color: colors.textMuted,
+    color: palette.textMuted,
+    fontFamily: designFonts.sans,
   },
 });

--- a/mobile/app/(auth)/settings/memories.tsx
+++ b/mobile/app/(auth)/settings/memories.tsx
@@ -6,7 +6,7 @@
  * Direct editing is not allowed - all changes go through AI validation.
  */
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useMemo } from 'react';
 import {
   View,
   Text,
@@ -22,10 +22,10 @@ import {
   Platform,
   RefreshControl,
 } from 'react-native';
-import { Stack, useRouter } from 'expo-router';
-import { Plus, Trash2, Edit3, X, Star, User, Check, MessageSquare } from 'lucide-react-native';
+import { Stack } from 'expo-router';
+import { Plus, Trash2, X, Star, Check, MessageSquare } from 'lucide-react-native';
 import { Swipeable } from 'react-native-gesture-handler';
-import { colors, spacing, radius } from '@/src/theme';
+import { designFonts, spacing, radius, useAppAppearance } from '@/src/theme';
 import {
   useMemories,
   useDeleteMemory,
@@ -49,6 +49,9 @@ const CATEGORY_LABELS: Record<MemoryCategory, string> = {
   PREFERENCE: 'Preference',
 };
 
+type AppPalette = ReturnType<typeof useAppAppearance>['palette'];
+type MemoriesStyles = ReturnType<typeof makeStyles>;
+
 // ============================================================================
 // Memory Item Component
 // ============================================================================
@@ -58,9 +61,11 @@ interface MemoryItemProps {
   onRequestEdit: (memory: UserMemoryDTO) => void;
   onDelete: (memory: UserMemoryDTO) => void;
   swipeableRef: (ref: Swipeable | null) => void;
+  palette: AppPalette;
+  styles: MemoriesStyles;
 }
 
-function MemoryItem({ memory, onRequestEdit, onDelete, swipeableRef }: MemoryItemProps) {
+function MemoryItem({ memory, onRequestEdit, onDelete, swipeableRef, palette, styles }: MemoryItemProps) {
   const renderRightActions = useCallback(
     (
       _progress: Animated.AnimatedInterpolation<number>,
@@ -109,7 +114,7 @@ function MemoryItem({ memory, onRequestEdit, onDelete, swipeableRef }: MemoryIte
             {CATEGORY_LABELS[memory.category]}
           </Text>
         </View>
-        <MessageSquare color={colors.textMuted} size={18} />
+        <MessageSquare color={palette.textMuted} size={18} />
       </TouchableOpacity>
     </Swipeable>
   );
@@ -122,9 +127,11 @@ function MemoryItem({ memory, onRequestEdit, onDelete, swipeableRef }: MemoryIte
 interface CreateModalProps {
   visible: boolean;
   onClose: () => void;
+  palette: AppPalette;
+  styles: MemoriesStyles;
 }
 
-function CreateMemoryModal({ visible, onClose }: CreateModalProps) {
+function CreateMemoryModal({ visible, onClose, palette, styles }: CreateModalProps) {
   const [input, setInput] = useState('');
   const [suggestion, setSuggestion] = useState<FormattedMemorySuggestion | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -184,7 +191,7 @@ function CreateMemoryModal({ visible, onClose }: CreateModalProps) {
           <View style={styles.modalHeader}>
             <Text style={styles.modalTitle}>Add Memory</Text>
             <TouchableOpacity onPress={handleClose} style={styles.modalCloseButton}>
-              <X color={colors.textSecondary} size={24} />
+              <X color={palette.textMuted} size={24} />
             </TouchableOpacity>
           </View>
 
@@ -201,7 +208,7 @@ function CreateMemoryModal({ visible, onClose }: CreateModalProps) {
               setError(null);
             }}
             placeholder="e.g., Talk to me like a surfer would"
-            placeholderTextColor={colors.textMuted}
+            placeholderTextColor={palette.textFaint}
             multiline
             autoFocus
             editable={!isProcessing}
@@ -245,7 +252,7 @@ function CreateMemoryModal({ visible, onClose }: CreateModalProps) {
                   disabled={!input.trim() || isProcessing}
                 >
                   {formatMemory.isPending ? (
-                    <ActivityIndicator color={colors.textOnAccent} size="small" />
+                    <ActivityIndicator color={palette.bg} size="small" />
                   ) : (
                     <Text style={styles.modalSaveButtonText}>Preview</Text>
                   )}
@@ -269,10 +276,10 @@ function CreateMemoryModal({ visible, onClose }: CreateModalProps) {
                   disabled={isProcessing}
                 >
                   {confirmMemory.isPending ? (
-                    <ActivityIndicator color={colors.textOnAccent} size="small" />
+                    <ActivityIndicator color={palette.bg} size="small" />
                   ) : (
                     <>
-                      <Check color={colors.textOnAccent} size={18} />
+                      <Check color={palette.bg} size={18} />
                       <Text style={styles.modalSaveButtonText}>Save</Text>
                     </>
                   )}
@@ -294,9 +301,11 @@ interface EditModalProps {
   visible: boolean;
   memory: UserMemoryDTO | null;
   onClose: () => void;
+  palette: AppPalette;
+  styles: MemoriesStyles;
 }
 
-function EditMemoryModal({ visible, memory, onClose }: EditModalProps) {
+function EditMemoryModal({ visible, memory, onClose, palette, styles }: EditModalProps) {
   const [changeRequest, setChangeRequest] = useState('');
   const [suggestion, setSuggestion] = useState<UpdateMemoryAIResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -362,7 +371,7 @@ function EditMemoryModal({ visible, memory, onClose }: EditModalProps) {
           <View style={styles.modalHeader}>
             <Text style={styles.modalTitle}>Edit Memory</Text>
             <TouchableOpacity onPress={handleClose} style={styles.modalCloseButton}>
-              <X color={colors.textSecondary} size={24} />
+              <X color={palette.textMuted} size={24} />
             </TouchableOpacity>
           </View>
 
@@ -387,7 +396,7 @@ function EditMemoryModal({ visible, memory, onClose }: EditModalProps) {
               setError(null);
             }}
             placeholder="e.g., Make it more casual"
-            placeholderTextColor={colors.textMuted}
+            placeholderTextColor={palette.textFaint}
             multiline
             editable={!isProcessing}
           />
@@ -427,7 +436,7 @@ function EditMemoryModal({ visible, memory, onClose }: EditModalProps) {
                   disabled={!changeRequest.trim() || isProcessing}
                 >
                   {updateMemoryAI.isPending ? (
-                    <ActivityIndicator color={colors.textOnAccent} size="small" />
+                    <ActivityIndicator color={palette.bg} size="small" />
                   ) : (
                     <Text style={styles.modalSaveButtonText}>Preview</Text>
                   )}
@@ -451,10 +460,10 @@ function EditMemoryModal({ visible, memory, onClose }: EditModalProps) {
                   disabled={isProcessing}
                 >
                   {confirmMemoryUpdate.isPending ? (
-                    <ActivityIndicator color={colors.textOnAccent} size="small" />
+                    <ActivityIndicator color={palette.bg} size="small" />
                   ) : (
                     <>
-                      <Check color={colors.textOnAccent} size={18} />
+                      <Check color={palette.bg} size={18} />
                       <Text style={styles.modalSaveButtonText}>Save</Text>
                     </>
                   )}
@@ -473,7 +482,8 @@ function EditMemoryModal({ visible, memory, onClose }: EditModalProps) {
 // ============================================================================
 
 export default function MemoriesScreen() {
-  const router = useRouter();
+  const { palette } = useAppAppearance();
+  const styles = useMemo(() => makeStyles(palette), [palette]);
   const { data: memories, isLoading, refetch, isRefetching } = useMemories();
   const deleteMemory = useDeleteMemory();
 
@@ -528,17 +538,18 @@ export default function MemoriesScreen() {
             headerShown: true,
             headerBackTitle: 'Back',
             headerStyle: {
-              backgroundColor: colors.bgPrimary,
+              backgroundColor: palette.bg,
             },
-            headerTintColor: colors.textPrimary,
+            headerTintColor: palette.text,
             headerTitleStyle: {
               fontWeight: '600',
-              color: colors.textPrimary,
+              color: palette.text,
+              fontFamily: designFonts.sans,
             },
           }}
         />
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.accent} />
+          <ActivityIndicator size="large" color={palette.accent} />
           <Text style={styles.loadingText}>Loading memories...</Text>
         </View>
       </>
@@ -553,12 +564,13 @@ export default function MemoriesScreen() {
           headerShown: true,
           headerBackTitle: 'Back',
           headerStyle: {
-            backgroundColor: colors.bgPrimary,
+            backgroundColor: palette.bg,
           },
-          headerTintColor: colors.textPrimary,
+          headerTintColor: palette.text,
           headerTitleStyle: {
             fontWeight: '600',
-            color: colors.textPrimary,
+            color: palette.text,
+            fontFamily: designFonts.sans,
           },
         }}
       />
@@ -571,14 +583,14 @@ export default function MemoriesScreen() {
             <RefreshControl
               refreshing={isRefetching}
               onRefresh={() => refetch()}
-              tintColor={colors.accent}
+              tintColor={palette.accent}
             />
           }
         >
           {!hasAnyMemories ? (
             // Empty state
             <View style={styles.emptyState}>
-              <Star color={colors.accent} size={48} />
+              <Star color={palette.accent} size={48} />
               <Text style={styles.emptyTitle}>No Memories Yet</Text>
               <Text style={styles.emptyDescription}>
                 Tap the + button to add things you'd like me to remember, like your
@@ -593,6 +605,8 @@ export default function MemoriesScreen() {
                   memory={memory}
                   onRequestEdit={handleRequestEdit}
                   onDelete={handleDelete}
+                  palette={palette}
+                  styles={styles}
                   swipeableRef={(ref) => {
                     if (ref) {
                       swipeableRefs.current.set(memory.id, ref);
@@ -613,7 +627,7 @@ export default function MemoriesScreen() {
           accessibilityRole="button"
           accessibilityLabel="Add new memory"
         >
-          <Plus color={colors.textOnAccent} size={28} />
+          <Plus color={palette.bg} size={28} />
         </TouchableOpacity>
       </View>
 
@@ -621,6 +635,8 @@ export default function MemoriesScreen() {
       <CreateMemoryModal
         visible={showCreateModal}
         onClose={() => setShowCreateModal(false)}
+        palette={palette}
+        styles={styles}
       />
 
       {/* Edit Memory Modal */}
@@ -628,6 +644,8 @@ export default function MemoriesScreen() {
         visible={editingMemory !== null}
         memory={editingMemory}
         onClose={() => setEditingMemory(null)}
+        palette={palette}
+        styles={styles}
       />
     </>
   );
@@ -637,10 +655,10 @@ export default function MemoriesScreen() {
 // Styles
 // ============================================================================
 
-const styles = StyleSheet.create({
+const makeStyles = (palette: AppPalette) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.bgPage,
+    backgroundColor: palette.bg,
   },
   scrollView: {
     flex: 1,
@@ -651,14 +669,15 @@ const styles = StyleSheet.create({
   },
   loadingContainer: {
     flex: 1,
-    backgroundColor: colors.bgPage,
+    backgroundColor: palette.bg,
     justifyContent: 'center',
     alignItems: 'center',
     gap: spacing.md,
   },
   loadingText: {
-    color: colors.textSecondary,
+    color: palette.textMuted,
     fontSize: 16,
+    fontFamily: designFonts.sans,
   },
 
   // Empty state
@@ -671,13 +690,15 @@ const styles = StyleSheet.create({
   emptyTitle: {
     fontSize: 22,
     fontWeight: '700',
-    color: colors.textPrimary,
+    color: palette.text,
+    fontFamily: designFonts.sans,
   },
   emptyDescription: {
     fontSize: 16,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     textAlign: 'center',
     lineHeight: 24,
+    fontFamily: designFonts.sans,
   },
 
   // Section
@@ -693,13 +714,15 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 17,
     fontWeight: '600',
-    color: colors.textPrimary,
+    color: palette.text,
+    fontFamily: designFonts.sans,
   },
   sectionSubtitle: {
     fontSize: 13,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     marginBottom: spacing.md,
     marginLeft: 26,
+    fontFamily: designFonts.sans,
   },
   memoryList: {
     gap: spacing.sm,
@@ -709,10 +732,12 @@ const styles = StyleSheet.create({
   memoryItem: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: radius.md,
     padding: spacing.lg,
     gap: spacing.md,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   memoryContent: {
     flex: 1,
@@ -720,17 +745,19 @@ const styles = StyleSheet.create({
   },
   memoryText: {
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.text,
     lineHeight: 22,
+    fontFamily: designFonts.sans,
   },
   memoryCategoryLabel: {
     fontSize: 12,
-    color: colors.textMuted,
+    color: palette.textMuted,
+    fontFamily: designFonts.sans,
   },
 
   // Delete action
   deleteAction: {
-    backgroundColor: colors.error,
+    backgroundColor: palette.danger,
     justifyContent: 'center',
     alignItems: 'center',
     width: 80,
@@ -752,7 +779,7 @@ const styles = StyleSheet.create({
     width: 60,
     height: 60,
     borderRadius: 30,
-    backgroundColor: colors.accent,
+    backgroundColor: palette.accent,
     justifyContent: 'center',
     alignItems: 'center',
     shadowColor: '#000',
@@ -765,18 +792,20 @@ const styles = StyleSheet.create({
   // Modal
   modalOverlay: {
     flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.7)',
+    backgroundColor: palette.scrim,
     justifyContent: 'center',
     alignItems: 'center',
     padding: spacing.xl,
   },
   modalContainer: {
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: radius.lg,
     padding: spacing.xl,
     width: '100%',
     maxWidth: 400,
     maxHeight: '80%',
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   modalHeader: {
     flexDirection: 'row',
@@ -787,93 +816,105 @@ const styles = StyleSheet.create({
   modalTitle: {
     fontSize: 20,
     fontWeight: '600',
-    color: colors.textPrimary,
+    color: palette.text,
+    fontFamily: designFonts.sans,
   },
   modalCloseButton: {
     padding: spacing.xs,
   },
   modalDescription: {
     fontSize: 14,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     marginBottom: spacing.md,
     lineHeight: 20,
+    fontFamily: designFonts.sans,
   },
   modalInput: {
-    backgroundColor: colors.bgTertiary,
+    backgroundColor: palette.bgPane,
     borderRadius: radius.sm,
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: palette.borderStrong,
     padding: spacing.md,
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.text,
     minHeight: 80,
     textAlignVertical: 'top',
     marginBottom: spacing.md,
+    fontFamily: designFonts.sans,
   },
 
   // Current memory (in edit modal)
   currentMemoryContainer: {
-    backgroundColor: colors.bgTertiary,
+    backgroundColor: palette.bgPane,
     borderRadius: radius.sm,
     padding: spacing.md,
     marginBottom: spacing.lg,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   currentMemoryLabel: {
     fontSize: 12,
-    color: colors.textMuted,
+    color: palette.textMuted,
     marginBottom: spacing.xs,
+    fontFamily: designFonts.sans,
   },
   currentMemoryContent: {
     fontSize: 15,
-    color: colors.textPrimary,
+    color: palette.text,
     fontStyle: 'italic',
     lineHeight: 22,
+    fontFamily: designFonts.sans,
   },
 
   // Error
   errorContainer: {
-    backgroundColor: colors.error + '20',
+    backgroundColor: palette.dangerSoft,
     borderRadius: radius.sm,
     padding: spacing.md,
     marginBottom: spacing.md,
   },
   errorText: {
     fontSize: 14,
-    color: colors.error,
+    color: palette.danger,
     textAlign: 'center',
+    fontFamily: designFonts.sans,
   },
 
   // Suggestion preview
   suggestionContainer: {
-    backgroundColor: colors.accent + '15',
+    backgroundColor: palette.accentSoft,
     borderRadius: radius.sm,
     borderWidth: 1,
-    borderColor: colors.accent + '40',
+    borderColor: palette.borderStrong,
     padding: spacing.md,
     marginBottom: spacing.md,
   },
   suggestionLabel: {
     fontSize: 12,
-    color: colors.accent,
+    color: palette.accentText,
     fontWeight: '600',
     marginBottom: spacing.xs,
+    fontFamily: designFonts.sans,
   },
   suggestionContent: {
     fontSize: 15,
-    color: colors.textPrimary,
+    color: palette.text,
     fontStyle: 'italic',
     lineHeight: 22,
+    fontFamily: designFonts.sans,
   },
   suggestionCategory: {
     fontSize: 12,
-    color: colors.textMuted,
+    color: palette.textMuted,
     marginTop: spacing.xs,
+    fontFamily: designFonts.sans,
   },
   suggestionReasoning: {
     fontSize: 12,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     marginTop: spacing.sm,
     fontStyle: 'italic',
+    fontFamily: designFonts.sans,
   },
 
   // Modal buttons
@@ -883,19 +924,22 @@ const styles = StyleSheet.create({
   },
   modalCancelButton: {
     flex: 1,
-    backgroundColor: colors.bgTertiary,
+    backgroundColor: palette.bgPane,
     borderRadius: radius.sm,
     paddingVertical: spacing.md,
     alignItems: 'center',
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   modalCancelButtonText: {
     fontSize: 16,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     fontWeight: '600',
+    fontFamily: designFonts.sans,
   },
   modalSaveButton: {
     flex: 1,
-    backgroundColor: colors.accent,
+    backgroundColor: palette.accent,
     borderRadius: radius.sm,
     paddingVertical: spacing.md,
     alignItems: 'center',
@@ -908,7 +952,8 @@ const styles = StyleSheet.create({
   },
   modalSaveButtonText: {
     fontSize: 16,
-    color: colors.textOnAccent,
+    color: palette.bg,
     fontWeight: '600',
+    fontFamily: designFonts.sans,
   },
 });

--- a/mobile/app/(auth)/settings/privacy.tsx
+++ b/mobile/app/(auth)/settings/privacy.tsx
@@ -4,7 +4,7 @@
  * Allows users to manage their privacy preferences.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -17,14 +17,23 @@ import {
 import { Stack } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { Shield, Eye, Users, FileText, ExternalLink } from 'lucide-react-native';
-import { colors } from '@/src/theme';
+import { designFonts, useAppAppearance } from '@/src/theme';
+import { usePrivacyPreferences, useUpdatePrivacyPreferences } from '@/src/hooks/useProfile';
 
 export default function PrivacySettingsScreen() {
-  // Local state for privacy settings - in a full implementation these would
-  // be persisted to the backend via API hooks
-  const [showActivityStatus, setShowActivityStatus] = useState(true);
-  const [allowSessionInvites, setAllowSessionInvites] = useState(true);
+  const { palette } = useAppAppearance();
+  const styles = useMemo(() => makeStyles(palette), [palette]);
+  const { data: privacyPreferencesData, isLoading: isLoadingPrivacyPreferences } = usePrivacyPreferences();
+  const updatePrivacyPreferences = useUpdatePrivacyPreferences({
+    onError: () => {
+      Alert.alert('Error', 'Could not update privacy settings. Please try again.');
+    },
+  });
   const [shareAnonymousAnalytics, setShareAnonymousAnalytics] = useState(true);
+  const privacyPreferences = privacyPreferencesData?.preferences;
+  const showActivityStatus = privacyPreferences?.showActivityStatus ?? true;
+  const allowSessionInvites = privacyPreferences?.allowSessionInvites ?? true;
+  const privacyControlsDisabled = isLoadingPrivacyPreferences || updatePrivacyPreferences.isPending;
 
   const handlePrivacyPolicyPress = () => {
     WebBrowser.openBrowserAsync('https://meetwithoutfear.com/privacy').catch(() => {
@@ -46,12 +55,13 @@ export default function PrivacySettingsScreen() {
           headerShown: true,
           headerBackTitle: 'Back',
           headerStyle: {
-            backgroundColor: colors.bgPrimary,
+            backgroundColor: palette.bg,
           },
-          headerTintColor: colors.textPrimary,
+          headerTintColor: palette.text,
           headerTitleStyle: {
             fontWeight: '600',
-            color: colors.textPrimary,
+            color: palette.text,
+            fontFamily: designFonts.sans,
           },
         }}
       />
@@ -59,7 +69,7 @@ export default function PrivacySettingsScreen() {
       <ScrollView style={styles.container} contentContainerStyle={styles.content}>
         {/* Privacy Info */}
         <View style={styles.infoCard}>
-          <Shield color={colors.accent} size={24} />
+          <Shield color={palette.accent} size={24} />
           <Text style={styles.infoText}>
             Your privacy is important to us. Control how your information is shared and used.
           </Text>
@@ -72,7 +82,7 @@ export default function PrivacySettingsScreen() {
           <View style={styles.settingItem}>
             <View style={styles.settingInfo}>
               <View style={styles.settingHeader}>
-                <Eye color={colors.accent} size={20} />
+                <Eye color={palette.accent} size={20} />
                 <Text style={styles.settingLabel}>Show Activity Status</Text>
               </View>
               <Text style={styles.settingDescription}>
@@ -81,16 +91,19 @@ export default function PrivacySettingsScreen() {
             </View>
             <Switch
               value={showActivityStatus}
-              onValueChange={setShowActivityStatus}
-              trackColor={{ false: colors.bgTertiary, true: colors.accent }}
-              thumbColor={colors.textPrimary}
+              onValueChange={(showActivityStatus) => {
+                updatePrivacyPreferences.mutate({ showActivityStatus });
+              }}
+              trackColor={{ false: palette.chipBg, true: palette.accent }}
+              thumbColor={palette.bgElev}
+              disabled={privacyControlsDisabled}
             />
           </View>
 
           <View style={styles.settingItem}>
             <View style={styles.settingInfo}>
               <View style={styles.settingHeader}>
-                <Users color={colors.accent} size={20} />
+                <Users color={palette.accent} size={20} />
                 <Text style={styles.settingLabel}>Allow Session Invites</Text>
               </View>
               <Text style={styles.settingDescription}>
@@ -99,9 +112,12 @@ export default function PrivacySettingsScreen() {
             </View>
             <Switch
               value={allowSessionInvites}
-              onValueChange={setAllowSessionInvites}
-              trackColor={{ false: colors.bgTertiary, true: colors.accent }}
-              thumbColor={colors.textPrimary}
+              onValueChange={(allowSessionInvites) => {
+                updatePrivacyPreferences.mutate({ allowSessionInvites });
+              }}
+              trackColor={{ false: palette.chipBg, true: palette.accent }}
+              thumbColor={palette.bgElev}
+              disabled={privacyControlsDisabled}
             />
           </View>
         </View>
@@ -120,8 +136,8 @@ export default function PrivacySettingsScreen() {
             <Switch
               value={shareAnonymousAnalytics}
               onValueChange={setShareAnonymousAnalytics}
-              trackColor={{ false: colors.bgTertiary, true: colors.accent }}
-              thumbColor={colors.textPrimary}
+              trackColor={{ false: palette.chipBg, true: palette.accent }}
+              thumbColor={palette.bgElev}
             />
           </View>
         </View>
@@ -132,18 +148,18 @@ export default function PrivacySettingsScreen() {
 
           <TouchableOpacity style={styles.linkItem} onPress={handlePrivacyPolicyPress}>
             <View style={styles.linkItemLeft}>
-              <FileText color={colors.accent} size={20} />
+              <FileText color={palette.accent} size={20} />
               <Text style={styles.linkItemLabel}>Privacy Policy</Text>
             </View>
-            <ExternalLink color={colors.textSecondary} size={18} />
+            <ExternalLink color={palette.textMuted} size={18} />
           </TouchableOpacity>
 
           <TouchableOpacity style={styles.linkItem} onPress={handleTermsPress}>
             <View style={styles.linkItemLeft}>
-              <FileText color={colors.accent} size={20} />
+              <FileText color={palette.accent} size={20} />
               <Text style={styles.linkItemLabel}>Terms of Service</Text>
             </View>
-            <ExternalLink color={colors.textSecondary} size={18} />
+            <ExternalLink color={palette.textMuted} size={18} />
           </TouchableOpacity>
         </View>
 
@@ -159,10 +175,10 @@ export default function PrivacySettingsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.bgPage,
+    backgroundColor: palette.bg,
   },
   content: {
     padding: 16,
@@ -171,17 +187,20 @@ const styles = StyleSheet.create({
   },
   infoCard: {
     flexDirection: 'row',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
     gap: 12,
     alignItems: 'center',
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   infoText: {
     flex: 1,
     fontSize: 14,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     lineHeight: 20,
+    fontFamily: designFonts.sans,
   },
   section: {
     gap: 12,
@@ -189,18 +208,21 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 13,
     fontWeight: '600',
-    color: colors.textSecondary,
+    color: palette.textMuted,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
     marginLeft: 4,
+    fontFamily: designFonts.sans,
   },
   settingItem: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   settingInfo: {
     flex: 1,
@@ -214,21 +236,25 @@ const styles = StyleSheet.create({
   },
   settingLabel: {
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.text,
     fontWeight: '500',
+    fontFamily: designFonts.sans,
   },
   settingDescription: {
     fontSize: 13,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     marginLeft: 28,
+    fontFamily: designFonts.sans,
   },
   linkItem: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   linkItemLeft: {
     flexDirection: 'row',
@@ -237,19 +263,21 @@ const styles = StyleSheet.create({
   },
   linkItemLabel: {
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.text,
     fontWeight: '500',
+    fontFamily: designFonts.sans,
   },
   notice: {
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
     borderLeftWidth: 3,
-    borderLeftColor: colors.accent,
+    borderLeftColor: palette.accent,
   },
   noticeText: {
     fontSize: 13,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     lineHeight: 20,
+    fontFamily: designFonts.sans,
   },
 });

--- a/mobile/app/(auth)/settings/voice.tsx
+++ b/mobile/app/(auth)/settings/voice.tsx
@@ -4,7 +4,7 @@
  * Allows users to manage their voice and speech preferences.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -15,7 +15,7 @@ import {
 } from 'react-native';
 import { Stack } from 'expo-router';
 import { Volume2, ChevronDown, Check } from 'lucide-react-native';
-import { colors } from '@/src/theme';
+import { designFonts, useAppAppearance } from '@/src/theme';
 import {
   useAutoSpeech,
   useVoiceSettings,
@@ -24,6 +24,8 @@ import {
 } from '@/src/hooks/useSpeech';
 
 export default function VoiceSettingsScreen() {
+  const { palette } = useAppAppearance();
+  const styles = useMemo(() => makeStyles(palette), [palette]);
   // Speech settings
   const { isAutoSpeechEnabled, setAutoSpeechEnabled } = useAutoSpeech();
   const { voiceSettings, setVoiceId, previewVoice } = useVoiceSettings();
@@ -43,12 +45,13 @@ export default function VoiceSettingsScreen() {
           headerShown: true,
           headerBackTitle: 'Back',
           headerStyle: {
-            backgroundColor: colors.bgPrimary,
+            backgroundColor: palette.bg,
           },
-          headerTintColor: colors.textPrimary,
+          headerTintColor: palette.text,
           headerTitleStyle: {
             fontWeight: '600',
-            color: colors.textPrimary,
+            color: palette.text,
+            fontFamily: designFonts.sans,
           },
         }}
       />
@@ -58,7 +61,7 @@ export default function VoiceSettingsScreen() {
           {/* Auto-Speech Toggle */}
           <View style={styles.settingItem}>
             <View style={styles.settingLeft}>
-              <Volume2 color={colors.accent} size={22} />
+              <Volume2 color={palette.accent} size={22} />
               <View style={styles.settingInfo}>
                 <Text style={styles.settingLabel}>Auto-Speech</Text>
                 <Text style={styles.settingDescription}>
@@ -69,8 +72,8 @@ export default function VoiceSettingsScreen() {
             <Switch
               value={isAutoSpeechEnabled}
               onValueChange={setAutoSpeechEnabled}
-              trackColor={{ false: colors.bgTertiary, true: colors.accent }}
-              thumbColor={colors.textPrimary}
+              trackColor={{ false: palette.chipBg, true: palette.accent }}
+              thumbColor={palette.bgElev}
             />
           </View>
 
@@ -85,7 +88,7 @@ export default function VoiceSettingsScreen() {
               <Text style={styles.pickerDescription}>{currentVoice.description}</Text>
             </View>
             <ChevronDown
-              color={colors.textSecondary}
+              color={palette.textMuted}
               size={20}
               style={{ transform: [{ rotate: showVoicePicker ? '180deg' : '0deg' }] }}
             />
@@ -112,7 +115,7 @@ export default function VoiceSettingsScreen() {
                     <Text style={styles.pickerOptionDescription}>{voice.description}</Text>
                   </View>
                   {voice.id === voiceSettings.voiceId && (
-                    <Check color={colors.accent} size={20} />
+                    <Check color={palette.accent} size={20} />
                   )}
                 </TouchableOpacity>
               ))}
@@ -126,10 +129,10 @@ export default function VoiceSettingsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.bgPage,
+    backgroundColor: palette.bg,
   },
   content: {
     padding: 16,
@@ -142,18 +145,21 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 13,
     fontWeight: '600',
-    color: colors.textSecondary,
+    color: palette.textMuted,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
     marginLeft: 4,
+    fontFamily: designFonts.sans,
   },
   settingItem: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   settingLeft: {
     flexDirection: 'row',
@@ -166,45 +172,54 @@ const styles = StyleSheet.create({
   },
   settingLabel: {
     fontSize: 17,
-    color: colors.textPrimary,
+    color: palette.text,
     fontWeight: '500',
+    fontFamily: designFonts.sans,
   },
   settingDescription: {
     fontSize: 13,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     marginTop: 2,
+    fontFamily: designFonts.sans,
   },
   // Voice Settings styles
   pickerButton: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     padding: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   pickerLeft: {
     flex: 1,
   },
   pickerLabel: {
     fontSize: 12,
-    color: colors.textMuted,
+    color: palette.textMuted,
     marginBottom: 4,
+    fontFamily: designFonts.sans,
   },
   pickerValue: {
     fontSize: 17,
-    color: colors.textPrimary,
+    color: palette.text,
     fontWeight: '500',
+    fontFamily: designFonts.sans,
   },
   pickerDescription: {
     fontSize: 13,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     marginTop: 2,
+    fontFamily: designFonts.sans,
   },
   pickerOptions: {
-    backgroundColor: colors.bgSecondary,
+    backgroundColor: palette.bgElev,
     borderRadius: 12,
     overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: palette.border,
   },
   pickerOption: {
     flexDirection: 'row',
@@ -212,37 +227,39 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     padding: 16,
     borderBottomWidth: 1,
-    borderBottomColor: colors.bgTertiary,
+    borderBottomColor: palette.divider,
   },
   pickerOptionSelected: {
-    backgroundColor: colors.bgTertiary,
+    backgroundColor: palette.selected,
   },
   pickerOptionLeft: {
     flex: 1,
   },
   pickerOptionName: {
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.text,
     fontWeight: '500',
+    fontFamily: designFonts.sans,
   },
   pickerOptionDescription: {
     fontSize: 13,
-    color: colors.textSecondary,
+    color: palette.textMuted,
     marginTop: 2,
+    fontFamily: designFonts.sans,
   },
   previewButton: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: colors.accent,
+    backgroundColor: palette.accent,
     borderRadius: 12,
     padding: 14,
     gap: 8,
   },
   previewButtonText: {
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.bg,
     fontWeight: '600',
+    fontFamily: designFonts.sans,
   },
 });
-

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -120,14 +120,20 @@ function AppShell({ includeMixpanel = true }: { includeMixpanel?: boolean }) {
 
   return (
     <View style={[styles.webBackdrop, { backgroundColor: palette.bg }]}>
-      <View style={styles.webFrame}>
+      <View style={[styles.webFrame, { backgroundColor: palette.bg }]}>
         <NativeAppBanner />
-        <GestureHandlerRootView style={styles.container}>
+        <GestureHandlerRootView style={[styles.container, { backgroundColor: palette.bg }]}>
           <SafeAreaProvider>
             <SessionDrawerProvider>
               <ToastProvider>
                 {includeMixpanel && <MixpanelInitializer />}
-                <Stack screenOptions={{ headerShown: false, gestureEnabled: false }}>
+                <Stack
+                  screenOptions={{
+                    headerShown: false,
+                    gestureEnabled: false,
+                    contentStyle: { backgroundColor: palette.bg },
+                  }}
+                >
                   <Stack.Screen name="(public)" />
                   <Stack.Screen name="(auth)" />
                   <Stack.Screen name="+not-found" options={{ headerShown: true }} />

--- a/mobile/src/components/ActivityDrawer.tsx
+++ b/mobile/src/components/ActivityDrawer.tsx
@@ -600,7 +600,7 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
   },
   backdrop: {
     flex: 1,
-    backgroundColor: palette.scrim,
+    backgroundColor: 'transparent',
   },
   drawer: {
     position: 'absolute',

--- a/mobile/src/components/HeaderBackButton.tsx
+++ b/mobile/src/components/HeaderBackButton.tsx
@@ -1,0 +1,41 @@
+import { ArrowLeft } from 'lucide-react-native';
+import { Pressable, StyleSheet } from 'react-native';
+
+import { useAppAppearance } from '../theme';
+
+interface HeaderBackButtonProps {
+  onPress: () => void;
+  accessibilityLabel?: string;
+  testID?: string;
+}
+
+export function HeaderBackButton({
+  onPress,
+  accessibilityLabel = 'Go back',
+  testID,
+}: HeaderBackButtonProps) {
+  const { palette } = useAppAppearance();
+
+  return (
+    <Pressable
+      style={styles.button}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+      testID={testID}
+    >
+      <ArrowLeft color={palette.textMuted} size={24} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -466,7 +466,7 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
   },
   backdrop: {
     flex: 1,
-    backgroundColor: palette.scrim,
+    backgroundColor: 'transparent',
   },
   drawer: {
     position: 'absolute',

--- a/mobile/src/components/PartnerInfoDrawer.tsx
+++ b/mobile/src/components/PartnerInfoDrawer.tsx
@@ -94,7 +94,7 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
   backdrop: {
     flex: 1,
     justifyContent: 'flex-end',
-    backgroundColor: palette.scrim,
+    backgroundColor: 'transparent',
   },
   backdropPressable: {
     flex: 1,

--- a/mobile/src/components/ScreenHeader.tsx
+++ b/mobile/src/components/ScreenHeader.tsx
@@ -10,10 +10,10 @@
 
 import React, { ReactNode } from 'react';
 import { StyleSheet, View, Text, Pressable, ActivityIndicator } from 'react-native';
-import { ArrowLeft } from 'lucide-react-native';
 import { useRouter } from 'expo-router';
 
 import { designFonts, useAppAppearance } from '../theme';
+import { HeaderBackButton } from './HeaderBackButton';
 
 // ============================================================================
 // Types
@@ -80,16 +80,7 @@ export function ScreenHeader({
       {/* Left section */}
       <View style={styles.leftSection}>
         {showBackButton ? (
-          <Pressable
-            style={styles.headerButton}
-            onPress={handleBackPress}
-            accessibilityRole="button"
-            accessibilityLabel="Go back"
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-            testID={`${testID}-back-button`}
-          >
-            <ArrowLeft color={palette.text} size={24} />
-          </Pressable>
+          <HeaderBackButton onPress={handleBackPress} testID={`${testID}-back-button`} />
         ) : (
           <View style={styles.headerButtonSpacer} />
         )}

--- a/mobile/src/components/SessionChatHeader.tsx
+++ b/mobile/src/components/SessionChatHeader.tsx
@@ -14,10 +14,11 @@ import {
   TouchableOpacity,
   ViewStyle,
 } from 'react-native';
-import { ArrowLeft, BookOpen, Menu } from 'lucide-react-native';
+import { BookOpen, Menu } from 'lucide-react-native';
 import { ConnectionStatus } from '@meet-without-fear/shared';
 import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
+import { HeaderBackButton } from './HeaderBackButton';
 
 // ============================================================================
 // Types
@@ -123,7 +124,6 @@ export function SessionChatHeader({
   };
 
   const displayName = partnerName || 'Meet Without Fear';
-  const LeftActionIcon = leftActionIcon === 'menu' ? Menu : ArrowLeft;
   const leftActionLabel = leftActionIcon === 'menu' ? 'Open session drawer' : 'Go back';
 
   // Center content - always partner name + status (whether tabs or not)
@@ -166,15 +166,23 @@ export function SessionChatHeader({
       {/* Left section: Back button */}
       <View style={styles.leftSection}>
         {onBackPress ? (
-          <TouchableOpacity
-            style={styles.backButton}
-            onPress={onBackPress}
-            accessibilityRole="button"
-            accessibilityLabel={leftActionLabel}
-            testID={`${testID}-back-button`}
-          >
-            <LeftActionIcon color={palette.textMuted} size={24} />
-          </TouchableOpacity>
+          leftActionIcon === 'menu' ? (
+            <TouchableOpacity
+              style={styles.backButton}
+              onPress={onBackPress}
+              accessibilityRole="button"
+              accessibilityLabel={leftActionLabel}
+              testID={`${testID}-back-button`}
+            >
+              <Menu color={palette.textMuted} size={24} />
+            </TouchableOpacity>
+          ) : (
+            <HeaderBackButton
+              onPress={onBackPress}
+              accessibilityLabel={leftActionLabel}
+              testID={`${testID}-back-button`}
+            />
+          )
         ) : (
           <View style={styles.backButtonSpacer} />
         )}

--- a/mobile/src/components/SessionEntryMoodCheck.tsx
+++ b/mobile/src/components/SessionEntryMoodCheck.tsx
@@ -5,10 +5,11 @@
  */
 
 import { useCallback, useMemo, useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Modal } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Modal, PanResponder } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Slider from '@react-native-community/slider';
 import { designFonts, useAppAppearance } from '@/theme';
+import { HeaderBackButton } from './HeaderBackButton';
 
 const FEELINGS = [
   { intensity: 10, label: 'Heated', hint: 'lit up, hard to breathe' },
@@ -54,6 +55,8 @@ export interface SessionEntryMoodCheckProps {
   initialValue?: number;
   /** Callback when user completes the check */
   onComplete: (intensity: number) => void;
+  /** Optional back action for full-screen presentation */
+  onBack?: () => void;
 }
 
 export function SessionEntryMoodCheck({
@@ -61,6 +64,7 @@ export function SessionEntryMoodCheck({
   fullScreen = false,
   initialValue = 5,
   onComplete,
+  onBack,
 }: SessionEntryMoodCheckProps) {
   const [value, setValue] = useState(initialValue);
   const { palette } = useAppAppearance();
@@ -76,10 +80,37 @@ export function SessionEntryMoodCheck({
     onComplete(value);
   }, [onComplete, value]);
 
+  const backSwipeResponder = useMemo(
+    () => PanResponder.create({
+      onMoveShouldSetPanResponder: (_, gestureState) =>
+        Boolean(onBack) &&
+        gestureState.x0 <= 28 &&
+        gestureState.dx > 12 &&
+        Math.abs(gestureState.dy) < 24,
+      onPanResponderRelease: (_, gestureState) => {
+        if (!onBack) return;
+        if (gestureState.dx > 70 || gestureState.vx > 0.65) {
+          onBack();
+        }
+      },
+    }),
+    [onBack]
+  );
+
   const content = (
-    <View style={fullScreen ? styles.fullScreenOverlay : styles.overlay}>
+    <View
+      style={fullScreen ? styles.fullScreenOverlay : styles.overlay}
+      {...(onBack ? backSwipeResponder.panHandlers : {})}
+    >
       <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']}>
         <View style={styles.topRow}>
+          {onBack && (
+            <HeaderBackButton
+              onPress={onBack}
+              accessibilityLabel="Back to home"
+              testID="mood-check-back-button"
+            />
+          )}
           <Text style={styles.topLabel}>Before we begin</Text>
           <View style={styles.topRule} />
         </View>
@@ -117,9 +148,9 @@ export function SessionEntryMoodCheck({
             <View style={styles.axis}>
               <Text style={styles.axisText}>Calm</Text>
               <View style={styles.axisRule} />
-              <Text style={styles.axisText}>Moderate</Text>
+              <Text style={styles.axisText}>Steady</Text>
               <View style={styles.axisRule} />
-              <Text style={styles.axisText}>Intense</Text>
+              <Text style={styles.axisText}>Heated</Text>
             </View>
           </View>
         </View>

--- a/mobile/src/components/TakeawayReviewSheet.tsx
+++ b/mobile/src/components/TakeawayReviewSheet.tsx
@@ -227,7 +227,7 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
       left: 0,
       right: 0,
       bottom: 0,
-      backgroundColor: palette.scrim,
+      backgroundColor: 'transparent',
     },
     sheet: {
       position: 'absolute',

--- a/mobile/src/components/TranscriptionDrawer.tsx
+++ b/mobile/src/components/TranscriptionDrawer.tsx
@@ -6,7 +6,7 @@
  *
  * Features:
  * - Slide-up animation using the project's Animated.Value spring pattern
- * - Semi-transparent black backdrop
+ * - Transparent backdrop
  * - Real-time transcript display with auto-scroll to bottom
  * - Recording timer (M:SS format) with pulsing red dot indicator
  * - "Connecting..." and "Start speaking..." placeholder states
@@ -144,7 +144,7 @@ export function TranscriptionDrawer({
 
   return (
     <View style={styles.overlay} pointerEvents={visible ? 'box-none' : 'none'}>
-      {/* Semi-transparent backdrop — tap to cancel */}
+      {/* Transparent backdrop — tap to cancel */}
       <Animated.View
         style={[
           styles.backdrop,
@@ -268,7 +268,7 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
       left: 0,
       right: 0,
       bottom: 0,
-      backgroundColor: palette.scrim,
+      backgroundColor: 'transparent',
     },
     backdropTouchable: {
       flex: 1,

--- a/mobile/src/hooks/index.ts
+++ b/mobile/src/hooks/index.ts
@@ -94,6 +94,8 @@ export {
   // Hooks
   useProfile,
   useUpdateProfile,
+  usePrivacyPreferences,
+  useUpdatePrivacyPreferences,
   useUpdatePushToken,
   useUnregisterPushToken,
   useAblyToken,

--- a/mobile/src/hooks/useProfile.ts
+++ b/mobile/src/hooks/useProfile.ts
@@ -19,6 +19,9 @@ import {
   UpdatePushTokenRequest,
   UpdatePushTokenResponse,
   AblyTokenResponse,
+  GetPrivacyPreferencesResponse,
+  UpdatePrivacyPreferencesRequest,
+  UpdatePrivacyPreferencesResponse,
 } from '@meet-without-fear/shared';
 
 // ============================================================================
@@ -29,6 +32,7 @@ export const profileKeys = {
   all: ['profile'] as const,
   me: () => [...profileKeys.all, 'me'] as const,
   ablyToken: () => [...profileKeys.all, 'ably'] as const,
+  privacyPreferences: () => [...profileKeys.all, 'privacy-preferences'] as const,
 };
 
 // ============================================================================
@@ -88,6 +92,54 @@ export function useUpdateProfile(
           user: data.user,
         };
       });
+    },
+    ...options,
+  });
+}
+
+// ============================================================================
+// Privacy Preferences Hooks
+// ============================================================================
+
+/**
+ * Fetch current user's privacy preferences.
+ */
+export function usePrivacyPreferences(
+  options?: Omit<UseQueryOptions<GetPrivacyPreferencesResponse, ApiClientError>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery({
+    queryKey: profileKeys.privacyPreferences(),
+    queryFn: async () => {
+      return get<GetPrivacyPreferencesResponse>('/auth/me/privacy-preferences');
+    },
+    staleTime: 5 * 60_000,
+    ...options,
+  });
+}
+
+/**
+ * Update current user's privacy preferences.
+ */
+export function useUpdatePrivacyPreferences(
+  options?: Omit<
+    UseMutationOptions<UpdatePrivacyPreferencesResponse, ApiClientError, UpdatePrivacyPreferencesRequest>,
+    'mutationFn'
+  >
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (request: UpdatePrivacyPreferencesRequest) => {
+      return patch<UpdatePrivacyPreferencesResponse, UpdatePrivacyPreferencesRequest>(
+        '/auth/me/privacy-preferences',
+        request
+      );
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData<GetPrivacyPreferencesResponse>(
+        profileKeys.privacyPreferences(),
+        data
+      );
     },
     ...options,
   });

--- a/mobile/src/screens/GratitudeScreen.tsx
+++ b/mobile/src/screens/GratitudeScreen.tsx
@@ -20,7 +20,6 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
-  ArrowLeft,
   Heart,
   Plus,
   Calendar,
@@ -42,6 +41,7 @@ import {
 } from '../hooks';
 import { useToast } from '../contexts/ToastContext';
 import { GratitudeEntryDTO } from '@meet-without-fear/shared';
+import { HeaderBackButton } from '../components/HeaderBackButton';
 import { createStyles } from '../theme/styled';
 import { colors } from '../theme';
 
@@ -245,9 +245,7 @@ export function GratitudeScreen({ onNavigateBack }: GratitudeScreenProps) {
       >
         {/* Header */}
         <View style={styles.header}>
-          <TouchableOpacity onPress={handleBack} style={styles.backButton} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-            <ArrowLeft size={24} color={colors.textPrimary} />
-          </TouchableOpacity>
+          <HeaderBackButton onPress={handleBack} />
           <Text style={styles.headerTitle}>See the Positive</Text>
           <TouchableOpacity onPress={handleAddEntry} style={styles.addButton}>
             <Plus size={24} color={colors.accent} />

--- a/mobile/src/screens/InnerThoughtsScreen.tsx
+++ b/mobile/src/screens/InnerThoughtsScreen.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { View, Text, TouchableOpacity, ActivityIndicator, Alert, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { ArrowLeft, Layers, MoreVertical, Lock, Sparkles } from 'lucide-react-native';
+import { Layers, MoreVertical, Lock, Sparkles } from 'lucide-react-native';
 import { MessageRole, MemorySuggestion, SuggestedAction } from '@meet-without-fear/shared';
 
 import { ChatInterface, ChatMessage } from '../components/ChatInterface';
@@ -18,6 +18,7 @@ import { MemorySuggestionCard } from '../components/MemorySuggestionCard';
 import { SuggestedActionButtons } from '../components/SuggestedActionButtons';
 import { TakeawayReviewSheet } from '../components/TakeawayReviewSheet';
 import { TranscriptionDrawer } from '../components/TranscriptionDrawer';
+import { HeaderBackButton } from '../components/HeaderBackButton';
 import { useInnerThoughtsSession, useSendInnerThoughtsMessage } from '../hooks';
 import { useVoiceInput } from '../hooks/useVoiceInput';
 import { createStyles } from '../theme/styled';
@@ -44,7 +45,11 @@ interface InnerThoughtsScreenProps {
   hideContentUntilReady?: boolean;
   /** Narrow URL-controlled fixture for visual audit surfaces. */
   auditFixture?: string | null;
+  /** Temporary home-composer destination while standalone inner work is disabled. */
+  comingSoonMode?: boolean;
 }
+
+const INNER_WORK_COMING_SOON_MESSAGE = 'Doing inner work by yourself is a feature coming soon.';
 
 // ============================================================================
 // Component
@@ -60,6 +65,7 @@ export function InnerThoughtsScreen({
   initialSuggestedActions,
   hideContentUntilReady = false,
   auditFixture = null,
+  comingSoonMode = false,
 }: InnerThoughtsScreenProps) {
   const styles = useStyles();
   const { palette } = useAppAppearance();
@@ -89,7 +95,7 @@ export function InnerThoughtsScreen({
 
   // Only fetch session if we have a valid sessionId (not creating)
   const { data, isLoading, error } = useInnerThoughtsSession(
-    isCreating ? undefined : sessionId
+    isCreating || comingSoonMode ? undefined : sessionId
   );
   const sendMessage = useSendInnerThoughtsMessage(sessionId);
 
@@ -104,6 +110,18 @@ export function InnerThoughtsScreen({
   // Convert inner thoughts messages to ChatMessage format
   // When creating with an initial message, show it optimistically
   const messages: ChatMessage[] = useMemo(() => {
+    if (comingSoonMode) {
+      return [{
+        id: 'inner-work-coming-soon',
+        sessionId: sessionId || 'inner-work-coming-soon',
+        senderId: null,
+        role: MessageRole.AI,
+        content: INNER_WORK_COMING_SOON_MESSAGE,
+        stage: 1,
+        timestamp: new Date().toISOString(),
+      }];
+    }
+
     // If creating with initial message, show it optimistically
     if (isCreating && initialMessage) {
       return [{
@@ -128,7 +146,7 @@ export function InnerThoughtsScreen({
       stage: 1, // Inner thoughts doesn't use stages, but ChatMessage requires it
       timestamp: msg.timestamp,
     }));
-  }, [session?.messages, sessionId, isCreating, initialMessage]);
+  }, [session?.messages, sessionId, isCreating, initialMessage, comingSoonMode]);
 
   const handleSendMessage = useCallback(
     async (content: string) => {
@@ -227,7 +245,7 @@ export function InnerThoughtsScreen({
   }, [voice]);
 
   // Loading state - but NOT when creating (we show typing indicator instead)
-  if (isLoading && !isCreating) {
+  if (isLoading && !isCreating && !comingSoonMode) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top', 'bottom']}>
         <View style={styles.centerContainer}>
@@ -239,7 +257,7 @@ export function InnerThoughtsScreen({
   }
 
   // Error state - but NOT when creating
-  if (!isCreating && (error || !session)) {
+  if (!isCreating && !comingSoonMode && (error || !session)) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top', 'bottom']}>
         <View style={styles.centerContainer}>
@@ -252,7 +270,9 @@ export function InnerThoughtsScreen({
     );
   }
 
-  const title = isCreating ? 'Inner Thoughts' : (session?.title || session?.theme || 'Inner Thoughts');
+  const title = comingSoonMode
+    ? 'Inner Work'
+    : isCreating ? 'Inner Thoughts' : (session?.title || session?.theme || 'Inner Thoughts');
   const isLinked = !!linkedPartnerName;
 
   return (
@@ -267,15 +287,7 @@ export function InnerThoughtsScreen({
           },
         ]}
       >
-        <TouchableOpacity
-          style={styles.headerBackButton}
-          onPress={handleBack}
-          accessibilityRole="button"
-          accessibilityLabel="Go back"
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-        >
-          <ArrowLeft color={palette.text} size={24} />
-        </TouchableOpacity>
+        <HeaderBackButton onPress={handleBack} />
 
         <View style={styles.headerContent}>
           <View style={styles.headerTitleRow}>
@@ -335,10 +347,12 @@ export function InnerThoughtsScreen({
         onSendMessage={handleSendMessage}
         isLoading={hideContentUntilReady ? false : (isCreating || sendMessage.isPending)}
         disabled={isCreating || sendMessage.isPending}
-        emptyStateTitle="Inner Thoughts"
-        emptyStateMessage="A private space for reflection. Share what's on your mind."
+        hideInput={comingSoonMode}
+        emptyStateTitle={comingSoonMode ? 'Inner Work' : 'Inner Thoughts'}
+        emptyStateMessage={comingSoonMode ? '' : "A private space for reflection. Share what's on your mind."}
         keyboardVerticalOffset={0}
         onVoicePress={Platform.OS !== 'web' ? handleVoicePress : undefined}
+        skipInitialHistory={comingSoonMode}
       />
 
       {/* Suggested Action Buttons - shown when AI suggests next steps */}

--- a/mobile/src/screens/InnerWorkHubScreen.tsx
+++ b/mobile/src/screens/InnerWorkHubScreen.tsx
@@ -9,7 +9,6 @@ import { useCallback } from 'react';
 import { View, Text, TouchableOpacity, FlatList, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
-  ArrowLeft,
   Sparkles,
   MessageCircle,
   ChevronRight,
@@ -18,6 +17,7 @@ import {
 
 import { useInnerThoughtsSessions } from '../hooks';
 import { InnerWorkSessionSummaryDTO } from '@meet-without-fear/shared';
+import { HeaderBackButton } from '../components/HeaderBackButton';
 import { createStyles } from '../theme/styled';
 import { colors, useAppAppearance } from '../theme';
 
@@ -127,13 +127,7 @@ export function InnerWorkHubScreen({
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top']}>
         <View style={[styles.header, { backgroundColor: palette.bg, borderBottomColor: palette.divider }]}>
-          <TouchableOpacity
-            onPress={handleBack}
-            style={styles.backButton}
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          >
-            <ArrowLeft size={24} color={palette.text} />
-          </TouchableOpacity>
+          <HeaderBackButton onPress={handleBack} />
           <Text style={[styles.headerTitle, { color: palette.text }]}>Inner Work</Text>
           <View style={styles.headerRight} />
         </View>
@@ -169,13 +163,7 @@ export function InnerWorkHubScreen({
     <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top']}>
       {/* Header */}
       <View style={[styles.header, { backgroundColor: palette.bg, borderBottomColor: palette.divider }]}>
-        <TouchableOpacity
-          onPress={handleBack}
-          style={styles.backButton}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-        >
-          <ArrowLeft size={24} color={palette.text} />
-        </TouchableOpacity>
+        <HeaderBackButton onPress={handleBack} />
         <View style={styles.headerTitleContainer}>
           <Text style={[styles.headerTitle, { color: palette.text }]}>Inner Work</Text>
           <View style={styles.privacyBadge}>

--- a/mobile/src/screens/MeditationScreen.tsx
+++ b/mobile/src/screens/MeditationScreen.tsx
@@ -16,7 +16,6 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
-  ArrowLeft,
   Sparkles,
   Play,
   Clock,
@@ -49,6 +48,7 @@ import {
 } from '../hooks';
 import { useToast } from '../contexts/ToastContext';
 import { MeditationType, formatDurationEstimate } from '@meet-without-fear/shared';
+import { HeaderBackButton } from '../components/HeaderBackButton';
 import { createStyles } from '../theme/styled';
 import { colors } from '../theme';
 
@@ -429,9 +429,7 @@ export function MeditationScreen({ onNavigateBack }: MeditationScreenProps) {
     return (
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
         <View style={styles.header}>
-          <TouchableOpacity onPress={handleBack} style={styles.backButton} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-            <ArrowLeft size={24} color={colors.textPrimary} />
-          </TouchableOpacity>
+          <HeaderBackButton onPress={handleBack} />
           <Text style={styles.headerTitle}>
             {selectedType === MeditationType.GUIDED ? 'Guided' : 'Unguided'} Meditation
           </Text>
@@ -533,9 +531,7 @@ export function MeditationScreen({ onNavigateBack }: MeditationScreenProps) {
     return (
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
         <View style={styles.header}>
-          <TouchableOpacity onPress={handleBack} style={styles.backButton} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-            <ArrowLeft size={24} color={colors.textPrimary} />
-          </TouchableOpacity>
+          <HeaderBackButton onPress={handleBack} />
           <Text style={styles.headerTitle}>
             {selectedType === MeditationType.GUIDED ? 'Guided' : 'Unguided'} Session
           </Text>
@@ -612,9 +608,7 @@ export function MeditationScreen({ onNavigateBack }: MeditationScreenProps) {
     return (
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
         <View style={styles.header}>
-          <TouchableOpacity onPress={handleBack} style={styles.backButton} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-            <ArrowLeft size={24} color={colors.textPrimary} />
-          </TouchableOpacity>
+          <HeaderBackButton onPress={handleBack} />
           <Text style={styles.headerTitle}>Saved Meditation</Text>
           <TouchableOpacity
             onPress={() => {
@@ -664,9 +658,7 @@ export function MeditationScreen({ onNavigateBack }: MeditationScreenProps) {
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={handleBack} style={styles.backButton} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-          <ArrowLeft size={24} color={colors.textPrimary} />
-        </TouchableOpacity>
+          <HeaderBackButton onPress={handleBack} />
         <Text style={styles.headerTitle}>Develop Loving Awareness</Text>
         <View style={{ width: 32 }} />
       </View>

--- a/mobile/src/screens/NeedsAssessmentScreen.tsx
+++ b/mobile/src/screens/NeedsAssessmentScreen.tsx
@@ -9,7 +9,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, ActivityIndicator, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
-  ArrowLeft,
   Brain,
   ChevronRight,
   RefreshCw,
@@ -32,6 +31,7 @@ import {
   useSpeech,
 } from '../hooks';
 import { NeedWithScoreDTO } from '@meet-without-fear/shared';
+import { HeaderBackButton } from '../components/HeaderBackButton';
 import { createStyles } from '../theme/styled';
 import { colors } from '../theme';
 
@@ -280,9 +280,7 @@ export function NeedsAssessmentScreen({
     return (
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
         <View style={styles.header}>
-          <TouchableOpacity onPress={handleBack} style={styles.backButton} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-            <ArrowLeft size={24} color={colors.textPrimary} />
-          </TouchableOpacity>
+          <HeaderBackButton onPress={handleBack} />
           <Text style={styles.headerTitle}>Baseline Assessment</Text>
           <Text style={styles.headerProgress}>{currentNeedIndex + 1}/{needs.length}</Text>
         </View>
@@ -348,9 +346,7 @@ export function NeedsAssessmentScreen({
     return (
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
         <View style={styles.header}>
-          <TouchableOpacity onPress={handleBack} style={styles.backButton} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-            <ArrowLeft size={24} color={colors.textPrimary} />
-          </TouchableOpacity>
+          <HeaderBackButton onPress={handleBack} />
           <Text style={styles.headerTitle}>Check In</Text>
           <View style={{ width: 32 }} />
         </View>
@@ -477,9 +473,7 @@ export function NeedsAssessmentScreen({
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={handleBack} style={styles.backButton} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-          <ArrowLeft size={24} color={colors.textPrimary} />
-        </TouchableOpacity>
+        <HeaderBackButton onPress={handleBack} />
         <Text style={styles.headerTitle}>Am I OK?</Text>
         <TouchableOpacity onPress={() => refetch()} style={styles.backButton}>
           <RefreshCw size={20} color={colors.textSecondary} />

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -817,7 +817,9 @@ export function UnifiedSessionScreen({
       if (event === 'partner.session_viewed' && data.empathyStatuses && user?.id) {
         // Partner viewed the session - update delivery status
         console.log('[UnifiedSessionScreen] Partner viewed session, updating cache');
-        updatePartnerLastActiveAt(data.activeAt, data.viewedAt);
+        if (data.presenceVisible !== false) {
+          updatePartnerLastActiveAt(data.activeAt, data.viewedAt);
+        }
         const statuses = data.empathyStatuses as Record<string, unknown>;
         if (statuses[user.id]) {
           queryClient.setQueryData(stageKeys.empathyStatus(sessionId), statuses[user.id]);
@@ -827,7 +829,9 @@ export function UnifiedSessionScreen({
       if (event === 'partner.share_tab_viewed' && data.empathyStatuses && user?.id) {
         // Partner viewed the Share tab - update delivery status
         console.log('[UnifiedSessionScreen] Partner viewed Share tab, updating cache');
-        updatePartnerLastActiveAt(data.activeAt, data.viewedAt);
+        if (data.presenceVisible !== false) {
+          updatePartnerLastActiveAt(data.activeAt, data.viewedAt);
+        }
         const statuses = data.empathyStatuses as Record<string, unknown>;
         if (statuses[user.id]) {
           queryClient.setQueryData(stageKeys.empathyStatus(sessionId), statuses[user.id]);
@@ -3125,6 +3129,7 @@ export function UnifiedSessionScreen({
         visible={true}
         fullScreen={true}
         initialValue={user?.lastMoodIntensity ?? 4}
+        onBack={onNavigateBack}
         onComplete={(intensity) => {
           // Save to user profile (persists across sessions)
           updateMood({ intensity });

--- a/shared/src/contracts/auth.ts
+++ b/shared/src/contracts/auth.ts
@@ -180,3 +180,33 @@ export const updateNotificationPreferencesResponseSchema = z.object({
 });
 
 export type UpdateNotificationPreferencesResponseInput = z.infer<typeof updateNotificationPreferencesResponseSchema>;
+
+// ============================================================================
+// Privacy Preferences
+// ============================================================================
+
+export const privacyPreferencesDTOSchema = z.object({
+  showActivityStatus: z.boolean(),
+  allowSessionInvites: z.boolean(),
+});
+
+export type PrivacyPreferencesDTOInput = z.infer<typeof privacyPreferencesDTOSchema>;
+
+export const updatePrivacyPreferencesRequestSchema = z.object({
+  showActivityStatus: z.boolean().optional(),
+  allowSessionInvites: z.boolean().optional(),
+});
+
+export type UpdatePrivacyPreferencesRequestInput = z.infer<typeof updatePrivacyPreferencesRequestSchema>;
+
+export const getPrivacyPreferencesResponseSchema = z.object({
+  preferences: privacyPreferencesDTOSchema,
+});
+
+export type GetPrivacyPreferencesResponseInput = z.infer<typeof getPrivacyPreferencesResponseSchema>;
+
+export const updatePrivacyPreferencesResponseSchema = z.object({
+  preferences: privacyPreferencesDTOSchema,
+});
+
+export type UpdatePrivacyPreferencesResponseInput = z.infer<typeof updatePrivacyPreferencesResponseSchema>;

--- a/shared/src/dto/auth.ts
+++ b/shared/src/dto/auth.ts
@@ -94,6 +94,35 @@ export interface UpdateNotificationPreferencesResponse {
 }
 
 // ============================================================================
+// Privacy Preferences
+// ============================================================================
+
+export interface PrivacyPreferencesDTO {
+  /** Let partners see presence/activity timestamps such as "last active" */
+  showActivityStatus: boolean;
+  /** Allow existing connected people to start a new invited session with this user */
+  allowSessionInvites: boolean;
+}
+
+export const DEFAULT_PRIVACY_PREFERENCES: PrivacyPreferencesDTO = {
+  showActivityStatus: true,
+  allowSessionInvites: true,
+};
+
+export interface GetPrivacyPreferencesResponse {
+  preferences: PrivacyPreferencesDTO;
+}
+
+export interface UpdatePrivacyPreferencesRequest {
+  showActivityStatus?: boolean;
+  allowSessionInvites?: boolean;
+}
+
+export interface UpdatePrivacyPreferencesResponse {
+  preferences: PrivacyPreferencesDTO;
+}
+
+// ============================================================================
 // Ably Token
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Polishes the home screen greeting, inner-work coming-soon route, and How it works drawer copy/styles.
- Unifies back navigation/header arrows and updates the session-entry mood check labels plus back/swipe behavior.
- Applies light/dark settings styling, transparent drawer backdrops, privacy preference APIs, and backend enforcement for activity visibility/session invites.

## Validation
- npm --prefix mobile run check
- npm --prefix shared run check
- npm --prefix backend run check
- npm --prefix mobile test -- --runTestsByPath app/(auth)/(tabs)/__tests__/index.test.tsx --runInBand
