### PR TITLE
[codex] Add inner thoughts partner branch flow

### DIFF
--- a/backend/prisma/migrations/20260510000000_add_inner_thoughts_branch_metadata/migration.sql
+++ b/backend/prisma/migrations/20260510000000_add_inner_thoughts_branch_metadata/migration.sql
@@ -1,0 +1,11 @@
+-- Add point-in-time metadata for Inner Thoughts sessions that branch into partner sessions.
+ALTER TABLE "InnerWorkSession"
+ADD COLUMN "linkedAtMessageId" TEXT,
+ADD COLUMN "contextSummarySnapshot" TEXT;
+
+CREATE INDEX "InnerWorkSession_linkedAtMessageId_idx" ON "InnerWorkSession"("linkedAtMessageId");
+
+ALTER TABLE "InnerWorkSession"
+ADD CONSTRAINT "InnerWorkSession_linkedAtMessageId_fkey"
+FOREIGN KEY ("linkedAtMessageId") REFERENCES "InnerWorkMessage"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -211,12 +211,16 @@ model InnerWorkSession {
   // When set, AI has access to partner session context and can reference it
   linkedPartnerSession   Session? @relation("LinkedInnerThoughts", fields: [linkedPartnerSessionId], references: [id], onDelete: SetNull)
   linkedPartnerSessionId String?
+  linkedAtMessage        InnerWorkMessage? @relation("InnerWorkBranchPoint", fields: [linkedAtMessageId], references: [id], onDelete: SetNull)
+  linkedAtMessageId      String?
   linkedAtStage          Int? // Stage when Inner Thoughts was opened (1, 2, 3, 4)
   linkedTrigger          String? // Why it was opened: "empathy_wait", "voluntary", "witness_wait"
+  contextSummarySnapshot String? @db.Text // Point-in-time context passed when a partner session was started
 
   @@index([userId, updatedAt])
   @@index([status])
   @@index([linkedPartnerSessionId])
+  @@index([linkedAtMessageId])
 }
 
 enum InnerWorkStatus {
@@ -248,6 +252,7 @@ model InnerWorkMessage {
   role      MessageRole
   content   String           @db.Text
   timestamp DateTime         @default(now())
+  branchForSessions InnerWorkSession[] @relation("InnerWorkBranchPoint")
 
   // NOTE: Message-level embedding removed per fact-ledger architecture
   // Session-level contentEmbedding on InnerWorkSession is used instead

--- a/backend/src/controllers/inner-work.ts
+++ b/backend/src/controllers/inner-work.ts
@@ -74,6 +74,8 @@ function mapSessionToSummary(
     updatedAt: Date;
     distilledAt?: Date | null;
     linkedPartnerSessionId?: string | null;
+    linkedAtMessageId?: string | null;
+    contextSummarySnapshot?: string | null;
     _count?: { messages: number };
   }
 ): InnerWorkSessionSummaryDTO {
@@ -88,6 +90,8 @@ function mapSessionToSummary(
     distilledAt: session.distilledAt?.toISOString() ?? null,
     messageCount: session._count?.messages ?? 0,
     linkedPartnerSessionId: session.linkedPartnerSessionId ?? null,
+    linkedAtMessageId: session.linkedAtMessageId ?? null,
+    contextSummarySnapshot: session.contextSummarySnapshot ?? null,
   };
 }
 

--- a/backend/src/controllers/invitations.ts
+++ b/backend/src/controllers/invitations.ts
@@ -32,6 +32,7 @@ const createSessionSchema = z.object({
   inviteName: z.string().min(1).optional(),
   context: z.string().optional(),
   innerThoughtsId: z.string().optional(),
+  linkedAtMessageId: z.string().optional(),
 }).refine(
   (data) => data.personId || data.inviteName,
   { message: 'Must provide personId or inviteName' }
@@ -313,7 +314,7 @@ export async function createSession(req: Request, res: Response): Promise<void> 
       return;
     }
 
-    const { personId, inviteName, innerThoughtsId } = parseResult.data;
+    const { personId, inviteName, innerThoughtsId, linkedAtMessageId, context } = parseResult.data;
 
     // Create or find relationship
     let relationship;
@@ -431,11 +432,26 @@ export async function createSession(req: Request, res: Response): Promise<void> 
     // If originated from Inner Thoughts, link it back (non-critical, outside transaction)
     if (innerThoughtsId) {
       try {
+        const validLinkedAtMessage = linkedAtMessageId
+          ? await prisma.innerWorkMessage.findFirst({
+              where: {
+                id: linkedAtMessageId,
+                sessionId: innerThoughtsId,
+              },
+              select: { id: true },
+            })
+          : null;
+
         await prisma.innerWorkSession.updateMany({
-          where: { id: innerThoughtsId, userId: user.id },
+          where: {
+            id: innerThoughtsId,
+            userId: user.id,
+          },
           data: {
             linkedPartnerSessionId: session.id,
             linkedTrigger: 'suggestion_start',
+            ...(validLinkedAtMessage ? { linkedAtMessageId: validLinkedAtMessage.id } : {}),
+            ...(context ? { contextSummarySnapshot: context } : {}),
           },
         });
         logger.info(`[createSession] Linked session ${session.id} to origin inner thoughts ${innerThoughtsId}`);

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1142,17 +1142,53 @@ export async function getInitialMessage(
       responseContent = getFallbackInitialMessage(userName, partnerName, isInvitationPhase, isInvitee);
     }
 
-    // Save the AI message (trim whitespace that Claude sometimes adds)
-    const aiMessage = await prisma.message.create({
-      data: {
-        sessionId,
-        senderId: null,
-        forUserId: user.id, // Track which user this AI response is for (data isolation)
-        role: 'AI',
-        content: responseContent.trim(),
-        stage: currentStage,
-      },
-    });
+    // Save the AI message (trim whitespace that Claude sometimes adds).
+    // This endpoint can be called twice during the Ready/compact transition;
+    // make the final write idempotent so concurrent calls do not create twins.
+    let aiMessage;
+    try {
+      aiMessage = await prisma.$transaction(async (tx) => {
+        const existing = await tx.message.findFirst({
+          where: {
+            sessionId,
+            forUserId: user.id,
+          },
+          orderBy: { timestamp: 'asc' },
+        });
+
+        if (existing) {
+          return existing;
+        }
+
+        return tx.message.create({
+          data: {
+            sessionId,
+            senderId: null,
+            forUserId: user.id, // Track which user this AI response is for (data isolation)
+            role: 'AI',
+            content: responseContent.trim(),
+            stage: currentStage,
+          },
+        });
+      }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034') {
+        const existing = await prisma.message.findFirst({
+          where: {
+            sessionId,
+            forUserId: user.id,
+          },
+          orderBy: { timestamp: 'asc' },
+        });
+        if (existing) {
+          aiMessage = existing;
+        } else {
+          throw error;
+        }
+      } else {
+        throw error;
+      }
+    }
 
     // Embed session content for cross-session retrieval (non-blocking)
     // Per fact-ledger architecture, we embed at session level

--- a/backend/src/controllers/session-state.ts
+++ b/backend/src/controllers/session-state.ts
@@ -172,6 +172,22 @@ export async function getSessionState(req: Request, res: Response): Promise<void
             orderBy: { createdAt: 'desc' },
             take: 1,
           },
+          linkedInnerThoughts: {
+            where: {
+              userId: user.id,
+              linkedTrigger: 'suggestion_start',
+              status: { not: 'ARCHIVED' },
+            },
+            orderBy: { updatedAt: 'desc' },
+            take: 1,
+            select: {
+              id: true,
+              title: true,
+              summary: true,
+              theme: true,
+              contextSummarySnapshot: true,
+            },
+          },
         },
       }),
 
