### PR TITLE
fix: remove LLM feel-heard auto-confirm pathway

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1910,7 +1910,6 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
 
       // Extract metadata from parsed response
       metadata.offerFeelHeardCheck = parsed.offerFeelHeardCheck;
-      metadata.feelHeardConfirmed = parsed.feelHeardConfirmed;
       metadata.offerReadyToShare = parsed.offerReadyToShare;
       if (parsed.proposedStrategies.length > 0) {
         metadata.proposedStrategies = parsed.proposedStrategies;
@@ -1934,7 +1933,6 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
 
       logger.info(`[sendMessageStream:${requestId}] Parsed metadata:`, {
         offerFeelHeardCheck: metadata.offerFeelHeardCheck,
-        feelHeardConfirmed: metadata.feelHeardConfirmed,
         offerReadyToShare: metadata.offerReadyToShare,
         hasDraft: !!parsed.draft,
         proposedNeedsCount: metadata.proposedNeeds?.length ?? 0,
@@ -2087,14 +2085,6 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       );
     }
 
-    const stage1ConfirmationAt = currentStage === 1 && metadata.feelHeardConfirmed === true
-      ? new Date()
-      : null;
-    if (stage1ConfirmationAt) {
-      metadata.feelHeardConfirmedAt = stage1ConfirmationAt.toISOString();
-      metadata.advancedToStage = 2;
-    }
-
     // =========================================================================
     // Signal that text streaming is complete (before DB saves for faster UX)
     // =========================================================================
@@ -2107,7 +2097,6 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     // Save AI message (only if streaming succeeded)
     // Trim whitespace that Claude sometimes adds
     // =========================================================================
-    const completedStage1FromLLM = currentStage === 1 && metadata.feelHeardConfirmed === true && progress?.id;
     const aiMessage = await prisma.message.create({
       data: {
         sessionId,
@@ -2115,7 +2104,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
         forUserId: user.id,
         role: 'AI',
         content: accumulatedText.trim(),
-        stage: completedStage1FromLLM ? 2 : effectiveStage, // Use effective stage (21 for Stage 2B) for analytics
+        stage: effectiveStage, // Use effective stage (21 for Stage 2B) for analytics
       },
     });
     logger.info(`[sendMessageStream:${requestId}] AI message created: ${aiMessage.id}`);
@@ -2126,76 +2115,17 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     // =========================================================================
     // Process metadata (persist to database)
     // =========================================================================
-    if (currentStage === 1 && progress?.id && (metadata.offerFeelHeardCheck || metadata.feelHeardConfirmed)) {
+    if (currentStage === 1 && progress?.id && metadata.offerFeelHeardCheck) {
       const currentGates = (progress.gatesSatisfied as Record<string, unknown>) ?? {};
-      const completedAt = stage1ConfirmationAt ?? new Date();
-      const confirmedAt = completedAt.toISOString();
       await prisma.stageProgress.update({
         where: { id: progress.id },
         data: {
           gatesSatisfied: {
             ...currentGates,
             feelHeardCheckOffered: true,
-            ...(metadata.feelHeardConfirmed
-              ? {
-                  feelHeardConfirmed: true,
-                  feelHeardConfirmedAt: confirmedAt,
-                  finalEmotionalReading: null,
-                  feedback: content,
-                }
-              : {}),
           },
-          ...(metadata.feelHeardConfirmed
-            ? {
-                status: 'COMPLETED' as const,
-                completedAt,
-              }
-            : {}),
         },
       });
-
-      if (metadata.feelHeardConfirmed) {
-        await prisma.stageProgress.upsert({
-          where: {
-            sessionId_userId_stage: {
-              sessionId,
-              userId: user.id,
-              stage: 2,
-            },
-          },
-          create: {
-            sessionId,
-            userId: user.id,
-            stage: 2,
-            status: 'IN_PROGRESS',
-            startedAt: completedAt,
-            gatesSatisfied: {},
-          },
-          update: {},
-        });
-
-        const partnerId = await getPartnerUserId(sessionId, user.id);
-        if (partnerId) {
-          await notifyPartner(sessionId, partnerId, 'partner.stage_completed', {
-            stage: 1,
-            completedBy: user.id,
-          });
-        }
-
-        const partnerCompleted = await hasPartnerCompletedStage1(sessionId, user.id);
-        if (partnerCompleted) {
-          await publishSessionEvent(sessionId, 'partner.advanced', {
-            fromStage: 1,
-            toStage: 2,
-          });
-        }
-
-        consolidateGlobalFacts(user.id, sessionId, `${sessionId}-${user.id}-llm-feel-heard`).catch((err: unknown) =>
-          logger.warn('[sendMessageStream] Failed to consolidate global facts after LLM feel-heard confirmation:', err)
-        );
-
-        logger.info(`[sendMessageStream:${requestId}] LLM confirmed Stage 1 feel-heard gate; advanced backend state to Stage 2`);
-      }
     }
 
     // Save topic frame (Stage 0 / invitation phase) - only if not already confirmed

--- a/backend/src/routes/__tests__/messages.test.ts
+++ b/backend/src/routes/__tests__/messages.test.ts
@@ -229,7 +229,7 @@ describe('Messages API (Fire-and-Forget)', () => {
   });
 
   describe('POST /sessions/:id/messages/stream (sendMessageStream)', () => {
-    it('advances Stage 1 through the backend gate when the LLM confirms typed felt-heard readiness', async () => {
+    it('does not auto-advance Stage 1 from LLM — feel-heard confirmation is button-only', async () => {
       const stage1Progress = {
         id: 'progress-1',
         sessionId: mockSessionId,
@@ -254,7 +254,7 @@ describe('Messages API (Fire-and-Forget)', () => {
         forUserId: mockUser.id,
         role: 'AI',
         content: 'That feels complete. Now let us turn toward what your partner might be experiencing in this.',
-        stage: 2,
+        stage: 1,
         timestamp: new Date('2026-05-07T08:00:01Z'),
       };
       const session = {
@@ -311,46 +311,31 @@ describe('Messages API (Fire-and-Forget)', () => {
 
       await sendMessageStream(req as Request, res as Response);
 
+      // AI message should stay on Stage 1 — no auto-advance
       expect(prisma.message.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
             role: 'AI',
-            stage: 2,
+            stage: 1,
           }),
         })
       );
+      // Only feelHeardCheckOffered is set; stage is NOT completed
       expect(prisma.stageProgress.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: 'progress-1' },
           data: expect.objectContaining({
-            status: 'COMPLETED',
             gatesSatisfied: expect.objectContaining({
               feelHeardCheckOffered: true,
-              feelHeardConfirmed: true,
-              feedback: userMessage.content,
             }),
           }),
         })
       );
-      expect(prisma.stageProgress.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: {
-            sessionId_userId_stage: {
-              sessionId: mockSessionId,
-              userId: mockUser.id,
-              stage: 2,
-            },
-          },
-          create: expect.objectContaining({
-            sessionId: mockSessionId,
-            userId: mockUser.id,
-            stage: 2,
-            status: 'IN_PROGRESS',
-          }),
-        })
-      );
-      expect(writeMock.mock.calls.map(([chunk]) => String(chunk)).join('')).toContain('"feelHeardConfirmed":true');
-      expect(writeMock.mock.calls.map(([chunk]) => String(chunk)).join('')).toContain('"advancedToStage":2');
+      // Stage 2 progress should NOT be created by LLM
+      expect(prisma.stageProgress.upsert).not.toHaveBeenCalled();
+      // Metadata should NOT contain feelHeardConfirmed or advancedToStage
+      const sseOutput = writeMock.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(sseOutput).not.toContain('"advancedToStage":2');
       expect(endMock).toHaveBeenCalled();
     });
   });

