### PR TITLE
[codex] Fix chat CTA and validation card behavior

### DIFF
--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Text,
   FlatList,
+  Keyboard,
   KeyboardAvoidingView,
   Platform,
   ListRenderItem,
@@ -246,11 +247,25 @@ export function ChatInterface({
   const animationScope = sessionId || localAnimationScopeRef.current;
   const animationScopeRef = useRef(animationScope);
   const seenAnimatedItemIdsRef = useRef(getSeenAnimatedItemIds(animationScope));
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
 
   if (animationScopeRef.current !== animationScope) {
     animationScopeRef.current = animationScope;
     seenAnimatedItemIdsRef.current = getSeenAnimatedItemIds(animationScope);
   }
+
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    const showSub = Keyboard.addListener(showEvent, () => setIsKeyboardVisible(true));
+    const hideSub = Keyboard.addListener(hideEvent, () => setIsKeyboardVisible(false));
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Cache-First Architecture: Derive "waiting for AI" from last message role
@@ -876,8 +891,8 @@ export function ChatInterface({
             failedMessage={failedMessage}
           />
         )}
-        {renderAboveInput?.()}
-        {renderBelowInput?.()}
+        {!isKeyboardVisible && renderAboveInput?.()}
+        {!isKeyboardVisible && renderBelowInput?.()}
       </View>
     </KeyboardAvoidingView>
   );

--- a/mobile/src/components/EmpathyValidationCard.tsx
+++ b/mobile/src/components/EmpathyValidationCard.tsx
@@ -24,6 +24,7 @@ import {
 } from 'react-native';
 import { Heart, Check, RefreshCw } from 'lucide-react-native';
 import { createStyles } from '../theme/styled';
+import { useAppAppearance } from '../theme';
 
 // Enable LayoutAnimation on Android
 if (
@@ -255,15 +256,19 @@ export function EmpathyValidationCard({
 // Styles
 // ============================================================================
 
-const useStyles = () =>
-  createStyles((t) => ({
+const useStyles = () => {
+  const { palette } = useAppAppearance();
+
+  return createStyles((t) => ({
     container: {
       marginHorizontal: t.spacing.lg,
       marginVertical: t.spacing.sm,
-      backgroundColor: t.colors.bgSecondary,
+      backgroundColor: palette.bgElev,
       borderRadius: 12,
+      borderWidth: 1,
+      borderColor: palette.border,
       borderLeftWidth: 3,
-      borderLeftColor: t.colors.accent,
+      borderLeftColor: palette.accent,
       padding: t.spacing.md,
       minHeight: 180,
     },
@@ -274,19 +279,19 @@ const useStyles = () =>
       gap: t.spacing.sm,
     },
     headerIcon: {
-      color: t.colors.accent,
+      color: palette.accent,
     },
     headerText: {
       fontSize: t.typography.fontSize.base,
       fontFamily: t.typography.fontFamily.medium,
       fontWeight: '600' as const,
-      color: t.colors.textPrimary,
+      color: palette.text,
     },
     empathyContent: {
       fontSize: t.typography.fontSize.base,
       fontFamily: t.typography.fontFamily.regular,
       fontStyle: 'italic' as const,
-      color: t.colors.textSecondary,
+      color: palette.textMuted,
       lineHeight: 20,
       marginBottom: t.spacing.sm,
     },
@@ -294,7 +299,7 @@ const useStyles = () =>
       fontSize: t.typography.fontSize.base,
       fontFamily: t.typography.fontFamily.medium,
       fontWeight: '500' as const,
-      color: t.colors.textPrimary,
+      color: palette.text,
       marginBottom: t.spacing.md,
     },
     buttonRow: {
@@ -304,9 +309,9 @@ const useStyles = () =>
     accurateButton: {
       flex: 1,
       minHeight: 44,
-      backgroundColor: 'rgba(34, 197, 94, 0.15)',
+      backgroundColor: palette.successSoft,
       borderWidth: 1,
-      borderColor: 'rgba(34, 197, 94, 0.3)',
+      borderColor: palette.success,
       borderRadius: 8,
       alignItems: 'center' as const,
       justifyContent: 'center' as const,
@@ -316,9 +321,9 @@ const useStyles = () =>
     notQuiteButton: {
       flex: 1,
       minHeight: 44,
-      backgroundColor: 'rgba(245, 158, 11, 0.15)',
+      backgroundColor: palette.warningSoft,
       borderWidth: 1,
-      borderColor: 'rgba(245, 158, 11, 0.3)',
+      borderColor: palette.warning,
       borderRadius: 8,
       alignItems: 'center' as const,
       justifyContent: 'center' as const,
@@ -329,13 +334,13 @@ const useStyles = () =>
       fontSize: t.typography.fontSize.base,
       fontFamily: t.typography.fontFamily.medium,
       fontWeight: '600' as const,
-      color: 'rgba(34, 197, 94, 1)',
+      color: palette.success,
     },
     notQuiteButtonText: {
       fontSize: t.typography.fontSize.base,
       fontFamily: t.typography.fontFamily.medium,
       fontWeight: '600' as const,
-      color: 'rgba(245, 158, 11, 1)',
+      color: palette.warning,
     },
     completedRow: {
       flexDirection: 'row' as const,
@@ -344,12 +349,12 @@ const useStyles = () =>
       marginTop: t.spacing.sm,
     },
     completedIcon: {
-      color: t.colors.success,
+      color: palette.success,
     },
     completedText: {
       fontSize: t.typography.fontSize.base,
       fontFamily: t.typography.fontFamily.regular,
-      color: t.colors.success,
+      color: palette.success,
     },
     supersededRow: {
       flexDirection: 'row' as const,
@@ -358,14 +363,15 @@ const useStyles = () =>
       marginTop: t.spacing.sm,
     },
     supersededIcon: {
-      color: t.colors.textMuted,
+      color: palette.textMuted,
     },
     supersededText: {
       fontSize: t.typography.fontSize.base,
       fontFamily: t.typography.fontFamily.regular,
       fontStyle: 'italic' as const,
-      color: t.colors.textMuted,
+      color: palette.textMuted,
     },
   }));
+};
 
 export default EmpathyValidationCard;

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -686,7 +686,7 @@ describe('Empathy Panel Visibility', () => {
     expect(result.panels.showEmpathyPanel).toBe(true);
   });
 
-  it('shows in refining mode before user sends another message when an attempt is reviewable', () => {
+  it('does not show in refining mode before user reflects, even when an attempt is reviewable', () => {
     const inputs = createInputs({
       myStage: Stage.PERSPECTIVE_STRETCH,
       compactMySigned: true,
@@ -698,10 +698,11 @@ describe('Empathy Panel Visibility', () => {
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showEmpathyPanel).toBe(true);
+    expect(result.panels.showEmpathyPanel).toBe(false);
+    expect(result.aboveInputPanel).not.toBe('empathy-statement');
   });
 
-  it('shows in refining mode before user sends another message when new AI content is reviewable', () => {
+  it('does not show in refining mode before user reflects, even when new AI content is reviewable', () => {
     const inputs = createInputs({
       myStage: Stage.PERSPECTIVE_STRETCH,
       compactMySigned: true,
@@ -713,7 +714,8 @@ describe('Empathy Panel Visibility', () => {
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showEmpathyPanel).toBe(true);
+    expect(result.panels.showEmpathyPanel).toBe(false);
+    expect(result.aboveInputPanel).not.toBe('empathy-statement');
   });
 
   it('does not show in refining mode before user sends another message when no content is reviewable', () => {

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -262,6 +262,7 @@ function computeShowInvitationPanel(inputs: ChatUIStateInputs): boolean {
  *
  * The panel shows "Review what you'll share" for initial empathy drafts.
  * During REFINING (after receiving shared context from partner), the panel
+ * stays hidden until the user has taken one reflection turn. After that it
  * re-appears as "Revisit what you'll share" so the user can resubmit their
  * revised empathy through the UI.
  */
@@ -280,16 +281,10 @@ function computeShowEmpathyPanel(inputs: ChatUIStateInputs): boolean {
 
   const currentStage = myStage ?? Stage.ONBOARDING;
 
-  // When refining (Stage 2B), the reconciler may already have a reviewable
-  // draft/attempt and the AI copy directs the user to "Revisit what you'll
-  // share." Only hold the panel before the user engages if there is no
-  // content to review yet.
-  if (
-    isRefiningEmpathy &&
-    inputs.messageCountSinceSharedContext === 0 &&
-    !hasEmpathyContent &&
-    !myAttemptContent
-  ) {
+  // When the partner has just shared context, the next user action should be
+  // reflection in chat. Do not offer review/resubmit until they have taken
+  // that first turn, even if an old attempt or draft is already reviewable.
+  if (isRefiningEmpathy && inputs.messageCountSinceSharedContext === 0) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Hide composer action panels while the mobile keyboard is visible so the chat input does not reserve space for CTAs during typing.
- Suppress the Stage 2 refining review CTA until the user has taken one reflection turn after receiving newly shared context.
- Move the empathy validation card onto the active appearance palette so it renders correctly in light mode.

## Validation

- `npm test -- --runInBand src/components/__tests__/ChatInterface.test.tsx`
- `npm test -- --runInBand src/utils/__tests__/chatUIState.test.ts`
- `npm run check`
