### PR TITLE
fix: refresh needs share state immediately

### DIFF
--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -191,10 +191,8 @@ export function NeedsDrawer({
     }
 
     const position = currentSnap.current === 'full' ? positionFullRef.current : position3Q;
-    setBackdropTouchableHeight(position);
-    drawerTranslate.setValue(position);
-    setContentHeight(drawerHostHeight - position);
-  }, [visible, drawerHostHeight, position3Q, drawerTranslate]);
+    snapTo(position, currentSnap.current === 'full' ? 0.6 : 0.4);
+  }, [visible, drawerHostHeight, position3Q, drawerTranslate, snapTo]);
 
   // -------------------------------------------------------------------------
   // Android back button

--- a/mobile/src/hooks/__tests__/useStages.test.ts
+++ b/mobile/src/hooks/__tests__/useStages.test.ts
@@ -41,6 +41,7 @@ import {
   useResolveSession,
   stageKeys,
 } from '../useStages';
+import { sessionKeys } from '../queryKeys';
 import {
   Stage,
   StageStatus,
@@ -87,15 +88,18 @@ jest.mock('../useAuth', () => ({
 const mockGet = api.get as jest.MockedFunction<typeof api.get>;
 const mockPost = api.post as jest.MockedFunction<typeof api.post>;
 
-// Create a wrapper with QueryClient
-function createWrapper(): React.FC<{ children: React.ReactNode }> {
-  const queryClient = new QueryClient({
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({
     defaultOptions: {
       queries: {
         retry: false,
       },
     },
   });
+}
+
+// Create a wrapper with QueryClient
+function createWrapper(queryClient = createTestQueryClient()): React.FC<{ children: React.ReactNode }> {
   return ({ children }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
 }
@@ -627,6 +631,68 @@ describe('useStages', () => {
           adjustments: undefined,
         });
       });
+
+      it('immediately marks needs confirmed in progress and session state caches', async () => {
+        mockPost.mockResolvedValueOnce({
+          confirmed: true,
+          confirmedAt: '2024-01-01T00:00:00.000Z',
+          partnerConfirmed: false,
+          canAdvance: false,
+        });
+
+        const queryClient = createTestQueryClient();
+        queryClient.setQueryData(stageKeys.progress(sessionId), {
+          sessionId,
+          myProgress: {
+            stage: Stage.NEED_MAPPING,
+            status: StageStatus.IN_PROGRESS,
+            startedAt: '2024-01-01T00:00:00.000Z',
+            completedAt: null,
+            gatesSatisfied: {},
+          },
+          partnerProgress: {
+            stage: Stage.NEED_MAPPING,
+            status: StageStatus.IN_PROGRESS,
+          },
+          canAdvance: false,
+        });
+        queryClient.setQueryData(sessionKeys.state(sessionId), {
+          progress: {
+            sessionId,
+            myProgress: {
+              stage: Stage.NEED_MAPPING,
+              status: StageStatus.IN_PROGRESS,
+              startedAt: '2024-01-01T00:00:00.000Z',
+              completedAt: null,
+              gatesSatisfied: {},
+            },
+            partnerProgress: {
+              stage: Stage.NEED_MAPPING,
+              status: StageStatus.IN_PROGRESS,
+            },
+            canAdvance: false,
+            milestones: { feelHeardConfirmedAt: null },
+          },
+        });
+
+        const { result } = renderHook(() => useConfirmNeeds(), {
+          wrapper: createWrapper(queryClient),
+        });
+
+        await act(async () => {
+          await result.current.mutateAsync({
+            sessionId,
+            needIds: ['need-1', 'need-2'],
+          });
+        });
+
+        expect(
+          queryClient.getQueryData<any>(stageKeys.progress(sessionId))?.myProgress.gatesSatisfied.needsConfirmed
+        ).toBe(true);
+        expect(
+          queryClient.getQueryData<any>(sessionKeys.state(sessionId))?.progress.myProgress.gatesSatisfied.needsConfirmed
+        ).toBe(true);
+      });
     });
 
     describe('useAddNeed hook', () => {
@@ -667,8 +733,10 @@ describe('useStages', () => {
     describe('useConsentShareNeeds hook', () => {
       it('consents to reveal confirmed needs to the partner', async () => {
         mockPost.mockResolvedValueOnce({
-          consent: true,
-          sharedNeedIds: ['need-1', 'need-2'],
+          consented: true,
+          sharedAt: '2024-01-01T00:00:00.000Z',
+          waitingForPartner: true,
+          needsRevealReady: false,
         });
 
         const { result } = renderHook(() => useConsentShareNeeds(), {
@@ -685,6 +753,68 @@ describe('useStages', () => {
         expect(mockPost).toHaveBeenCalledWith(`/sessions/${sessionId}/needs/consent`, {
           needIds: ['need-1', 'need-2'],
         });
+      });
+
+      it('immediately marks needs shared in progress and session state caches', async () => {
+        mockPost.mockResolvedValueOnce({
+          consented: true,
+          sharedAt: '2024-01-01T00:00:00.000Z',
+          waitingForPartner: false,
+          needsRevealReady: true,
+        });
+
+        const queryClient = createTestQueryClient();
+        queryClient.setQueryData(stageKeys.progress(sessionId), {
+          sessionId,
+          myProgress: {
+            stage: Stage.NEED_MAPPING,
+            status: StageStatus.GATE_PENDING,
+            startedAt: '2024-01-01T00:00:00.000Z',
+            completedAt: null,
+            gatesSatisfied: { needsConfirmed: true },
+          },
+          partnerProgress: {
+            stage: Stage.NEED_MAPPING,
+            status: StageStatus.GATE_PENDING,
+          },
+          canAdvance: false,
+        });
+        queryClient.setQueryData(sessionKeys.state(sessionId), {
+          progress: {
+            sessionId,
+            myProgress: {
+              stage: Stage.NEED_MAPPING,
+              status: StageStatus.GATE_PENDING,
+              startedAt: '2024-01-01T00:00:00.000Z',
+              completedAt: null,
+              gatesSatisfied: { needsConfirmed: true },
+            },
+            partnerProgress: {
+              stage: Stage.NEED_MAPPING,
+              status: StageStatus.GATE_PENDING,
+            },
+            canAdvance: false,
+            milestones: { feelHeardConfirmedAt: null },
+          },
+        });
+
+        const { result } = renderHook(() => useConsentShareNeeds(), {
+          wrapper: createWrapper(queryClient),
+        });
+
+        await act(async () => {
+          await result.current.mutateAsync({
+            sessionId,
+            needIds: ['need-1', 'need-2'],
+          });
+        });
+
+        expect(
+          queryClient.getQueryData<any>(stageKeys.progress(sessionId))?.myProgress.gatesSatisfied.needsShared
+        ).toBe(true);
+        expect(
+          queryClient.getQueryData<any>(sessionKeys.state(sessionId))?.progress.myProgress.gatesSatisfied.needsShared
+        ).toBe(true);
       });
     });
 

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -99,6 +99,49 @@ type ProgressCacheWithGates = GetProgressResponse & {
   };
 };
 
+function patchStage3Gates(
+  queryClient: ReturnType<typeof useQueryClient>,
+  sessionId: string,
+  gates: Record<string, unknown>,
+) {
+  const mergeProgress = <T extends { myProgress?: { gatesSatisfied?: unknown; gates?: unknown } }>(
+    old: T | undefined,
+  ): T | undefined => {
+    if (!old?.myProgress) return old;
+    const existingGates =
+      (old.myProgress.gatesSatisfied as Record<string, unknown> | null | undefined) ??
+      (old.myProgress.gates as Record<string, unknown> | null | undefined) ??
+      {};
+
+    return {
+      ...old,
+      myProgress: {
+        ...old.myProgress,
+        gatesSatisfied: {
+          ...existingGates,
+          ...gates,
+        },
+      },
+    };
+  };
+
+  queryClient.setQueryData<ProgressCacheWithGates>(
+    stageKeys.progress(sessionId),
+    mergeProgress,
+  );
+
+  queryClient.setQueryData<SessionStateResponse>(
+    sessionKeys.state(sessionId),
+    (old) => {
+      if (!old) return old;
+      return {
+        ...old,
+        progress: mergeProgress(old.progress) ?? old.progress,
+      };
+    },
+  );
+}
+
 // ============================================================================
 // Progress Hook
 // ============================================================================
@@ -1470,6 +1513,10 @@ export function useConfirmNeeds(
       });
     },
     onSuccess: (_, { sessionId }) => {
+      patchStage3Gates(queryClient, sessionId, {
+        needsConfirmed: true,
+        needsConfirmedAt: new Date().toISOString(),
+      });
       queryClient.invalidateQueries({ queryKey: stageKeys.needs(sessionId) });
       queryClient.invalidateQueries({ queryKey: stageKeys.needsComparison(sessionId) });
       queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
@@ -1530,7 +1577,11 @@ export function useConsentShareNeeds(
         needIds,
       });
     },
-    onSuccess: (_, { sessionId }) => {
+    onSuccess: (data, { sessionId }) => {
+      patchStage3Gates(queryClient, sessionId, {
+        needsShared: true,
+        sharedAt: data.sharedAt,
+      });
       queryClient.invalidateQueries({ queryKey: stageKeys.needs(sessionId) });
       queryClient.invalidateQueries({ queryKey: stageKeys.needsComparison(sessionId) });
       queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });


### PR DESCRIPTION
## Summary
- let the needs drawer keep animating during layout measurement instead of snapping to the measured open position
- immediately patch Stage 3 progress/session-state caches after confirming needs and sharing needs
- add regression coverage that confirm/share mutations update both progress and consolidated session-state caches

## Local replay
- used cloned production session cmoyye2jc001fmp1xv3ys1ntv in local E2E mode
- verified the drawer now slides from below the viewport instead of appearing at its final position immediately
- confirmed needs, reopened the card, shared needs, and verified the card immediately changed to Shared / Open review without waiting for app wake/refetch
- verified waiting copy appears immediately after sharing while the partner has not shared

## Tests
- npm --workspace mobile test -- NeedsDrawer.test.tsx useStages.test.ts --runInBand --forceExit
- npm --workspace mobile run check -- --pretty false