### PR TITLE
Add guardrails against literal topic-restatement strategies

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -2092,6 +2092,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
         aiResponse: aiMessage.content,
         structuredProposals: metadata.stage4Proposals,
         compatibilityProposedStrategies: metadata.proposedStrategies,
+        topicFrame: session.topicFrame || undefined,
       });
       const stage4CaptureMetadata: NonNullable<SessionStateToolInput['stage4Capture']> = {
         appliedOperationCount: captureResult.appliedOperationCount,

--- a/backend/src/services/__tests__/stage4-capture.service.test.ts
+++ b/backend/src/services/__tests__/stage4-capture.service.test.ts
@@ -369,6 +369,40 @@ describe('stage4-capture.service', () => {
     );
   });
 
+  it('rejects structured proposals that restate the topic frame', async () => {
+    const result = await captureStage4Turn(
+      captureInput({
+        userMessage: 'ok sure',
+        topicFrame: "Shantam's son defecates on Darryl's lawn",
+        structuredProposals: [
+          {
+            action: 'ADD',
+            classification: 'PROPOSAL',
+            description: "When his son does defecate on Darryl's lawn, Shantam cleans it up immediately",
+            kind: Stage4ProposalKind.INDIVIDUAL_COMMITMENT,
+            ownerUserId: userId,
+            needsAddressed: [],
+          },
+        ],
+      })
+    );
+
+    expect(prisma.strategyProposal.create).not.toHaveBeenCalled();
+    expect(result.appliedOperationCount).toBe(0);
+  });
+
+  it('allows proposals that do not restate the topic frame', async () => {
+    const result = await captureStage4Turn(
+      captureInput({
+        userMessage: 'I can send a Sunday planning text each week for a month.',
+        topicFrame: "Shantam's son defecates on Darryl's lawn",
+      })
+    );
+
+    expect(prisma.strategyProposal.create).toHaveBeenCalled();
+    expect(result.appliedOperationCount).toBe(1);
+  });
+
   it('does not treat complete-enough-to-start language as a closure signal', async () => {
     const result = await captureStage4Turn(captureInput({
       userMessage: 'That feels complete enough to start. I am nervous, but this list feels small enough that I could actually try it.',

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -981,6 +981,11 @@ Needs more detail: vague ("communicate better"), permanent ("always do X"), high
 Not a proposal: guarded process consent or a boundary about the exercise ("I can talk about next steps", "I won't pretend this fixes everything", "I am not agreeing that this was my fault", "I can try to stay open"). Classify it as PROCESS or REFLECTION unless the same turn names a concrete future action someone will try.
 Not a proposal yet: a desired outcome, test, or success marker ("I'd walk away knowing where I stand", "I could live with either answer", "I'd know whether this can change"). Reflect it as a success criterion, then ask what concrete action would produce that outcome.
 
+PROPOSAL QUALITY:
+Never generate proposals that literally restate the conflict topic or its surface-level details. Proposals must address underlying needs (safety, communication, respect, boundaries, trust), not the surface-level problem.
+If the topic is about a specific incident or behavior, proposals should address the relational pattern underneath — not prescribe literal actions about the incident itself.
+Always use second person ("you") when referring to the current user, never third-person names. When referring to ${partnerName}, use their name or "they" — never as if narrating about both people from outside.
+
 When a proposal is vague, help sharpen it by asking about ONE missing criterion at a time. Don't dump all four criteria at once.
 
 AI IDEAS:

--- a/backend/src/services/stage4-capture.service.ts
+++ b/backend/src/services/stage4-capture.service.ts
@@ -24,6 +24,7 @@ export type Stage4CaptureInput = {
   recentStage4Messages?: Array<{ role: 'USER' | 'AI'; userId?: string; content: string; timestamp: string }>;
   structuredProposals?: Stage4StructuredProposalInput[];
   compatibilityProposedStrategies?: string[];
+  topicFrame?: string;
 };
 
 export type Stage4StructuredProposalInput = {
@@ -253,6 +254,34 @@ function isConcreteProposal(description: string): boolean {
   return hasEnoughSpecificity(description);
 }
 
+const TOPIC_OVERLAP_THRESHOLD = 0.6;
+const MIN_STEM_LENGTH = 4;
+
+function normalizeWord(word: string): string {
+  return word.replace(/[''\u2019]s$/i, '').replace(/(?:ing|tion|ment|ness|ates|ated|ting|ted|ies|es|ed|ly|s)$/i, '');
+}
+
+function fuzzyWordMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  const stemA = normalizeWord(a);
+  const stemB = normalizeWord(b);
+  if (stemA.length >= MIN_STEM_LENGTH && stemB.length >= MIN_STEM_LENGTH && stemA === stemB) return true;
+  return false;
+}
+
+function getTopicOverlapScore(haystack: string, needle: string): number {
+  const haystackWords = normalizeText(haystack).split(' ').filter(Boolean);
+  const needleWords = normalizeText(needle).split(' ').filter((word) => word.length > 2);
+  if (needleWords.length === 0) return 0;
+  const overlap = needleWords.filter((nw) => haystackWords.some((hw) => fuzzyWordMatch(hw, nw))).length;
+  return overlap / needleWords.length;
+}
+
+function isTopicRestatement(description: string, topicFrame: string | undefined): boolean {
+  if (!topicFrame) return false;
+  return getTopicOverlapScore(description, topicFrame) >= TOPIC_OVERLAP_THRESHOLD;
+}
+
 function hasRemoveIntent(text: string): boolean {
   return [
     /\b(?:remove|delete)\b.*\b(?:proposal|idea|strategy|that|this|it|one)\b/i,
@@ -279,6 +308,7 @@ function extractAddOperations(input: Stage4CaptureInput): Stage4InventoryOperati
     if (proposal.classification !== 'PROPOSAL' || !proposal.kind) continue;
     const description = cleanProposalDescription(proposal.description);
     if (!description) continue;
+    if (isTopicRestatement(description, input.topicFrame)) continue;
     if (action === 'REVISE' && proposal.targetProposalId) {
       operations.push({
         type: 'REVISE_PROPOSAL',
@@ -318,6 +348,7 @@ function extractAddOperations(input: Stage4CaptureInput): Stage4InventoryOperati
   compatibility.forEach((description, index) => {
     const cleaned = cleanProposalDescription(description);
     if (!isConcreteProposal(cleaned)) return;
+    if (isTopicRestatement(cleaned, input.topicFrame)) return;
     const kind = inferProposalKind(description);
     operations.push({
       type: 'ADD_PROPOSAL',
@@ -344,6 +375,7 @@ function extractAddOperations(input: Stage4CaptureInput): Stage4InventoryOperati
       if (isNonCommitmentFirstPerson(raw)) continue;
       const description = cleanProposalDescription(match[1] ?? '');
       if (!isConcreteProposal(description)) continue;
+      if (isTopicRestatement(description, input.topicFrame)) continue;
       const kind = inferProposalKind(raw);
       operations.push({
         type: 'ADD_PROPOSAL',


### PR DESCRIPTION
## Changes
- Add: Prompt guardrail in Stage 4 forbidding proposals that literally restate the conflict topic — proposals must address underlying needs (safety, communication, respect, boundaries), not the surface-level problem
- Add: Prompt instruction enforcing second-person voice ("you") instead of third-person names when referring to the current user
- Add: Topic-overlap quality gate in capture service using fuzzy word matching (stem normalization) to reject proposals with >=60% word overlap with the session topic frame
- Add: `topicFrame` field threaded from session through to the Stage 4 capture pipeline
- Add: Tests for structured proposal topic-restatement rejection and non-matching proposal pass-through

Related to #553

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr (U0ASRE7NZL7)
- **Original message:** "Buggy strategies list"

## Docs updated
No doc changes needed — behavioral guardrails added to existing prompt and capture pipeline, no architectural change.