### PR TITLE
fix: reconciler detects Stage 2 position shifts via notableFacts

### DIFF
--- a/backend/src/services/reconciler/analysis.ts
+++ b/backend/src/services/reconciler/analysis.ts
@@ -14,6 +14,7 @@ import {
   buildReconcilerPrompt,
   type ReconcilerContext,
 } from '../stage-prompts';
+import type { CategorizedFact } from '../background-classifier';
 import { extractJsonFromResponse } from '../../utils/json-extractor';
 import type {
   ReconcilerResult,
@@ -58,6 +59,8 @@ export interface ReconcilerAnalysisInput {
   subject: UserInfo;
   empathyStatement: string;
   witnessingContent: WitnessingContent;
+  /** Current known facts from the subject's UserVessel (may include Stage 2 updates) */
+  subjectFacts?: CategorizedFact[];
 }
 
 // ============================================================================
@@ -195,6 +198,38 @@ async function extractThemes(content: string, sessionId: string, userId?: string
   });
 
   return result?.themes || [];
+}
+
+// ============================================================================
+// Helper: Load subject facts from UserVessel
+// ============================================================================
+
+/**
+ * Load notable facts for a user from their UserVessel.
+ * Used by runReconciler (two-direction flow).
+ */
+async function loadSubjectFactsForReconciler(
+  sessionId: string,
+  userId: string
+): Promise<CategorizedFact[] | undefined> {
+  const vessel = await prisma.userVessel.findUnique({
+    where: { userId_sessionId: { userId, sessionId } },
+    select: { notableFacts: true },
+  });
+
+  if (!vessel?.notableFacts || !Array.isArray(vessel.notableFacts)) {
+    return undefined;
+  }
+
+  const facts = (vessel.notableFacts as unknown[]).filter(
+    (f): f is CategorizedFact => {
+      if (typeof f !== 'object' || f === null) return false;
+      const obj = f as Record<string, unknown>;
+      return typeof obj.category === 'string' && typeof obj.fact === 'string';
+    }
+  );
+
+  return facts.length > 0 ? facts : undefined;
 }
 
 // ============================================================================
@@ -405,6 +440,7 @@ export async function analyzeEmpathyGap(
     empathyStatement: input.empathyStatement,
     witnessingContent: input.witnessingContent.userMessages,
     extractedThemes: input.witnessingContent.themes,
+    subjectFacts: input.subjectFacts,
   };
 
   const prompt = buildReconcilerPrompt(context);
@@ -553,10 +589,12 @@ export async function runReconciler(
     };
   }
 
-  // Get witnessing content for both users
-  const [userAWitnessing, userBWitnessing] = await Promise.all([
+  // Get witnessing content and notable facts for both users
+  const [userAWitnessing, userBWitnessing, userAFacts, userBFacts] = await Promise.all([
     getWitnessingContent(sessionId, participants.userA.id),
     getWitnessingContent(sessionId, participants.userB.id),
+    loadSubjectFactsForReconciler(sessionId, participants.userA.id),
+    loadSubjectFactsForReconciler(sessionId, participants.userB.id),
   ]);
 
   // Run analysis for each direction (or just one if forUserId is specified)
@@ -571,6 +609,7 @@ export async function runReconciler(
       subject: participants.userB,
       empathyStatement: userAEmpathy.statement,
       witnessingContent: userBWitnessing,
+      subjectFacts: userBFacts,
     });
   }
 
@@ -582,6 +621,7 @@ export async function runReconciler(
       subject: participants.userA,
       empathyStatement: userBEmpathy.statement,
       witnessingContent: userAWitnessing,
+      subjectFacts: userAFacts,
     });
   }
 

--- a/backend/src/services/reconciler/state.ts
+++ b/backend/src/services/reconciler/state.ts
@@ -38,6 +38,7 @@ import {
   getWitnessingContent,
   analyzeEmpathyGap,
 } from './analysis';
+import type { CategorizedFact } from '../background-classifier';
 import { checkAttempts, hasContextAlreadyBeenShared, markResultHandledAlreadyShared } from './circuit-breaker';
 import { generateShareSuggestion } from './sharing';
 
