### PR TITLE
Fix Stage 2 post-validation wait state

### DIFF
--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -1233,17 +1233,46 @@ export async function validateEmpathy(
       })
       : null;
 
+    const partnerHasValidatedMyAttempt = partnerValidation?.validated === true;
+    if (validated && !partnerHasValidatedMyAttempt) {
+      const waitMessage =
+        "You confirmed this feels right. We'll hold here while your partner reviews what you shared. Once they respond, we'll move you into the next step.";
+
+      const existingWaitMessage = await prisma.message.findFirst({
+        where: {
+          sessionId,
+          forUserId: user.id,
+          role: MessageRole.AI,
+          content: waitMessage,
+        },
+      });
+
+      if (!existingWaitMessage) {
+        await prisma.message.create({
+          data: {
+            sessionId,
+            senderId: null,
+            forUserId: user.id,
+            role: MessageRole.AI,
+            content: waitMessage,
+            stage: 2,
+            timestamp: now,
+          },
+        });
+      }
+    }
+
     successResponse(res, {
       validated,
       validatedAt: now.toISOString(),
       feedbackShared: validationRecord.feedbackShared,
       awaitingRevision: validated === false,
       canAdvance: validated,
-      partnerValidated: partnerValidation ? partnerValidation.validated : false,
+      partnerValidated: partnerHasValidatedMyAttempt,
     });
 
     // Check if both have validated (Accurate/Partial) and trigger transition
-    if (validated && partnerValidation?.validated) {
+    if (validated && partnerHasValidatedMyAttempt) {
       triggerStage3Transition(sessionId, user.id, partnerId).catch(err =>
         logger.error('[validateEmpathy] Failed to trigger stage 3 transition:', err)
       );

--- a/backend/src/routes/__tests__/stage2.test.ts
+++ b/backend/src/routes/__tests__/stage2.test.ts
@@ -483,6 +483,11 @@ describe('Stage 2 API', () => {
         feedbackShared: false,
       });
       (prisma.empathyValidation.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.message.findFirst as jest.Mock).mockResolvedValue(null);
+      (prisma.message.create as jest.Mock).mockResolvedValue({
+        id: 'wait-message-1',
+        timestamp: new Date(),
+      });
       (prisma.stageProgress.update as jest.Mock).mockResolvedValue({
         gatesSatisfied: { empathyValidated: true },
       });
@@ -505,6 +510,18 @@ describe('Stage 2 API', () => {
 
       expect(prisma.empathyValidation.upsert).toHaveBeenCalled();
       expect(prisma.stageProgress.update).toHaveBeenCalled();
+      expect(prisma.message.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            sessionId: 'session-123',
+            senderId: null,
+            forUserId: 'user-1',
+            role: 'AI',
+            content: expect.stringContaining('You confirmed this feels right'),
+            stage: 2,
+          }),
+        })
+      );
       expect(notifyPartner).toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -282,6 +282,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     feelHeardConfirmedAt,
     isConfirmingFeelHeard,
     hasEmpathyContent: hasLiveProposedEmpathyStatement || !!empathyDraftData?.draft?.content,
