### PR TITLE
fix: graceful offline error with retry on session load

### DIFF
--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -2,7 +2,7 @@
 title: Chat Interface
 sidebar_position: 3
 description: The primary conversation interface where users interact with the AI.
-updated: 2026-05-09
+updated: 2026-05-10
 status: living
 ---
 # Chat Interface
@@ -205,7 +205,13 @@ flowchart TB
 
 ## Session entry flow
 
-Before the chat list renders, `UnifiedSessionScreen` can swap in a full-screen mood check (`SessionEntryMoodCheck`) — this is the default entry when `shouldShowMoodCheck` is true. Only after the user submits (or dismisses) the mood reading does the usual chat layout show.
+Before the chat list renders, `UnifiedSessionScreen` checks three guard states in order:
+
+1. **Loading** — shows spinner + "Loading session..." while the `/state` endpoint (and retries) are in flight.
+2. **Load error** — if the state fetch fails (network timeout, offline, server error) after React Query retries are exhausted, shows "Couldn't load session" with a **Retry** button and a **Go back** link. The existing `AppState` foreground listener also auto-retries when the app returns from background.
+3. **Access denied** — 403/404 shows "You don't have access to this session." with a Go back link.
+
+After these guards pass, the mood check may appear (`SessionEntryMoodCheck`) if `shouldShowMoodCheck` is true. Only after the user submits (or dismisses) the mood reading does the usual chat layout show.
 
 ## App-level overlays
 

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -238,7 +238,7 @@ export function useUnifiedSession(
   // Consolidated Session State (reduces initial requests from ~5 to 1)
   // Returns session, progress, messages, invitation, and compact in one request
   // -------------------------------------------------------------------------
-  const { data: stateData, isLoading: loadingState, error: stateError } = useSessionState(sessionId);
+  const { data: stateData, isLoading: loadingState, error: stateError, refetch: refetchState } = useSessionState(sessionId);
 
   // If the /state endpoint returns 403 (no access) or 404 (session deleted/missing),
   // disable all child queries to prevent hundreds of redundant errors from polling.
@@ -262,7 +262,7 @@ export function useUnifiedSession(
   // Messages - use infinite scroll for pagination
   // The useSessionState hook hydrates the messages cache, so this will get a cache hit
   // Gate behind !loadingState to prevent initial parallel burst before /state resolves (see #428)
-  const stateResolved = !loadingState;
+  const stateResolved = !loadingState && !stateError;
   const {
     data: messagesData,
     isLoading: loadingMessages,
@@ -1193,6 +1193,8 @@ export function useUnifiedSession(
   return {
     // Loading state
     isLoading: loadingSession || loadingProgress || loadingMessages,
+    loadError: accessDenied ? null : stateError,
+    refetchSession: refetchState,
     accessDenied,
     isFetchingInitialMessage,
 

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -654,16 +654,17 @@ export function UnifiedSessionScreen({
     markSessionViewed,
 
   } = useUnifiedSession(sessionId);
+  const sessionQueriesEnabled = !accessDenied && !loadError;
 
   // Server-side pending actions for badge count (replaces client-side computation)
-  // Gate behind !accessDenied to prevent polling when session is deleted (#428)
-  const pendingActionsQuery = usePendingActions(sessionId, { enabled: !accessDenied });
+  // Gate behind a clean session load to prevent polling when session state fails (#428, #522)
+  const pendingActionsQuery = usePendingActions(sessionId, { enabled: sessionQueriesEnabled });
 
   // Sharing status for the header button. Keep these duplicate header queries
   // behind the same stage/access gates as useUnifiedSession so the badge does
   // not reintroduce the Stage 2 share-offer request storm this PR removes.
   const sharingStatus = useSharingStatus(sessionId, {
-    enabled: !accessDenied && currentStage >= Stage.PERSPECTIVE_STRETCH,
+    enabled: sessionQueriesEnabled && currentStage >= Stage.PERSPECTIVE_STRETCH,
     enableEmpathyStatus: currentStage >= Stage.PERSPECTIVE_STRETCH,
     enablePartnerEmpathy: currentStage >= Stage.PERSPECTIVE_STRETCH,
     enableShareOffer: currentStage === Stage.PERSPECTIVE_STRETCH,
@@ -760,10 +761,10 @@ export function UnifiedSessionScreen({
   });
 
   // Real-time presence and event tracking
-  // Disable when session is invalid to prevent Ably subscription cascading errors (#428)
+  // Disable when session is invalid or failed to load to prevent cascading errors (#428, #522)
   const { partnerOnline, connectionStatus, reconnect: _reconnectRealtime } = useRealtime({
     sessionId,
-    enabled: !accessDenied,
+    enabled: sessionQueriesEnabled,
     enablePresence: true,
     onSessionEvent: (event, data) => {
       console.log('[UnifiedSessionScreen] Received realtime event:', event);

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -534,6 +534,8 @@ export function UnifiedSessionScreen({
   const {
     // Loading
     isLoading,
+    loadError,
+    refetchSession,
     accessDenied,
     isFetchingInitialMessage,
 
@@ -3163,6 +3165,30 @@ export function UnifiedSessionScreen({
       <View style={styles.centerContainer}>
         <ActivityIndicator size="large" color={styles.accentColor.color} />
         <Text style={styles.loadingText}>Loading session...</Text>
+      </View>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Load Error — network/server failure (retries exhausted)
+  // The foreground recovery effect (AppState listener) will auto-retry when
+  // the app returns from background, so the user can also just reopen.
+  // -------------------------------------------------------------------------
+  if (loadError) {
+    return (
+      <View style={styles.centerContainer}>
+        <Text style={styles.loadingText}>Couldn't load session</Text>
+        <Text style={[styles.loadingText, { fontSize: 14, marginTop: 4, opacity: 0.7 }]}>
+          Check your connection and try again.
+        </Text>
+        <TouchableOpacity onPress={() => refetchSession()} style={{ marginTop: 20 }}>
+          <Text style={[styles.loadingText, { textDecorationLine: 'underline' }]}>Retry</Text>
+        </TouchableOpacity>
+        {onNavigateBack && (
+          <TouchableOpacity onPress={onNavigateBack} style={{ marginTop: 12 }}>
+            <Text style={[styles.loadingText, { textDecorationLine: 'underline' }]}>Go back</Text>
+          </TouchableOpacity>
+        )}
       </View>
     );
   }


### PR DESCRIPTION
## Changes
- Fix: Show "Couldn't load session" error screen with Retry button when session state fetch fails (network timeout, offline, server error)
- Fix: Prevent ghost session rendering (showing "Partner" as name) by gating child queries behind successful state resolution
- Fix: Add Go back navigation from error state
- Note: Foreground auto-retry already works via existing AppState listener that invalidates session state queries

Related to #522

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** When my internet is out and I tap a notification it tries to load the session then. We should detect this and fail gracefully with a retry button. Also we should retry on foreground.

## Docs updated
- `docs/mobile/wireframes/chat-interface.md` — added session entry guard states (loading → error → access denied)