### PR TITLE
[codex] Add light and dark splash config

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -11,7 +11,7 @@
     "splash": {
       "image": "./assets/images/icon.png",
       "resizeMode": "contain",
-      "backgroundColor": "#0f172a"
+      "backgroundColor": "#F7F6F3"
     },
     "ios": {
       "supportsTablet": false,
@@ -29,7 +29,7 @@
       "splash": {
         "image": "./assets/images/icon.png",
         "resizeMode": "contain",
-        "backgroundColor": "#0f172a"
+        "backgroundColor": "#F7F6F3"
       }
     },
     "android": {
@@ -79,7 +79,11 @@
         {
           "image": "./assets/images/icon.png",
           "resizeMode": "contain",
-          "backgroundColor": "#0f172a"
+          "backgroundColor": "#F7F6F3",
+          "dark": {
+            "image": "./assets/images/icon.png",
+            "backgroundColor": "#0f172a"
+          }
         }
       ],
       [


### PR DESCRIPTION
## Summary
- Sets the default native splash background to the light app background.
- Adds a dark-mode splash override for devices using dark appearance.

## Validation
- npm --prefix mobile run check
