### PR TITLE
fix: restore web banner and harden auth recovery

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1986,41 +1986,15 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       }
 
       // Guard: empty AI response after parsing + dispatch means the model emitted
-      // content entirely inside tags we couldn't route (e.g. an unknown dispatch
-      // tag with no user-facing text). Try a contextual dispatch as EXPLAIN_PROCESS
-      // before falling back to a static message (issue #312 — static fallback was
-      // producing response loops).
+      // no usable user-facing text, or the upstream stream failed without
+      // producing text. Treat this as a failed turn so the frontend can show its
+      // retry/error state instead of saving a misleading canned response.
       if (!accumulatedText.trim()) {
-        logger.warn(`[sendMessageStream:${requestId}] Empty AI response after tag stripping — attempting contextual fallback`, {
+        logger.error(`[sendMessageStream:${requestId}] Empty AI response after tag stripping`, {
           dispatchTag: dispatchTag ?? null,
           scrubbedPlannerText: scrubbedResponse.scrubbed,
         });
-        // Try to generate a context-aware response via the process explainer
-        let fallback: string | null = null;
-        try {
-          const fallbackContext: DispatchContext = {
-            userMessage: content,
-            conversationHistory: history.map((m) => ({
-              role: m.role === 'USER' ? 'user' as const : 'assistant' as const,
-              content: m.content,
-            })),
-            userName,
-            partnerName,
-            sessionId,
-            turnId,
-            currentStage,
-            invitationSent: session.status !== 'CREATED',
-            partnerJoined: session.status === 'ACTIVE',
-          };
-          fallback = await handleDispatch('EXPLAIN_PROCESS', fallbackContext);
-        } catch (err) {
-          logger.error(`[sendMessageStream:${requestId}] Contextual fallback failed`, err);
-        }
-        if (!fallback) {
-          fallback = 'I hear you. Could you say a bit more about what\'s on your mind?';
-        }
-        sendSSE(res, { event: 'chunk', data: { text: fallback } });
-        accumulatedText = fallback;
+        throw new Error('AI response was empty after tag stripping');
       }
 
       finalizeTurnMetrics(turnId);

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -230,5 +230,14 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
+    ...Platform.select({
+      web: {
+        // Establish a positioning context so Expo Router's absolutely-positioned
+        // Stack screens anchor here instead of webFrame, keeping the
+        // NativeAppBanner visible above them.
+        position: 'relative' as const,
+      },
+      default: {},
+    }),
   },
 });

--- a/mobile/app/sso-callback.web.tsx
+++ b/mobile/app/sso-callback.web.tsx
@@ -15,7 +15,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet, TouchableOpacity } from 'react-native';
 import { useRouter } from 'expo-router';
-import { useClerk, useSignIn, useSignUp } from '@clerk/clerk-expo';
+import { useAuth as useClerkAuth, useClerk, useSignIn, useSignUp } from '@clerk/clerk-expo';
 
 import { colors } from '@/theme';
 
