### PR TITLE
[codex] implement prompt-cached hybrid reconciler

### DIFF
--- a/backend/src/services/__tests__/reconciler.test.ts
+++ b/backend/src/services/__tests__/reconciler.test.ts
@@ -96,7 +96,8 @@ jest.mock('../../lib/request-context', () => ({
 
 // Mock stage-prompts
 jest.mock('../../services/stage-prompts', () => ({
-  buildReconcilerPrompt: jest.fn().mockReturnValue('Mock reconciler prompt'),
+  buildReconcilerPrompt: jest.fn().mockReturnValue({ staticBlock: 'Mock reconciler prompt', dynamicBlock: '' }),
+  buildReconcilerEvidencePacket: jest.fn().mockReturnValue('Mock reconciler evidence packet'),
   buildShareOfferPrompt: jest.fn().mockReturnValue('Mock share offer prompt'),
   buildReconcilerSummaryPrompt: jest.fn().mockReturnValue('Mock summary prompt'),
   buildStagePrompt: jest.fn().mockReturnValue('Mock stage prompt'),
@@ -119,6 +120,7 @@ jest.mock('../../services/stage-prompts', () => ({
 
 // Import after mocks
 import {
+  analyzeEmpathyGap,
   checkAttempts,
   incrementAttempts,
   hasContextAlreadyBeenShared,
@@ -126,11 +128,14 @@ import {
   generatePostShareContinuation,
   generateShareSuggestionForDirection,
   checkAndRevealBothIfReady,
+  loadRecentSubjectStage2Turns,
   runReconciler,
   respondToShareSuggestion,
   runReconcilerForDirection,
 } from '../reconciler';
 import { transition } from '../empathy-state-machine';
+import { getSonnetResponse } from '../../lib/bedrock';
+import { buildReconcilerEvidencePacket, buildReconcilerPrompt } from '../../services/stage-prompts';
 
 describe('Reconciler Service', () => {
   beforeEach(() => {
@@ -276,6 +281,98 @@ describe('Reconciler Service', () => {
           },
         },
       });
+    });
+  });
+
+  describe('Hybrid reconciler evidence loading', () => {
+    it('loads recent Stage 2 subject-owned turns with immediately preceding AI referent prompts', async () => {
+      (prisma.message.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'ai-1',
+          role: 'AI',
+          content: 'Did you actually do X?',
+          stage: 2,
+        },
+        {
+          id: 'user-1',
+          role: 'USER',
+          content: 'Yeah, I did.',
+          stage: 2,
+        },
+        {
+          id: 'ai-2',
+          role: 'AI',
+          content: 'What changed for you?',
+          stage: 2,
+        },
+        {
+          id: 'user-2',
+          role: 'USER',
+          content: 'I can see why that landed badly.',
+          stage: 2,
+        },
+      ]);
+
+      const turns = await loadRecentSubjectStage2Turns('session-1', 'subject-1');
+
+      expect(prisma.message.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: {
+          sessionId: 'session-1',
+          stage: 2,
+          OR: [
+            { senderId: 'subject-1', role: 'USER' },
+            { forUserId: 'subject-1', role: 'AI' },
+          ],
+        },
+      }));
+      expect(turns).toEqual([
+        { role: 'assistant', content: 'Did you actually do X?', stage: 2 },
+        { role: 'user', content: 'Yeah, I did.', stage: 2 },
+        { role: 'assistant', content: 'What changed for you?', stage: 2 },
+        { role: 'user', content: 'I can see why that landed badly.', stage: 2 },
+      ]);
+    });
+
+    it('passes PromptBlocks plus evidence packet to Sonnet, including facts and hot buffer in context', async () => {
+      (prisma.reconcilerResult.findFirst as jest.Mock).mockResolvedValue(null);
+      (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue({
+        notableFacts: [
+          { category: 'Conflict', fact: 'Subject now acknowledges doing X.' },
+        ],
+      });
+      (prisma.message.findMany as jest.Mock).mockResolvedValue([
+        { id: 'ai-1', role: 'AI', content: 'Did you do X?', stage: 2 },
+        { id: 'user-1', role: 'USER', content: 'Yeah, I did.', stage: 2 },
+      ]);
+
+      await analyzeEmpathyGap({
+        sessionId: 'session-1',
+        guesser: { id: 'guesser-1', name: 'Adam' },
+        subject: { id: 'subject-1', name: 'Eve' },
+        empathyStatement: 'I think you felt wrongly accused.',
+        witnessingContent: {
+          userMessages: 'I did not do X.',
+          themes: ['defensive'],
+        },
+      });
+
+      expect(buildReconcilerPrompt).toHaveBeenCalledWith(expect.objectContaining({
+        subjectFacts: [
+          { category: 'Conflict', fact: 'Subject now acknowledges doing X.' },
+        ],
+        recentSubjectTurns: [
+          { role: 'assistant', content: 'Did you do X?', stage: 2 },
+          { role: 'user', content: 'Yeah, I did.', stage: 2 },
+        ],
+      }));
+      expect(buildReconcilerEvidencePacket).toHaveBeenCalledWith(expect.objectContaining({
+        subjectFacts: expect.any(Array),
+        recentSubjectTurns: expect.any(Array),
+      }));
+      expect(getSonnetResponse).toHaveBeenCalledWith(expect.objectContaining({
+        systemPrompt: { staticBlock: 'Mock reconciler prompt', dynamicBlock: '' },
+        messages: [{ role: 'user', content: 'Mock reconciler evidence packet' }],
+      }));
     });
   });
 

--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -1,4 +1,4 @@
-import { buildStagePrompt, buildStagePromptString, buildInitialMessagePrompt, PromptContext, PromptBlocks, BuildStagePromptOptions, buildInnerWorkPrompt, InsightContext } from '../stage-prompts';
+import { buildStagePrompt, buildStagePromptString, buildInitialMessagePrompt, PromptContext, PromptBlocks, BuildStagePromptOptions, buildInnerWorkPrompt, InsightContext, buildReconcilerPrompt, buildReconcilerEvidencePacket } from '../stage-prompts';
 import type { ContextBundle } from '../context-assembler';
 import type { MemoryIntentResult } from '../memory-intent';
 
@@ -852,6 +852,51 @@ describe('Stage Prompts Service', () => {
       expect(prompt).toContain('HOW TO USE INSIGHTS');
       expect(prompt).toContain('Don\'t force insights');
       expect(prompt).toContain('EXAMPLES OF NATURAL INTEGRATION');
+    });
+  });
+
+  describe('buildReconcilerPrompt', () => {
+    const reconcilerContext = {
+      guesserName: 'Adam',
+      subjectName: 'Eve',
+      empathyStatement: 'I think you felt wrongly accused and scared.',
+      witnessingContent: 'I felt scared, but I also denied yelling at first.',
+      extractedThemes: ['scared', 'defensive'],
+      subjectFacts: [
+        { category: 'Conflict', fact: 'Eve later acknowledged yelling during the argument.' },
+      ],
+      recentSubjectTurns: [
+        { role: 'assistant' as const, content: 'Did you actually yell?', stage: 2 },
+        { role: 'user' as const, content: 'Yeah, I did.', stage: 2 },
+      ],
+    };
+
+    it('keeps reconciler instructions in a cacheable static block without per-session evidence', () => {
+      const result = buildReconcilerPrompt(reconcilerContext);
+
+      expect(result).toHaveProperty('staticBlock');
+      expect(result).toHaveProperty('dynamicBlock');
+      expect(result.staticBlock).toContain('TRUTH HIERARCHY');
+      expect(result.staticBlock).toContain('Stage 1 witnessing is the emotional anchor');
+      expect(result.staticBlock).toContain('Recent Stage 2 subject messages are the freshest signal');
+      expect(result.staticBlock).not.toContain('Adam');
+      expect(result.staticBlock).not.toContain('Eve');
+      expect(result.staticBlock).not.toContain('Yeah, I did.');
+      expect(result.staticBlock).not.toContain('Eve later acknowledged');
+    });
+
+    it('puts run-specific evidence in the evidence packet with the required sections', () => {
+      const packet = buildReconcilerEvidencePacket(reconcilerContext);
+
+      expect(packet).toContain('1. EMOTIONAL ANCHOR (Stage 1)');
+      expect(packet).toContain('2. FACTUAL BASELINE (Ledger)');
+      expect(packet).toContain('3. RECENT SIGNAL (Stage 2 Hot Buffer)');
+      expect(packet).toContain('If Section 3 contradicts Section 2 or Stage 1 factual claims');
+      expect(packet).toContain('Adam');
+      expect(packet).toContain('Eve');
+      expect(packet).toContain('[Conflict] Eve later acknowledged yelling during the argument.');
+      expect(packet).toContain('Stage 2 AI framing prompt: Did you actually yell?');
+      expect(packet).toContain('Stage 2 Eve subject-owned reply: Yeah, I did.');
     });
   });
 

--- a/backend/src/services/reconciler/analysis.ts
+++ b/backend/src/services/reconciler/analysis.ts
@@ -7,13 +7,15 @@
 
 import { prisma } from '../../lib/prisma';
 import { logger } from '../../lib/logger';
-import { MessageRole } from '@meet-without-fear/shared';
 import { getSonnetResponse, getHaikuJson, BrainActivityCallType } from '../../lib/bedrock';
 import { getCurrentUserId } from '../../lib/request-context';
 import {
+  buildReconcilerEvidencePacket,
   buildReconcilerPrompt,
   type ReconcilerContext,
+  type PromptBlocks,
 } from '../stage-prompts';
+import { type CategorizedFact } from '../partner-session-classifier';
 import { extractJsonFromResponse } from '../../utils/json-extractor';
 import type {
   ReconcilerResult,
@@ -68,7 +70,7 @@ export interface ReconcilerAnalysisInput {
  * Get a JSON response from Sonnet, parsing the result.
  */
 export async function getSonnetJson<T>(options: {
-  systemPrompt: string;
+  systemPrompt: string | PromptBlocks;
   messages: Array<{ role: 'user' | 'assistant'; content: string }>;
   maxTokens: number;
   sessionId?: string;
@@ -103,6 +105,97 @@ export async function getSonnetJson<T>(options: {
     logger.warn('Failed to parse AI JSON response', { operation: effectiveOperation, error: (error as Error).message, rawResponse: response });
     return null;
   }
+}
+
+function normalizeCategorizedFacts(rawFacts: unknown): CategorizedFact[] | undefined {
+  if (!Array.isArray(rawFacts)) {
+    return undefined;
+  }
+
+  const facts = rawFacts
+    .filter((fact): fact is { category: string; fact: string } => {
+      if (typeof fact !== 'object' || fact === null) return false;
+      const candidate = fact as Record<string, unknown>;
+      return typeof candidate.category === 'string' && typeof candidate.fact === 'string';
+    })
+    .map((fact) => ({
+      category: fact.category.trim(),
+      fact: fact.fact.trim(),
+    }))
+    .filter((fact) => fact.category.length > 0 && fact.fact.length > 0);
+
+  return facts.length > 0 ? facts : undefined;
+}
+
+async function loadSubjectFacts(
+  sessionId: string,
+  subjectId: string
+): Promise<CategorizedFact[] | undefined> {
+  const vessel = await prisma.userVessel.findUnique({
+    where: {
+      userId_sessionId: {
+        userId: subjectId,
+        sessionId,
+      },
+    },
+    select: { notableFacts: true },
+  });
+
+  return normalizeCategorizedFacts(vessel?.notableFacts);
+}
+
+export async function loadRecentSubjectStage2Turns(
+  sessionId: string,
+  subjectId: string,
+  maxSubjectUserTurns = 5
+): Promise<Array<{ role: 'user' | 'assistant'; content: string; stage: number }>> {
+  const messages = await prisma.message.findMany({
+    where: {
+      sessionId,
+      stage: 2,
+      OR: [
+        {
+          senderId: subjectId,
+          role: 'USER',
+        },
+        {
+          forUserId: subjectId,
+          role: 'AI',
+        },
+      ],
+    },
+    orderBy: { timestamp: 'asc' },
+    select: {
+      role: true,
+      content: true,
+      stage: true,
+    },
+  });
+
+  const subjectUserIndexes = messages
+    .map((message, index) => message.role === 'USER' ? index : -1)
+    .filter((index) => index >= 0)
+    .slice(-maxSubjectUserTurns);
+
+  const selectedIndexes = new Set<number>();
+  for (const userIndex of subjectUserIndexes) {
+    const previousMessage = messages[userIndex - 1];
+    if (previousMessage?.role === 'AI') {
+      selectedIndexes.add(userIndex - 1);
+    }
+    selectedIndexes.add(userIndex);
+  }
+
+  return Array.from(selectedIndexes)
+    .sort((a, b) => a - b)
+    .map((index) => {
+      const message = messages[index];
+      return {
+        role: message.role === 'AI' ? 'assistant' as const : 'user' as const,
+        content: message.content,
+        stage: message.stage,
+      };
+    });
 }
 
 // ============================================================================
@@ -397,6 +490,10 @@ export async function analyzeEmpathyGap(
 
   // Generate turnId upfront so COST and RECONCILER logs group together
   const turnId = `${input.sessionId}-${Date.now()}`;
+  const [subjectFacts, recentSubjectTurns] = await Promise.all([
+    loadSubjectFacts(input.sessionId, input.subject.id),
+    loadRecentSubjectStage2Turns(input.sessionId, input.subject.id),
+  ]);
 
   // Build context for the AI prompt
   const context: ReconcilerContext = {
@@ -405,15 +502,24 @@ export async function analyzeEmpathyGap(
     empathyStatement: input.empathyStatement,
     witnessingContent: input.witnessingContent.userMessages,
     extractedThemes: input.witnessingContent.themes,
+    subjectFacts,
+    recentSubjectTurns,
   };
 
   const prompt = buildReconcilerPrompt(context);
-  logger.debug('Built analysis prompt', { promptLength: prompt.length });
+  const evidencePacket = buildReconcilerEvidencePacket(context);
+  logger.debug('Built analysis prompt', {
+    staticPromptLength: prompt.staticBlock.length,
+    dynamicPromptLength: prompt.dynamicBlock.length,
+    evidencePacketLength: evidencePacket.length,
+    subjectFactCount: subjectFacts?.length ?? 0,
+    recentSubjectTurnCount: recentSubjectTurns.length,
+  });
 
   // Call AI to analyze the gap
   const result = await getSonnetJson<ReconcilerResult>({
     systemPrompt: prompt,
-    messages: [{ role: 'user', content: 'Analyze the empathy gap and provide your assessment.' }],
+    messages: [{ role: 'user', content: evidencePacket }],
     maxTokens: 2048,
     sessionId: input.sessionId,
     turnId,

--- a/backend/src/services/reconciler/index.ts
+++ b/backend/src/services/reconciler/index.ts
@@ -33,6 +33,8 @@ export {
 
 // Analysis
 export {
+  analyzeEmpathyGap,
+  loadRecentSubjectStage2Turns,
   runReconciler,
 } from './analysis';
 

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -14,6 +14,7 @@
 import { logger } from '../lib/logger';
 import { type ContextBundle } from './context-assembler';
 import { type SurfaceStyle } from './memory-intent';
+import { type CategorizedFact } from './partner-session-classifier';
 
 // ============================================================================
 // Response Protocol (Semantic Router Format)
@@ -1922,81 +1923,78 @@ export interface ReconcilerContext {
   witnessingContent: string;
   /** Key themes extracted from subject's witnessing */
   extractedThemes?: string[];
+  /** Current subject-owned fact ledger entries */
+  subjectFacts?: CategorizedFact[];
+  /** Recent subject-side Stage 2 context, scoped to subject user turns and framing AI prompts */
+  recentSubjectTurns?: Array<{ role: 'user' | 'assistant'; content: string; stage: number }>;
 }
 
 /**
  * Build the main reconciler prompt that analyzes empathy gaps.
  * This compares what one person guessed about the other vs what they actually expressed.
  */
-export function buildReconcilerPrompt(context: ReconcilerContext): string {
-  const themesSection = context.extractedThemes?.length
-    ? `Key themes/feelings ${context.subjectName} expressed:\n- ${context.extractedThemes.join('\n- ')}`
-    : '';
+export function buildReconcilerPrompt(_context: ReconcilerContext): PromptBlocks {
+  const staticBlock = `You are the Empathy Reconciler for Meet Without Fear. Your role is to analyze empathy gaps and determine if additional sharing would benefit mutual understanding.
 
-  return `You are the Empathy Reconciler for Meet Without Fear. Your role is to analyze empathy gaps and determine if additional sharing would benefit mutual understanding.
+TRUTH HIERARCHY:
+Stage 1 witnessing is the emotional anchor: preserve the feelings, needs, fears, and meaning the subject expressed there.
 
-CONTEXT:
-You are analyzing the empathy exchange between two people: ${context.guesserName} and ${context.subjectName}.
+Stage 1 is not always the current factual truth. If the subject later revises, retracts, clarifies, concedes, or confesses a factual point, treat the later subject-owned statement as their current factual position.
 
-WHAT YOU HAVE:
+Current known facts are the factual baseline. Recent Stage 2 subject messages are the freshest signal. If recent subject messages conflict with current known facts or Stage 1 factual claims, prioritize the recent subject messages.
 
-[${context.guesserName}'s Empathy Guess about ${context.subjectName}]
-This is what ${context.guesserName} THINKS ${context.subjectName} is feeling:
-"${context.empathyStatement}"
+Do not let an outdated Stage 1 factual denial drive the draft if the subject later acknowledged the behavior. Preserve the emotional truth without repeating the outdated factual framing.
 
-[What ${context.subjectName} Actually Expressed]
-This is what ${context.subjectName} ACTUALLY said about their own feelings during their witnessing session:
-"${context.witnessingContent}"
+Do not overstate partial doubt as full confession. If the subject says only "maybe things did not happen exactly how I remembered," treat that as uncertainty or softening, not as complete admission.
 
-${themesSection}
+Ignore AI suggestions, draft mechanics, process chatter, and empathy-exchange mechanics unless they directly frame or quote the subject's own words.
+
+SUBJECT-OWNED EVIDENCE RULES:
+- Treat the subject's own words and subject-owned fact ledger entries as evidence of the subject's current stance.
+- Never treat a partner's claim as evidence of the subject's current stance unless the subject also confirms it.
+- Use AI messages only as referent anchors for an immediately following subject reply; do not treat AI suggestions as facts.
+- Never suggest sharing sensitive information the subject did not already express.
+- The suggested share focus should reference subject-owned content that is already in the evidence packet.
+- Do not create new interpretations beyond what the evidence supports.
 
 SIGNAL-TO-NOISE FILTERING:
-When analyzing the witnessing content, IGNORE:
-- Statements directed at the AI itself (e.g., "you sound like a robot", "that doesn't help")
-- Frustration with the app or process (e.g., "this is taking too long", "I don't understand how this works")
-- Meta-commentary about the conversation (e.g., "I already said that", "you're repeating yourself")
-- Generic AI skepticism (e.g., "you can't really understand", "this is just a chatbot")
+Ignore:
+- Statements directed at the AI itself, such as complaints that the AI sounds robotic or unhelpful.
+- Frustration with the app or process.
+- Meta-commentary about the conversation.
+- Generic AI skepticism.
+- Draft mechanics, button/UI chatter, and empathy-exchange mechanics.
 
-ONLY ANALYZE content that reveals ${context.subjectName}'s actual feelings about ${context.guesserName} or their relationship situation. The gap analysis should focus on emotional content about the relationship, not process noise.
+Only analyze content that reveals the subject's actual feelings, needs, fears, meaning, or current factual stance about the partner or relationship situation.
 
 YOUR TASK:
-Compare ${context.guesserName}'s guess about ${context.subjectName} with what ${context.subjectName} actually expressed. Identify:
+Compare the guesser's empathy statement with the subject-owned evidence. Identify:
 
-1. ALIGNMENT: What did ${context.guesserName} get right?
-   - Which feelings or needs did they accurately perceive?
-   - What aspects of ${context.subjectName}'s experience did they understand?
-
-2. GAPS: What did ${context.guesserName} miss or misunderstand?
-   - Which important feelings were not captured?
-   - What needs or fears were overlooked?
-   - Were there any misattributions (thinking ${context.subjectName} felt X when they actually felt Y)?
-
+1. ALIGNMENT: What did the guesser get right?
+2. GAPS: What did the guesser miss or misunderstand?
 3. DEPTH ASSESSMENT: How complete is the understanding?
-   - Surface-level match but missing underlying emotions?
-   - Got the emotions but missed the context or trigger?
-   - Fundamental misunderstanding vs. just incomplete picture?
 
 ASSESSMENT CRITERIA:
 
 HIGH ALIGNMENT (no sharing needed):
-- ${context.guesserName} captured 80%+ of ${context.subjectName}'s core feelings
-- No significant misattributions
-- Underlying needs are understood
-- Minor gaps are not emotionally charged
+- The guesser captured 80%+ of the subject's core feelings.
+- No significant misattributions.
+- Underlying needs are understood.
+- Minor gaps are not emotionally charged.
 -> Recommendation: PROCEED (no additional sharing needed)
 
 MODERATE GAP (optional sharing):
-- ${context.guesserName} got the general direction right
-- Some important feelings are missing
-- No harmful misattributions
-- Sharing could deepen understanding but isn't critical
--> Recommendation: OFFER_OPTIONAL (ask ${context.subjectName} if they want to share more)
+- The guesser got the general direction right.
+- Some important feelings are missing.
+- No harmful misattributions.
+- Sharing could deepen understanding but is not critical.
+-> Recommendation: OFFER_OPTIONAL (ask the subject if they want to share more)
 
 SIGNIFICANT GAP (sharing recommended):
-- Key feelings or needs were missed
-- There's a misattribution that could cause harm if uncorrected
-- ${context.subjectName}'s core experience isn't reflected
-- Sharing specific information would meaningfully bridge the gap
+- Key feelings or needs were missed.
+- There is a misattribution that could cause harm if uncorrected.
+- The subject's core experience is not reflected.
+- Sharing specific subject-owned information would meaningfully bridge the gap.
 -> Recommendation: OFFER_SHARING (specific information would help)
 
 RESPOND IN THIS JSON FORMAT:
@@ -2005,32 +2003,80 @@ RESPOND IN THIS JSON FORMAT:
   "alignment": {
     "score": <number 0-100>,
     "summary": "<1-2 sentences describing what was understood correctly>",
-    "correctlyIdentified": ["<list of feelings/needs ${context.guesserName} got right>"]
+    "correctlyIdentified": ["<list of feelings/needs the guesser got right>"]
   },
   "gaps": {
     "severity": "none" | "minor" | "moderate" | "significant",
     "summary": "<1-2 sentences describing what was missed>",
     "missedFeelings": ["<list of feelings/needs that were missed>"],
     "misattributions": ["<list of any incorrect assumptions, or empty>"],
-    "mostImportantGap": "<the single most important thing ${context.guesserName} doesn't understand about ${context.subjectName}>" | null
+    "mostImportantGap": "<the single most important thing the guesser does not understand about the subject>" | null
   },
   "recommendation": {
     "action": "PROCEED" | "OFFER_OPTIONAL" | "OFFER_SHARING",
     "rationale": "<why this recommendation>",
     "sharingWouldHelp": true | false,
-    "suggestedShareFocus": "<if sharing would help, what specific aspect should ${context.subjectName} consider sharing?>" | null
+    "suggestedShareFocus": "<if sharing would help, what specific subject-owned aspect should the subject consider sharing?>" | null
   }
 }
 \`\`\`
 
 IMPORTANT PRINCIPLES:
-- Never suggest sharing sensitive information the person didn't already express
-- The suggested share focus should reference content ${context.subjectName} already shared in witnessing
-- Don't create new interpretations - only reference what was actually said
-- Phrase the suggested share focus as subject-owned context, not as what ${context.guesserName} thinks or has already understood
-- Do not frame the share focus as departure, rejection, or a permanent break unless ${context.subjectName} explicitly said that
-- Err on the side of OFFER_OPTIONAL rather than OFFER_SHARING - let people choose
-- If the gap is about context/history that wasn't shared, acknowledge that honestly`;
+- Phrase the suggested share focus as subject-owned context, not as what the guesser thinks or has already understood.
+- Do not frame the share focus as departure, rejection, or a permanent break unless the subject explicitly said that.
+- Err on the side of OFFER_OPTIONAL rather than OFFER_SHARING; let people choose.
+- If the gap is about context/history that was not shared, acknowledge that honestly.`;
+
+  return {
+    staticBlock,
+    dynamicBlock: 'Run-specific evidence is supplied in the user message.',
+  };
+}
+
+/**
+ * Build the per-run evidence packet for reconciler analysis.
+ * This remains outside the cached static system block.
+ */
+export function buildReconcilerEvidencePacket(context: ReconcilerContext): string {
+  const themesSection = context.extractedThemes?.length
+    ? `\nKey themes/feelings ${context.subjectName} expressed:\n- ${context.extractedThemes.join('\n- ')}`
+    : '\nKey themes/feelings: none extracted';
+
+  const factLines = context.subjectFacts?.length
+    ? context.subjectFacts.map((fact) => `- [${fact.category}] ${fact.fact}`).join('\n')
+    : '- No current ledger facts available.';
+
+  const recentSignal = context.recentSubjectTurns?.length
+    ? context.recentSubjectTurns
+        .map((turn) => {
+          const label = turn.role === 'assistant' ? 'AI framing prompt' : `${context.subjectName} subject-owned reply`;
+          return `- Stage ${turn.stage} ${label}: ${turn.content}`;
+        })
+        .join('\n')
+    : '- No recent Stage 2 subject-owned signal available.';
+
+  return `CONTEXT:
+You are analyzing the empathy exchange between two people: ${context.guesserName} and ${context.subjectName}.
+
+If Section 3 contradicts Section 2 or Stage 1 factual claims, Section 3 is the current factual signal. Preserve Stage 1 sentiment, but update factual framing.
+
+1. EMOTIONAL ANCHOR (Stage 1)
+
+[${context.guesserName}'s Empathy Guess about ${context.subjectName}]
+This is what ${context.guesserName} THINKS ${context.subjectName} is feeling:
+"${context.empathyStatement}"
+
+[What ${context.subjectName} Actually Expressed in Stage 1]
+This is what ${context.subjectName} ACTUALLY said about their own feelings during their witnessing session:
+"${context.witnessingContent}"
+
+${themesSection}
+
+2. FACTUAL BASELINE (Ledger)
+${factLines}
+
+3. RECENT SIGNAL (Stage 2 Hot Buffer)
+${recentSignal}`;
 }
 
 /**

--- a/docs/backend/prompting-architecture.md
+++ b/docs/backend/prompting-architecture.md
@@ -3,7 +3,7 @@ title: Backend Prompting Architecture Audit
 sidebar_position: 5
 description: "Last Updated: 2026-03-11"
 created: 2026-03-11
-updated: 2026-04-20
+updated: 2026-05-10
 status: living
 ---
 # Backend Prompting Architecture Audit
@@ -781,9 +781,9 @@ sequenceDiagram
 
     Controller->>Reconciler: runReconciler()
 
-    Reconciler->>Database: Get both users'<br/>witnessing content
+    Reconciler->>Database: Get both users'<br/>witnessing content,<br/>notableFacts, Stage 2 hot buffer
 
-    Reconciler->>Sonnet: buildReconcilerPrompt()<br/>Analyze empathy gaps
+    Reconciler->>Sonnet: buildReconcilerPrompt() PromptBlocks<br/>+ evidence packet<br/>Analyze empathy gaps
     Sonnet-->>Reconciler: Analysis (JSON)
 
     Reconciler->>Reconciler: Extract insights<br/>aUnderstandingB<br/>bUnderstandingA

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -3,7 +3,7 @@ title: "Stage 2: Perspective Stretch - Empathy Exchange Flow"
 sidebar_position: 6
 description: This document describes the empathy exchange flow in Stage 2, including the reconciler system that analyzes empathy accuracy and manages the sharing of addit...
 created: 2026-03-11
-updated: 2026-05-02
+updated: 2026-05-10
 status: living
 ---
 # Stage 2: Perspective Stretch - Empathy Exchange Flow
@@ -92,7 +92,7 @@ The reconciler runs when one user confirms "feel heard" (completing Stage 1) and
 
 > **Implementation Note:** The reconciler has been refactored into a modular `backend/src/services/reconciler/` directory:
 > - `state.ts` — Empathy status transitions, reveal logic. Contains `runReconcilerForDirection()` (asymmetric) and `checkAndRevealBothIfReady()` (serializable transaction for mutual reveal).
-> - `analysis.ts` — Core AI gap analysis (`analyzeEmpathyGap()`), theme extraction, witnessing content retrieval.
+> - `analysis.ts` — Core AI gap analysis (`analyzeEmpathyGap()`), theme extraction, witnessing content retrieval. It also loads the subject's `notableFacts` from UserVessel and a scoped Stage 2 subject hot buffer so later subject-owned shifts (for example, denial → confession) can update stale Stage 1 factual framing while preserving Stage 1 as the emotional anchor.
 > - `sharing.ts` — Share suggestion generation, refinement, and response handling.
 > - `circuit-breaker.ts` — Attempt counting to prevent infinite refinement loops (max 3 per direction).
 > - `index.ts` — Barrel re-exports.
@@ -117,7 +117,7 @@ flowchart TB
     B -->|No| C[No action needed]
     B -->|Yes| D[Run Reconciler Analysis]
 
-    D --> E{Analyze gaps in<br/>partner's empathy attempt}
+    D --> E{Analyze gaps using<br/>witnessing + notableFacts<br/>+ Stage 2 subject hot buffer}
 
     E --> F{Gap Severity?}
 


### PR DESCRIPTION
## Summary
- Splits the reconciler into cacheable static PromptBlocks plus a per-run evidence packet.
- Adds subject notable facts and a scoped Stage 2 subject hot buffer to reconciler evidence.
- Updates reconciler docs to reflect the consolidated notableFacts + hot-buffer design.
- Covers the prompt split, evidence packet structure, and subject-owned hot-buffer behavior with focused tests.

## Relationship to #499
This PR supersedes #499. It keeps the useful notableFacts behavior from #499, adds the scoped Stage 2 hot buffer for stale-ledger cases, and preserves prompt caching by keeping run-specific evidence out of the cacheable system block.

## Why
Stage 1 should remain the emotional anchor, but later subject-owned Stage 2 clarifications can supersede stale factual framing. This keeps prompt caching intact while giving the reconciler fresh subject-owned signal for denial-to-confession and stale-ledger cases.

## Validation
- npm --prefix backend test -- --runTestsByPath src/services/__tests__/stage-prompts.test.ts src/services/__tests__/reconciler.test.ts --runInBand
- npm --prefix backend run check
