### PR TITLE
Add AI framing message before validation feedback in Stage 2

### DIFF
--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -37,6 +37,7 @@ import {
   hasContextAlreadyBeenShared,
   markResultHandledAlreadyShared,
   incrementAttempts,
+  generateValidationFeedbackReflection,
 } from '../services/reconciler';
 import { isSessionCreator } from '../utils/session';
 import { publishSessionEvent } from '../services/realtime';
@@ -1156,6 +1157,46 @@ export async function validateEmpathy(
         },
       });
 
+      // Get names for AI framing message
+      const [validatorUser, guesserUser] = await Promise.all([
+        prisma.user.findUnique({
+          where: { id: user.id },
+          select: { firstName: true, name: true },
+        }),
+        prisma.user.findUnique({
+          where: { id: partnerId },
+          select: { firstName: true, name: true },
+        }),
+      ]);
+      const validatorName = validatorUser?.firstName || validatorUser?.name || 'your partner';
+      const guesserName = guesserUser?.firstName || guesserUser?.name || 'User';
+
+      // Generate AI framing message before showing feedback card
+      const framingMessage = await generateValidationFeedbackReflection(
+        sessionId,
+        guesserName,
+        validatorName,
+      );
+
+      // Create messages with guaranteed ordering (100ms apart)
+      const baseTime = now.getTime();
+      const framingTimestamp = new Date(baseTime);
+      const feedbackTimestamp = new Date(baseTime + 100);
+
+      // AI framing message — introduces the feedback to the guesser
+      await prisma.message.create({
+        data: {
+          sessionId,
+          senderId: null,
+          forUserId: partnerId,
+          role: MessageRole.AI,
+          content: framingMessage,
+          stage: 2,
+          timestamp: framingTimestamp,
+        },
+      });
+
+      // VALIDATION_FEEDBACK card — the actual feedback content
       await prisma.message.create({
         data: {
           sessionId,
@@ -1164,7 +1205,7 @@ export async function validateEmpathy(
           role: MessageRole.VALIDATION_FEEDBACK,
           content: trimmedFeedback,
           stage: 2,
-          timestamp: now,
+          timestamp: feedbackTimestamp,
         },
       });
     }

--- a/backend/src/routes/__tests__/stage2.test.ts
+++ b/backend/src/routes/__tests__/stage2.test.ts
@@ -648,6 +648,11 @@ describe('Stage 2 API', () => {
         timestamp: new Date(),
       });
       (prisma.empathyValidation.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.user.findUnique as jest.Mock).mockImplementation(({ where }: any) => {
+        if (where.id === 'user-1') return Promise.resolve({ firstName: null, name: 'Validator' });
+        if (where.id === 'partner-1') return Promise.resolve({ firstName: null, name: 'Guesser' });
+        return Promise.resolve(null);
+      });
 
       await validateEmpathy(req, res);
 
@@ -674,6 +679,19 @@ describe('Stage 2 API', () => {
           }),
         })
       );
+      // AI framing message created before the feedback card
+      expect(prisma.message.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            sessionId: 'session-123',
+            senderId: null,
+            forUserId: 'partner-1',
+            role: 'AI',
+            stage: 2,
+          }),
+        })
+      );
+      // VALIDATION_FEEDBACK card created with +100ms offset
       expect(prisma.message.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
@@ -686,6 +704,7 @@ describe('Stage 2 API', () => {
           }),
         })
       );