@@ -221,6 +237,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
     }
 
     const session = sessionWithRelations;
+    const sourceInnerThoughts = session.linkedInnerThoughts[0] ?? null;
     const partnerId = await getPartnerUserId(sessionId, user.id);
 
     // Get my membership (for nickname I use for partner)
@@ -421,6 +438,15 @@ export async function getSessionState(req: Request, res: Response): Promise<void
         partnerLastViewedAt: partnerShowsActivity ? partnerVessel?.lastViewedAt?.toISOString() ?? null : null,
         partnerLastActiveAt: partnerLastActiveAt?.toISOString() ?? null,
         lastSeenChatItemId: userVessel?.lastSeenChatItemId ?? null,
+        sourceInnerThoughts: sourceInnerThoughts
+          ? {
+              id: sourceInnerThoughts.id,
+              title: sourceInnerThoughts.title,
+              summary: sourceInnerThoughts.summary,
+              theme: sourceInnerThoughts.theme,
+              contextSummarySnapshot: sourceInnerThoughts.contextSummarySnapshot,
+            }
+          : null,
       },
 
       // Stage progress

--- a/mobile/app/(auth)/(tabs)/__tests__/index.test.tsx
+++ b/mobile/app/(auth)/(tabs)/__tests__/index.test.tsx
@@ -274,7 +274,7 @@ describe('HomeScreen', () => {
     expect(screen.getByText('What would you like to work through?')).toBeTruthy();
   });
 
