### PR TITLE
[codex] Show shared artifacts in chat

### DIFF
--- a/mobile/src/components/ActivityDrawer.tsx
+++ b/mobile/src/components/ActivityDrawer.tsx
@@ -408,7 +408,10 @@ export function ActivityDrawer({
   }, [visible, openDrawer]);
 
   useEffect(() => {
-    if (!visible || !focusMatch) return;
+    if (!visible || !focusMatch) {
+      setHighlightedItemId(null);
+      return;
+    }
 
     setHighlightedItemId(focusMatch.id);
 

--- a/mobile/src/components/ActivityDrawer.tsx
+++ b/mobile/src/components/ActivityDrawer.tsx
@@ -17,6 +17,7 @@ import {
   StyleSheet,
   BackHandler,
   useWindowDimensions,
+  type FlatList as FlatListType,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { appWidthStyle } from '@/theme';
@@ -53,7 +54,14 @@ export interface ActivityDrawerProps {
   partnerAccepted?: boolean;
   sessionStatus?: string;
   partnerEmpathyValidated?: boolean;
+  focusTarget?: ActivityDrawerFocusTarget | null;
   testID?: string;
+}
+
+export interface ActivityDrawerFocusTarget {
+  type: 'context' | 'empathy';
+  direction: 'sent' | 'received';
+  timestamp?: string;
 }
 
 // ============================================================================
@@ -221,6 +229,7 @@ export function ActivityDrawer({
   partnerAccepted = false,
   sessionStatus,
   partnerEmpathyValidated,
+  focusTarget,
   testID = 'activity-drawer',
 }: ActivityDrawerProps) {
   const insets = useSafeAreaInsets();
@@ -248,8 +257,13 @@ export function ActivityDrawer({
     enabled: visible && isSessionActive,
   });
   const pendingActionsQuery = usePendingActions(sessionId);
-  const pendingActions = pendingActionsQuery.data?.actions ?? [];
+  const pendingActions = useMemo(
+    () => pendingActionsQuery.data?.actions ?? [],
+    [pendingActionsQuery.data?.actions],
+  );
   const { mutate: markShareTabViewed } = useMarkShareTabViewed(sessionId);
+  const listRef = useRef<FlatListType<TimelineItem>>(null);
+  const [highlightedItemId, setHighlightedItemId] = useState<string | null>(null);
 
   // Mark as viewed when drawer opens
   useEffect(() => {
@@ -298,6 +312,25 @@ export function ActivityDrawer({
     () => allItems.filter((item) => !item.actionRequired),
     [allItems],
   );
+
+  const focusMatch = useMemo(() => {
+    if (!focusTarget) return null;
+
+    const sameKindItems = allItems.filter(
+      (item) => item.type === focusTarget.type && item.direction === focusTarget.direction,
+    );
+    if (sameKindItems.length === 0) return null;
+    if (!focusTarget.timestamp) return sameKindItems[sameKindItems.length - 1];
+
+    const targetTime = new Date(focusTarget.timestamp).getTime();
+    if (Number.isNaN(targetTime)) return sameKindItems[sameKindItems.length - 1];
+
+    return sameKindItems.reduce((best, item) => {
+      const bestDelta = Math.abs(new Date(best.timestamp).getTime() - targetTime);
+      const itemDelta = Math.abs(new Date(item.timestamp).getTime() - targetTime);
+      return itemDelta < bestDelta ? item : best;
+    });
+  }, [allItems, focusTarget]);
 
   // -------------------------------------------------------------------------
   // Animation refs
@@ -374,6 +407,29 @@ export function ActivityDrawer({
     }
   }, [visible, openDrawer]);
 
+  useEffect(() => {
+    if (!visible || !focusMatch) return;
+
+    setHighlightedItemId(focusMatch.id);
+
+    const timeout = setTimeout(() => {
+      const historyIndex = historyItems.findIndex((item) => item.id === focusMatch.id);
+      if (historyIndex >= 0) {
+        listRef.current?.scrollToIndex({
+          index: historyIndex,
+          animated: true,
+          viewPosition: 0.35,
+        });
+        return;
+      }
+
+      // Attention items render in the list header, above history.
+      listRef.current?.scrollToOffset({ offset: 0, animated: true });
+    }, 280);
+
+    return () => clearTimeout(timeout);
+  }, [visible, focusMatch, historyItems]);
+
   // -------------------------------------------------------------------------
   // Android back button
   // -------------------------------------------------------------------------
@@ -439,6 +495,7 @@ export function ActivityDrawer({
     ({ item }: { item: TimelineItem }) => (
       <TimelineItemCard
         item={item}
+        highlighted={item.id === highlightedItemId}
         onOpenRefinement={onOpenRefinement}
         onShareAsIs={onShareAsIs}
         onOpenEmpathyDetail={onOpenEmpathyDetail}
@@ -446,7 +503,7 @@ export function ActivityDrawer({
         testID={`${testID}-item-${item.id}`}
       />
     ),
-    [onOpenRefinement, onShareAsIs, onOpenEmpathyDetail, onShareInvitation, testID],
+    [highlightedItemId, onOpenRefinement, onShareAsIs, onOpenEmpathyDetail, onShareInvitation, testID],
   );
 
   const keyExtractor = useCallback((item: TimelineItem) => item.id, []);
@@ -515,10 +572,17 @@ export function ActivityDrawer({
         {/* Wrapper constrains FlatList frame to the visible drawer area */}
         <View style={listHeight > 0 ? { height: listHeight, overflow: 'hidden' } : { flex: 1 }}>
           <FlatList
+            ref={listRef}
             style={{ flex: 1 }}
             data={historyItems}
             renderItem={renderTimelineItem}
             keyExtractor={keyExtractor}
+            onScrollToIndexFailed={({ index, averageItemLength }) => {
+              listRef.current?.scrollToOffset({
+                offset: Math.max(0, averageItemLength * index),
+                animated: true,
+              });
+            }}
             contentContainerStyle={[styles.listContent, { paddingBottom: 32 + insets.bottom }]}
             showsVerticalScrollIndicator={false}
             ListHeaderComponent={
@@ -559,6 +623,7 @@ export function ActivityDrawer({
                           key={item.id}
                           item={item}
                           centered
+                          highlighted={item.id === highlightedItemId}
                           onOpenRefinement={onOpenRefinement}
                           onShareAsIs={onShareAsIs}
                           onOpenEmpathyDetail={onOpenEmpathyDetail}

--- a/mobile/src/components/ChatBubble.tsx
+++ b/mobile/src/components/ChatBubble.tsx
@@ -17,12 +17,14 @@ export interface ChatBubbleMessage {
   role: MessageRole;
   content: string;
   timestamp: string;
+  senderId?: string | null;
   isIntervention?: boolean;
   status?: MessageDeliveryStatus;
   /** If true, skip animation (for messages loaded from history) */
   skipTypewriter?: boolean;
   /** Delivery status for shared content messages (EMPATHY_STATEMENT, SHARED_CONTEXT) */
   sharedContentDeliveryStatus?: SharedContentDeliveryStatus;
+  sharedContentDirection?: 'sent' | 'received';
 }
 
 interface ChatBubbleProps {
@@ -252,9 +254,13 @@ export function ChatBubble({
     // Empathy statements - use fade-in for new messages
     if (isEmpathyStatement) {
       const deliveryStatus = message.sharedContentDeliveryStatus;
+      const header =
+        message.sharedContentDirection === 'received'
+          ? (partnerName ? `Empathy from ${partnerName}` : 'Empathy from your partner')
+          : 'What you shared';
       const content = (
         <View>
-          <Text style={styles.empathyStatementHeader}>What you shared</Text>
+          <Text style={styles.empathyStatementHeader}>{header}</Text>
           <Text style={styles.empathyStatementText}>{message.content}</Text>
           {/* Delivery status indicator - only show when we have a status */}
           {deliveryStatus && (
@@ -279,6 +285,8 @@ export function ChatBubble({
     if (isSharedContext) {
       const contextLabel = isValidationFeedback
         ? (partnerName ? `Feedback from ${partnerName}` : 'Feedback from your partner')
+        : message.sharedContentDirection === 'sent'
+          ? (partnerName ? `Context shared with ${partnerName}` : 'Context shared')
         : (partnerName ? `New context from ${partnerName}` : 'New context from your partner');
       const deliveryStatus = message.sharedContentDeliveryStatus;
       const content = (

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -32,6 +32,8 @@ export interface ChatMessage extends MessageDTO {
   status?: MessageDeliveryStatus;
   /** Delivery status for shared content (empathy statements, shared context) */
   sharedContentDeliveryStatus?: SharedContentDeliveryStatus;
+  /** Whether the shared artifact was sent by the current user or received from partner */
+  sharedContentDirection?: 'sent' | 'received';
 }
 
 export { ChatIndicatorType } from './ChatIndicator';
@@ -165,7 +167,11 @@ interface ChatInterfaceProps {
   /** Callback when "Context shared" indicator is tapped - navigates to Sharing Status
    * @param timestamp - The timestamp of the shared context (for scrolling to it)
    */
-  onContextSharedPress?: (timestamp?: string, isFromMe?: boolean) => void;
+  onContextSharedPress?: (
+    timestamp?: string,
+    isFromMe?: boolean,
+    indicatorType?: ChatIndicatorType,
+  ) => void;
   /** Validation cards to render inline (e.g., partner's empathy attempt for validation) */
   validationCards?: ChatValidationCardItem[];
   /** Callback when user taps "Yes, mostly" on a validation card */
@@ -629,7 +635,7 @@ export function ChatInterface({
       const isTappableIndicator = item.indicatorType === 'context-shared'
         || item.indicatorType === 'empathy-shared';
       const onPress = isTappableIndicator && onContextSharedPress
-        ? () => onContextSharedPress(item.timestamp, item.metadata?.isFromMe)
+        ? () => onContextSharedPress(item.timestamp, item.metadata?.isFromMe, item.indicatorType)
         : undefined;
       return (
         <ChatIndicator
@@ -694,9 +700,11 @@ export function ChatInterface({
       role: message.role,
       content: message.content,
       timestamp: message.timestamp,
+      senderId: message.senderId,
       status: message.status,
       skipTypewriter: !shouldAnimateTypewriter,
       sharedContentDeliveryStatus: message.sharedContentDeliveryStatus,
+      sharedContentDirection: message.sharedContentDirection,
     };
 
     return (
@@ -716,7 +724,7 @@ export function ChatInterface({
         {renderMessageExtra?.(message)}
       </>
     );
-  }, [listItems, shouldAnimateItem, nextAnimatableMessageId, animatingItemId, onTypewriterComplete, isSpeaking, currentId, handleSpeakerPress, customEmptyState, styles, partnerName, renderMessageExtra, onValidateAccurate, onValidateNotQuite, markItemAnimationSeen]);
+  }, [listItems, shouldAnimateItem, nextAnimatableMessageId, animatingItemId, onTypewriterComplete, isSpeaking, currentId, handleSpeakerPress, customEmptyState, styles, partnerName, renderMessageExtra, onContextSharedPress, onValidateAccurate, onValidateNotQuite, markItemAnimationSeen]);
 
   const keyExtractor = useCallback((item: ChatListItem) => item.id, []);
 

--- a/mobile/src/components/TimelineItemCard.tsx
+++ b/mobile/src/components/TimelineItemCard.tsx
@@ -35,6 +35,7 @@ export interface TimelineItem {
 export interface TimelineItemCardProps {
   item: TimelineItem;
   centered?: boolean;
+  highlighted?: boolean;
   onOpenRefinement?: (offerId: string, suggestion: string) => void;
   onShareAsIs?: (offerId: string) => void;
   onOpenEmpathyDetail?: (attemptId: string, content: string) => void;
@@ -99,6 +100,7 @@ function formatRelativeTimestamp(iso: string): string {
 export function TimelineItemCard({
   item,
   centered = false,
+  highlighted = false,
   onOpenRefinement,
   onShareAsIs,
   onOpenEmpathyDetail,
@@ -217,7 +219,7 @@ export function TimelineItemCard({
   if (isTappable) {
     return (
       <Pressable
-        style={[styles.card, bubbleStyle]}
+        style={[styles.card, bubbleStyle, highlighted && styles.highlightedCard]}
         onPress={handleCardPress}
         accessibilityRole="button"
         accessibilityLabel={
@@ -234,7 +236,7 @@ export function TimelineItemCard({
 
   return (
     <View
-      style={[styles.card, bubbleStyle]}
+      style={[styles.card, bubbleStyle, highlighted && styles.highlightedCard]}
       testID={resolvedTestID}
     >
       {cardContent}
@@ -253,6 +255,15 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
     marginBottom: 10,
     borderWidth: 1,
     borderColor: palette.border,
+  },
+  highlightedCard: {
+    borderColor: palette.accent,
+    borderWidth: 2,
+    shadowColor: palette.accent,
+    shadowOpacity: 0.22,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 4,
   },
   bubbleSent: {
     backgroundColor: palette.infoSoft,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -54,6 +54,7 @@ import { ViewEmpathyStatementDrawer } from '../components/ViewEmpathyStatementDr
 import { MemorySuggestionCard } from '../components/MemorySuggestionCard';
 // SegmentedControl removed - tabs are now integrated in SessionChatHeader
 import { ActivityDrawer } from '../components/ActivityDrawer';
+import type { ActivityDrawerFocusTarget } from '../components/ActivityDrawer';
 import { PartnerInfoDrawer } from '../components/PartnerInfoDrawer';
 import { NeedsDrawer, NeedsDrawerMode } from '../components/NeedsDrawer';
 import { RefinementModalScreen } from './RefinementModalScreen';
@@ -1281,6 +1282,7 @@ export function UnifiedSessionScreen({
   // Activity Menu Modal
   // -------------------------------------------------------------------------
   const [showActivityMenu, setShowActivityMenu] = useState(false);
+  const [activityFocusTarget, setActivityFocusTarget] = useState<ActivityDrawerFocusTarget | null>(null);
   const [showPartnerInfo, setShowPartnerInfo] = useState(false);
   const topicFrame = invitation && 'topicFrame' in invitation
     ? (invitation.topicFrame as string | null)
@@ -2065,14 +2067,92 @@ export function UnifiedSessionScreen({
   // Prepare Messages for Display
   // -------------------------------------------------------------------------
   const displayMessages = useMemo((): ChatMessage[] => {
-    // Find all EMPATHY_STATEMENT messages to detect superseded ones
-    // User may have multiple empathy statements if they revised their understanding
-    const empathyStatements = messages.filter(
-      (m) => m.role === MessageRole.EMPATHY_STATEMENT
+    const baseMessages: ChatMessage[] = [...messages];
+    const myAttempt = empathyStatusData?.myAttempt;
+    const partnerAttempt = empathyStatusData?.partnerAttempt;
+    const mySharedContext = empathyStatusData?.mySharedContext;
+
+    if (myAttempt?.content && myAttempt.sharedAt) {
+      const hasMyAttemptMessage = baseMessages.some(
+        (message) =>
+          message.role === MessageRole.EMPATHY_STATEMENT &&
+          message.senderId === user?.id &&
+          message.timestamp === myAttempt.sharedAt,
+      );
+
+      if (!hasMyAttemptMessage) {
+        baseMessages.push({
+          id: `my-empathy-${myAttempt.id}`,
+          sessionId,
+          senderId: user?.id ?? null,
+          role: MessageRole.EMPATHY_STATEMENT,
+          content: myAttempt.content,
+          stage: Stage.PERSPECTIVE_STRETCH,
+          timestamp: myAttempt.sharedAt,
+          sharedContentDeliveryStatus: myAttempt.deliveryStatus,
+          sharedContentDirection: 'sent',
+        });
+      }
+    }
+
+    if (partnerAttempt?.content && (partnerAttempt.revealedAt || partnerAttempt.sharedAt)) {
+      const partnerTimestamp = partnerAttempt.revealedAt || partnerAttempt.sharedAt;
+      const hasPartnerAttemptMessage = baseMessages.some(
+        (message) =>
+          message.role === MessageRole.EMPATHY_STATEMENT &&
+          message.senderId === partnerAttempt.sourceUserId &&
+          message.timestamp === partnerTimestamp,
+      );
+
+      if (!hasPartnerAttemptMessage) {
+        baseMessages.push({
+          id: `partner-empathy-${partnerAttempt.id}`,
+          sessionId,
+          senderId: partnerAttempt.sourceUserId,
+          role: MessageRole.EMPATHY_STATEMENT,
+          content: partnerAttempt.content,
+          stage: Stage.PERSPECTIVE_STRETCH,
+          timestamp: partnerTimestamp,
+          sharedContentDeliveryStatus: 'delivered',
+          sharedContentDirection: 'received',
+        });
+      }
+    }
+
+    // The subject's accepted/refined share is stored on the empathy status
+    // response, but the backend only creates a SHARED_CONTEXT chat message for
+    // the recipient. Synthesize a local chat item so the sender's chat shows
+    // the same shared artifact inline too.
+    if (mySharedContext?.content && mySharedContext.sharedAt) {
+      const hasSelfSharedContextMessage = baseMessages.some(
+        (message) =>
+          message.role === MessageRole.SHARED_CONTEXT &&
+          message.senderId === user?.id &&
+          message.timestamp === mySharedContext.sharedAt,
+      );
+
+      if (!hasSelfSharedContextMessage) {
+        baseMessages.push({
+          id: `my-shared-context-${mySharedContext.sharedAt}`,
+          sessionId,
+          senderId: user?.id ?? null,
+          role: MessageRole.SHARED_CONTEXT,
+          content: mySharedContext.content,
+          stage: Stage.PERSPECTIVE_STRETCH,
+          timestamp: mySharedContext.sharedAt,
+          sharedContentDeliveryStatus: mySharedContext.deliveryStatus ?? undefined,
+          sharedContentDirection: 'sent',
+        });
+      }
+    }
+
+    // Find self-authored EMPATHY_STATEMENT messages to detect superseded revisions.
+    const myEmpathyStatements = baseMessages.filter(
+      (m) => m.role === MessageRole.EMPATHY_STATEMENT && m.senderId === user?.id
     );
 
     // Sort by timestamp to find the latest one
-    const sortedStatements = [...empathyStatements].sort(
+    const sortedStatements = [...myEmpathyStatements].sort(
       (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
     );
 
@@ -2080,17 +2160,41 @@ export function UnifiedSessionScreen({
     const latestEmpathyId = sortedStatements[0]?.id;
 
     // Enrich messages with delivery status for shared content
-    return messages.map((message) => {
+    return baseMessages.map((message) => {
+      const sharedContentDirection =
+        message.role === MessageRole.EMPATHY_STATEMENT ||
+        message.role === MessageRole.SHARED_CONTEXT
+          ? (message.senderId === user?.id ? 'sent' as const : 'received' as const)
+          : undefined;
+
+      if (message.role === MessageRole.SHARED_CONTEXT) {
+        const deliveryStatus =
+          message.senderId === user?.id
+            ? (mySharedContext?.deliveryStatus ?? undefined)
+            : undefined;
+
+        return {
+          ...message,
+          sharedContentDeliveryStatus:
+            message.sharedContentDeliveryStatus ?? deliveryStatus,
+          sharedContentDirection,
+        };
+      }
+
       // For EMPATHY_STATEMENT messages, determine which delivery status to use:
       // - If this is NOT the latest empathy statement, mark as superseded
       // - If content matches myAttempt (guesser's empathy statement), use myAttempt.deliveryStatus
-      // - Otherwise, if sharedContentDeliveryStatus exists (subject shared via reconciler), use that
       if (message.role === MessageRole.EMPATHY_STATEMENT) {
         // Check if this is a superseded (older) empathy statement
-        if (empathyStatements.length > 1 && message.id !== latestEmpathyId) {
+        if (
+          message.senderId === user?.id &&
+          myEmpathyStatements.length > 1 &&
+          message.id !== latestEmpathyId
+        ) {
           return {
             ...message,
             sharedContentDeliveryStatus: 'superseded' as const,
+            sharedContentDirection,
           };
         }
 
@@ -2103,13 +2207,7 @@ export function UnifiedSessionScreen({
           return {
             ...message,
             sharedContentDeliveryStatus: empathyStatusData.myAttempt.deliveryStatus,
-          };
-        }
-        // Otherwise, this is shared context from the subject (via reconciler)
-        if (empathyStatusData?.sharedContentDeliveryStatus) {
-          return {
-            ...message,
-            sharedContentDeliveryStatus: empathyStatusData.sharedContentDeliveryStatus,
+            sharedContentDirection,
           };
         }
         // Fallback: If message already has a status (from optimistic update), preserve it
@@ -2117,26 +2215,26 @@ export function UnifiedSessionScreen({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const existingStatus = (message as any).sharedContentDeliveryStatus;
         if (existingStatus) {
-          return { ...message, sharedContentDeliveryStatus: existingStatus };
+          return { ...message, sharedContentDeliveryStatus: existingStatus, sharedContentDirection };
         }
         // Default to 'pending' for empathy statements without a status
         // (e.g., when empathyStatusData is still loading)
         return {
           ...message,
           sharedContentDeliveryStatus: 'pending' as const,
+          sharedContentDirection,
         };
       }
       return message;
-    })
-    // Filter out EMPATHY_STATEMENT messages (shown as tappable indicators)
-    // and own SHARED_CONTEXT messages (collapsed to indicator pills).
-    // Partner's SHARED_CONTEXT messages are kept inline so the user can read them in chat.
-    .filter((message) => {
-      if (message.role === MessageRole.EMPATHY_STATEMENT) return false;
-      if (message.role === MessageRole.SHARED_CONTEXT && message.senderId === user?.id) return false;
-      return true;
     });
-  }, [messages, empathyStatusData?.myAttempt?.content, empathyStatusData?.myAttempt?.deliveryStatus, empathyStatusData?.sharedContentDeliveryStatus]);
+  }, [
+    messages,
+    empathyStatusData?.myAttempt,
+    empathyStatusData?.mySharedContext,
+    empathyStatusData?.partnerAttempt,
+    sessionId,
+    user?.id,
+  ]);
 
   // -------------------------------------------------------------------------
   // Validation Cards (Inline in Chat FlatList)
@@ -3471,6 +3569,7 @@ export function UnifiedSessionScreen({
           session?.status === SessionStatus.INVITED && invitation?.isInviter
             ? () => {
                 setShowShareLaterTooltip(false);
+                setActivityFocusTarget(null);
                 setShowActivityMenu(true);
               }
             : undefined
@@ -3480,6 +3579,7 @@ export function UnifiedSessionScreen({
           !isInOnboardingUnsigned
             ? () => {
                 setShowShareLaterTooltip(false);
+                setActivityFocusTarget(null);
                 setShowActivityMenu(true);
               }
             : undefined
@@ -3543,8 +3643,13 @@ export function UnifiedSessionScreen({
           // arriving while viewing don't trigger a separator
           lastSeenChatItemId={lastSeenChatItemIdForSeparator}
           lastViewedAt={lastViewedAtForAnimation}
-          // Open activity menu when "Context shared" or "Empathy shared" indicator is tapped
-          onContextSharedPress={() => {
+          // Open activity menu and focus the corresponding "Context shared" / "Empathy shared" item.
+          onContextSharedPress={(timestamp, isFromMe, indicatorType) => {
+            setActivityFocusTarget({
+              type: indicatorType === 'empathy-shared' ? 'empathy' : 'context',
+              direction: isFromMe === false ? 'received' : 'sent',
+              timestamp,
+            });
             setShowActivityMenu(true);
           }}
           customCards={chatCustomCards}
@@ -3933,7 +4038,11 @@ export function UnifiedSessionScreen({
         sessionId={sessionId}
         partnerName={partnerName}
         sessionStatus={session?.status}
-        onClose={() => setShowActivityMenu(false)}
+        focusTarget={activityFocusTarget}
+        onClose={() => {
+          setShowActivityMenu(false);
+          setActivityFocusTarget(null);
+        }}
         onOpenRefinement={(offerId, suggestion) => {
           setShowActivityMenu(false);
           setRefinementInitialSuggestion(suggestion);
@@ -3975,6 +4084,7 @@ export function UnifiedSessionScreen({
             setRefinementOfferId(null);
             trackShareDraftSent(sessionId, (shareOfferData?.suggestion?.action ?? 'OFFER_OPTIONAL') as 'OFFER_SHARING' | 'OFFER_OPTIONAL', true);
             // Open activity drawer to show updated share status
+            setActivityFocusTarget(null);
             setShowActivityMenu(true);
             // Refresh activity menu data
             queryClient.invalidateQueries({ queryKey: stageKeys.pendingActions(sessionId) });


### PR DESCRIPTION
## Changes
- Show shared artifacts directly in the chat flow instead of hiding sent empathy/context behind drawer-only indicators.
- Add synthetic inline chat items for status-backed empathy/context artifacts when the backend does not provide a normal message for the current viewer.
- Preserve drawer navigation from shared indicators by scrolling to and highlighting the matching activity item.
- Label sent vs received shared artifacts so inline chat copy reads consistently for both participants.

## Provenance
- **Channel:** Codex desktop
- **Requested by:** Shantam
- **Original message:** "When I tap the line in the chat that says empathy shared, it opens the drawer, but it should also scroll to and highlight the corresponding item..." followed by "Please update the chat to have all things shared"

## Docs updated
- No doc changes needed — mobile UI behavior change only.

## Validation
- `npm run check --workspace @meet-without-fear/mobile`
- `git diff --check -- mobile/src/components/ActivityDrawer.tsx mobile/src/components/ChatBubble.tsx mobile/src/components/ChatInterface.tsx mobile/src/components/TimelineItemCard.tsx mobile/src/screens/UnifiedSessionScreen.tsx`