@@ -29,11 +29,41 @@ const CONTINUE_SIGN_UP_URL = 'https://accounts.meetwithoutfear.com/sign-up/conti
 
 export default function SsoCallbackScreen() {
   const clerk = useClerk();
+  const { isSignedIn } = useClerkAuth();
   const { signIn } = useSignIn();
   const { signUp } = useSignUp();
   const router = useRouter();
   const started = useRef(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingResult, setPendingResult] = useState<{
+    missing?: string;
+    status?: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    router.replace('/');
+  }, [isSignedIn, router]);
+
+  useEffect(() => {
+    if (!pendingResult || isSignedIn || error) return;
+
+    const timer = setTimeout(() => {
+      if (isSignedIn) return;
+
+      if (pendingResult.missing) {
+        setError(
+          `Sign-up couldn't complete: missing ${pendingResult.missing}. If this doesn't finish on its own, check your Clerk dashboard's required fields.`,
+        );
+      } else if (pendingResult.status) {
+        setError(`Sign-in ended in status "${pendingResult.status}" without a session.`);
+      } else {
+        setError('Sign-in didn\'t complete. Please try again.');
+      }
+    }, 2500);
+
+    return () => clearTimeout(timer);
+  }, [error, isSignedIn, pendingResult]);
 
   useEffect(() => {
     if (!clerk || started.current) return;
@@ -70,20 +100,15 @@ export default function SsoCallbackScreen() {
           return;
         }
 
-        // No session and no navigation — surface whatever Clerk knows.
+        // Clerk's Expo web wrapper may update `isSignedIn` one render after
+        // handleRedirectCallback returns. Avoid flashing a false failure while
+        // that state settles; a separate effect surfaces real errors if no
+        // session appears shortly after the callback completes.
         const missing =
           signUp?.missingFields?.join(', ') ||
           signUp?.unverifiedFields?.join(', ');
-        const status = signUp?.status || signIn?.status;
-        if (missing) {
-          setError(
-            `Sign-up couldn't complete: missing ${missing}. If this doesn't finish on its own, check your Clerk dashboard's required fields.`,
-          );
-        } else if (status) {
-          setError(`Sign-in ended in status "${status}" without a session.`);
-        } else {
-          setError('Sign-in didn\'t complete. Please try again.');
-        }
+        const status = signUp?.status || signIn?.status || undefined;
+        setPendingResult({ missing, status });
       } catch (err) {
         console.error('[sso-callback] handleRedirectCallback failed:', err);
         const message =

--- a/mobile/src/components/NativeAppBanner.tsx
+++ b/mobile/src/components/NativeAppBanner.tsx
@@ -1,7 +1,7 @@
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { Download, X } from 'lucide-react-native';
 
-import { colors, typography } from '../theme';
+import { typography, useAppAppearance } from '../theme';
 import { useNativeAppBannerDismissal } from '../hooks/useNativeAppBannerDismissal';
 
 const APP_SCHEME_URL = 'meetwithoutfear://';
@@ -49,31 +49,36 @@ function openNativeAppOrDownload(): void {
 
 export function NativeAppBanner() {
   const { dismissed, dismiss } = useNativeAppBannerDismissal();
+  const { palette } = useAppAppearance();
 
   if (Platform.OS !== 'web' || dismissed) return null;
 
   return (
-    <View style={styles.container}>
-      <Download size={18} color={colors.accent} />
-      <Text style={styles.label} numberOfLines={2}>
+    <View style={[styles.container, { backgroundColor: palette.bgElev, borderBottomColor: palette.border }]}>
+      <Download size={18} color={palette.accent} />
+      <Text style={[styles.label, { color: palette.text }]} numberOfLines={2}>
         Get the native app for a better experience
       </Text>
       <Pressable
         onPress={openNativeAppOrDownload}
-        style={({ pressed }) => [styles.openButton, pressed && styles.openButtonPressed]}
+        style={({ pressed }) => [
+          styles.openButton,
+          { backgroundColor: palette.accent },
+          pressed && { backgroundColor: palette.accentText },
+        ]}
         accessibilityRole="button"
         accessibilityLabel="Open in native app, or download it"
       >
-        <Text style={styles.openButtonLabel}>Open in app</Text>
+        <Text style={[styles.openButtonLabel, { color: palette.bg }]}>Open in app</Text>
       </Pressable>
       <Pressable
         onPress={dismiss}
-        style={({ pressed }) => [styles.dismiss, pressed && styles.dismissPressed]}
+        style={({ pressed }) => [styles.dismiss, pressed && { backgroundColor: palette.selected }]}
         accessibilityRole="button"
         accessibilityLabel="Dismiss banner"
         hitSlop={8}
       >
-        <X size={18} color={colors.textSecondary} />
+        <X size={18} color={palette.textMuted} />
       </Pressable>
     </View>
   );
@@ -86,35 +91,25 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 12,
     gap: 10,
-    backgroundColor: colors.bgSecondary,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.border,
+    zIndex: 1,
   },
   label: {
     flex: 1,
-    color: colors.textPrimary,
     fontSize: typography.fontSize.base,
     fontWeight: '500',
   },
   openButton: {
-    backgroundColor: colors.accent,
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 8,
   },
-  openButtonPressed: {
-    backgroundColor: colors.accentHover,
-  },
   openButtonLabel: {
-    color: colors.textOnAccent,
     fontSize: typography.fontSize.base,
     fontWeight: '600',
   },
   dismiss: {
     padding: 4,
     borderRadius: 6,
-  },
-  dismissPressed: {
-    backgroundColor: colors.bgTertiary,
   },
 });

--- a/mobile/src/providers/ClerkAuthFlow.tsx
+++ b/mobile/src/providers/ClerkAuthFlow.tsx
@@ -5,6 +5,8 @@
  */
 
 import { useEffect } from 'react';
+import { Platform } from 'react-native';
+import { usePathname, useRouter } from 'expo-router';
 import { ClerkProvider, ClerkLoaded, useAuth as useClerkAuth } from '@clerk/clerk-expo';
 import { tokenCache } from '@clerk/clerk-expo/token-cache';
 
@@ -12,6 +14,8 @@ import { AuthContext } from '../hooks/useAuthTypes';
 import { useAuthProviderClerk } from '../hooks/useAuthProviderClerk';
 import { QueryProvider } from './QueryProvider';
 import { setTokenProvider } from '../lib/api';
+
+export const WEB_AUTH_SESSION_MARKER_KEY = 'mwf.auth.hasLocalSession';
 
 interface ClerkAuthFlowProps {
   publishableKey: string;
@@ -31,6 +35,96 @@ function ClerkAuthSetup() {
       signOut,
     });
   }, [getToken, signOut]);