@@ -143,6 +144,39 @@ async function markEmpathyReady(
 }
 
 // ============================================================================
+// Helper: Load subject's notable facts from UserVessel
+// ============================================================================
+
+/**
+ * Load the subject's current notable facts from their UserVessel.
+ * These facts are updated by the background classifier throughout the conversation
+ * (including Stage 2), so they reflect position shifts like denial → confession.
+ */
+async function loadSubjectFacts(
+  sessionId: string,
+  subjectId: string
+): Promise<CategorizedFact[] | undefined> {
+  const vessel = await prisma.userVessel.findUnique({
+    where: { userId_sessionId: { userId: subjectId, sessionId } },
+    select: { notableFacts: true },
+  });
+
+  if (!vessel?.notableFacts || !Array.isArray(vessel.notableFacts)) {
+    return undefined;
+  }
+
+  const facts = (vessel.notableFacts as unknown[]).filter(
+    (f): f is CategorizedFact => {
+      if (typeof f !== 'object' || f === null) return false;
+      const obj = f as Record<string, unknown>;
+      return typeof obj.category === 'string' && typeof obj.fact === 'string';
+    }
+  );
+
+  return facts.length > 0 ? facts : undefined;
+}
+
+// ============================================================================
 // Main Function: runReconcilerForDirection
 // ============================================================================
 
@@ -226,13 +260,16 @@ export async function runReconcilerForDirection(
   }
   logger.debug('Found guesser empathy statement', { length: empathyData.statement.length });
 
-  // Get subject's witnessing content (Stage 1)
-  const witnessingContent = await getWitnessingContent(sessionId, subjectId);
+  // Get subject's witnessing content (Stage 1) and current notable facts in parallel
+  const [witnessingContent, subjectFacts] = await Promise.all([
+    getWitnessingContent(sessionId, subjectId),
+    loadSubjectFacts(sessionId, subjectId),
+  ]);
   if (!witnessingContent.userMessages) {
     logger.error('Subject has no Stage 1 content', { subjectId: subjectInfo.id, sessionId });
     throw new Error('Subject has no Stage 1 content');
   }