--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -863,9 +863,8 @@ describe('Stage Prompts Service', () => {
       expect(prompt).toContain('<thinking>');
       // The flag instruction is in format "FeelHeardCheck: [Y if ready..., N otherwise]"
       expect(prompt).toContain('FeelHeardCheck:');
-      expect(prompt).toContain('FeelHeardConfirmed:');
+      expect(prompt).not.toContain('FeelHeardConfirmed:');
       expect(prompt).toMatch(/FeelHeardCheck.*Y.*N/s);
-      expect(prompt).toMatch(/FeelHeardConfirmed.*Y.*N/s);
       expect(prompt).toContain('Do NOT invite more freeform chat unless the input remains visible');
     });
 
@@ -903,7 +902,7 @@ describe('Stage Prompts Service', () => {
       const prompt = fullPrompt(buildStagePrompt(3, context));
 
       expect(prompt).toContain('The only XML-style tags you may use are exactly <thinking>, <draft>, <needs>, and <dispatch>.');
-      expect(prompt).toContain('Flags such as FeelHeardCheck, FeelHeardConfirmed, ReadyShare, NeedsReady, Mode, and Strategy must be plain lines inside <thinking>');
+      expect(prompt).toContain('Flags such as FeelHeardCheck, ReadyShare, NeedsReady, Mode, and Strategy must be plain lines inside <thinking>');
       expect(prompt).toContain('never turn them into tags like <needs_ready>, <ready_share>, or <feel_heard_check>');
       expect(prompt).toContain('The <needs> tag is only for the structured Stage 3 needs JSON shown above');
     });

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -33,7 +33,6 @@ function buildResponseProtocol(stage: number, options?: {
   const flags: string[] = ['UserIntensity: [1-10]'];
   if (stage === 1) {
     flags.push('FeelHeardCheck: [Y/N]');
-    flags.push('FeelHeardConfirmed: [Y/N]');
   } else if (stage === 2) {
     flags.push('ReadyShare: [Y/N]');
   } else if (stage === 3) {
@@ -109,7 +108,7 @@ Strategy: [brief]${strategySection}
 
 Then write the user-facing response (plain text, no tags).
 IMPORTANT: The only XML-style tags you may use are exactly <thinking>, <draft>, <needs>, and <dispatch>.
-Flags such as FeelHeardCheck, FeelHeardConfirmed, ReadyShare, NeedsReady, Mode, and Strategy must be plain lines inside <thinking>; never turn them into tags like <needs_ready>, <ready_share>, or <feel_heard_check>.
+Flags such as FeelHeardCheck, ReadyShare, NeedsReady, Mode, and Strategy must be plain lines inside <thinking>; never turn them into tags like <needs_ready>, <ready_share>, or <feel_heard_check>.
 The <needs> tag is only for the structured Stage 3 needs JSON shown above. The user-facing response must be purely conversational — no brackets, flags, annotations, planning, or "I should" language.
 
 OFF-RAMPS (only when needed):
@@ -598,9 +597,7 @@ Feel-heard check:
 - Set FeelHeardCheck:Y only when ALL of these are true: (1) they've affirmed something you reflected back, (2) you can name their core concern, (3) their intensity is stabilizing or steady, and (4) for long-running/high-conflict patterns, you have also heard the cost, what they tried, and the boundary or grief underneath.
 - Be proactive only after the real emotional shape is present. Don't wait for perfect wording, but don't offer the gate just because the factual pattern is clear.
 - When FeelHeardCheck:Y, end your response with a gentle acknowledgment that they can confirm below. Example: "...if that captures it, you can let me know below when you're ready." Do NOT invite more freeform chat unless the input remains visible. Do NOT say "tap the button" or mention UI elements directly. Keep it conversational. Keep setting Y until they act on the prompt.
-- Even when FeelHeardCheck:Y, stay in listening mode. Do NOT pivot to advice, action, or next steps.
-- Set FeelHeardConfirmed:Y only when the user's latest message clearly means they feel heard or are ready to move on from Stage 1. This may be explicit ("I feel heard", "ready") or natural language confirmation that your reflection captured it. If they seem uncertain, add new material, answer with a correction, or ask for more witnessing, set FeelHeardConfirmed:N.
-- When FeelHeardConfirmed:Y, write a Stage 2 transition that acknowledges Stage 1 is complete and asks them to imagine their partner's side. Do not keep asking Stage 1 listening questions in that response.
+- Even when FeelHeardCheck:Y, stay in listening mode. Do NOT pivot to advice, action, or next steps. The user will confirm via a button in the UI — do NOT try to detect verbal confirmation or advance the stage yourself.
 
 ${buildResponseProtocol(1)}`;
 

--- a/backend/src/services/stage-tools.ts
+++ b/backend/src/services/stage-tools.ts
@@ -64,9 +64,6 @@ export const SESSION_STATE_TOOL_NAME = 'update_session_state';
  */
 export interface SessionStateToolInput {
   offerFeelHeardCheck?: boolean;
-  feelHeardConfirmed?: boolean;
-  feelHeardConfirmedAt?: string;
-  advancedToStage?: number;
   offerReadyToShare?: boolean;
   proposedEmpathyStatement?: string;
   proposedStrategies?: string[];
@@ -98,9 +95,6 @@ export function parseSessionStateToolInput(
       : false,
     offerReadyToShare: typeof input.offerReadyToShare === 'boolean'
       ? input.offerReadyToShare
-      : false,
-    feelHeardConfirmed: typeof input.feelHeardConfirmed === 'boolean'
-      ? input.feelHeardConfirmed
       : false,
     proposedEmpathyStatement: typeof input.proposedEmpathyStatement === 'string'
       ? input.proposedEmpathyStatement

--- a/backend/src/utils/__tests__/micro-tag-parser.test.ts
+++ b/backend/src/utils/__tests__/micro-tag-parser.test.ts
@@ -372,12 +372,11 @@ That gives this a clearer shape.`;
       const raw = `<thinking>Just some analysis</thinking>Response`;
       const result = parseMicroTagResponse(raw);
       expect(result.offerFeelHeardCheck).toBe(false);
-      expect(result.feelHeardConfirmed).toBe(false);
       expect(result.offerReadyToShare).toBe(false);
       expect(result.stage4ProposalBlockPresent).toBe(false);
     });
 
-    it('extracts FeelHeardConfirmed:Y as true', () => {
+    it('ignores FeelHeardConfirmed flag (feel-heard confirmation is button-only)', () => {
       const raw = `<thinking>
 Mode: WITNESS
 FeelHeardCheck:Y
@@ -388,7 +387,7 @@ Let's move into the next part.`;
       const result = parseMicroTagResponse(raw);
 
       expect(result.offerFeelHeardCheck).toBe(true);
-      expect(result.feelHeardConfirmed).toBe(true);
+      expect(result).not.toHaveProperty('feelHeardConfirmed');
     });
 
     it('trims whitespace from draft content', () => {

--- a/backend/src/utils/micro-tag-parser.ts
+++ b/backend/src/utils/micro-tag-parser.ts
@@ -44,8 +44,6 @@ export interface ParsedMicroTagResponse {
   dispatchTag: string | null;
   /** Extracted from thinking: FeelHeardCheck:Y */
   offerFeelHeardCheck: boolean;
-  /** Extracted from thinking: FeelHeardConfirmed:Y */
-  feelHeardConfirmed: boolean;
   /** Extracted from thinking: ReadyShare:Y */
   offerReadyToShare: boolean;
   /** Extracted from thinking: ProposedStrategy lines (Stage 4) */
@@ -286,7 +284,6 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
 
   // 3. Extract flags from thinking string (no JSON needed!)
   const offerFeelHeardCheck = feelHeardControlTag ?? /FeelHeardCheck:\s*Y/i.test(thinking);
-  const feelHeardConfirmed = /FeelHeardConfirmed:\s*Y/i.test(thinking);
   const offerReadyToShare = readyShareControlTag ?? /ReadyShare:\s*Y/i.test(thinking);
 
   // 4. Extract proposed strategies from thinking (Stage 4)
@@ -325,7 +322,6 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
         topicFrame: empathy,
         dispatchTag: null,
         offerFeelHeardCheck,
-        feelHeardConfirmed,
         offerReadyToShare,
         proposedStrategies,
         stage4Proposals,
@@ -344,7 +340,6 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
     topicFrame: draft,
     dispatchTag,
     offerFeelHeardCheck,
-    feelHeardConfirmed,
     offerReadyToShare,
     proposedStrategies,
     stage4Proposals,


### PR DESCRIPTION
## Changes
- Remove: `FeelHeardConfirmed` flag from AI prompt — the AI no longer has the ability to auto-confirm the feel-heard gate
- Remove: `FeelHeardConfirmed` extraction from `micro-tag-parser.ts` — the flag is no longer parsed from AI responses
- Remove: `feelHeardConfirmed` field from `SessionStateToolInput` interface and its parsing logic
- Remove: LLM-based Stage 1 completion pathway in `messages.ts` — no more auto-advancing to Stage 2 from AI response metadata
- Keep: `offerFeelHeardCheck` (FeelHeardCheck:Y) — the AI can still signal when to show the button
- Keep: Button-tap pathway (`POST /sessions/:id/feel-heard`) — this is the only way to confirm feeling heard
- Update: Tests to verify the LLM does NOT auto-advance Stage 1

Related to #490

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** "I just tried the app and at the end of stage one the felt heard button popped up for a split second and then went away. Then the app moved onto stage two as if I had clicked heard"

## Docs updated
No doc changes needed — the button-tap pathway (`POST /sessions/:id/feel-heard`) and its gate names are unchanged. The `stage-1.md` doc describes the button-tap flow, which remains correct.