### PR TITLE
fix: enforce FIELD_ENCRYPTION_KEY in production

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -56,6 +56,15 @@ if (process.env.E2E_AUTH_BYPASS === 'true' && process.env.NODE_ENV === 'producti
   );
 }
 
+// Fail fast: FIELD_ENCRYPTION_KEY is required in production
+if (!process.env.FIELD_ENCRYPTION_KEY && process.env.NODE_ENV === 'production') {
+  throw new Error(
+    'FATAL: FIELD_ENCRYPTION_KEY is not set in a production environment. ' +
+    'All sensitive fields (messages, empathy drafts, conversation summaries) would be stored as plaintext. ' +
+    'Generate a key with: openssl rand -base64 32'
+  );
+}
+
 const PORT = process.env.PORT || 3000;
 
 // Create HTTP server from Express app (required for WebSocket upgrade handling)

--- a/backend/src/utils/__tests__/field-encryption.test.ts
+++ b/backend/src/utils/__tests__/field-encryption.test.ts
@@ -122,10 +122,15 @@ describe('field-encryption', () => {
     });
   });
 
-  describe('graceful degradation (no key)', () => {
+  describe('graceful degradation (no key, non-production)', () => {
     beforeEach(() => {
       _resetForTesting();
       delete process.env.FIELD_ENCRYPTION_KEY;
+      process.env.NODE_ENV = 'test';
+    });
+
+    afterEach(() => {
+      delete process.env.NODE_ENV;
     });
 
     it('encrypt returns plaintext unchanged when no key is set', () => {
@@ -141,6 +146,26 @@ describe('field-encryption', () => {
     it('isEncrypted still detects format even without key', () => {
       expect(isEncrypted('enc:v1:abc:def:ghi')).toBe(true);
       expect(isEncrypted('not encrypted')).toBe(false);
+    });
+  });
+
+  describe('production enforcement (no key)', () => {
+    beforeEach(() => {
+      _resetForTesting();
+      delete process.env.FIELD_ENCRYPTION_KEY;
+      process.env.NODE_ENV = 'production';
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = 'test';
+    });
+
+    it('encrypt throws when no key is set in production', () => {
+      expect(() => encrypt('sensitive data')).toThrow('FIELD_ENCRYPTION_KEY is not set in production');
+    });
+
+    it('decrypt throws when no key is set in production', () => {
+      expect(() => decrypt('enc:v1:abc:def:ghi')).toThrow('FIELD_ENCRYPTION_KEY is not set in production');
     });
   });
 

--- a/backend/src/utils/field-encryption.ts
+++ b/backend/src/utils/field-encryption.ts
@@ -9,7 +9,7 @@
  *
  * Configuration:
  *   FIELD_ENCRYPTION_KEY — 32-byte key, base64-encoded.
- *   If not set, encrypt/decrypt pass through unchanged (graceful degradation for dev/test).
+ *   Required in production (throws on missing key). In dev/test, passes through unchanged.
  */
 
 import crypto from 'crypto';
@@ -21,7 +21,6 @@ const AUTH_TAG_LENGTH = 16; // 128 bits
 const ENCRYPTED_PREFIX = 'enc:v1:';
 
 let encryptionKey: Buffer | null = null;
-let keyWarningLogged = false;
 
 /**
  * Lazily resolves the encryption key from the environment.
@@ -32,12 +31,12 @@ function getKey(): Buffer | null {
 
   const raw = process.env.FIELD_ENCRYPTION_KEY;
   if (!raw) {
-    if (!keyWarningLogged && process.env.NODE_ENV === 'production') {
-      logger.warn(
-        '[FieldEncryption] FIELD_ENCRYPTION_KEY is not set. Sensitive fields will NOT be encrypted. ' +
-          'Set a 32-byte base64-encoded key to enable application-level encryption.',
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        '[FieldEncryption] FIELD_ENCRYPTION_KEY is not set in production. ' +
+          'Sensitive fields must not be stored as plaintext. ' +
+          'Generate a key with: openssl rand -base64 32',
       );
-      keyWarningLogged = true;
     }
     return null;
   }
@@ -132,5 +131,4 @@ export function isEncrypted(value: string): boolean {
  */
 export function _resetForTesting(): void {
   encryptionKey = null;
-  keyWarningLogged = false;
 }

--- a/docs/backend/security/index.md
+++ b/docs/backend/security/index.md
@@ -37,7 +37,7 @@ Consent decisions and retrieval attempts recorded for review
 - **Stage enforcement source of truth**: App-layer retrieval contracts + StageProgress gates.
 - **Consent scope**: All consent records are tied to a session + targetId + targetType; revocation must cascade to SharedVessel content (set `consentActive=false`) and mark dependent outputs stale.
 - **Admin access**: Only for global library curation; no access to user vessels. Admin queries must keep explicit user/session/relationship filters.
-- **Encryption**: TLS to Postgres, Render at-rest encryption, hash push tokens, and avoid storing secrets in user rows. Application-level field encryption (AES-256-GCM) auto-encrypts sensitive fields on write and auto-decrypts on read when `FIELD_ENCRYPTION_KEY` is set; gracefully degrades to plaintext passthrough when unset.
+- **Encryption**: TLS to Postgres, Render at-rest encryption, hash push tokens, and avoid storing secrets in user rows. Application-level field encryption (AES-256-GCM) auto-encrypts sensitive fields on write and auto-decrypts on read. `FIELD_ENCRYPTION_KEY` is required in production (server refuses to start without it); in dev/test it passes through unchanged.
 - **Audit log**: Log every `/consent/decide`, `/consent/revoke`, and retrieval contract rejection.
 
 ---

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -23,6 +23,7 @@ All required environment variables for Meet Without Fear services.
 | `AWS_ACCESS_KEY_ID` | AWS credentials for Bedrock | `AKIA...` |
 | `AWS_SECRET_ACCESS_KEY` | AWS credentials for Bedrock | (secret) |
 | `AWS_REGION` | AWS region for Bedrock | `us-west-2` |
+| `FIELD_ENCRYPTION_KEY` | 32-byte base64 key for AES-256-GCM field encryption. Server refuses to start without it in production. Generate with `openssl rand -base64 32` | (secret) |
 
 ### Optional
 
@@ -111,6 +112,7 @@ Set via Render dashboard or `render.yaml`:
 - `JWT_REFRESH_SECRET`: Generate with `generateValue: true`
 - `ABLY_API_KEY`: Set manually (secret)
 - `AWS_*`: Set manually (secrets)
+- `FIELD_ENCRYPTION_KEY`: Generate with `openssl rand -base64 32` (secret)
 
 ## Secrets Management
 


### PR DESCRIPTION
## Changes
- Add: fail-fast startup guard in `server.ts` — throws if `FIELD_ENCRYPTION_KEY` is missing in production (matches existing `E2E_AUTH_BYPASS` pattern)
- Fix: `getKey()` in `field-encryption.ts` now throws in production instead of silently degrading to plaintext passthrough
- Add: production enforcement tests (encrypt/decrypt throw when key missing in production)
- Update: `docs/deployment/environment-variables.md` — `FIELD_ENCRYPTION_KEY` listed as required production variable
- Update: `docs/backend/security/index.md` — reflects mandatory key requirement in production

Related to #543

## Provenance
- **Channel:** #security-audit
- **Requested by:** Automated weekly security audit
- **Original message:** Weekly security audit cron — 2026-05-11
- **Prompt(s) used:** general-pr workspace

## Docs updated
- `docs/deployment/environment-variables.md` — added FIELD_ENCRYPTION_KEY to Required table and Production section
- `docs/backend/security/index.md` — updated encryption bullet to reflect mandatory key in production

## Note
This PR only addresses the code-hardening portion of #543. The following require separate work:
- **PII field expansion** (email, firstName, etc.) needs architectural design for blind indexing since `User.email` has a `@unique` index
- **Backfill migration** to encrypt existing plaintext data
- **Verify key is set in Render** — requires manual dashboard access