### PR TITLE
fix: prevent partner name refilling after clear (#510)

### DIFF
--- a/mobile/app/(auth)/session/new.tsx
+++ b/mobile/app/(auth)/session/new.tsx
@@ -12,7 +12,7 @@
  * and pre-fills the partner name if available.
  */
 
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -60,6 +60,7 @@ export default function NewSessionScreen() {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [innerThoughtsContext, setInnerThoughtsContext] = useState<GenerateContextResponse | null>(null);
+  const hasPreFilledPartnerName = useRef(false);
   const [showNotificationDrawer, setShowNotificationDrawer] = useState(false);
   const [notificationLoading, setNotificationLoading] = useState(false);
   const [pendingSubmit, setPendingSubmit] = useState<(() => Promise<void>) | null>(null);
@@ -91,13 +92,14 @@ export default function NewSessionScreen() {
 
   // Pre-fill partner name from query params (from InnerThoughtsScreen navigation)
   useEffect(() => {
-    if (partnerName && !firstName) {
+    if (partnerName && !hasPreFilledPartnerName.current) {
+      hasPreFilledPartnerName.current = true;
       const nameParts = partnerName.split(' ');
       setFirstName(nameParts[0] || '');
       setLastName(nameParts.slice(1).join(' ') || '');
       setMode('new'); // Switch to new person mode since we have a name
     }
-  }, [partnerName, firstName]);
+  }, [partnerName]);
 
   // Determine if we have people to pick from
   const hasPeople = people.length > 0;


### PR DESCRIPTION
## Changes
- Fix: partner name input no longer snaps back after the user clears it
- Add a `useRef` guard (`hasPreFilledPartnerName`) so the pre-fill effect runs only once on mount
- Remove `firstName` from the effect's dependency array to prevent re-triggering

Related to #510

## Provenance
- **Channel:** DM (Shantam)
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** When I start a new partner session from the inner thoughts CTA, it pre fills the name in the input. That's good but when I delete the last character of the filled in name, it fills in the whole thing again. I should be able to delete the name and it should stay blank.

## Docs updated
No doc changes needed — single-line bug fix in a React effect dependency array.