### PR TITLE
[codex] Polish public auth screens and Mixpanel aliasing

### DIFF
--- a/mobile/app/(public)/auth-options.tsx
+++ b/mobile/app/(public)/auth-options.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -10,7 +10,7 @@ import { useRouter } from 'expo-router';
 import { useOAuth } from '@clerk/clerk-expo';
 import * as WebBrowser from 'expo-web-browser';
 import { AntDesign } from '@expo/vector-icons';
-import { colors } from '@/theme';
+import { designFonts, useAppAppearance } from '@/theme';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -22,6 +22,8 @@ export default function AuthOptionsScreen() {
   const { startOAuthFlow: startGoogleOAuth } = useOAuth({ strategy: 'oauth_google' });
   const { startOAuthFlow: startAppleOAuth } = useOAuth({ strategy: 'oauth_apple' });
   const router = useRouter();
+  const { palette } = useAppAppearance();
+  const styles = useStyles();
   const [error, setError] = useState<string | null>(null);
 
   const handleOAuthSignIn = async (startOAuthFlow: typeof startGoogleOAuth, provider: string) => {
@@ -66,7 +68,7 @@ export default function AuthOptionsScreen() {
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
         <TouchableOpacity style={styles.backButton} onPress={handleBack}>
-          <AntDesign name="left" size={24} color={colors.textPrimary} />
+          <AntDesign name="left" size={24} color={palette.text} />
         </TouchableOpacity>
       </View>
 
@@ -80,7 +82,7 @@ export default function AuthOptionsScreen() {
           style={styles.oauthButton}
           onPress={() => handleOAuthSignIn(startGoogleOAuth, 'Google')}
         >
-          <AntDesign name="google" size={20} color={colors.textPrimary} style={styles.buttonIcon} />
+          <AntDesign name="google" size={20} color={palette.text} style={styles.buttonIcon} />
           <Text style={styles.oauthButtonText}>Continue with Google</Text>
         </TouchableOpacity>
 
@@ -88,7 +90,7 @@ export default function AuthOptionsScreen() {
           style={styles.oauthButton}
           onPress={() => handleOAuthSignIn(startAppleOAuth, 'Apple')}
         >
-          <AntDesign name={'apple1' as any} size={20} color={colors.textPrimary} style={styles.buttonIcon} />
+          <AntDesign name={'apple1' as any} size={20} color={palette.text} style={styles.buttonIcon} />
           <Text style={styles.oauthButtonText}>Continue with Apple</Text>
         </TouchableOpacity>
       </View>
@@ -96,63 +98,68 @@ export default function AuthOptionsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.bgPrimary,
-  },
-  header: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  backButton: {
-    width: 40,
-    height: 40,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  content: {
-    flex: 1,
-    paddingHorizontal: 24,
-    justifyContent: 'center',
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: colors.textPrimary,
-    marginBottom: 8,
-    textAlign: 'center',
-  },
-  subtitle: {
-    fontSize: 16,
-    color: colors.textSecondary,
-    marginBottom: 32,
-    textAlign: 'center',
-  },
-  error: {
-    fontSize: 14,
-    color: colors.error,
-    marginBottom: 16,
-    paddingHorizontal: 4,
-    textAlign: 'center',
-  },
-  oauthButton: {
-    backgroundColor: colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: colors.border,
-    paddingVertical: 14,
-    borderRadius: 12,
-    alignItems: 'center',
-    marginBottom: 12,
-    flexDirection: 'row',
-    justifyContent: 'center',
-  },
-  oauthButtonText: {
-    color: colors.textPrimary,
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  buttonIcon: {
-    marginRight: 8,
-  },
-});
+const useStyles = () => {
+  const { palette } = useAppAppearance();
+
+  return useMemo(() => StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: palette.bg,
+    },
+    header: {
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+    },
+    backButton: {
+      width: 40,
+      height: 40,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    content: {
+      flex: 1,
+      paddingHorizontal: 24,
+      justifyContent: 'center',
+    },
+    title: {
+      fontFamily: designFonts.serif,
+      fontSize: 34,
+      fontWeight: '400',
+      color: palette.text,
+      marginBottom: 8,
+      textAlign: 'center',
+    },
+    subtitle: {
+      fontSize: 16,
+      color: palette.textMuted,
+      marginBottom: 32,
+      textAlign: 'center',
+    },
+    error: {
+      fontSize: 14,
+      color: palette.danger,
+      marginBottom: 16,
+      paddingHorizontal: 4,
+      textAlign: 'center',
+    },
+    oauthButton: {
+      backgroundColor: palette.bgElev,
+      borderWidth: 1,
+      borderColor: palette.border,
+      paddingVertical: 14,
+      borderRadius: 12,
+      alignItems: 'center',
+      marginBottom: 12,
+      flexDirection: 'row',
+      justifyContent: 'center',
+    },
+    oauthButtonText: {
+      color: palette.text,
+      fontSize: 16,
+      fontWeight: '500',
+    },
+    buttonIcon: {
+      marginRight: 8,
+    },
+  }), [palette]);
+};

--- a/mobile/app/(public)/auth-options.web.tsx
+++ b/mobile/app/(public)/auth-options.web.tsx
@@ -17,7 +17,7 @@
  * `useClerk().handleRedirectCallback()` finalizes the session.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -29,7 +29,7 @@ import {
 import { useRouter } from 'expo-router';
 import { useClerk, useSignIn, useSignUp } from '@clerk/clerk-expo';
 import { AntDesign } from '@expo/vector-icons';
-import { colors } from '@/theme';
+import { designFonts, useAppAppearance } from '@/theme';
 
 type OAuthStrategy = 'oauth_google' | 'oauth_apple';
 
@@ -38,6 +38,8 @@ export default function AuthOptionsScreenWeb() {
   const { signUp, isLoaded: signUpLoaded } = useSignUp();
   const clerk = useClerk();
   const router = useRouter();
+  const { palette } = useAppAppearance();
+  const styles = useStyles();
   const [error, setError] = useState<string | null>(null);
   const [busyProvider, setBusyProvider] = useState<OAuthStrategy | null>(null);
 
@@ -105,7 +107,7 @@ export default function AuthOptionsScreenWeb() {
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
         <TouchableOpacity style={styles.backButton} onPress={handleBack} accessibilityLabel="Go back">
-          <AntDesign name="left" size={24} color={colors.textPrimary} />
+          <AntDesign name="left" size={24} color={palette.text} />
         </TouchableOpacity>
       </View>
 
@@ -149,6 +151,9 @@ function OAuthButton({
   busy: boolean;
   disabled: boolean;
 }) {
+  const { palette } = useAppAppearance();
+  const styles = useStyles();
+
   return (
     <TouchableOpacity
       style={[styles.oauthButton, disabled && styles.oauthButtonDisabled]}
@@ -158,75 +163,80 @@ function OAuthButton({
       accessibilityState={{ disabled, busy }}
     >
       {busy ? (
-        <ActivityIndicator size="small" color={colors.textPrimary} style={styles.buttonIcon} />
+        <ActivityIndicator size="small" color={palette.text} style={styles.buttonIcon} />
       ) : (
-        <AntDesign name={iconName} size={20} color={colors.textPrimary} style={styles.buttonIcon} />
+        <AntDesign name={iconName} size={20} color={palette.text} style={styles.buttonIcon} />
       )}
       <Text style={styles.oauthButtonText}>{label}</Text>
     </TouchableOpacity>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.bgPrimary,
-  },
-  header: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  backButton: {
-    width: 40,
-    height: 40,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  content: {
-    flex: 1,
-    paddingHorizontal: 24,
-    justifyContent: 'center',
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: colors.textPrimary,
-    marginBottom: 8,
-    textAlign: 'center',
-  },
-  subtitle: {
-    fontSize: 16,
-    color: colors.textSecondary,
-    marginBottom: 32,
-    textAlign: 'center',
-  },
-  error: {
-    fontSize: 14,
-    color: colors.error,
-    marginBottom: 16,
-    paddingHorizontal: 4,
-    textAlign: 'center',
-  },
-  oauthButton: {
-    backgroundColor: colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: colors.border,
-    paddingVertical: 14,
-    borderRadius: 12,
-    alignItems: 'center',
-    marginBottom: 12,
-    flexDirection: 'row',
-    justifyContent: 'center',
-  },
-  oauthButtonDisabled: {
-    opacity: 0.5,
-  },
-  oauthButtonText: {
-    color: colors.textPrimary,
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  buttonIcon: {
-    marginRight: 8,
-  },
-});
+const useStyles = () => {
+  const { palette } = useAppAppearance();
+
+  return useMemo(() => StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: palette.bg,
+    },
+    header: {
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+    },
+    backButton: {
+      width: 40,
+      height: 40,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    content: {
+      flex: 1,
+      paddingHorizontal: 24,
+      justifyContent: 'center',
+    },
+    title: {
+      fontFamily: designFonts.serif,
+      fontSize: 34,
+      fontWeight: '400',
+      color: palette.text,
+      marginBottom: 8,
+      textAlign: 'center',
+    },
+    subtitle: {
+      fontSize: 16,
+      color: palette.textMuted,
+      marginBottom: 32,
+      textAlign: 'center',
+    },
+    error: {
+      fontSize: 14,
+      color: palette.danger,
+      marginBottom: 16,
+      paddingHorizontal: 4,
+      textAlign: 'center',
+    },
+    oauthButton: {
+      backgroundColor: palette.bgElev,
+      borderWidth: 1,
+      borderColor: palette.border,
+      paddingVertical: 14,
+      borderRadius: 12,
+      alignItems: 'center',
+      marginBottom: 12,
+      flexDirection: 'row',
+      justifyContent: 'center',
+    },
+    oauthButtonDisabled: {
+      opacity: 0.5,
+    },
+    oauthButtonText: {
+      color: palette.text,
+      fontSize: 16,
+      fontWeight: '500',
+    },
+    buttonIcon: {
+      marginRight: 8,
+    },
+  }), [palette]);
+};

--- a/mobile/app/(public)/index.tsx
+++ b/mobile/app/(public)/index.tsx
@@ -1,15 +1,34 @@
-import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView, Alert } from 'react-native';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Animated,
+  Easing,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  SafeAreaView,
+  Alert,
+} from 'react-native';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
-import { colors } from '@/theme';
+import { ArrowRight } from 'lucide-react-native';
 import { Logo } from '@/src/components';
+import { designFonts, useAppAppearance } from '@/src/theme';
+
+const SPLASH_PAIRS = [
+  ['Heated', 'Heard'],
+  ['Enemy', 'Human'],
+  ['Blame', 'Needs'],
+  ['Opposition', 'Win-win'],
+] as const;
 
 /**
- * Welcome screen - the first screen users see
- * Centered branding with single "Get Started" CTA
+ * Welcome screen - the first screen users see before authentication.
  */
 export default function WelcomeScreen() {
   const router = useRouter();
+  const { palette } = useAppAppearance();
+  const styles = useStyles();
 
   const handleGetStarted = () => {
     router.push('/(public)/auth-options');
@@ -29,95 +48,243 @@ export default function WelcomeScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.content}>
-        {/* Centered Branding Section */}
-        <View style={styles.brandingSection}>
-          <Logo size={160} />
-          <Text style={styles.logo}>Meet Without Fear</Text>
-          <Text style={styles.tagline}>Work through conflict together</Text>
+      <View style={styles.centerSection}>
+        <View style={styles.mark}>
+          <Logo size={132} />
+          <Text style={styles.wordmark}>meet without fear</Text>
         </View>
 
-        {/* CTA Section */}
-        <View style={styles.ctaSection}>
-          <TouchableOpacity style={styles.primaryButton} onPress={handleGetStarted}>
-            <Text style={styles.primaryButtonText}>Get Started</Text>
+        <AnimatedPhrasePair />
+
+        <Text style={styles.subtitle}>
+          A quieter way through{'\n'}the conversations that matter most.
+        </Text>
+      </View>
+
+      <View style={styles.footer}>
+        <TouchableOpacity style={styles.primaryButton} onPress={handleGetStarted}>
+          <Text style={styles.primaryButtonText}>Get started</Text>
+          <ArrowRight color={palette.bg} size={16} strokeWidth={1.8} />
+        </TouchableOpacity>
+
+        <View style={styles.legalLinks}>
+          <TouchableOpacity onPress={handleTerms}>
+            <Text style={styles.legalText}>Terms of Service</Text>
           </TouchableOpacity>
-        </View>
-
-        {/* Legal Links */}
-        <View style={styles.legalSection}>
-          <View style={styles.legalLinks}>
-            <TouchableOpacity onPress={handleTerms}>
-              <Text style={styles.legalText}>Terms of Service</Text>
-            </TouchableOpacity>
-            <Text style={styles.legalDivider}>|</Text>
-            <TouchableOpacity onPress={handlePrivacy}>
-              <Text style={styles.legalText}>Privacy Policy</Text>
-            </TouchableOpacity>
-          </View>
+          <Text style={styles.legalDivider}>·</Text>
+          <TouchableOpacity onPress={handlePrivacy}>
+            <Text style={styles.legalText}>Privacy Policy</Text>
+          </TouchableOpacity>
         </View>
       </View>
     </SafeAreaView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.bgPrimary,
-  },
-  content: {
-    flex: 1,
-    paddingHorizontal: 24,
-    justifyContent: 'space-between',
-  },
-  brandingSection: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  logo: {
-    fontSize: 36,
-    fontWeight: 'bold',
-    color: colors.textPrimary,
-    marginTop: 24,
-    marginBottom: 16,
-    textAlign: 'center',
-  },
-  tagline: {
-    fontSize: 18,
-    color: colors.textSecondary,
-    textAlign: 'center',
-  },
-  ctaSection: {
-    paddingBottom: 24,
-  },
-  primaryButton: {
-    backgroundColor: colors.accent,
-    paddingVertical: 18,
-    borderRadius: 12,
-    alignItems: 'center',
-  },
-  primaryButtonText: {
-    color: colors.textOnAccent,
-    fontSize: 18,
-    fontWeight: '600',
-  },
-  legalSection: {
-    paddingBottom: 24,
-  },
-  legalLinks: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  legalText: {
-    color: colors.textMuted,
-    fontSize: 14,
-  },
-  legalDivider: {
-    color: colors.textMuted,
-    fontSize: 14,
-    marginHorizontal: 12,
-  },
-});
+function AnimatedPhrasePair() {
+  const styles = useStyles();
+  const phraseOpacity = useRef(new Animated.Value(1)).current;
+  const phraseOffset = useRef(new Animated.Value(0)).current;
+  const activeIndexRef = useRef(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const animateNext = () => {
+      const nextIndex = (activeIndexRef.current + 1) % SPLASH_PAIRS.length;
+
+      Animated.parallel([
+        Animated.timing(phraseOpacity, {
+          toValue: 0,
+          duration: 300,
+          easing: Easing.in(Easing.cubic),
+          useNativeDriver: true,
+        }),
+        Animated.timing(phraseOffset, {
+          toValue: -8,
+          duration: 300,
+          easing: Easing.in(Easing.cubic),
+          useNativeDriver: true,
+        }),
+      ]).start(({ finished }) => {
+        if (!finished || !mounted) return;
+        activeIndexRef.current = nextIndex;
+        setActiveIndex(nextIndex);
+        phraseOpacity.setValue(0);
+        phraseOffset.setValue(10);
+
+        Animated.parallel([
+          Animated.timing(phraseOpacity, {
+            toValue: 1,
+            duration: 460,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true,
+          }),
+          Animated.timing(phraseOffset, {
+            toValue: 0,
+            duration: 460,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true,
+          }),
+        ]).start();
+      });
+    };
+
+    const timer = setInterval(animateNext, 2600);
+    return () => {
+      mounted = false;
+      clearInterval(timer);
+    };
+  }, [phraseOffset, phraseOpacity]);
+
+  return (
+    <View style={styles.phrasePair}>
+      <Animated.View
+        style={[
+          styles.phraseLayer,
+          {
+            opacity: phraseOpacity,
+            transform: [{ translateY: phraseOffset }],
+          },
+        ]}
+      >
+        <PhrasePairRow pair={SPLASH_PAIRS[activeIndex]} />
+      </Animated.View>
+    </View>
+  );
+}
+
+function PhrasePairRow({ pair }: { pair: readonly [string, string] }) {
+  const styles = useStyles();
+  const [phraseA, phraseB] = pair;
+
+  return (
+    <View style={styles.phraseRow}>
+      <Text style={styles.phraseA}>{phraseA}</Text>
+      <Text style={styles.phraseArrow}>→</Text>
+      <Text style={styles.phraseB}>{phraseB}</Text>
+    </View>
+  );
+}
+
+const useStyles = () => {
+  const { palette } = useAppAppearance();
+
+  return useMemo(() => StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: palette.bg,
+      paddingTop: 18,
+    },
+    centerSection: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: 28,
+      gap: 18,
+    },
+    mark: {
+      alignItems: 'center',
+      gap: 14,
+      marginBottom: 4,
+    },
+    wordmark: {
+      fontFamily: designFonts.serif,
+      fontSize: 24,
+      fontStyle: 'italic',
+      letterSpacing: 0.1,
+      color: palette.text,
+    },
+    phrasePair: {
+      position: 'relative',
+      minHeight: 56,
+      width: '100%',
+      marginTop: 14,
+      marginBottom: 22,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    phraseLayer: {
+      position: 'absolute',
+      inset: 0,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    phraseRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 18,
+    },
+    phraseA: {
+      fontFamily: designFonts.serif,
+      fontSize: 38,
+      lineHeight: 42,
+      fontStyle: 'italic',
+      color: palette.textMuted,
+    },
+    phraseArrow: {
+      fontFamily: designFonts.serif,
+      fontSize: 26,
+      lineHeight: 30,
+      color: palette.accent,
+      marginTop: -2,
+    },
+    phraseB: {
+      fontFamily: designFonts.serif,
+      fontSize: 38,
+      lineHeight: 42,
+      color: palette.text,
+    },
+    subtitle: {
+      fontSize: 16,
+      lineHeight: 24,
+      color: palette.textMuted,
+      textAlign: 'center',
+      maxWidth: 300,
+    },
+    footer: {
+      paddingHorizontal: 22,
+      paddingBottom: 28,
+      alignItems: 'center',
+      gap: 24,
+    },
+    primaryButton: {
+      width: '100%',
+      minHeight: 54,
+      borderRadius: 999,
+      backgroundColor: palette.accent,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      paddingHorizontal: 18,
+      paddingVertical: 16,
+    },
+    primaryButtonText: {
+      color: palette.bg,
+      fontSize: 15,
+      fontWeight: '500',
+    },
+    legalLinks: {
+      flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'center',
+      gap: 8,
+    },
+    legalText: {
+      color: palette.textFaint,
+      fontFamily: designFonts.mono,
+      fontSize: 10,
+      letterSpacing: 0.8,
+      textTransform: 'uppercase',
+    },
+    legalDivider: {
+      color: palette.textFaint,
+      fontFamily: designFonts.mono,
+      fontSize: 10,
+      opacity: 0.6,
+    },
+  }), [palette]);
+};