-  logger.debug('Found subject witnessing content', { themes: witnessingContent.themes.length, chars: witnessingContent.userMessages.length });
+  logger.debug('Found subject witnessing content', { themes: witnessingContent.themes.length, chars: witnessingContent.userMessages.length, factsCount: subjectFacts?.length ?? 0 });
 
   // Run the analysis
   const result = await analyzeEmpathyGap({
@@ -241,6 +278,7 @@ export async function runReconcilerForDirection(
     subject: subjectInfo,
     empathyStatement: empathyData.statement,
     witnessingContent,
+    subjectFacts,
   });
 
   // Determine outcome based on gaps

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -1916,6 +1916,8 @@ export interface ReconcilerContext {
   witnessingContent: string;
   /** Key themes extracted from subject's witnessing */
   extractedThemes?: string[];
+  /** Current known facts about the subject (may include Stage 2 updates that supersede Stage 1 positions) */
+  subjectFacts?: Array<{ category: string; fact: string }>;
 }
 
 /**
@@ -1925,6 +1927,12 @@ export interface ReconcilerContext {
 export function buildReconcilerPrompt(context: ReconcilerContext): string {
   const themesSection = context.extractedThemes?.length
     ? `Key themes/feelings ${context.subjectName} expressed:\n- ${context.extractedThemes.join('\n- ')}`
+    : '';
+
+  const factsSection = context.subjectFacts?.length
+    ? `\n[Current Known Facts about ${context.subjectName}]
+These facts reflect the most up-to-date understanding of ${context.subjectName}'s situation, including any evolution during the conversation (e.g., a denial in Stage 1 that became a confession in Stage 2). Where these facts conflict with the Stage 1 witnessing content above, the facts represent ${context.subjectName}'s CURRENT position.
+${context.subjectFacts.map(f => `- [${f.category}] ${f.fact}`).join('\n')}\n`
     : '';
 
   return `You are the Empathy Reconciler for Meet Without Fear. Your role is to analyze empathy gaps and determine if additional sharing would benefit mutual understanding.
@@ -1943,6 +1951,7 @@ This is what ${context.subjectName} ACTUALLY said about their own feelings durin
 "${context.witnessingContent}"
 
 ${themesSection}
+${factsSection}
 
 SIGNAL-TO-NOISE FILTERING:
 When analyzing the witnessing content, IGNORE:

--- a/docs/backend/prompting-architecture.md
+++ b/docs/backend/prompting-architecture.md
@@ -3,7 +3,7 @@ title: Backend Prompting Architecture Audit
 sidebar_position: 5
 description: "Last Updated: 2026-03-11"
 created: 2026-03-11
-updated: 2026-04-20
+updated: 2026-05-10
 status: living
 ---
 # Backend Prompting Architecture Audit
@@ -780,7 +780,7 @@ sequenceDiagram
 
     Controller->>Reconciler: runReconciler()
 
-    Reconciler->>Database: Get both users'<br/>witnessing content
+    Reconciler->>Database: Get both users'<br/>witnessing content + notableFacts
 
     Reconciler->>Sonnet: buildReconcilerPrompt()<br/>Analyze empathy gaps
     Sonnet-->>Reconciler: Analysis (JSON)

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -3,7 +3,7 @@ title: "Stage 2: Perspective Stretch - Empathy Exchange Flow"
 sidebar_position: 6
 description: This document describes the empathy exchange flow in Stage 2, including the reconciler system that analyzes empathy accuracy and manages the sharing of addit...
 created: 2026-03-11
-updated: 2026-05-02
+updated: 2026-05-10
 status: living
 ---
 # Stage 2: Perspective Stretch - Empathy Exchange Flow
@@ -92,7 +92,7 @@ The reconciler runs when one user confirms "feel heard" (completing Stage 1) and
 
 > **Implementation Note:** The reconciler has been refactored into a modular `backend/src/services/reconciler/` directory:
 > - `state.ts` — Empathy status transitions, reveal logic. Contains `runReconcilerForDirection()` (asymmetric) and `checkAndRevealBothIfReady()` (serializable transaction for mutual reveal).
-> - `analysis.ts` — Core AI gap analysis (`analyzeEmpathyGap()`), theme extraction, witnessing content retrieval.
+> - `analysis.ts` — Core AI gap analysis (`analyzeEmpathyGap()`), theme extraction, witnessing content retrieval. Also loads the subject's `notableFacts` from UserVessel as supplementary context — these facts are updated throughout the conversation (including Stage 2) and help the reconciler detect position shifts (e.g., denial → confession).
 > - `sharing.ts` — Share suggestion generation, refinement, and response handling.
 > - `circuit-breaker.ts` — Attempt counting to prevent infinite refinement loops (max 3 per direction).
 > - `index.ts` — Barrel re-exports.
@@ -117,7 +117,7 @@ flowchart TB
     B -->|No| C[No action needed]
     B -->|Yes| D[Run Reconciler Analysis]
 
-    D --> E{Analyze gaps in<br/>partner's empathy attempt}
+    D --> E{Analyze gaps using<br/>witnessing + notableFacts}
 
     E --> F{Gap Severity?}
 


### PR DESCRIPTION
## Changes
- Add: `subjectFacts` field to `ReconcilerAnalysisInput` and `ReconcilerContext` types
- Add: `loadSubjectFacts` helper in `state.ts` and `loadSubjectFactsForReconciler` in `analysis.ts` to load current `notableFacts` from UserVessel
- Add: "Current Known Facts" section to reconciler prompt — explicitly tells the AI that facts reflect the most up-to-date understanding and may supersede Stage 1 positions
- Fix: Both `runReconcilerForDirection()` (asymmetric) and `runReconciler()` (two-direction) now pass facts to `analyzeEmpathyGap()`

Related to #498

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** This is an interesting edge case. In the stage one I denied doing it but eventually in stage two I confessed. We should think about how to handle this.
- **Prompt(s) used:** Slack triage → feedback issue → general-pr

## Docs updated
- `docs/backend/reconciler-flow.md` — updated decision tree diagram label and analysis.ts description to mention notableFacts
- `docs/backend/prompting-architecture.md` — updated reconciler sequence diagram to show notableFacts retrieval