+
+  return null;
+}
+
+function readWebSessionMarker(): boolean {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return true;
+  try {
+    return window.localStorage.getItem(WEB_AUTH_SESSION_MARKER_KEY) === '1';
+  } catch {
+    return true;
+  }
+}
+
+function writeWebSessionMarker(): void {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(WEB_AUTH_SESSION_MARKER_KEY, '1');
+  } catch {
+    // If storage is unavailable, don't block auth. This guard is specifically
+    // for the normal browser storage-cleared case.
+  }
+}
+
+function clearWebSessionMarker(): void {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(WEB_AUTH_SESSION_MARKER_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+function hasExistingClerkAppStorage(): boolean {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return false;
+  try {
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (key?.startsWith('__clerk_') || key === '__client') {
+        return true;
+      }
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+/**
+ * On web, Clerk can recover a signed-in session from its own browser/client
+ * state after first-party app storage has been cleared. For this app, clearing
+ * site data should mean "this browser is no longer trusted for MWF", so require
+ * a first-party marker that is created only by our successful callback flow.
+ */
+function WebAuthPersistenceGuard() {
+  const { isLoaded, isSignedIn, signOut } = useClerkAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || !isLoaded) return;
+
+    if (!isSignedIn) {
+      clearWebSessionMarker();
+      return;
+    }
+
+    if (pathname === '/sso-callback') {
+      writeWebSessionMarker();
+      return;
+    }
+
+    if (readWebSessionMarker()) return;
+
+    // One-time migration for users who signed in before this marker existed.
+    // If app-origin Clerk storage is still present, this is an ordinary
+    // pre-existing session. If site data was cleared, these keys are gone and
+    // a recovered Clerk cookie/session should not be accepted silently.
+    if (hasExistingClerkAppStorage()) {
+      writeWebSessionMarker();
+      return;
+    }
+
+    signOut({ redirectUrl: undefined })
+      .catch((error) => {
+        console.warn('[Auth] Failed to clear recovered Clerk session:', error);
+      })
+      .finally(() => {
+        router.replace('/(public)');
+      });
+  }, [isLoaded, isSignedIn, pathname, router, signOut]);
 
   return null;
 }
@@ -57,6 +151,7 @@ export function ClerkAuthFlow({ publishableKey, children, onReady }: ClerkAuthFl
       <ClerkLoaded>
         {onReady && <OnReadyCallback onReady={onReady} />}
         <ClerkAuthSetup />
+        <WebAuthPersistenceGuard />
         <QueryProvider>
           <AuthProviderWrapper>
             {children}


### PR DESCRIPTION
## Changes
- Fix: restored the native-app download banner on web by anchoring Stack screens under `GestureHandlerRootView` and moving the banner to the dynamic appearance palette.
- Fix: prevented the OAuth callback from briefly showing a false "Sign-in failed" state while Clerk's web auth state settles.
- Fix: added a first-party web session marker so clearing app site data causes the app to reject a cookie-only recovered Clerk session and sign out instead.
- Fix: empty/stripped AI streaming responses now fail the turn and use the frontend retry/error state instead of saving a misleading canned process explanation.

## Root Cause
- Expo Router Stack screens were absolutely positioned relative to the web frame and covered the banner.
- `sso-callback.web.tsx` checked `clerk.session` immediately after `handleRedirectCallback()`, but Clerk Expo web can update `isSignedIn` one render later.
- Clerk web can recover a session from its own browser/client state even when first-party app storage has been cleared, so the app needed its own trust marker for site-data-cleared recovery.
- The streaming message controller previously converted empty model output into a generic process explanation fallback, which hid the real failure and created confusing chat history.

## Validation
- `npm run check` in `mobile`
- `npm run check --workspace=backend`

Related to #502

## Docs updated
No doc changes needed — web UI/auth behavior and backend streaming failure handling fixes.
