### PR TITLE
fix: prevent squashed intensity slider after breathing exercise

### DIFF
--- a/mobile/src/components/IntensityCheck.tsx
+++ b/mobile/src/components/IntensityCheck.tsx
@@ -133,6 +133,7 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
   container: {
     ...appWidthStyle,
     flex: 1,
+    width: '100%',
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 24,


### PR DESCRIPTION
## Changes
- Fix: Add `width: '100%'` to IntensityCheck container style so the slider fills available width instead of being shrink-wrapped by parent `alignItems: 'center'`

Related to #514

## Root cause
IntensityCheck's container had no explicit width. In BreathingExercise, the parent `content` view uses `alignItems: 'center'`, which shrink-wraps children without explicit width to their content size. The sibling `exerciseContent` view avoided this with `width: '100%'`, but IntensityCheck didn't have it.

## Provenance
- **Channel:** #agentic-devs
- **Requested by:** Shantam
- **Original message:** "The slider here after doing the breathing has a max width I think because we were trying to fix that but then we put a global max width and now it seems like the slider is squashed."

## Docs updated
No doc changes needed — single-line CSS fix.