### PR TITLE
Fix Stage 2 stream and share-offer reliability

### DIFF
--- a/backend/src/controllers/reconciler.ts
+++ b/backend/src/controllers/reconciler.ts
@@ -361,7 +361,7 @@ export async function respondToShareOfferHandler(
     });
 
     // Notify partner if content was shared
-    if (result.status === 'shared') {
+    if (result.status === 'shared' && result.guesserUpdated) {
       // Get partner ID
       const members = await prisma.relationshipMember.findMany({
         where: {

--- a/backend/src/routes/__tests__/reconciler.test.ts
+++ b/backend/src/routes/__tests__/reconciler.test.ts
@@ -626,6 +626,87 @@ describe('Reconciler API', () => {
         })
       );
     });
+
+    it('accepts late share offer after guesser empathy is already validated without changing terminal status', async () => {
+      const req = mockRequest({
+        user: { id: 'partner-1', name: 'Bob' },
+        body: { action: 'accept' },
+      });
+      const res = mockResponse();
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.reconcilerShareOffer.findFirst as jest.Mock).mockResolvedValue(mockShareOffer());
+      (prisma.empathyAttempt.findFirst as jest.Mock).mockResolvedValue({
+        id: 'attempt-1',
+        status: 'VALIDATED',
+      });
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue({ stage: 2 });
+      (prisma.message.count as jest.Mock).mockResolvedValue(0);
+      (prisma.message.create as jest.Mock).mockResolvedValue({
+        id: 'msg-1',
+        stage: 2,
+        timestamp: new Date(),
+      });
+      (prisma.relationshipMember.findMany as jest.Mock).mockResolvedValue([
+        { userId: 'user-1' },
+        { userId: 'partner-1' },
+      ]);
+
+      await respondToShareOfferHandler(req, res);
+
+      expect(prisma.reconcilerShareOffer.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'ACCEPTED',
+            deliveryStatus: 'DELIVERED',
+          }),
+        })
+      );
+      expect(prisma.empathyAttempt.updateMany).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            status: 'shared',
+            guesserUpdated: true,
+          }),
+        })
+      );
+    });
+
+    it('returns idempotent success for repeated accept after share offer was already accepted', async () => {
+      const req = mockRequest({
+        user: { id: 'partner-1', name: 'Bob' },
+        body: { action: 'accept' },
+      });
+      const res = mockResponse();
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.reconcilerShareOffer.findFirst as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockShareOffer({
+          status: 'ACCEPTED',
+          sharedContent: 'Already shared context.',
+        }));
+
+      await respondToShareOfferHandler(req, res);
+
+      expect(prisma.reconcilerShareOffer.updateMany).not.toHaveBeenCalled();
+      expect(prisma.message.create).not.toHaveBeenCalled();
+      expect(notifyPartner).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            status: 'shared',
+            sharedContent: 'Already shared context.',
+            guesserUpdated: false,
+          }),
+        })
+      );
+    });
   });
 
   describe('POST /sessions/:id/reconciler/share-offer/skip (skipShareOfferHandler)', () => {

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -10,7 +10,7 @@ import { logger } from '../../lib/logger';
 import { EmpathyStatus, MessageRole } from '@meet-without-fear/shared';
 import type { Prisma } from '@prisma/client';
 import { getSonnetResponse } from '../../lib/bedrock';
-import { transition } from '../empathy-state-machine';
+import { canTransition, transition } from '../empathy-state-machine';
 import {
   buildShareOfferPrompt,
   buildStagePrompt,
@@ -696,6 +696,39 @@ export async function respondToShareSuggestion(
   });
 
   if (!shareOffer) {
+    const processedOffer = await prisma.reconcilerShareOffer.findFirst({
+      where: {
+        userId,
+        result: { sessionId },
+        status: { in: ['ACCEPTED', 'DECLINED'] },
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    if (processedOffer?.status === 'ACCEPTED' && response.action !== 'decline') {
+      logger.info('Share offer already accepted; returning idempotent response', {
+        userId,
+        sessionId,
+      });
+      return {
+        status: 'shared',
+        sharedContent: processedOffer.sharedContent,
+        guesserUpdated: false,
+      };
+    }
+
+    if (processedOffer?.status === 'DECLINED' && response.action === 'decline') {
+      logger.info('Share offer already declined; returning idempotent response', {
+        userId,
+        sessionId,
+      });
+      return {
+        status: 'declined',
+        sharedContent: null,
+        guesserUpdated: false,
+      };
+    }
+
     logger.warn('No OFFERED/PENDING share offer found', { userId, sessionId });
     throw new Error('No pending share offer found');
   }
@@ -733,16 +766,24 @@ export async function respondToShareSuggestion(
       const attemptForDecline = await tx.empathyAttempt.findFirst({
         where: { sessionId, sourceUserId: shareOffer.result.guesserId },
       });
-      if (attemptForDecline) {
-        transition(attemptForDecline.status as EmpathyStatus, 'DECLINE_SHARING');
+      const currentStatus = attemptForDecline?.status as EmpathyStatus | undefined;
+      if (currentStatus && canTransition(currentStatus, 'DECLINE_SHARING')) {
+        transition(currentStatus, 'DECLINE_SHARING');
+        await tx.empathyAttempt.updateMany({
+          where: { sessionId, sourceUserId: shareOffer.result.guesserId },
+          data: {
+            status: 'READY',
+            statusVersion: { increment: 1 },
+          },
+        });
+      } else if (currentStatus === EmpathyStatus.VALIDATED) {
+        logger.info('Share offer declined after empathy validation; leaving terminal status unchanged', {
+          sessionId,
+          guesserId: shareOffer.result.guesserId,
+        });
+      } else if (currentStatus) {
+        transition(currentStatus, 'DECLINE_SHARING');
       }
-      await tx.empathyAttempt.updateMany({
-        where: { sessionId, sourceUserId: shareOffer.result.guesserId },
-        data: {
-          status: 'READY',
-          statusVersion: { increment: 1 },
-        },
-      });
 
       // Delete the SHARE_SUGGESTION message now that user has responded
       await tx.message.deleteMany({
@@ -870,13 +911,22 @@ export async function respondToShareSuggestion(
     const attemptForRefine = await tx.empathyAttempt.findFirst({
       where: { sessionId, sourceUserId: shareOffer.result.guesserId },
     });
-    if (attemptForRefine) {
-      transition(attemptForRefine.status as EmpathyStatus, 'CONTEXT_SHARED');
+    const currentStatus = attemptForRefine?.status as EmpathyStatus | undefined;
+    const shouldMoveToRefining = currentStatus && canTransition(currentStatus, 'CONTEXT_SHARED');
+    if (shouldMoveToRefining) {
+      transition(currentStatus, 'CONTEXT_SHARED');
+      await tx.empathyAttempt.updateMany({
+        where: { sessionId, sourceUserId: shareOffer.result.guesserId },
+        data: { status: 'REFINING', statusVersion: { increment: 1 } },
+      });
+    } else if (currentStatus === EmpathyStatus.VALIDATED) {
+      logger.info('Share offer accepted after empathy validation; delivering context without changing terminal status', {
+        sessionId,
+        guesserId: shareOffer.result.guesserId,
+      });
+    } else if (currentStatus) {
+      transition(currentStatus, 'CONTEXT_SHARED');
     }
-    await tx.empathyAttempt.updateMany({
-      where: { sessionId, sourceUserId: shareOffer.result.guesserId },
-      data: { status: 'REFINING', statusVersion: { increment: 1 } },
-    });
 
     // Create messages with guaranteed ordering (100ms apart)
     const baseTime = now.getTime();

--- a/docs/product/stage-2-reliability-track-1-5-plan.md
+++ b/docs/product/stage-2-reliability-track-1-5-plan.md
@@ -1,0 +1,241 @@
+# Stage 2 Reliability Track 1.5 Plan
+
+Status: proposed follow-up after PR #548
+Date: 2026-05-11
+
+## Purpose
+
+PR #548 improved Stage 0-2 gold alignment and merged the Darryl/Shantam gold scenario, prompt guidance, deterministic Stage 2 copy, waiting-state UI fixes, and gold-loop harness updates.
+
+Before the larger context architecture upgrade, do a small reliability PR that removes product-state noise from Stage 2 gold loops:
+
+1. Stage 2 stream timeout / reload recovery.
+2. `VALIDATED + CONTEXT_SHARED` share-offer state transition errors.
+
+The goal is not to tune prompts. The goal is to make Stage 2 state and streaming reliable enough that future gold-loop/context work is evaluated on facilitation quality, not transient product-state bugs.
+
+## Starting Evidence
+
+Final James/Catherine run from PR #548:
+
+- Run: `eval/runs/20260511-062632-james-catherine-iter-01`
+- Service logs: `eval/runs/20260511-062627-james-catherine-services/backend.log`
+- Scratch log: `eval/runs/20260511-062632-james-catherine-iter-01/scratch/2026-05-11-cmp18jqjq0008px5ddpjrlkvp-catherine.md`
+- Score: `eval_warn`, `overall_score: 4.0`
+- Product reliability target: stream stalled until reload.
+
+Relevant evidence:
+
+```text
+[useStreamingMessage] 15s timeout - closing stuck connection
+```
+
+Backend service log showed the corresponding SSE requests completed with `200`, suggesting the immediate timeout may be client-side stuck-stream detection, missed cache update, realtime propagation, or UI state not observing the completed DB message.
+
+The same backend log also showed two recovered `500`s:
+
+```text
+Invalid empathy state transition: VALIDATED + CONTEXT_SHARED. No valid transition defined for this combination.
+```
+
+This happened while accepting a share offer after empathy validation, then the run recovered through the refinement finalize path.
+
+## Non-Goals
+
+- Do not change Stage 1/2 prompt alignment guidance.
+- Do not add or remove gold moments.
+- Do not implement durable process facts.
+- Do not remove regex readiness heuristics here.
+- Do not broaden context windows here unless directly required to fix reliability.
+- Do not mask backend `500`s in the UI without fixing the state transition.
+
+## Workstream A - Stage 2 Stream Timeout / Reload Recovery
+
+### Questions To Answer
+
+- Did the backend finish generating and persist the AI message before the client timed out?
+- Did the SSE stream finish but the frontend fail to append or refetch the message?
+- Did the client close the stream at 15s while the backend was still doing useful work?
+- Is the 15s timeout too short for current model latency, or is the timeout firing after completion because state did not clear?
+- Does reload recover because DB state is correct but client cache is stale?
+
+### Candidate Files To Inspect
+
+Backend:
+
+- `backend/src/controllers/messages.ts`
+- streaming response helpers used by `sendMessageStream`
+- realtime publish paths after message creation
+- message history endpoints used after streaming.
+
+Mobile:
+
+- `mobile/src/hooks/useStreamingMessage.ts`
+- chat/message cache update hooks
+- `mobile/src/hooks/useUnifiedSession.ts`
+- `mobile/src/hooks/useStages.ts`
+- `mobile/src/screens/UnifiedSessionScreen.tsx`
+- realtime subscription hooks used for session/message updates.
+
+Eval evidence:
+
+- `eval/runs/20260511-062627-james-catherine-services/backend.log`
+- `eval/runs/20260511-062632-james-catherine-iter-01/codex-catherine.jsonl`
+- `eval/runs/20260511-062632-james-catherine-iter-01/transcripts/catherine-stage2.md`
+
+### Likely Fix Shape
+
+Prefer one of these, based on diagnosis:
+
+- If backend generation can exceed 15s, make the client timeout reflect model latency reality or reset only when no bytes/events/progress have arrived.
+- If backend has completed and persisted the AI message, make timeout recovery automatically refetch messages/state before requiring manual reload.
+- If realtime/cache updates are missed, ensure the stream completion path invalidates/refetches the message list and clears local streaming state.
+- If the SSE response can finish without a final client-visible event, add or verify a terminal event that the client consumes.
+
+### Acceptance Criteria
+
+- A stream timeout no longer leaves the user stuck until manual reload.
+- If a stream times out after the backend persisted a message, the client automatically recovers by refetching and rendering the message.
+- If a stream truly fails before persistence, the user sees a retry/error state that does not corrupt stage progress.
+- Add at least one focused mobile test or hook test for timeout recovery/refetch behavior.
+
+## Workstream B - `VALIDATED + CONTEXT_SHARED` Transition Error
+
+### Questions To Answer
+
+- Why can a share offer remain actionable after the empathy attempt is already `VALIDATED`?
+- Is `CONTEXT_SHARED` valid after `VALIDATED`, or should the action be rejected as stale/idempotent?
+- Should accepting share content after validation create only a normal shared-context message without changing empathy attempt state?
+- Why did the UI allow two repeated attempts after the first `500`?
+
+### Candidate Files To Inspect
+
+Backend:
+
+- `backend/src/services/empathy-state-machine.ts`
+- `backend/src/services/reconciler/sharing.ts`
+- `backend/src/controllers/reconciler.ts`
+- `backend/src/controllers/stage2.ts`
+- `backend/src/routes/__tests__/stage2.test.ts`
+- `backend/src/services/__tests__/reconciler.test.ts`
+
+Mobile:
+
+- share offer renderers and accept handlers,
+- `mobile/src/hooks/useSharingStatus.ts`,
+- pending action/share-offer fetch paths.
+
+### Likely Fix Shape
+
+Prefer explicit state-machine semantics over catch-and-continue:
+
+- If share offers are stale after validation, hide/expire them and return a safe idempotent response.
+- If context sharing after validation is legitimate, add an explicit transition or alternate code path that does not try to transition `VALIDATED` to `CONTEXT_SHARED`.
+- Ensure duplicate accept attempts are idempotent.
+- Ensure the UI does not keep presenting an action that has already become invalid.
+
+### Acceptance Criteria
+
+- No `500` occurs when accepting a share offer after empathy validation.
+- Repeated accept attempts are idempotent or return a clear non-500 stale-action response.
+- Stage 2 share offers cannot block or corrupt empathy validation/revision flow.
+- Add backend tests for `VALIDATED + CONTEXT_SHARED` or the chosen replacement semantics.
+
+## Validation Plan
+
+### Local Tests
+
+Run targeted tests first:
+
+```bash
+npm test --workspace backend -- stage2.test.ts reconciler.test.ts stage2-copy.test.ts
+npm test --prefix mobile -- getWaitingStatus.test.ts chatUIState.test.ts
+```
+
+Add tests for any modified streaming hook, share-offer state machine, or UI action logic.
+
+Then run:
+
+```bash
+npm run check --workspace backend
+npm run check --prefix mobile
+python3 scripts/test_mwf_moment_eval.py
+python3 -m py_compile scripts/mwf_gold_loop.py
+```
+
+### Real Gold Loop Smoke
+
+At minimum rerun James/Catherine Stage 0-2 because it produced both reliability signals:
+
+```bash
+MOCK_LLM=false python3 scripts/mwf_gold_loop.py run \
+  --scenario james-catherine \
+  --stop-after-stage 2 \
+  --target-score 4.0 \
+  --max-iterations 1 \
+  --start-services \
+  --no-improve-on-final-fail
+```
+
+If the changes touch shared Stage 2 paths broadly, also run:
+
+```bash
+MOCK_LLM=false python3 scripts/mwf_gold_loop.py run \
+  --scenario darryl-shantam \
+  --stop-after-stage 2 \
+  --target-score 4.0 \
+  --max-iterations 1 \
+  --start-services \
+  --no-improve-on-final-fail
+```
+
+### Log Checks
+
+After each gold loop, inspect service logs for:
+
+```bash
+rg -n "15s timeout|closing stuck|SSE error|Connection error|Invalid empathy state transition|VALIDATED \\+ CONTEXT_SHARED| -> 500" eval/runs/<service-dir>/backend.log eval/runs/<iter-dir>/*.jsonl eval/runs/<iter-dir>/scratch
+```
+
+Done means no unrecovered stream timeout and no `VALIDATED + CONTEXT_SHARED` `500`.
+
+## Done Definition
+
+- Stage 2 stream timeout has a diagnosed owner and a tested recovery/fix.
+- `VALIDATED + CONTEXT_SHARED` no longer produces backend `500`s.
+- James/Catherine Stage 0-2 reaches target without the same product reliability warning.
+- Hard invariants pass.
+- PR is small enough to review as product reliability, not prompt alignment.
+- Remaining risks are documented in the PR body.
+
+## Suggested Branch And PR
+
+Branch:
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c codex/stage2-reliability-track-1-5
+```
+
+PR title:
+
+```text
+Fix Stage 2 stream and share-offer reliability
+```
+
+PR body should include:
+
+- root cause for stream timeout,
+- root cause for `VALIDATED + CONTEXT_SHARED`,
+- tests added,
+- gold-loop run directory,
+- log grep showing the old errors are absent.
+
+## Suggested Goal Prompt
+
+Use from repo root:
+
+```text
+/goal Follow docs/product/stage-2-reliability-track-1-5-plan.md exactly. Keep this as a small product reliability PR between #548 and the context architecture upgrade. Do not tune prompts or add context architecture changes. Diagnose and fix Stage 2 stream timeout/reload recovery and the VALIDATED + CONTEXT_SHARED share-offer transition error, then validate with focused tests and at least James/Catherine Stage 0-2 real gold loop.
+```

--- a/mobile/src/hooks/__tests__/useStreamingMessage.test.ts
+++ b/mobile/src/hooks/__tests__/useStreamingMessage.test.ts
@@ -1,0 +1,104 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Stage } from '@meet-without-fear/shared';
+import { useStreamingMessage } from '../useStreamingMessage';
+import { messageKeys, sessionKeys, stageKeys, timelineKeys } from '../queryKeys';
+
+jest.mock('../../lib/api', () => ({
+  getAuthToken: jest.fn().mockResolvedValue('test-token'),
+  isE2EAuthMode: jest.fn().mockReturnValue(false),
+  getE2EAuthHeaders: jest.fn().mockReturnValue(null),
+}));
+
+const mockEventSourceInstances: Array<{ close: jest.Mock }> = [];
+
+jest.mock('react-native-sse', () => {
+  class MockEventSource {
+    listeners: Record<string, Array<(event: { data?: string; message?: string }) => void>> = {};
+    close = jest.fn();
+
+    constructor() {
+      mockEventSourceInstances.push(this);
+    }
+
+    addEventListener(
+      eventName: string,
+      listener: (event: { data?: string; message?: string }) => void
+    ) {
+      this.listeners[eventName] = this.listeners[eventName] || [];
+      this.listeners[eventName].push(listener);
+    }
+  }
+  return { __esModule: true, default: MockEventSource };
+});
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient): React.FC<{ children: React.ReactNode }> {
+  return ({ children }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useStreamingMessage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockEventSourceInstances.length = 0;
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('recovers a stuck stream timeout by refetching persisted messages instead of entering error state', async () => {
+    const queryClient = createQueryClient();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const refetchSpy = jest.spyOn(queryClient, 'refetchQueries');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const { result, unmount } = renderHook(() => useStreamingMessage(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.sendMessage({
+        sessionId: 'session-123',
+        content: 'This is still processing',
+        currentStage: Stage.PERSPECTIVE_STRETCH,
+      });
+    });
+
+    expect(result.current.status).toBe('sending');
+    expect(mockEventSourceInstances).toHaveLength(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(15000);
+    });
+
+    expect(mockEventSourceInstances[0].close).toHaveBeenCalled();
+    expect(result.current.status).toBe('idle');
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.failedMessageContent).toBeNull();
+
+    expect(refetchSpy).toHaveBeenCalledWith({ queryKey: messageKeys.list('session-123') });
+    expect(refetchSpy).toHaveBeenCalledWith({ queryKey: messageKeys.infinite('session-123') });
+    expect(refetchSpy).toHaveBeenCalledWith({ queryKey: timelineKeys.infinite('session-123') });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: sessionKeys.state('session-123') });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: stageKeys.empathyStatus('session-123') });
+    expect(warnSpy).toHaveBeenCalledWith('[useStreamingMessage] 15s timeout - recovering persisted messages');
+
+    unmount();
+    queryClient.clear();
+    warnSpy.mockRestore();
+  });
+});

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -458,6 +458,38 @@ export function useStreamingMessage(
     [queryClient]
   );
 
+  const recoverTimedOutStream = useCallback(
+    (sessionId: string, stage?: Stage) => {
+      if (pendingUpdateRef.current) {
+        clearTimeout(pendingUpdateRef.current);
+        pendingUpdateRef.current = null;
+      }
+
+      // The backend may have persisted the message even if the client-side SSE
+      // connection stopped producing events. Pull server truth instead of
+      // forcing the user to manually reload the chat.
+      reconcilePersistedMessages(sessionId);
+      queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
+      queryClient.invalidateQueries({ queryKey: timelineKeys.infinite(sessionId) });
+      if (stage === Stage.PERSPECTIVE_STRETCH) {
+        queryClient.invalidateQueries({ queryKey: stageKeys.empathyStatus(sessionId) });
+      }
+      if (stage === Stage.NEED_MAPPING) {
+        queryClient.invalidateQueries({ queryKey: stageKeys.needs(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.needsComparison(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+      }
+
+      accumulatedTextRef.current = '';
+      aiMessageIdRef.current = '';
+      optimisticUserIdRef.current = '';
+      activeUserMessageIdRef.current = '';
+      realUserIdRef.current = '';
+      setStatus('idle');
+    },
+    [queryClient, reconcilePersistedMessages]
+  );
+
   /**
    * Handle metadata from the AI response
    */
@@ -613,13 +645,12 @@ export function useStreamingMessage(
           // Only trigger if EventSource is still active (connection still open)
           // The timer is cleared on complete/error, so reaching here means we're stuck
           if (eventSourceRef.current) {
-            console.warn('[useStreamingMessage] 15s timeout - closing stuck connection');
+            console.warn('[useStreamingMessage] 15s timeout - recovering persisted messages');
             // Close the stuck connection
             eventSourceRef.current.close();
             eventSourceRef.current = null;
-            cleanupFailedStream(sessionId, currentStage);
-            // Transition to idle so typing indicator disappears
-            setStatus('idle');
+            fallbackTimerRef.current = null;
+            recoverTimedOutStream(sessionId, currentStage);
           }
         }, FALLBACK_TIMEOUT);
 
@@ -918,7 +949,7 @@ export function useStreamingMessage(
         onError?.(error as Error);
       }
     },
-    [addMessageToCache, updateMessageInCache, cleanupFailedStream, handleMetadata, invalidateAfterSuccessfulStream, reconcilePersistedMessages, queryClient, onComplete, onError]
+    [addMessageToCache, updateMessageInCache, cleanupFailedStream, handleMetadata, invalidateAfterSuccessfulStream, reconcilePersistedMessages, recoverTimedOutStream, queryClient, onComplete, onError]
   );
 
   /**


### PR DESCRIPTION
## Summary

Small Track 1.5 reliability PR between #548 and the larger context architecture work.

Fixes two Stage 2 reliability issues observed in the final James/Catherine gold loop after #548:

- client-side stuck stream timeout required manual reload even when the backend may have persisted the AI message;
- accepting a late share offer after empathy was already `VALIDATED` could hit `Invalid empathy state transition: VALIDATED + CONTEXT_SHARED` and return a backend `500`.

Changes:

- `useStreamingMessage` now recovers a stuck stream timeout by refetching persisted messages/state instead of cleaning up as failed and relying on reload.
- late accepted share offers after terminal empathy validation now deliver shared context without mutating terminal empathy status;
- repeated accepted/declined share-offer responses are idempotent;
- partner realtime notification only fires when the guesser state/content actually changed;
- added focused backend/mobile tests;
- added `docs/product/stage-2-reliability-track-1-5-plan.md` documenting the reliability track.

## Validation

Goal session reported these passed:

- `npm test --workspace backend -- stage2.test.ts reconciler.test.ts stage2-copy.test.ts`
- `npm test --prefix mobile -- getWaitingStatus.test.ts chatUIState.test.ts useStreamingMessage.test.ts`
- `npm run check --workspace backend`
- `npm run check --prefix mobile`
- `python3 scripts/test_mwf_moment_eval.py`
- `python3 -m py_compile scripts/mwf_gold_loop.py`

Real gold loop:

- `eval/runs/20260511-113411-james-catherine-iter-01`
- score: `4.0`
- target reached: `true`
- invariants: `pass`

I also verified the old failure signatures were absent from the new run artifacts/logs:

- `15s timeout`
- `closing stuck`
- `SSE error`
- `Connection error`
- `Invalid empathy state transition`
- `VALIDATED + CONTEXT_SHARED`
- backend `-> 500`

## Known remaining warnings

The final James/Catherine run is still `eval_warn`, but for different non-reliability reasons:

- Stage 1 asked Catherine a needs-like question before Stage 3.
- The scorer wants clearer transcript/stop-boundary handling when one side's validation is not captured before the Stage 2 stop boundary.

Those are prompt/eval calibration follow-ups, not the Track 1.5 reliability bugs.

## Reviewer focus

- Is the timeout recovery behavior correct when the backend persisted the message but the SSE client got stuck?
- Are late `VALIDATED` share-offer accepts safe to treat as context delivery without changing terminal empathy status?
- Is idempotent repeated share-offer handling scoped tightly enough?