+    hasLiveProposedEmpathyStatement,
     empathyAlreadyConsented: empathyDraftData?.alreadyConsented ?? false,
     hasSharedEmpathyLocal,
     isRefiningEmpathy: empathyStatusData?.hasNewSharedContext ?? false,

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -1181,6 +1181,8 @@ export function useValidateEmpathy(
       queryClient.invalidateQueries({ queryKey: sessionKeys.detail(sessionId) });
       queryClient.invalidateQueries({ queryKey: stageKeys.pendingActions(sessionId) });
       queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
+      queryClient.refetchQueries({ queryKey: messageKeys.infinite(sessionId) });
+      queryClient.refetchQueries({ queryKey: messageKeys.list(sessionId) });
       // When both users validated, the server triggers stage transition async.
       // Delayed refetch ensures we pick up the new stage after the transition commits.
       if (data.canAdvance && data.partnerValidated) {

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1569,6 +1569,13 @@ export function UnifiedSessionScreen({
   const isEmpathyValidated =
     isLocalEmpathyValidationActive && localEmpathyValidationAction?.action === 'accepted';
   const isEmpathyShared = completedActions.has('shared-empathy');
+  const effectiveMyValidation = isEmpathyValidated
+    ? {
+        ...sharingStatus.myValidation,
+        validated: true,
+        awaitingRevision: false,
+      }
+    : sharingStatus.myValidation;
 
   useEffect(() => {
     if (showFeedbackCoachChat && !feedbackCoachInitializedRef.current) {
@@ -1734,7 +1741,7 @@ export function UnifiedSessionScreen({
         content: empathyStatusData.myAttempt.content,
       } : undefined,
       partnerEmpathyHeldStatus: empathyStatusData.partnerEmpathyHeldStatus,
-      myValidation: sharingStatus.myValidation,
+      myValidation: effectiveMyValidation,
       partnerValidated: sharingStatus.partnerValidated,
       messageCountSinceSharedContext: empathyStatusData.messageCountSinceSharedContext,
     } : undefined,

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -739,7 +739,7 @@ describe('Empathy Panel Visibility', () => {
     expect(result.aboveInputPanel).not.toBe('empathy-statement');
   });
 
-  it('does not show in refining mode before user reflects, even when new AI content is reviewable', () => {
+  it('does not show in refining mode before user reflects when only prior draft content is reviewable', () => {
     const inputs = createInputs({
       myStage: Stage.PERSPECTIVE_STRETCH,
       compactMySigned: true,
@@ -753,6 +753,23 @@ describe('Empathy Panel Visibility', () => {
     const result = computeChatUIState(inputs);
     expect(result.panels.showEmpathyPanel).toBe(false);
     expect(result.aboveInputPanel).not.toBe('empathy-statement');
+  });
+
+  it('shows in refining mode once the AI has produced a revised draft', () => {
+    const inputs = createInputs({
+      myStage: Stage.PERSPECTIVE_STRETCH,
+      compactMySigned: true,
+      myProgress: { stage: Stage.PERSPECTIVE_STRETCH },
+      isRefiningEmpathy: true,
+      messageCountSinceSharedContext: 0,
+      hasEmpathyContent: true,
+      hasLiveProposedEmpathyStatement: true,
+      empathyStatus: { hasNewSharedContext: true },
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.panels.showEmpathyPanel).toBe(true);
+    expect(result.aboveInputPanel).toBe('empathy-statement');
   });
 
   it('does not show in refining mode before user sends another message when no content is reviewable', () => {

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -394,6 +394,24 @@ describe('Input Hiding (shouldHideInput)', () => {
     expect(result.shouldHideInput).toBe(true);
   });
 
+  it('shows a waiting banner and hides input after I validate partner empathy but partner has not validated mine', () => {
+    const inputs = createInputs({
+      myStage: Stage.PERSPECTIVE_STRETCH,
+      compactMySigned: true,
+      myProgress: { stage: Stage.PERSPECTIVE_STRETCH },
+      hasPartnerEmpathy: true,
+      myValidation: { validated: true },
+      partnerValidated: false,
+      empathyStatus: { myAttemptStatus: 'REVEALED' },
+      empathyDraft: { alreadyConsented: true },
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.waitingStatus).toBe('partner-validating-empathy');
+    expect(result.aboveInputPanel).toBe('waiting-banner');
+    expect(result.shouldHideInput).toBe(true);
+  });
+
   it('shows a waiting banner and hides input after sending empathy revision feedback', () => {
     const inputs = createInputs({
       myStage: Stage.PERSPECTIVE_STRETCH,

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -88,6 +88,7 @@ export interface ChatUIStateInputs extends WaitingStatusInputs {
 
   // Stage 2: Empathy
   hasEmpathyContent: boolean; // liveProposedEmpathyStatement || empathyDraftData?.draft?.content
+  hasLiveProposedEmpathyStatement: boolean;
   empathyAlreadyConsented: boolean;
   hasSharedEmpathyLocal: boolean; // Local latch to prevent flash
 
@@ -282,9 +283,13 @@ function computeShowEmpathyPanel(inputs: ChatUIStateInputs): boolean {
   const currentStage = myStage ?? Stage.ONBOARDING;
 
   // When the partner has just shared context, the next user action should be
-  // reflection in chat. Do not offer review/resubmit until they have taken
-  // that first turn, even if an old attempt or draft is already reviewable.
-  if (isRefiningEmpathy && inputs.messageCountSinceSharedContext === 0) {
+  // reflection in chat. Do not offer review/resubmit until either they have
+  // taken that first turn or the AI has produced a fresh revised draft.
+  if (
+    isRefiningEmpathy &&
+    inputs.messageCountSinceSharedContext === 0 &&
+    !inputs.hasLiveProposedEmpathyStatement
+  ) {
     return false;
   }
 
@@ -780,6 +785,7 @@ export function createDefaultChatUIStateInputs(): ChatUIStateInputs {
     feelHeardConfirmedAt: undefined,
     isConfirmingFeelHeard: false,
     hasEmpathyContent: false,
+    hasLiveProposedEmpathyStatement: false,
     empathyAlreadyConsented: false,
     hasSharedEmpathyLocal: false,
     isRefiningEmpathy: false,


### PR DESCRIPTION
## Summary
- hide the chat input immediately after a local positive empathy validation while waiting for the partner
- persist a short AI follow-up message for the validator when the other partner still needs to review their empathy
- refetch message queries after validation so the follow-up appears without requiring page refresh

## Context
In the live James/Catherine gold loop, the validation card switched to “You confirmed this feels right,” but the freeform input stayed visible and there was no immediate next-step message. The DB showed only one side had validated, so the correct state is waiting for the partner to review the user’s empathy statement.

## Tests
- `npm --workspace mobile test -- --runTestsByPath src/utils/__tests__/chatUIState.test.ts --runInBand`
- `npm --workspace backend test -- stage2.test.ts --runInBand`
- `npm --workspace mobile run check`
- `npm --workspace backend run check`

Note: this worktree needed `npm run prisma -- generate` after `npm ci` before backend tests/checks, otherwise generated Prisma types were stale/missing.