-  it('shows New Conversation and Inner Work entry points', () => {
+  it('shows New Conversation and Inner Thoughts entry points', () => {
     mockUseSessions.mockReturnValue({
       data: { items: [], hasMore: false },
       isLoading: false,
@@ -283,7 +283,7 @@ describe('HomeScreen', () => {
     renderWithProviders(<HomeScreen />);
 
     expect(screen.getByText('New conversation')).toBeTruthy();
-    expect(screen.getByText('Inner work')).toBeTruthy();
+    expect(screen.getByText('Inner thoughts')).toBeTruthy();
   });
 
   it('shows Continue button when there is a recent session with partner nickname', () => {

--- a/mobile/app/(auth)/(tabs)/index.tsx
+++ b/mobile/app/(auth)/(tabs)/index.tsx
@@ -4,11 +4,10 @@
  * Simplified landing page with:
  * - Big greeting: "Hi [username]"
  * - Main question: "What can I help you work through today?"
- * - Low-profile quick actions: Continue with [nickname], New Session, Inner Work
+ * - Low-profile quick actions: Continue with [nickname], New Session, Inner Thoughts
  * - Pending invitation CTA: "Accept [name]'s invitation" (if invited)
  *
- * Inner Work navigates to the hub for all inner work features:
- * - Self-Reflection, Needs Assessment, Gratitude, Meditation
+ * Inner Thoughts navigates to the private reflection list.
  */
 
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react';
@@ -29,6 +28,7 @@ import {
 import { useRouter } from 'expo-router';
 import { ArrowRight, ArrowUp, Plus, Layers, UserPlus, Menu, Settings, X } from 'lucide-react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { SessionStatus, type SessionSummaryDTO } from '@meet-without-fear/shared';
 
 import { useAuth } from '@/src/hooks/useAuth';
 import { useBiometricAuth, usePendingInvitation, useSessionDrawer } from '@/src/hooks';
@@ -132,6 +132,10 @@ export default function HomeScreen() {
 
   // Get the partner's nickname or name for the continue button
   const partnerDisplayName = mostRecentSession?.partner?.nickname || mostRecentSession?.partner?.name;
+  const continueCopy = useMemo(() => {
+    if (!mostRecentSession || !partnerDisplayName) return null;
+    return getContinueSessionCopy(mostRecentSession, partnerDisplayName);
+  }, [mostRecentSession, partnerDisplayName]);
 
   // Handle sending a message from the home page chat input.
   const handleHomeChat = useCallback((message: string) => {
@@ -165,7 +169,7 @@ export default function HomeScreen() {
   };
 
   const handleInnerWork = () => {
-    // Navigate to Inner Work hub
+    // Navigate to the Inner Thoughts list.
     router.push('/inner-work');
   };
 
@@ -280,7 +284,7 @@ export default function HomeScreen() {
                   )}
 
                   {/* Continue with partner - only show if there's a recent session and no pending invitation */}
-                  {!hasPendingInvitation && mostRecentSession && partnerDisplayName && (
+                  {!hasPendingInvitation && mostRecentSession && partnerDisplayName && continueCopy && (
                     <TouchableOpacity
                       style={[styles.actionCard, styles.primaryActionCard]}
                       onPress={handleContinueSession}
@@ -292,48 +296,41 @@ export default function HomeScreen() {
                         <View style={styles.actionPing} />
                       </View>
                       <View style={styles.actionTextBlock}>
-                        <Text style={styles.actionEyebrow}>Continue</Text>
-                        <Text style={styles.actionTitle}>A note for {partnerDisplayName}</Text>
-                        <Text style={styles.actionSub}>Pick up where you left off</Text>
+                        <Text style={styles.actionEyebrow}>{continueCopy.eyebrow}</Text>
+                        <Text style={styles.actionTitle}>{continueCopy.title}</Text>
+                        <Text style={styles.actionSub}>{continueCopy.subtitle}</Text>
                       </View>
                       <ArrowRight color={palette.textFaint} size={16} />
                     </TouchableOpacity>
                   )}
 
-                  {/* New Session */}
-                  <TouchableOpacity
-                    style={styles.actionCard}
-                    onPress={handleNewSession}
-                    accessibilityRole="button"
-                    accessibilityLabel="Start new session"
-                  >
-                    <View style={styles.actionIcon}>
-                      <Plus color={palette.textMuted} size={18} />
-                    </View>
-                    <View style={styles.actionTextBlock}>
-                      <Text style={styles.actionTitle}>New conversation</Text>
-                      <Text style={styles.actionSub}>Start with someone close to you</Text>
-                    </View>
-                    <ArrowRight color={palette.textFaint} size={16} />
-                  </TouchableOpacity>
+                  <View style={styles.secondaryActionsGroup}>
+                    <View style={styles.secondaryActionsRule} />
+                    <View style={styles.secondaryActionsRow}>
+                      {/* New Session */}
+                      <TouchableOpacity
+                        style={styles.secondaryButton}
+                        onPress={handleNewSession}
+                        accessibilityRole="button"
+                        accessibilityLabel="Start new session"
+                      >
+                        <Plus color={palette.accentText} size={18} />
+                        <Text style={styles.secondaryButtonText}>New conversation</Text>
+                      </TouchableOpacity>
 
-                  {SHOW_INNER_WORK_BUTTON && (
-                    <TouchableOpacity
-                      style={styles.actionCard}
-                      onPress={handleInnerWork}
-                      accessibilityRole="button"
-                      accessibilityLabel="Inner Work"
-                    >
-                      <View style={styles.actionIcon}>
-                        <Layers color={palette.textMuted} size={18} />
-                      </View>
-                      <View style={styles.actionTextBlock}>
-                        <Text style={styles.actionTitle}>Inner work</Text>
-                        <Text style={styles.actionSub}>Sit with what came up, just for you</Text>
-                      </View>
-                      <ArrowRight color={palette.textFaint} size={16} />
-                    </TouchableOpacity>
-                  )}
+                      {SHOW_INNER_WORK_BUTTON && (
+                        <TouchableOpacity
+                          style={styles.secondaryButton}
+                          onPress={handleInnerWork}
+                          accessibilityRole="button"
+                          accessibilityLabel="Inner Thoughts"
+                        >
+                          <Layers color={palette.textMuted} size={17} />
+                          <Text style={styles.secondaryButtonText}>Inner thoughts</Text>
+                        </TouchableOpacity>
+                      )}
+                    </View>
+                  </View>
                 </View>
 
                 <View style={styles.whisper}>
@@ -390,6 +387,52 @@ function getGreetingLabel() {
   if (hour < 12) return 'Good morning';
   if (hour < 17) return 'Good afternoon';
   return 'Good evening';
+}
+
+function getContinueSessionCopy(session: SessionSummaryDTO, partnerName: string) {
+  const userStatus = session.statusSummary?.userStatus;
+  const partnerStatus = session.statusSummary?.partnerStatus;
+
+  switch (session.status) {
+    case SessionStatus.CREATED:
+      return {
+        eyebrow: 'Draft',
+        title: `Finish inviting ${partnerName}`,
+        subtitle: userStatus || 'Prepare the invitation when you are ready',
+      };
+    case SessionStatus.INVITED:
+      return {
+        eyebrow: 'Invitation sent',
+        title: `Waiting for ${partnerName}`,
+        subtitle: partnerStatus || `${partnerName} can join when ready`,
+      };
+    case SessionStatus.PAUSED:
+      return {
+        eyebrow: 'Paused',
+        title: `Return to ${partnerName}`,
+        subtitle: userStatus || 'Take your time and continue when ready',
+      };
+    case SessionStatus.RESOLVED:
+      return {
+        eyebrow: 'Resolved',
+        title: `Review session with ${partnerName}`,
+        subtitle: userStatus || 'Look back at what you worked through',
+      };
+    case SessionStatus.ABANDONED:
+      return {
+        eyebrow: 'Ended',
+        title: `View session with ${partnerName}`,
+        subtitle: partnerStatus || 'This conversation was not completed',
+      };
+    case SessionStatus.ACTIVE:
+    case SessionStatus.WAITING:
+    default:
+      return {
+        eyebrow: 'Continue',
+        title: `Continue with ${partnerName}`,
+        subtitle: userStatus || partnerStatus || 'Pick up where you left off',
+      };
+  }
 }
 
 function HomeComposer({
@@ -685,7 +728,7 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) =>
       fontFamily: designFonts.sans,
     },
     actionsSection: {
-      gap: 8,
+      gap: 6,
     },
     chatInputSection: {
       borderTopWidth: 1,
@@ -706,6 +749,37 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) =>
     primaryActionCard: {
       borderLeftWidth: 3,
       borderLeftColor: palette.accent,
+    },
+    secondaryActionsGroup: {
+      marginTop: 18,
+      marginBottom: 16,
+    },
+    secondaryActionsRule: {
+      height: 1,
+      marginBottom: 18,
+      backgroundColor: palette.divider,
+    },
+    secondaryActionsRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+    },
+    secondaryButton: {
+      flex: 1,
+      minHeight: 66,
+      borderRadius: 12,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 7,
+      backgroundColor: palette.bgElev,
+      borderWidth: 1,
+      borderColor: palette.border,
+    },
+    secondaryButtonText: {
+      color: palette.text,
+      fontSize: 13.5,
+      fontWeight: '600',
+      fontFamily: designFonts.sans,
     },
     actionIcon: {
       width: 38,
@@ -751,6 +825,15 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) =>
     },
     actionEyebrow: {
       color: palette.accentText,
+      fontSize: 9.5,
+      letterSpacing: 1,
+      textTransform: 'uppercase',
+      fontWeight: '700',
+      marginBottom: 4,
+      fontFamily: designFonts.mono,
+    },
+    privateActionEyebrow: {
+      color: palette.textFaint,
       fontSize: 9.5,
       letterSpacing: 1,
       textTransform: 'uppercase',

--- a/mobile/app/(auth)/inner-work/self-reflection/[id].tsx
+++ b/mobile/app/(auth)/inner-work/self-reflection/[id].tsx
@@ -50,6 +50,7 @@ export default function SelfReflectionChatScreen() {
   const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
   // Store suggested actions from session creation (e.g., "Start conversation with Jason")
   const [initialSuggestedActions, setInitialSuggestedActions] = useState<SuggestedAction[] | undefined>(undefined);
+  const [initialSuggestedActionMessageId, setInitialSuggestedActionMessageId] = useState<string | undefined>(undefined);
   // Track when the fade transition has completed (only for new sessions)
   const [transitionComplete, setTransitionComplete] = useState(!isNewSession || hasInitialMessage);
   const createSession = useCreateInnerThoughtsSession();
@@ -92,6 +93,7 @@ export default function SelfReflectionChatScreen() {
             // Capture suggested actions from the AI response (e.g., "Start conversation with Jason")
             if (result.suggestedActions && result.suggestedActions.length > 0) {
               setInitialSuggestedActions(result.suggestedActions);
+              setInitialSuggestedActionMessageId(result.initialMessage.id);
             }
 
             // Update state instead of router.replace() to avoid component remount
@@ -135,6 +137,7 @@ export default function SelfReflectionChatScreen() {
         isCreating={isCreating}
         initialMessage={initialMessage}
         initialSuggestedActions={initialSuggestedActions}
+        initialSuggestedActionMessageId={initialSuggestedActionMessageId}
         hideContentUntilReady={!isComingSoon && !transitionComplete}
         comingSoonMode={isComingSoon}
       />

--- a/mobile/app/(auth)/session/[id]/index.tsx
+++ b/mobile/app/(auth)/session/[id]/index.tsx
@@ -10,14 +10,20 @@ import { Stage } from '@meet-without-fear/shared';
  * Uses AI and Partner tabs to separate private coaching from shared content.
  */
 export default function SessionScreen() {
-  const { id, tendingEntryId, auditFixture } = useLocalSearchParams<{
+  const { id, tendingEntryId, auditFixture, fromInnerThoughtsCreate } = useLocalSearchParams<{
     id: string;
     tendingEntryId?: string;
     auditFixture?: string;
+    fromInnerThoughtsCreate?: string;
   }>();
   const router = useRouter();
 
   const handleNavigateBack = () => {
+    if (fromInnerThoughtsCreate === '1') {
+      router.replace('/(auth)/(tabs)');
+      return;
+    }
+
     if (router.canGoBack()) {
       router.back();
       return;

--- a/mobile/app/(auth)/session/new.tsx
+++ b/mobile/app/(auth)/session/new.tsx
@@ -49,9 +49,10 @@ export default function NewSessionScreen() {
   const router = useRouter();
   const { palette } = useAppAppearance();
   const styles = useStyles();
-  const { partnerName, innerThoughtsId } = useLocalSearchParams<{
+  const { partnerName, innerThoughtsId, linkedAtMessageId } = useLocalSearchParams<{
     partnerName?: string;
     innerThoughtsId?: string;
+    linkedAtMessageId?: string;
   }>();
 
   const [mode, setMode] = useState<'pick' | 'new'>('pick');
@@ -121,6 +122,7 @@ export default function NewSessionScreen() {
           personId: selectedPerson.id,
           ...(context && { context }),
           ...(linkedInnerThoughtsId && { innerThoughtsId: linkedInnerThoughtsId }),
+          ...(linkedAtMessageId && { linkedAtMessageId }),
         });
         // Handle existing active session response
         if ('existingActiveSession' in response && !bypassDuplicateCheck) {
@@ -147,7 +149,11 @@ export default function NewSessionScreen() {
         }
         // Track session creation
         trackSessionCreated(response.session.id, selectedPerson.id);
-        router.replace(`/session/${response.session.id}`);
+        router.replace(
+          linkedInnerThoughtsId
+            ? `/session/${response.session.id}?fromInnerThoughtsCreate=1`
+            : `/session/${response.session.id}`
+        );
       } catch (error) {
         console.error('Failed to create session:', error);
         Alert.alert('Error', 'Failed to create session. Please try again.');
@@ -167,12 +173,17 @@ export default function NewSessionScreen() {
           inviteName,
           ...(context && { context }),
           ...(linkedInnerThoughtsId && { innerThoughtsId: linkedInnerThoughtsId }),
+          ...(linkedAtMessageId && { linkedAtMessageId }),
         });
         // Track person selection (new person) and session creation
         // Note: personId not available in response, using relationshipId
         trackPersonSelected(response.session.relationshipId, true);
         trackSessionCreated(response.session.id, response.session.relationshipId);
-        router.replace(`/session/${response.session.id}`);
+        router.replace(
+          linkedInnerThoughtsId
+            ? `/session/${response.session.id}?fromInnerThoughtsCreate=1`
+            : `/session/${response.session.id}`
+        );
       } catch (error) {
         console.error('Failed to create session:', error);
         Alert.alert('Error', 'Failed to create session. Please try again.');

--- a/mobile/src/components/SessionDrawer/index.tsx
+++ b/mobile/src/components/SessionDrawer/index.tsx
@@ -307,7 +307,6 @@ function ConversationsList({ onClose }: { onClose: () => void }) {
     ({ section }: { section: SessionSection }) => (
       <View style={styles.sectionHeader}>
         <Text style={styles.sectionTitle}>{section.title}</Text>
-        <Text style={styles.sectionCount}>{section.data.length}</Text>
         <View style={styles.sectionRule} />
       </View>
     ),
@@ -636,13 +635,6 @@ const useStyles = () => {
       color: palette.textFaint,
       textTransform: 'uppercase',
       letterSpacing: 1,
-      fontFamily: designFonts.mono,
-    },
-    sectionCount: {
-      fontSize: 10.5,
-      fontWeight: '700',
-      color: palette.textFaint,
-      opacity: 0.75,
       fontFamily: designFonts.mono,
     },
     sectionRule: {

--- a/mobile/src/screens/InnerThoughtsScreen.tsx
+++ b/mobile/src/screens/InnerThoughtsScreen.tsx
@@ -10,10 +10,10 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { View, Text, TouchableOpacity, ActivityIndicator, Alert, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { Layers, MoreVertical, Lock, Sparkles } from 'lucide-react-native';
+import { ArrowUpRight, Layers, MoreVertical, Lock, Sparkles } from 'lucide-react-native';
 import { MessageRole, MemorySuggestion, SuggestedAction } from '@meet-without-fear/shared';
 
-import { ChatInterface, ChatMessage } from '../components/ChatInterface';
+import { ChatInterface, ChatCustomCardItem, ChatMessage } from '../components/ChatInterface';
 import { MemorySuggestionCard } from '../components/MemorySuggestionCard';
 import { SuggestedActionButtons } from '../components/SuggestedActionButtons';
 import { TakeawayReviewSheet } from '../components/TakeawayReviewSheet';
@@ -41,6 +41,8 @@ interface InnerThoughtsScreenProps {
   initialMessage?: string;
   /** Initial suggested actions from session creation (when user sent first message) */
   initialSuggestedActions?: SuggestedAction[];
+  /** AI message that produced the initial suggested actions */
+  initialSuggestedActionMessageId?: string;
   /** Hide chat content until transition completes (for fade-in effect) */
   hideContentUntilReady?: boolean;
   /** Narrow URL-controlled fixture for visual audit surfaces. */
@@ -63,6 +65,7 @@ export function InnerThoughtsScreen({
   isCreating = false,
   initialMessage,
   initialSuggestedActions,
+  initialSuggestedActionMessageId,
   hideContentUntilReady = false,
   auditFixture = null,
   comingSoonMode = false,
@@ -84,14 +87,18 @@ export function InnerThoughtsScreen({
   const [suggestedActions, setSuggestedActions] = useState<SuggestedAction[]>(
     initialSuggestedActions || []
   );
+  const [suggestedActionMessageId, setSuggestedActionMessageId] = useState<string | undefined>(
+    initialSuggestedActionMessageId
+  );
 
   // Update suggested actions when they arrive from session creation
   // (useState default only applies on initial mount, so we need this effect)
   useEffect(() => {
     if (initialSuggestedActions && initialSuggestedActions.length > 0) {
       setSuggestedActions(initialSuggestedActions);
+      setSuggestedActionMessageId(initialSuggestedActionMessageId);
     }
-  }, [initialSuggestedActions]);
+  }, [initialSuggestedActions, initialSuggestedActionMessageId]);
 
   // Only fetch session if we have a valid sessionId (not creating)
   const { data, isLoading, error } = useInnerThoughtsSession(
@@ -148,6 +155,51 @@ export function InnerThoughtsScreen({
     }));
   }, [session?.messages, sessionId, isCreating, initialMessage, comingSoonMode]);
 
+  const linkedAtMessage = useMemo(
+    () => messages.find((message) => message.id === session?.linkedAtMessageId),
+    [messages, session?.linkedAtMessageId]
+  );
+
+  const branchPointCards: ChatCustomCardItem[] = useMemo(() => {
+    if (!session?.linkedPartnerSessionId || !linkedAtMessage) {
+      return [];
+    }
+
+    const partnerLabel = linkedPartnerName || 'partner session';
+
+    return [{
+      id: `inner-thoughts-branch-${session.linkedPartnerSessionId}`,
+      type: 'custom-card',
+      timestamp: linkedAtMessage.timestamp,
+      animate: false,
+      render: () => (
+        <TouchableOpacity
+          style={[styles.branchMarker, { borderColor: palette.border, backgroundColor: palette.chipBg }]}
+          onPress={onNavigateToPartnerSession || (() => router.push(`/session/${session.linkedPartnerSessionId}`))}
+          accessibilityRole="button"
+          accessibilityLabel={`Open session with ${partnerLabel}`}
+        >
+          <ArrowUpRight color={palette.accent} size={16} />
+          <Text style={[styles.branchMarkerText, { color: palette.text }]} numberOfLines={2}>
+            Started a session with {partnerLabel}
+          </Text>
+        </TouchableOpacity>
+      ),
+    }];
+  }, [
+    linkedAtMessage,
+    linkedPartnerName,
+    onNavigateToPartnerSession,
+    palette.accent,
+    palette.border,
+    palette.chipBg,
+    palette.text,
+    router,
+    session?.linkedPartnerSessionId,
+    styles.branchMarker,
+    styles.branchMarkerText,
+  ]);
+
   const handleSendMessage = useCallback(
     async (content: string) => {
       try {
@@ -159,9 +211,11 @@ export function InnerThoughtsScreen({
         // Check for suggested actions in response
         if (result.suggestedActions && result.suggestedActions.length > 0) {
           setSuggestedActions(result.suggestedActions);
+          setSuggestedActionMessageId(result.aiMessage.id);
         } else {
           // Clear previous suggestions when no new ones
           setSuggestedActions([]);
+          setSuggestedActionMessageId(undefined);
         }
       } catch (err) {
         console.error('Failed to send inner thoughts message:', err);
@@ -176,6 +230,7 @@ export function InnerThoughtsScreen({
 
   const handleDismissSuggestedActions = useCallback(() => {
     setSuggestedActions([]);
+    setSuggestedActionMessageId(undefined);
   }, []);
 
   const handleActionPress = useCallback((action: SuggestedAction) => {
@@ -188,7 +243,11 @@ export function InnerThoughtsScreen({
         // Navigate to new session flow, optionally with person name pre-filled
         router.push({
           pathname: '/session/new',
-          params: action.personName ? { partnerName: action.personName, innerThoughtsId: sessionId } : { innerThoughtsId: sessionId },
+          params: {
+            ...(action.personName ? { partnerName: action.personName } : {}),
+            innerThoughtsId: sessionId,
+            ...(suggestedActionMessageId ? { linkedAtMessageId: suggestedActionMessageId } : {}),
+          },
         });
         break;
       case 'start_meditation':
@@ -201,7 +260,7 @@ export function InnerThoughtsScreen({
         router.push('/inner-work/needs');
         break;
     }
-  }, [router, sessionId]);
+  }, [router, sessionId, suggestedActionMessageId]);
 
   const handleBack = useCallback(() => {
     onNavigateBack?.();
@@ -273,8 +332,6 @@ export function InnerThoughtsScreen({
   const title = comingSoonMode
     ? 'Inner Work'
     : isCreating ? 'Inner Thoughts' : (session?.title || session?.theme || 'Inner Thoughts');
-  const isLinked = !!linkedPartnerName;
-
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top', 'bottom']}>
       {/* Header - styled like the rest of the app */}
@@ -297,18 +354,7 @@ export function InnerThoughtsScreen({
             </Text>
             <Lock size={12} color={palette.textMuted} />
           </View>
-          {isLinked ? (
-            <>
-              <TouchableOpacity onPress={onNavigateToPartnerSession}>
-                <Text style={[styles.linkedSubtitle, { color: palette.accent }]} numberOfLines={1}>
-                  ↩ Back to session with {linkedPartnerName}
-                </Text>
-              </TouchableOpacity>
-              <Text style={[styles.privacyNote, { color: palette.textMuted }]}>
-                Private — {linkedPartnerName} cannot see this
-              </Text>
-            </>
-          ) : !isCreating && session?.theme && session?.title ? (
+          {!isCreating && session?.theme && session?.title ? (
             <Text style={[styles.headerSubtitle, { color: palette.textMuted }]} numberOfLines={1}>
               {session.theme}
             </Text>
@@ -350,9 +396,11 @@ export function InnerThoughtsScreen({
         hideInput={comingSoonMode}
         emptyStateTitle={comingSoonMode ? 'Inner Work' : 'Inner Thoughts'}
         emptyStateMessage={comingSoonMode ? '' : "A private space for reflection. Share what's on your mind."}
+        customEmptyState={hideContentUntilReady ? <View /> : undefined}
         keyboardVerticalOffset={0}
         onVoicePress={Platform.OS !== 'web' ? handleVoicePress : undefined}
         skipInitialHistory={comingSoonMode}
+        customCards={branchPointCards}
       />
 
       {/* Suggested Action Buttons - shown when AI suggests next steps */}
@@ -468,15 +516,23 @@ const useStyles = () =>
       color: t.colors.textMuted,
       marginTop: 2,
     },
-    linkedSubtitle: {
-      fontSize: 12,
-      color: t.colors.accent,
-      marginTop: 2,
+    branchMarker: {
+      alignSelf: 'center',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      maxWidth: '86%',
+      marginVertical: 6,
+      paddingHorizontal: 12,
+      paddingVertical: 9,
+      borderRadius: 8,
+      borderWidth: 1,
     },
-    privacyNote: {
-      fontSize: 11,
-      color: t.colors.textMuted,
-      marginTop: 2,
+    branchMarkerText: {
+      flexShrink: 1,
+      fontSize: 13,
+      fontWeight: '600',
+      lineHeight: 18,
     },
     memorySuggestionContainer: {
       position: 'absolute',

--- a/mobile/src/screens/InnerWorkHubScreen.tsx
+++ b/mobile/src/screens/InnerWorkHubScreen.tsx
@@ -13,6 +13,7 @@ import {
   MessageCircle,
   ChevronRight,
   Lock,
+  Plus,
 } from 'lucide-react-native';
 
 import { useInnerThoughtsSessions } from '../hooks';
@@ -138,7 +139,7 @@ export function InnerWorkHubScreen({
       <SafeAreaView style={[styles.container, { backgroundColor: palette.bg }]} edges={['top']}>
         <View style={[styles.header, { backgroundColor: palette.bg, borderBottomColor: palette.divider }]}>
           <HeaderBackButton onPress={handleBack} />
-          <Text style={[styles.headerTitle, { color: palette.text }]}>Inner Work</Text>
+          <Text style={[styles.headerTitle, { color: palette.text }]}>Inner Thoughts</Text>
           <View style={styles.headerRight} />
         </View>
         <View style={styles.errorContainer}>
@@ -175,13 +176,21 @@ export function InnerWorkHubScreen({
       <View style={[styles.header, { backgroundColor: palette.bg, borderBottomColor: palette.divider }]}>
         <HeaderBackButton onPress={handleBack} />
         <View style={styles.headerTitleContainer}>
-          <Text style={[styles.headerTitle, { color: palette.text }]}>Inner Work</Text>
+          <Text style={[styles.headerTitle, { color: palette.text }]}>Inner Thoughts</Text>
           <View style={styles.privacyBadge}>
             <Lock size={10} color={palette.textMuted} />
             <Text style={[styles.privacyText, { color: palette.textMuted }]}>Your private space</Text>
           </View>
         </View>
-        <View style={styles.headerRight} />
+        <TouchableOpacity
+          style={[styles.headerIconButton, { backgroundColor: palette.bgElev, borderColor: palette.border }]}
+          onPress={handleNewSession}
+          activeOpacity={0.75}
+          accessibilityRole="button"
+          accessibilityLabel="Start new Inner Thoughts session"
+        >
+          <Plus size={20} color={palette.text} />
+        </TouchableOpacity>
       </View>
 
       <FlatList
@@ -189,25 +198,6 @@ export function InnerWorkHubScreen({
         keyExtractor={(item) => item.id}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
-        ListHeaderComponent={
-          <TouchableOpacity
-            style={[
-              styles.newSessionButton,
-              {
-                backgroundColor: palette.bgElev,
-                borderColor: palette.border,
-              },
-            ]}
-            onPress={handleNewSession}
-            activeOpacity={0.8}
-          >
-            <View style={[styles.newSessionIconContainer, { backgroundColor: palette.accentSoft }]}>
-              <MessageCircle size={22} color={palette.accent} />
-            </View>
-            <Text style={[styles.newSessionText, { color: palette.text }]}>New Session</Text>
-            <ChevronRight size={20} color={palette.accent} />
-          </TouchableOpacity>
-        }
         renderItem={({ item }) => (
           <SessionListItem session={item} onPress={() => handleSessionPress(item.id)} />
         )}
@@ -324,38 +314,20 @@ const styles = createStyles((t) => ({
     color: t.colors.textMuted,
   },
   headerRight: {
-    width: 32,
+    width: 36,
+  },
+  headerIconButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 
   // List
   listContent: {
     padding: t.spacing.md,
-  },
-
-  // New Session Button
-  newSessionButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: t.colors.bgSecondary,
-    borderRadius: t.radius.sm,
-    padding: t.spacing.md,
-    marginBottom: t.spacing.md,
-    borderWidth: 1,
-    borderColor: t.colors.border,
-  },
-  newSessionIconContainer: {
-    width: 36,
-    height: 36,
-    borderRadius: t.radius.sm,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: t.spacing.sm,
-  },
-  newSessionText: {
-    flex: 1,
-    fontSize: 16,
-    fontWeight: '600',
-    color: t.colors.textPrimary,
   },
 
   // Session Item

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -11,7 +11,7 @@ import { View, Text, ActivityIndicator, TouchableOpacity, Animated, Modal, AppSt
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useQueryClient } from '@tanstack/react-query';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-// useRouter removed - share navigation replaced by ActivityDrawer
+import { useRouter } from 'expo-router';
 import {
   Stage,
   MessageRole,
@@ -526,6 +526,7 @@ export function UnifiedSessionScreen({
   const { user, updateUser } = useAuth();
   const { mutate: updateMood } = useUpdateMood();
   const queryClient = useQueryClient();
+  const router = useRouter();
   const { showError } = useToast();
 
   // Real-time presence tracking
@@ -2613,9 +2614,60 @@ export function UnifiedSessionScreen({
     handleCloseRedesignedStage4,
   ]);
 
+  const sourceInnerThoughts = session?.sourceInnerThoughts ?? null;
+  const sourceInnerThoughtsCards = useMemo((): ChatCustomCardItem[] => {
+    if (!sourceInnerThoughts) return [];
+
+    const timestamp = timestampBeforeChatStart(displayMessages[0]?.timestamp || session?.createdAt);
+
+    return [{
+      type: 'custom-card',
+      id: `source-inner-thoughts-${sourceInnerThoughts.id}`,
+      timestamp,
+      animate: false,
+      render: () => (
+        <TouchableOpacity
+          style={styles.sourceInnerThoughtsCard}
+          onPress={() => router.push({
+            pathname: '/inner-work/self-reflection/[id]',
+            params: {
+              id: sourceInnerThoughts.id,
+              partnerSessionId: sessionId,
+              partnerName,
+            },
+          })}
+          accessibilityRole="button"
+          accessibilityLabel="Open source Inner Thoughts"
+        >
+          <Text style={styles.sourceInnerThoughtsIcon}>↙</Text>
+          <View style={styles.sourceInnerThoughtsTextWrap}>
+            <Text style={styles.sourceInnerThoughtsLabel} numberOfLines={1}>
+              From Inner Thoughts
+            </Text>
+            <Text style={styles.sourceInnerThoughtsTitle} numberOfLines={2}>
+              {sourceInnerThoughts.title || sourceInnerThoughts.theme || sourceInnerThoughts.summary || 'Private reflection'}
+            </Text>
+          </View>
+        </TouchableOpacity>
+      ),
+    }];
+  }, [
+    displayMessages,
+    partnerName,
+    router,
+    session?.createdAt,
+    sessionId,
+    sourceInnerThoughts,
+    styles.sourceInnerThoughtsCard,
+    styles.sourceInnerThoughtsIcon,
+    styles.sourceInnerThoughtsLabel,
+    styles.sourceInnerThoughtsTextWrap,
+    styles.sourceInnerThoughtsTitle,
+  ]);
+
   const chatCustomCards = useMemo(
-    () => [...inviteeOpeningCards, ...needsReviewCards, ...stage4RedesignCards],
-    [inviteeOpeningCards, needsReviewCards, stage4RedesignCards]
+    () => [...sourceInnerThoughtsCards, ...inviteeOpeningCards, ...needsReviewCards, ...stage4RedesignCards],
+    [sourceInnerThoughtsCards, inviteeOpeningCards, needsReviewCards, stage4RedesignCards]
   );
 
   // -------------------------------------------------------------------------
@@ -3970,6 +4022,41 @@ const useStyles = () => {
     },
     accentColor: {
       color: palette.accent,
+    },
+    sourceInnerThoughtsCard: {
+      alignSelf: 'center',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 9,
+      width: '86%',
+      maxWidth: 520,
+      marginVertical: 10,
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      backgroundColor: palette.bgElev,
+      borderWidth: 1,
+      borderColor: palette.border,
+      borderRadius: 8,
+    },
+    sourceInnerThoughtsIcon: {
+      fontSize: 15,
+      color: palette.accent,
+      fontWeight: '700',
+    },
+    sourceInnerThoughtsTextWrap: {
+      flex: 1,
+      minWidth: 0,
+    },
+    sourceInnerThoughtsLabel: {
+      fontSize: 11,
+      fontWeight: '700',
+      color: palette.accent,
+      textTransform: 'uppercase',
+    },
+    sourceInnerThoughtsTitle: {
+      marginTop: 1,
+      fontSize: 13,
+      color: palette.textMuted,
     },
 
     // Invitation Draft

--- a/mobile/src/screens/__tests__/InnerWorkHubScreen.test.tsx
+++ b/mobile/src/screens/__tests__/InnerWorkHubScreen.test.tsx
@@ -62,7 +62,7 @@ describe('InnerWorkHubScreen', () => {
 
     render(<InnerWorkHubScreen onStartNewSession={onStartNewSession} />);
 
-    fireEvent.press(screen.getByText('New Session'));
+    fireEvent.press(screen.getByLabelText('Start new Inner Thoughts session'));
 
     expect(onStartNewSession).toHaveBeenCalledTimes(1);
   });

--- a/shared/src/contracts/sessions.ts
+++ b/shared/src/contracts/sessions.ts
@@ -76,6 +76,7 @@ export const createSessionRequestSchema = z
     inviteName: z.string().min(1, 'Name is required').max(100, 'Name too long').optional(),
     context: z.string().max(500, 'Context too long').optional(),
     innerThoughtsId: z.string().cuid().optional(), // Link to originating Inner Thoughts session
+    linkedAtMessageId: z.string().cuid().optional(),
   })
   .refine(data => data.personId || data.inviteName, {
     message: 'Must provide personId or inviteName',

--- a/shared/src/dto/inner-work.ts
+++ b/shared/src/dto/inner-work.ts
@@ -33,6 +33,10 @@ export interface InnerWorkSessionSummaryDTO {
   messageCount: number;
   /** If linked to a partner session, the session ID */
   linkedPartnerSessionId: string | null;
+  /** Message that produced the start-partner-session branch, when known */
+  linkedAtMessageId: string | null;
+  /** Snapshot of the context passed into the partner session at creation time */
+  contextSummarySnapshot: string | null;
 }
 
 // ============================================================================

--- a/shared/src/dto/session-state.ts
+++ b/shared/src/dto/session-state.ts
@@ -48,6 +48,14 @@ export interface SessionStateResponse {
     partnerLastActiveAt: string | null;
     // ID of last chat item seen (for "new messages" line placement)
     lastSeenChatItemId: string | null;
+    // Originating Inner Thoughts session, when this partner session was started from one.
+    sourceInnerThoughts: {
+      id: string;
+      title: string | null;
+      summary: string | null;
+      theme: string | null;
+      contextSummarySnapshot: string | null;
+    } | null;
   };
 
   // Stage progress

--- a/shared/src/dto/session.ts
+++ b/shared/src/dto/session.ts
@@ -106,6 +106,8 @@ export interface CreateSessionRequest {
 
   // Optional: link to Inner Thoughts session that originated this partner session
   innerThoughtsId?: string;
+  // Optional: Inner Thoughts message where the user tapped the start-session action
+  linkedAtMessageId?: string;
 }
 
 export interface CreateSessionResponse {


### PR DESCRIPTION
## Summary
- Link partner sessions back to the exact Inner Thoughts message that started them, including schema/migration and shared DTO support.
- Show Inner Thoughts origin/branch markers inline in chat instead of persistent header banners.
- Make initial partner-session messages idempotent to avoid duplicate first AI prompts.
- Refine home, drawer, and Inner Thoughts list UI labels and controls.

## Validation
- npm --workspace shared run check
- npm --workspace backend run check
- npm --workspace mobile run check
- npm --workspace mobile test -- InnerWorkHubScreen.test.tsx --runInBand
- npm --workspace mobile test -- index.test.tsx --runInBand
- git diff --check
- Local browser smoke test on http://localhost:8082
