### PR TITLE
fix: keep needs drawer open and readable

### DIFF
--- a/mobile/src/components/NeedCard.tsx
+++ b/mobile/src/components/NeedCard.tsx
@@ -6,7 +6,7 @@
  */
 
 import { View, Text, TouchableOpacity, StyleSheet, ViewStyle } from 'react-native';
-import { colors } from '@/theme';
+import { useAppAppearance } from '@/theme';
 
 // ============================================================================
 // Types
@@ -34,6 +34,9 @@ export function NeedCard({
   style,
   testID,
 }: NeedCardProps) {
+  const { palette } = useAppAppearance();
+  const styles = makeStyles(palette);
+
   const cardContent = (
     <>
       <Text style={styles.category}>
@@ -67,12 +70,12 @@ export function NeedCard({
 // Styles
 // ============================================================================
 
-const styles = StyleSheet.create({
+const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => StyleSheet.create({
   card: {
-    backgroundColor: 'rgba(147, 197, 253, 0.15)',
+    backgroundColor: palette.infoSoft,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: 'rgba(147, 197, 253, 0.3)',
+    borderColor: palette.info,
     padding: 16,
     marginBottom: 12,
     marginHorizontal: 16,
@@ -81,12 +84,12 @@ const styles = StyleSheet.create({
   category: {
     fontSize: 14,
     fontWeight: '600',
-    color: colors.textPrimary,
+    color: palette.textMuted,
     marginBottom: 4,
   },
   description: {
     fontSize: 16,
-    color: colors.textPrimary,
+    color: palette.text,
     lineHeight: 22,
   },
 });

--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -103,8 +103,12 @@ export function NeedsDrawer({
   const drawerTranslate = useRef(new Animated.Value(drawerHostHeight)).current;
   const backdropOpacity = useRef(new Animated.Value(0)).current;
   const isDragging = useRef(false);
+  const isClosing = useRef(false);
   const currentSnap = useRef<'3q' | 'full'>('3q');
+  const wasOpened = useRef(visible);
+  const [isMounted, setIsMounted] = useState(visible);
   const [contentHeight, setContentHeight] = useState(drawerHostHeight - position3Q);
+  const [backdropTouchableHeight, setBackdropTouchableHeight] = useState(position3Q);
 
   const handleHostLayout = useCallback((event: LayoutChangeEvent) => {
     const measuredHeight = event.nativeEvent.layout.height;
@@ -120,6 +124,7 @@ export function NeedsDrawer({
   // -------------------------------------------------------------------------
   const snapTo = useCallback(
     (position: number, backdrop: number) => {
+      setBackdropTouchableHeight(position);
       setContentHeight(drawerHostHeightRef.current - position);
       Animated.parallel([
         Animated.spring(drawerTranslate, {
@@ -139,11 +144,16 @@ export function NeedsDrawer({
   );
 
   const openDrawer = useCallback(() => {
+    isClosing.current = false;
     currentSnap.current = '3q';
+    drawerTranslate.setValue(drawerHostHeightRef.current);
+    backdropOpacity.setValue(0);
     snapTo(position3QRef.current, 0.4);
-  }, [snapTo]);
+  }, [backdropOpacity, drawerTranslate, snapTo]);
 
   const closeDrawer = useCallback(() => {
+    if (isClosing.current) return;
+    isClosing.current = true;
     Animated.parallel([
       Animated.timing(drawerTranslate, {
         toValue: drawerHostHeightRef.current,
@@ -157,15 +167,22 @@ export function NeedsDrawer({
       }),
     ]).start(() => {
       currentSnap.current = '3q';
+      wasOpened.current = false;
+      isClosing.current = false;
+      setIsMounted(false);
       onClose();
     });
   }, [drawerTranslate, backdropOpacity, onClose]);
 
   useEffect(() => {
     if (visible) {
+      wasOpened.current = true;
+      setIsMounted(true);
       openDrawer();
+    } else if (wasOpened.current) {
+      closeDrawer();
     }
-  }, [visible, openDrawer]);
+  }, [visible, openDrawer, closeDrawer]);
 
   useEffect(() => {
     if (!visible) {
@@ -174,6 +191,7 @@ export function NeedsDrawer({
     }
 
     const position = currentSnap.current === 'full' ? positionFullRef.current : position3Q;
+    setBackdropTouchableHeight(position);
     drawerTranslate.setValue(position);
     setContentHeight(drawerHostHeight - position);
   }, [visible, drawerHostHeight, position3Q, drawerTranslate]);
@@ -383,7 +401,7 @@ export function NeedsDrawer({
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
-  if (!visible) return null;
+  if (!isMounted) return null;
 
   const headerText = mode === 'needs' ? 'Your Needs' : 'Needs Side by Side';
 
@@ -396,12 +414,13 @@ export function NeedsDrawer({
     >
       {/* Backdrop */}
       <Pressable
-        style={styles.backdropPressable}
+        style={[styles.backdropPressable, { height: backdropTouchableHeight }]}
         onPress={() => {
           if (!isDragging.current) closeDrawer();
         }}
         accessibilityRole="button"
         accessibilityLabel={`Close ${headerText}`}
+        testID={`${testID}-backdrop`}
       >
         <Animated.View
           style={[styles.backdrop, { opacity: backdropOpacity }]}
@@ -437,6 +456,9 @@ export function NeedsDrawer({
             {headerText}
           </Text>
 
+          {mode === 'needs' && renderNeedsButtons()}
+          {mode === 'reveal' && renderRevealButtons()}
+
           {/* Scrollable content */}
           <ScrollView
             style={styles.scrollView}
@@ -446,10 +468,6 @@ export function NeedsDrawer({
             {mode === 'needs' && renderNeedsMode()}
             {mode === 'reveal' && renderRevealMode()}
           </ScrollView>
-
-          {/* Fixed footer buttons */}
-          {mode === 'needs' && renderNeedsButtons()}
-          {mode === 'reveal' && renderRevealButtons()}
         </View>
       </Animated.View>
     </View>
@@ -462,7 +480,11 @@ export function NeedsDrawer({
 
 const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => StyleSheet.create({
   backdropPressable: {
-    ...StyleSheet.absoluteFillObject,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 0,
   },
   backdrop: {
     flex: 1,
@@ -472,6 +494,7 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
     position: 'absolute',
     left: 0,
     right: 0,
+    zIndex: 1,
     backgroundColor: palette.bgPane,
     borderWidth: 1,
     borderColor: palette.border,
@@ -530,10 +553,12 @@ const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => 
     marginHorizontal: 16,
   },
 
-  // Fixed button area at bottom of drawer
+  // Action area
   fixedButtonArea: {
     borderTopWidth: 1,
+    borderBottomWidth: 1,
     borderTopColor: palette.border,
+    borderBottomColor: palette.border,
     backgroundColor: palette.bgPane,
     paddingHorizontal: 16,
     paddingTop: 12,

--- a/mobile/src/components/__tests__/NeedCard.test.tsx
+++ b/mobile/src/components/__tests__/NeedCard.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import { NeedCard } from '../NeedCard';
 
 describe('NeedCard', () => {
@@ -29,5 +30,12 @@ describe('NeedCard', () => {
     render(<NeedCard need={defaultNeed} testID="need-card" />);
     const card = screen.getByTestId('need-card');
     expect(card).toBeTruthy();
+  });
+
+  it('uses the current appearance palette for readable text', () => {
+    render(<NeedCard need={defaultNeed} testID="need-card" />);
+
+    expect(StyleSheet.flatten(screen.getByText('Security').props.style).color).toBe('#6c6961');
+    expect(StyleSheet.flatten(screen.getByText('A need for safety and stability').props.style).color).toBe('#1a1815');
   });
 });

--- a/mobile/src/components/__tests__/NeedsDrawer.test.tsx
+++ b/mobile/src/components/__tests__/NeedsDrawer.test.tsx
@@ -72,7 +72,7 @@ describe('NeedsDrawer', () => {
     const onValidateNeeds = jest.fn();
     const onNeedsNotValidYet = jest.fn();
 
-    render(
+    const { unmount } = render(
       <NeedsDrawer
         visible
         onClose={jest.fn()}
@@ -87,6 +87,19 @@ describe('NeedsDrawer', () => {
     fireEvent.press(screen.getByTestId('needs-drawer-validate-needs'));
     expect(onValidateNeeds).toHaveBeenCalledTimes(1);
 
+    unmount();
+
+    render(
+      <NeedsDrawer
+        visible
+        onClose={jest.fn()}
+        mode="reveal"
+        needs={needs}
+        partnerNeeds={partnerNeeds}
+        onValidateNeeds={onValidateNeeds}
+        onNeedsNotValidYet={onNeedsNotValidYet}
+      />
+    );
     fireEvent.press(screen.getByTestId('needs-drawer-not-valid-yet'));
     expect(onNeedsNotValidYet).toHaveBeenCalledTimes(1);
   });
@@ -120,5 +133,55 @@ describe('NeedsDrawer', () => {
 
     expect(StyleSheet.flatten(screen.getByTestId('needs-drawer-sheet').props.style).height).toBe(620);
     expect(StyleSheet.flatten(screen.getByTestId('needs-drawer-content').props.style).height).toBe(465);
+  });
+
+  it('limits backdrop presses to the area above the visible sheet', () => {
+    render(
+      <NeedsDrawer
+        visible
+        onClose={jest.fn()}
+        mode="needs"
+        needs={needs}
+      />
+    );
+
+    fireEvent(screen.getByTestId('needs-drawer'), 'layout', {
+      nativeEvent: { layout: { height: 620 } },
+    });
+
+    const backdropStyle = StyleSheet.flatten(screen.getByTestId('needs-drawer-backdrop').props.style);
+    expect(backdropStyle.top).toBe(0);
+    expect(backdropStyle.bottom).toBeUndefined();
+    expect(backdropStyle.height).toBe(155);
+  });
+
+  it('keeps the sheet layered above the backdrop', () => {
+    render(
+      <NeedsDrawer
+        visible
+        onClose={jest.fn()}
+        mode="needs"
+        needs={needs}
+      />
+    );
+
+    const sheetStyle = StyleSheet.flatten(screen.getByTestId('needs-drawer-sheet').props.style);
+    expect(sheetStyle.zIndex).toBeGreaterThan(0);
+  });
+
+  it('closes when the user presses the backdrop', () => {
+    const onClose = jest.fn();
+
+    render(
+      <NeedsDrawer
+        visible
+        onClose={onClose}
+        mode="needs"
+        needs={needs}
+      />
+    );
+
+    fireEvent.press(screen.getByTestId('needs-drawer-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- keep the Stage 3 needs drawer mounted during close animations and layered above its backdrop
- constrain the backdrop close target to the area above the visible sheet instead of the whole viewport
- move needs drawer actions out of the original Review button hit zone so repeated taps cannot accidentally trigger Chat to refine / confirm / validate
- make NeedCard use the active appearance palette so needs remain readable in light mode

## Local replay
- cloned production session cmoyye2jc001fmp1xv3ys1ntv into local dev DB
- opened Shantam side via E2E auth at localhost:8082
- reproduced on main/earlier patch with fixed-coordinate touch taps at the Review button location: every other tap closed the drawer
- inspected elementFromPoint after open and found the repeated tap was landing on needs-drawer-adjust (Chat to refine), not just the backdrop
- verified the updated branch keeps the drawer open across repeated taps at the original Review coordinate; the hit target is inert review content
- verified tapping the actual backdrop area above the sheet still closes the drawer
- verified needs text is readable in light mode

## Tests
- npm --workspace mobile test -- NeedsDrawer.test.tsx NeedCard.test.tsx --runInBand