### PR TITLE
Fix empathy statement duplicate superseded label

### DIFF
--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -110,6 +110,7 @@ import {
   trackShareDraftSent,
 } from '../services/analytics';
 import { shouldShowSessionEntryMoodCheck } from '../utils/sessionEntryMoodCheck';
+import { hasNewerDistinctEmpathyStatement, isSameEmpathyAttemptMessage } from '../utils/empathyMessageMatching';
 
 // ============================================================================
 // Types
@@ -2078,10 +2079,7 @@ export function UnifiedSessionScreen({
 
     if (myAttempt?.content && myAttempt.sharedAt) {
       const hasMyAttemptMessage = baseMessages.some(
-        (message) =>
-          message.role === MessageRole.EMPATHY_STATEMENT &&
-          message.senderId === user?.id &&
-          message.timestamp === myAttempt.sharedAt,
+        (message) => isSameEmpathyAttemptMessage(message, user?.id, myAttempt),
       );
 
       if (!hasMyAttemptMessage) {
@@ -2103,9 +2101,10 @@ export function UnifiedSessionScreen({
       const partnerTimestamp = partnerAttempt.revealedAt || partnerAttempt.sharedAt;
       const hasPartnerAttemptMessage = baseMessages.some(
         (message) =>
-          message.role === MessageRole.EMPATHY_STATEMENT &&
-          message.senderId === partnerAttempt.sourceUserId &&
-          message.timestamp === partnerTimestamp,
+          isSameEmpathyAttemptMessage(message, partnerAttempt.sourceUserId, {
+            content: partnerAttempt.content,
+            sharedAt: partnerTimestamp,
+          }),
       );
 
       if (!hasPartnerAttemptMessage) {
@@ -2193,7 +2192,8 @@ export function UnifiedSessionScreen({
         if (
           message.senderId === user?.id &&
           myEmpathyStatements.length > 1 &&
-          message.id !== latestEmpathyId
+          message.id !== latestEmpathyId &&
+          hasNewerDistinctEmpathyStatement(message, myEmpathyStatements)
         ) {
           return {
             ...message,

--- a/mobile/src/utils/__tests__/empathyMessageMatching.test.ts
+++ b/mobile/src/utils/__tests__/empathyMessageMatching.test.ts
@@ -1,0 +1,59 @@
+import { MessageRole } from '@meet-without-fear/shared';
+import type { EmpathyAttemptDTO, MessageDTO } from '@meet-without-fear/shared';
+import {
+  hasNewerDistinctEmpathyStatement,
+  isSameEmpathyAttemptMessage,
+} from '../empathyMessageMatching';
+
+describe('empathy message matching', () => {
+  const baseMessage: Pick<MessageDTO, 'id' | 'role' | 'senderId' | 'content' | 'timestamp'> = {
+    id: 'message-1',
+    senderId: 'james',
+    role: MessageRole.EMPATHY_STATEMENT,
+    content: 'I can see that you felt alone and dismissed.',
+    timestamp: '2026-05-11T18:00:00.250Z',
+  };
+
+  const baseAttempt: Pick<EmpathyAttemptDTO, 'content' | 'sharedAt'> = {
+    content: baseMessage.content,
+    sharedAt: '2026-05-11T18:00:00.000Z',
+  };
+
+  it('matches the first empathy message when message timestamp differs slightly from sharedAt', () => {
+    expect(isSameEmpathyAttemptMessage(baseMessage, 'james', baseAttempt)).toBe(true);
+  });
+
+  it('does not match a different empathy statement from a later revision', () => {
+    expect(isSameEmpathyAttemptMessage(
+      {
+        ...baseMessage,
+        id: 'message-2',
+        content: 'I can see that you felt alone, dismissed, and unsure I was with you.',
+        timestamp: '2026-05-11T18:02:00.000Z',
+      },
+      'james',
+      baseAttempt,
+    )).toBe(false);
+  });
+
+  it('does not mark a duplicate first-share message as superseded', () => {
+    const duplicateMessage = {
+      ...baseMessage,
+      id: 'message-duplicate',
+      timestamp: '2026-05-11T18:00:00.500Z',
+    };
+
+    expect(hasNewerDistinctEmpathyStatement(baseMessage, [baseMessage, duplicateMessage])).toBe(false);
+  });
+
+  it('marks an older empathy message as superseded when a newer distinct revision exists', () => {
+    const revisedMessage = {
+      ...baseMessage,
+      id: 'message-2',
+      content: 'I can see that you felt alone, dismissed, and unsure I was with you.',
+      timestamp: '2026-05-11T18:02:00.000Z',
+    };
+
+    expect(hasNewerDistinctEmpathyStatement(baseMessage, [baseMessage, revisedMessage])).toBe(true);
+  });
+});

--- a/mobile/src/utils/empathyMessageMatching.ts
+++ b/mobile/src/utils/empathyMessageMatching.ts
@@ -1,0 +1,55 @@
+import { MessageRole } from '@meet-without-fear/shared';
+import type { EmpathyAttemptDTO, MessageDTO } from '@meet-without-fear/shared';
+
+const EMPATHY_ATTEMPT_MESSAGE_TIMESTAMP_TOLERANCE_MS = 10_000;
+
+function parseTimestamp(timestamp?: string | null): number | null {
+  if (!timestamp) return null;
+  const time = new Date(timestamp).getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
+type EmpathyMessageLike = Pick<MessageDTO, 'id' | 'role' | 'senderId' | 'content' | 'timestamp'>;
+
+export function isSameEmpathyAttemptMessage(
+  message: EmpathyMessageLike,
+  sourceUserId: string | null | undefined,
+  attempt: Pick<EmpathyAttemptDTO, 'content' | 'sharedAt'>,
+): boolean {
+  if (
+    message.role !== MessageRole.EMPATHY_STATEMENT ||
+    message.senderId !== sourceUserId ||
+    message.content !== attempt.content
+  ) {
+    return false;
+  }
+
+  if (message.timestamp === attempt.sharedAt) {
+    return true;
+  }
+
+  const messageTime = parseTimestamp(message.timestamp);
+  const sharedTime = parseTimestamp(attempt.sharedAt);
+  if (messageTime === null || sharedTime === null) {
+    return false;
+  }
+
+  return Math.abs(messageTime - sharedTime) <= EMPATHY_ATTEMPT_MESSAGE_TIMESTAMP_TOLERANCE_MS;
+}
+
+export function hasNewerDistinctEmpathyStatement(
+  message: EmpathyMessageLike,
+  empathyStatements: EmpathyMessageLike[],
+): boolean {
+  const messageTime = parseTimestamp(message.timestamp);
+  if (messageTime === null) return false;
+
+  return empathyStatements.some((candidate) => {
+    if (candidate.id === message.id || candidate.content === message.content) {
+      return false;
+    }
+
+    const candidateTime = parseTimestamp(candidate.timestamp);
+    return candidateTime !== null && candidateTime > messageTime;
+  });
+}


### PR DESCRIPTION
## Summary
- dedupe synthesized empathy statement chat items when the real chat message timestamp differs slightly from EmpathyAttempt.sharedAt
- only mark empathy statements as superseded when a newer distinct statement exists
- add pure utility coverage for timestamp-tolerant matching and superseded detection

## Evidence
Live test session `cmp1jjdlo0008px3vl7sgwnwx` showed the backend writes EmpathyAttempt.sharedAt and Message.timestamp a few ms apart:
- Catherine: sharedAt `2026-05-11T18:40:20.812Z`, message timestamp `2026-05-11T18:40:20.816Z` (4ms)
- James: sharedAt `2026-05-11T18:47:08.078Z`, message timestamp `2026-05-11T18:47:08.082Z` (4ms)

The previous exact timestamp check failed to recognize those as the same first-share message, causing a synthetic duplicate that could render as “Updated version below.”

## Tests
- `npm --workspace mobile test -- --runTestsByPath src/utils/__tests__/empathyMessageMatching.test.ts --runInBand`
- `npm --workspace mobile run check`