--- a/mobile/src/components/MixpanelInitializer.tsx
+++ b/mobile/src/components/MixpanelInitializer.tsx
@@ -95,8 +95,10 @@ export function MixpanelInitializer() {
 
         if (!hasAliased && !wasResetThisSession) {
           // First-time login: create alias to merge anonymous events
-          alias(userId);
-          await AsyncStorage.setItem(aliasFlag, 'true');
+          const didAlias = await alias(userId);
+          if (didAlias) {
+            await AsyncStorage.setItem(aliasFlag, 'true');
+          }
         }
 
         // Clear the reset flag now that we've handled the login

--- a/mobile/src/services/mixpanel.ts
+++ b/mobile/src/services/mixpanel.ts
@@ -10,8 +10,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 interface IMixpanel {
   init: () => Promise<void>;
   track: (eventName: string, properties?: Record<string, unknown>) => void;
-  identify: (userId: string) => void;
-  alias: (alias: string, distinctId?: string) => void;
+  identify: (userId: string) => void | Promise<void>;
+  alias: (alias: string, distinctId: string) => void;
+  getDistinctId: () => Promise<string>;
   getPeople: () => {
     set: (prop: string, to: unknown) => void;
     setOnce: (prop: string, to: unknown) => void;
@@ -36,6 +37,7 @@ const createNoOpClient = (): IMixpanel => {
     identify: (userId) => log('Identify:', userId),
     alias: (alias, distinctId) =>
       log('Alias:', alias, `(from_distinct_id: ${distinctId ?? 'CURRENT'})`),
+    getDistinctId: async () => 'dev-anonymous-distinct-id',
     getPeople: () => ({
       set: (prop, to) => log('Set User Property:', { [prop]: to }),
       setOnce: (prop, to) => log('Set User Property Once:', { [prop]: to }),
@@ -106,7 +108,7 @@ export const identify = (userId: string): void => {
   }
 
   try {
-    mixpanelClient?.identify(userId);
+    void mixpanelClient?.identify(userId);
     identifiedUserId = userId;
   } catch (error) {
     console.error('[Mixpanel] identify() failed:', error);
@@ -123,15 +125,35 @@ export const identify = (userId: string): void => {
  *
  * @param aliasId - The user's identifier (e.g., UUID)
  */
-export const alias = (aliasId: string): void => {
+const isValidDistinctId = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+export const alias = async (aliasId: string): Promise<boolean> => {
   assertInit();
-  // Pass only the new aliasId.
-  // The SDK will automatically merge from the current anonymous distinct_id.
+  if (!isValidDistinctId(aliasId)) {
+    console.warn('[Mixpanel] alias() skipped: aliasId is not a valid string');
+    return false;
+  }
+
   try {
-    mixpanelClient?.alias(aliasId);
+    const distinctId = await mixpanelClient?.getDistinctId();
+
+    if (!isValidDistinctId(distinctId)) {
+      console.warn('[Mixpanel] alias() skipped: current distinctId is not a valid string');
+      return false;
+    }
+
+    if (distinctId === aliasId) {
+      console.log('[Mixpanel] alias() skipped: distinctId already matches user');
+      return true;
+    }
+
+    mixpanelClient?.alias(aliasId, distinctId);
     console.log('[Mixpanel] alias() completed for user:', aliasId);
+    return true;
   } catch (error) {
     console.error('[Mixpanel] alias() failed:', error);
+    return false;
   }
 };
 

--- a/mobile/src/services/mixpanel.web.ts
+++ b/mobile/src/services/mixpanel.web.ts
@@ -69,17 +69,25 @@ export const identify = (userId: string): void => {
   }
 };
 
-export const alias = (aliasId: string): void => {
+export const alias = async (aliasId: string): Promise<boolean> => {
   assertInit();
+  if (typeof aliasId !== 'string' || aliasId.trim().length === 0) {
+    console.warn('[Mixpanel Web] alias() skipped: aliasId is not a valid string');
+    return false;
+  }
+
   if (!hasToken) {
     log('Alias:', aliasId);
-    return;
+    return true;
   }
+
   try {
     mixpanel.alias(aliasId);
     console.log('[Mixpanel Web] alias() completed for user:', aliasId);
+    return true;
   } catch (error) {
     console.error('[Mixpanel Web] alias() failed:', error);
+    return false;
   }
 };
 


### PR DESCRIPTION
## Summary
- Restyles the logged-out welcome and auth option screens with the app appearance palette and design fonts.
- Adds the animated welcome phrase treatment and updated CTA/legal link styling.
- Hardens Mixpanel aliasing so alias flags are only persisted after a successful alias attempt.

## Validation
- npm --prefix mobile run check
