### PR TITLE
fix: include topicFrame in stage 1–4 prompt context

### DIFF
--- a/backend/src/controllers/sessions.ts
+++ b/backend/src/controllers/sessions.ts
@@ -982,6 +982,7 @@ export async function confirmInvitationMessage(req: Request, res: Response): Pro
       isInvitationPhase: false,
       isStageTransition: true,
       previousStage: 0,
+      topicFrame: session.topicFrameConfirmedAt ? session.topicFrame : undefined,
     };
 
     // Notify session that invitation was confirmed

--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -1200,6 +1200,25 @@ describe('Stage Prompts Service', () => {
     });
   });
 
+  describe('topicFrame in dynamic guidance', () => {
+    it('includes topicFrame in dynamic block for stages 1–4 when provided', () => {
+      for (const stage of [1, 2, 3, 4]) {
+        const blocks = buildStagePrompt(stage, createContext({ topicFrame: 'Mealtime poking' }));
+        expect(blocks.dynamicBlock).toContain('CONVERSATION TOPIC: "Mealtime poking"');
+      }
+    });
+
+    it('omits topicFrame from dynamic block when null', () => {
+      const blocks = buildStagePrompt(1, createContext({ topicFrame: null }));
+      expect(blocks.dynamicBlock).not.toContain('CONVERSATION TOPIC');
+    });
+
+    it('omits topicFrame from dynamic block when undefined', () => {
+      const blocks = buildStagePrompt(1, createContext());
+      expect(blocks.dynamicBlock).not.toContain('CONVERSATION TOPIC');
+    });
+  });
+
   describe('buildStagePrompt — Stage 1 witness cadence', () => {
     it('keeps the first high-resistance final open-floor check separate from the felt-heard gate', () => {
       const blocks = buildStagePrompt(1, createContext({ turnCount: 5 }));

--- a/backend/src/services/ai-orchestrator.ts
+++ b/backend/src/services/ai-orchestrator.ts
@@ -94,6 +94,8 @@ export interface OrchestratorContext {
   sharedContextFromPartner?: string | null;
   /** Whether the user is in onboarding mode (compact not yet signed) */
   isOnboarding?: boolean;
+  /** Confirmed topic of the conversation (only set when topicFrameConfirmedAt is non-null) */
+  topicFrame?: string | null;
 }
 
 export interface OrchestratorResult {
@@ -371,6 +373,7 @@ export async function orchestrateResponse(
       invalidMemoryRequest: undefined,
       sharedContentHistory,
       milestoneContext,
+      topicFrame: context.topicFrame,
     },
     {
       isInvitationPhase: context.isInvitationPhase,

--- a/backend/src/services/ai.ts
+++ b/backend/src/services/ai.ts
@@ -64,6 +64,8 @@ export interface FullAIContext extends WitnessContext {
   sharedContextFromPartner?: string | null;
   /** Whether the user is in onboarding mode (compact not yet signed) */
   isOnboarding?: boolean;
+  /** Confirmed topic of the conversation (only set when topicFrameConfirmedAt is non-null) */
+  topicFrame?: string | null;
   /**
    * Topic/area the subject should focus on when generating a share draft.
    * Set when user taps "Yes, help me share" in the ShareTopicDrawer.
@@ -137,6 +139,7 @@ export async function getOrchestratedResponse(
     isRefiningEmpathy: context.isRefiningEmpathy,
     sharedContextFromPartner: context.sharedContextFromPartner,
     isOnboarding: context.isOnboarding,
+    topicFrame: context.topicFrame,
   };
 
   return orchestrateResponse(orchestratorContext);

--- a/backend/src/services/chat-router/session-processor.ts
+++ b/backend/src/services/chat-router/session-processor.ts
@@ -251,6 +251,7 @@ export async function processSessionMessage(
     isInvitationPhase,
     isStageTransition,
     previousStage,
+    topicFrame: session.topicFrameConfirmedAt ? session.topicFrame : undefined,
   };
 
   if (isStageTransition) {

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -384,6 +384,10 @@ ${INVALID_MEMORY_GUIDANCE}`;
 function buildBaseDynamicGuidance(context: PromptContext): string {
   const parts: string[] = [];
 
+  if (context.topicFrame) {
+    parts.push(`CONVERSATION TOPIC: "${context.topicFrame}"`);
+  }
+
   const lastUserMessage = getLastUserMessage(context);
   if (lastUserMessage && isProcessQuestion(lastUserMessage)) {
     parts.push(PROCESS_OVERVIEW);
@@ -473,6 +477,8 @@ export interface PromptContext {
    * this — it has its own in-app UI for re-sharing or abandoning invites.
    */
   invitedSessionNudge?: string | null;
+  /** The confirmed topic of this conversation (stages 1–4) */
+  topicFrame?: string | null;
 }
 
 /** Simplified context for initial message generation (no context bundle needed) */

--- a/docs/backend/prompting-architecture.md
+++ b/docs/backend/prompting-architecture.md
@@ -484,6 +484,7 @@ graph TD
    When `PromptContext.invitedSessionNudge` is set (non-null), its content is appended to the dynamic block as `OPERATIONAL NUDGE:`. This signals the AI to weave in an invite-expiry reminder. Only used for Slack-originated `INVITED` sessions approaching their 7-day TTL.
 
 5. **Dynamic Elements:**
+   - **Conversation topic** (`topicFrame`) — when the session has a confirmed topic (`topicFrameConfirmedAt` is set), the topic is injected at the top of the dynamic block as `CONVERSATION TOPIC: "{topicFrame}"`. This gives the AI awareness of the agreed-upon topic during stages 1–4.
    - **Stage turn count** (`stageTurnCount`) — counts only messages in the *current stage*, not the session total. This ensures stage-specific guards (e.g. `earlyStage3`, feel-heard timing) fire correctly regardless of how many turns occurred in prior stages.
    - Emotional intensity
    - Surfacing style


### PR DESCRIPTION
## Changes
- Fix: Thread `topicFrame` through the prompt pipeline so AI has awareness of the conversation topic during stages 1–4
- Add: `topicFrame` field to `PromptContext`, `OrchestratorContext`, and `FullAIContext` interfaces
- Add: Topic injection in `buildBaseDynamicGuidance` — appears as `CONVERSATION TOPIC: "{topicFrame}"` at the top of the dynamic block
- Guard: Only included when `topicFrameConfirmedAt` is set (prevents unconfirmed drafts leaking into prompts)
- Test: 3 new tests verifying topic presence/absence in dynamic block

Related to #496

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (<@U0AD3TF2U7L>)
- **Original message:** "I just realized that the topic of the conversation doesn't seem to be included in the context of the prompt for the stages. Can you confirm whether this is the case? The AI should definitely have the topic."
- **Prompt(s) used:** general-pr

## Docs updated
- `docs/backend/prompting-architecture.md` — added topicFrame to dynamic elements list