+      expect(prisma.message.create).toHaveBeenCalledTimes(2);
       expect(notifyPartner).toHaveBeenCalledWith(
         'session-123',
         'partner-1',

--- a/backend/src/services/__tests__/reconciler.test.ts
+++ b/backend/src/services/__tests__/reconciler.test.ts
@@ -126,6 +126,7 @@ import {
   hasContextAlreadyBeenShared,
   getFallbackContinuation,
   generatePostShareContinuation,
+  generateValidationFeedbackReflection,
   generateShareSuggestionForDirection,
   checkAndRevealBothIfReady,
   loadRecentSubjectStage2Turns,
@@ -554,7 +555,48 @@ describe('Reconciler Service', () => {
   });
 
   // ==========================================================================
-  // 6. generateShareSuggestionForDirection
+  // 6. generateValidationFeedbackReflection
+  // ==========================================================================
+
+  describe('generateValidationFeedbackReflection', () => {
+    it('returns trimmed AI response on success', async () => {
+      const { getSonnetResponse } = require('../../lib/bedrock');
+      (getSonnetResponse as jest.Mock).mockResolvedValueOnce('  Jordan shared some thoughts about what felt off.  ');
+
+      const result = await generateValidationFeedbackReflection('session-1', 'Alex', 'Jordan');
+
+      expect(result).toBe('Jordan shared some thoughts about what felt off.');
+      expect(getSonnetResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'session-1',
+          operation: 'reconciler-validation-feedback-reflection',
+        })
+      );
+    });
+
+    it('returns fallback when getSonnetResponse returns null', async () => {
+      const { getSonnetResponse } = require('../../lib/bedrock');
+      (getSonnetResponse as jest.Mock).mockResolvedValueOnce(null);
+
+      const result = await generateValidationFeedbackReflection('session-1', 'Alex', 'Jordan');
+
+      expect(result).toContain('Jordan');
+      expect(result).toContain('shared some thoughts');
+    });
+
+    it('returns fallback when getSonnetResponse throws', async () => {
+      const { getSonnetResponse } = require('../../lib/bedrock');
+      (getSonnetResponse as jest.Mock).mockRejectedValueOnce(new Error('Bedrock error'));
+
+      const result = await generateValidationFeedbackReflection('session-1', 'Alex', 'Jordan');
+
+      expect(result).toContain('Jordan');
+      expect(result).toContain('shared some thoughts');
+    });
+  });
+
+  // ==========================================================================
+  // 7. generateShareSuggestionForDirection
   // ==========================================================================
 
   describe('generateShareSuggestionForDirection', () => {

--- a/backend/src/services/reconciler/index.ts
+++ b/backend/src/services/reconciler/index.ts
@@ -49,6 +49,7 @@ export {
   generatePostShareContinuation,
   getFallbackContinuation,
   generateContextReceivedReflection,
+  generateValidationFeedbackReflection,
 } from './sharing';
 
 // State

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -327,6 +327,61 @@ Respond with ONLY the message text, no additional formatting.`;
 }
 
 // ============================================================================
+// Helper: Generate Validation-Feedback Reflection
+// ============================================================================
+
+/**
+ * Generate a reflection AI message for the guesser after they receive validation feedback.
+ * Placed before the VALIDATION_FEEDBACK card to frame the situation and invite reflection.
+ *
+ * Falls back to hardcoded message on AI failure.
+ */
+export async function generateValidationFeedbackReflection(
+  sessionId: string,
+  guesserName: string,
+  subjectName: string,
+): Promise<string> {
+  const fallback = `${subjectName} shared some thoughts about what didn't feel fully captured in your empathy attempt. Take a moment to read their feedback — it can help you understand their experience more deeply before you revise.`;
+
+  try {
+    const turnId = `${sessionId}-val-feedback-reflection-${Date.now()}`;
+    const prompt = `${guesserName}'s partner ${subjectName} just provided feedback on ${guesserName}'s empathy attempt, indicating that it didn't fully capture their experience. The feedback will appear directly below your message in a labeled card.
+
+Generate a short message (1-3 sentences) that frames the situation for ${guesserName}. Explain that ${subjectName} has shared thoughts about what didn't feel fully captured, and invite ${guesserName} to read the feedback and reflect on it before revising their understanding.
+
+Tone: warm, encouraging, non-judgmental. This is a normal part of the process — getting feedback is how understanding deepens.
+Do NOT paraphrase or reveal the feedback content. Do NOT use the word "reconciler".
+
+Respond with ONLY the message text, no additional formatting.`;
+
+    const response = await getSonnetResponse({
+      systemPrompt: prompt,
+      messages: [{ role: 'user', content: 'Generate the validation feedback reflection message.' }],
+      maxTokens: 256,
+      sessionId,
+      turnId,
+      operation: 'reconciler-validation-feedback-reflection',
+    });
+
+    if (!response) {
+      logger.warn('generateValidationFeedbackReflection: Sonnet returned null, using fallback');
+      return fallback;
+    }
+
+    const trimmed = response.trim();
+    if (trimmed.length > 0) {
+      logger.debug('Generated validation feedback reflection message', { sessionId });
+      return trimmed;
+    }
+
+    return fallback;
+  } catch (error) {
+    logger.error('generateValidationFeedbackReflection failed', { error: (error as Error).message });
+    return fallback;
+  }
+}
+
+// ============================================================================
 // Share Suggestion Generation
 // ============================================================================
 

--- a/docs/backend/api/stage-2.md
+++ b/docs/backend/api/stage-2.md
@@ -3,7 +3,7 @@ title: "Stage 2 API: Perspective Stretch"
 sidebar_position: 7
 description: Endpoints for building and exchanging empathy attempts.
 slug: /backend/api/stage-2
-updated: 2026-05-11
+updated: 2026-05-12
 status: living
 ---
 # Stage 2 API: Perspective Stretch
@@ -258,10 +258,12 @@ Validation: feedback max 1000 chars; one validation per recipient per attempt (i
 For the "Not quite" path, mobile first collects rough notes with the `What feels off?`
 step, then the Feedback Coach refines those notes into a final message. The final send
 uses this validation endpoint with `validated: false` and the coach-approved `feedback`.
-The backend stores the validation, creates a targeted partner chat message with role
-`VALIDATION_FEEDBACK`, updates the partner's empathy attempt to `REFINING`, and emits
-`empathy.status_updated` for that partner with `status: 'REFINING'`,
-`feedbackShared: true`, and `validationFeedback`.
+The backend stores the validation, generates an AI framing message (via Sonnet) that
+introduces the feedback to the guesser, then creates two messages with guaranteed
+ordering (100ms apart): the AI framing message (role `AI`) followed by the feedback
+card (role `VALIDATION_FEEDBACK`). It updates the partner's empathy attempt to
+`REFINING` and emits `empathy.status_updated` for that partner with
+`status: 'REFINING'`, `feedbackShared: true`, and `validationFeedback`.
 
 ### Gate keys set by Stage 2 endpoints
 - `empathyDraftReady`: set when `readyToShare: true` on draft save
@@ -300,7 +302,7 @@ curl -X POST /api/v1/sessions/sess_abc123/empathy/validate \
 ### Revision Loop
 
 If feedback is shared:
-1. Partner receives a targeted `VALIDATION_FEEDBACK` message and their attempt status becomes `REFINING`
+1. Partner receives an AI framing message followed by a `VALIDATION_FEEDBACK` card, and their attempt status becomes `REFINING`
 2. Partner can revise and resubmit their empathy attempt
 3. User receives the revised attempt and can validate again
 4. Partner can also accept or decline the remaining difference via `/empathy/skip-refinement`

--- a/docs/backend/reconciler-flow.md
+++ b/docs/backend/reconciler-flow.md
@@ -276,7 +276,8 @@ sequenceDiagram
         UI->>API: POST /empathy/validation-feedback/refine<br/>(optional iterations)
         UI->>API: POST /empathy/validate<br/>{ validated: false, feedback }
         API->>API: Status -> REFINING
-        API->>API: Create targeted chat message<br/>role VALIDATION_FEEDBACK
+        API->>API: Create AI framing message (role AI, forUserId=guesser)
+        API->>API: Create feedback card (role VALIDATION_FEEDBACK, +100ms offset)
         API->>Guesser: empathy.status_updated<br/>with validationFeedback
     end
 ```

--- a/docs/diagrams/reconciler-paths.md
+++ b/docs/diagrams/reconciler-paths.md
@@ -21,7 +21,7 @@ The reconciler runs **asymmetrically**. Two entry points:
 
 ## NEEDS_WORK Status (Legacy/Deprecated)
 
-The `NEEDS_WORK` status exists in the Prisma schema but is **legacy and unreachable** from the reconciler. Reconciler gap paths use `AWAITING_SHARING` and `REFINING`. Post-reveal accuracy feedback also uses `REFINING`: when `validated: false` is submitted with feedback, the partner's `EmpathyAttempt` moves from `REVEALED` to `REFINING` and the feedback is delivered as a targeted `VALIDATION_FEEDBACK` message.
+The `NEEDS_WORK` status exists in the Prisma schema but is **legacy and unreachable** from the reconciler. Reconciler gap paths use `AWAITING_SHARING` and `REFINING`. Post-reveal accuracy feedback also uses `REFINING`: when `validated: false` is submitted with feedback, the partner's `EmpathyAttempt` moves from `REVEALED` to `REFINING` and the feedback is delivered as two targeted messages: an AI framing message (role `AI`) followed by the feedback card (role `VALIDATION_FEEDBACK`).
 
 ## Ably Event Payloads
 


### PR DESCRIPTION
## Changes
- Add: `generateValidationFeedbackReflection()` in `sharing.ts` — Sonnet-generated AI message that frames partner feedback for the guesser, with hardcoded fallback
- Fix: `validateEmpathy()` in `stage2.ts` now creates two messages with guaranteed 100ms ordering: AI framing message → VALIDATION_FEEDBACK card (was only creating the feedback card with no context)
- Add: Export the new function from `reconciler/index.ts`
- Update: `docs/backend/api/stage-2.md` to document the two-message pattern

Related to #523

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** I should not have had to ask this. There should always be an AI message framing the situation. This makes it seem like I'm now going to respond to the other person.

## Docs updated
- `docs/backend/api/stage-2.md` — updated validation feedback flow description and revision loop to reflect the new AI framing message