### PR TITLE
Fix empathy notification timing copy

### DIFF
--- a/backend/src/services/__tests__/push.test.ts
+++ b/backend/src/services/__tests__/push.test.ts
@@ -112,8 +112,8 @@ describe('Push Notification Service', () => {
         expect.objectContaining({
           to: validPushToken,
           sound: 'default',
-          title: 'Their empathy is ready',
-          body: 'Read what They understood about your experience.',
+          title: 'They shared empathy',
+          body: "We're checking it now and will show it when it is ready to read.",
           data: expect.objectContaining({
             screen: 'session',
             sessionId: testSessionId,
@@ -329,6 +329,43 @@ describe('Push Notification Service', () => {
       const result = await sendPushNotification(testUserId, 'session.resolved', {}, testSessionId);
 
       expect(result).toBe(true);
+    });
+
+    it('uses readable-empathy copy only for the reveal event', async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        pushToken: validPushToken,
+      });
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+        relationship: {
+          members: [
+            {
+              userId: testUserId,
+              nickname: null,
+              user: { firstName: 'Jason', name: 'Jason Person' },
+            },
+            {
+              userId: 'actor-123',
+              nickname: null,
+              user: { firstName: 'Darryl', name: 'Darryl Person' },
+            },
+          ],
+        },
+      });
+      mockSendPushNotificationsAsync.mockResolvedValue([{ status: 'ok' }]);
+
+      await sendPushNotification(
+        testUserId,
+        'empathy.revealed',
+        { triggeredByUserId: 'actor-123' },
+        testSessionId,
+      );
+
+      expect(mockSendPushNotificationsAsync).toHaveBeenCalledWith([
+        expect.objectContaining({
+          title: 'Empathy exchange is ready',
+          body: 'You can now read what Darryl understood about your experience.',
+        }),
+      ]);
     });
 
     it('returns false on send error', async () => {

--- a/backend/src/services/push.ts
+++ b/backend/src/services/push.ts
@@ -67,8 +67,8 @@ export const PUSH_MESSAGES: Record<SessionEvent, PushMessageTemplate> = {
     body: '{actor} is ready for the next step with you.',
   },
   'partner.empathy_shared': {
-    title: '{actorPossessive} empathy is ready',
-    body: 'Read what {actor} understood about your experience.',
+    title: '{actor} shared empathy',
+    body: "We're checking it now and will show it when it is ready to read.",
   },
   'partner.additional_context_shared': {
     title: 'More context shared',
@@ -160,8 +160,8 @@ export const PUSH_MESSAGES: Record<SessionEvent, PushMessageTemplate> = {
     body: 'Use the new context to refine your empathy when you are ready.',
   },
   'empathy.revealed': {
-    title: 'Your empathy is revealed',
-    body: 'Your empathy statement has been shared with {actor}.',
+    title: 'Empathy exchange is ready',
+    body: 'You can now read what {actor} understood about your experience.',
   },
   'empathy.refining': {
     title: 'New context to consider',


### PR DESCRIPTION
## Summary
- Change the empathy-submitted push notification so it no longer says the recipient can read the empathy before the reconciler finishes.
- Move the readable-empathy promise to the actual empathy reveal notification.
- Add a focused push notification test for the reveal copy.

## Root cause
`partner.empathy_shared` fires when a partner submits their empathy attempt, but that attempt may still be held behind reconciler analysis or a share-suggestion flow. The old push copy promised readable content too early.

## Validation
- `npm --workspace backend test -- src/services/__tests__/push.test.ts --runInBand`
- `npm --workspace backend run check` was attempted locally but blocked because the current dependency install cannot resolve `@clerk/express`.
