### PR TITLE
Restart MWF context architecture work on clean Adam/Eve and James/Catherine baseline

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1522,7 +1522,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       empathyDraft: empathyDraftContent || undefined,
       isRefiningEmpathy: isRefiningEmpathy || undefined,
       stage4InventoryContext,
-      topicFrame: session.topicFrame || undefined,
+      topicFrame: session.topicFrameConfirmedAt ? session.topicFrame : undefined,
     }, { isInvitationPhase });
 
     // Prompt already includes semantic tag format instructions via buildResponseProtocol()

--- a/backend/src/services/__tests__/ai-orchestrator.test.ts
+++ b/backend/src/services/__tests__/ai-orchestrator.test.ts
@@ -237,6 +237,24 @@ describe('AI Orchestrator', () => {
       expect(result.offerFeelHeardCheck).toBe(true);
     });
 
+    it('suppresses early Stage 1 feel-heard checks even when the model requests one', async () => {
+      mockGetModelCompletion.mockResolvedValue(MICRO_TAG_RESPONSE_FEEL_HEARD);
+
+      const result = await orchestrateResponse(buildContext({ stage: 1, turnCount: 4 }));
+
+      expect(result.usedMock).toBe(false);
+      expect(result.offerFeelHeardCheck).toBe(false);
+    });
+
+    it('does not apply the Stage 1 feel-heard turn guard to other stages', async () => {
+      mockGetModelCompletion.mockResolvedValue(MICRO_TAG_RESPONSE_READY_SHARE);
+
+      const result = await orchestrateResponse(buildContext({ stage: 2, turnCount: 4 }));
+
+      expect(result.usedMock).toBe(false);
+      expect(result.offerReadyToShare).toBe(true);
+    });
+
     it('parses ReadyShare flag from thinking block (stage 2)', async () => {
       mockGetModelCompletion.mockResolvedValue(MICRO_TAG_RESPONSE_READY_SHARE);
 

--- a/backend/src/services/__tests__/context-assembler.test.ts
+++ b/backend/src/services/__tests__/context-assembler.test.ts
@@ -170,6 +170,284 @@ describe('Context Assembler', () => {
       });
     });
 
+    describe('Topic Frame Formatting', () => {
+      it('includes confirmed topic frame as orientation context', () => {
+        const bundle = createMinimalBundle({
+          topicFrame: {
+            text: 'Trust around late-night texting',
+            confirmedAt: '2026-05-12T00:00:00.000Z',
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).toContain('--- Conversation topic ---');
+        expect(formatted).toContain('Confirmed topic: "Trust around late-night texting"');
+        expect(formatted).toContain('Use this as orientation only');
+        expect(formatted).toContain('Stage gates still come from StageProgress');
+      });
+
+      it('omits topic frame when not present', () => {
+        const formatted = formatContextForPrompt(createMinimalBundle());
+
+        expect(formatted).not.toContain('--- Conversation topic ---');
+        expect(formatted).not.toContain('Confirmed topic:');
+      });
+    });
+
+    describe('Consented Share State Formatting', () => {
+      it('includes typed consent and share lifecycle as orientation context', () => {
+        const bundle = createMinimalBundle({
+          consentedShareState: {
+            items: [
+              {
+                kind: 'empathy_attempt',
+                direction: 'user_to_partner',
+                lifecycleStatus: 'VALIDATED',
+                content: 'I think you felt shut out when I made the decision alone.',
+                sharedAt: '2026-05-12T00:00:00.000Z',
+                revealedAt: '2026-05-12T00:05:00.000Z',
+                validatedAt: '2026-05-12T00:10:00.000Z',
+              },
+              {
+                kind: 'additional_context',
+                direction: 'partner_to_user',
+                lifecycleStatus: 'ACCEPTED/DELIVERED',
+                content: 'I needed to know my effort still mattered.',
+                sharedAt: '2026-05-12T00:02:00.000Z',
+                deliveredAt: '2026-05-12T00:03:00.000Z',
+              },
+            ],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).toContain('--- Consented partner/share state ---');
+        expect(formatted).toContain('Use this only for orientation');
+        expect(formatted).toContain('Stage gates still come from StageProgress');
+        expect(formatted).toContain('empathy/share/validation lifecycle state');
+        expect(formatted).toContain('- You shared empathy attempt (VALIDATED; shared 2026-05-12T00:00:00.000Z; revealed 2026-05-12T00:05:00.000Z; validated 2026-05-12T00:10:00.000Z): I think you felt shut out when I made the decision alone.');
+        expect(formatted).toContain('- Partner shared additional context (ACCEPTED/DELIVERED; shared 2026-05-12T00:02:00.000Z; delivered 2026-05-12T00:03:00.000Z): I needed to know my effort still mattered.');
+      });
+
+      it('omits consented share state when no items are present', () => {
+        const bundle = createMinimalBundle({
+          consentedShareState: {
+            items: [],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).not.toContain('--- Consented partner/share state ---');
+      });
+
+      it('does not render partner content when lifecycle says it is not visible to this user', () => {
+        const bundle = createMinimalBundle({
+          consentedShareState: {
+            items: [
+              {
+                kind: 'empathy_attempt',
+                direction: 'partner_to_user',
+                lifecycleStatus: 'READY',
+                sharedAt: '2026-05-12T00:00:00.000Z',
+              },
+            ],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).toContain('- Partner shared empathy attempt (READY; shared 2026-05-12T00:00:00.000Z) (content not yet visible to this user)');
+      });
+
+      it('truncates long share-state content to keep prompt size bounded', () => {
+        const longContent = 'b'.repeat(500);
+        const bundle = createMinimalBundle({
+          consentedShareState: {
+            items: [
+              {
+                kind: 'additional_context',
+                direction: 'user_to_partner',
+                lifecycleStatus: 'ACCEPTED/SEEN',
+                content: longContent,
+              },
+            ],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).toContain(`${'b'.repeat(359)}…`);
+        expect(formatted).not.toContain(longContent);
+      });
+    });
+
+    describe('Prior Stage Summaries Formatting', () => {
+      it('includes prior-stage summaries as continuity context', () => {
+        const bundle = createMinimalBundle({
+          stageContext: {
+            stage: 2,
+            gatesSatisfied: {},
+          },
+          priorStageSummaries: {
+            stages: [
+              {
+                stage: 1,
+                lifecycleStatus: 'COMPLETED',
+                completedAt: '2026-05-12T00:10:00.000Z',
+                userTurnCount: 2,
+                assistantTurnCount: 2,
+                highlights: [
+                  {
+                    role: 'user',
+                    content: 'I felt like every practical objection meant she was already halfway gone.',
+                    stage: 1,
+                    timestamp: '2026-05-12T00:01:00.000Z',
+                  },
+                  {
+                    role: 'assistant',
+                    content: 'The fear is not just about the trip, it is about losing the marriage.',
+                    stage: 1,
+                    timestamp: '2026-05-12T00:02:00.000Z',
+                  },
+                ],
+              },
+            ],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).toContain('--- Prior stage summaries (current user lane only) ---');
+        expect(formatted).toContain('Use this only for continuity');
+        expect(formatted).toContain('Stage gates still come from StageProgress');
+        expect(formatted).toContain('Stage 1 (COMPLETED; completed 2026-05-12T00:10:00.000Z): 2 user turn(s), 2 AI turn(s).');
+        expect(formatted).toContain('- User: I felt like every practical objection meant she was already halfway gone.');
+        expect(formatted).toContain('- AI: The fear is not just about the trip, it is about losing the marriage.');
+      });
+
+      it('omits prior-stage summaries when no stages are present', () => {
+        const bundle = createMinimalBundle({
+          priorStageSummaries: {
+            stages: [],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).not.toContain('--- Prior stage summaries');
+      });
+
+      it('truncates long prior-stage highlights to keep prompt size bounded', () => {
+        const longContent = 'c'.repeat(500);
+        const bundle = createMinimalBundle({
+          priorStageSummaries: {
+            stages: [
+              {
+                stage: 0,
+                lifecycleStatus: 'COMPLETED',
+                userTurnCount: 1,
+                assistantTurnCount: 0,
+                highlights: [
+                  {
+                    role: 'user',
+                    content: longContent,
+                    stage: 0,
+                    timestamp: '2026-05-12T00:00:00.000Z',
+                  },
+                ],
+              },
+            ],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).toContain(`${'c'.repeat(239)}…`);
+        expect(formatted).not.toContain(longContent);
+      });
+    });
+
+    describe('Current Stage History Formatting', () => {
+      it('includes full current-user stage history as continuity context', () => {
+        const bundle = createMinimalBundle({
+          stageContext: {
+            stage: 2,
+            gatesSatisfied: {},
+          },
+          currentStageHistory: {
+            stage: 2,
+            messages: [
+              {
+                role: 'user',
+                content: 'I think Eve feels boxed in by the safe life I built.',
+                stage: 2,
+                timestamp: '2026-05-12T00:00:00.000Z',
+              },
+              {
+                role: 'assistant',
+                content: 'That sounds like a real attempt to imagine her side.',
+                stage: 2,
+                timestamp: '2026-05-12T00:01:00.000Z',
+              },
+              {
+                role: 'empathy_statement',
+                content: 'I think you might feel like stability became a cage.',
+                stage: 2,
+                timestamp: '2026-05-12T00:02:00.000Z',
+              },
+            ],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).toContain('--- Current Stage 2 history (current user lane only) ---');
+        expect(formatted).toContain('Use this only for continuity');
+        expect(formatted).toContain('Stage gates still come from StageProgress');
+        expect(formatted).toContain('- User: I think Eve feels boxed in by the safe life I built.');
+        expect(formatted).toContain('- AI: That sounds like a real attempt to imagine her side.');
+        expect(formatted).toContain('- Empathy statement: I think you might feel like stability became a cage.');
+      });
+
+      it('omits current stage history when no messages are present', () => {
+        const bundle = createMinimalBundle({
+          currentStageHistory: {
+            stage: 2,
+            messages: [],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).not.toContain('Current Stage 2 history');
+      });
+
+      it('truncates long stage-history entries to keep prompt size bounded', () => {
+        const longContent = 'a'.repeat(500);
+        const bundle = createMinimalBundle({
+          currentStageHistory: {
+            stage: 1,
+            messages: [
+              {
+                role: 'user',
+                content: longContent,
+                stage: 1,
+                timestamp: '2026-05-12T00:00:00.000Z',
+              },
+            ],
+          },
+        });
+
+        const formatted = formatContextForPrompt(bundle);
+
+        expect(formatted).toContain(`${'a'.repeat(359)}…`);
+        expect(formatted).not.toContain(longContent);
+      });
+    });
+
     describe('Session Isolation', () => {
       it('does not include global facts when undefined (session isolation)', () => {
         // Per session isolation spec: globalFacts should be undefined until consent UI is built

--- a/backend/src/services/__tests__/stage-prompts.test.ts
+++ b/backend/src/services/__tests__/stage-prompts.test.ts
@@ -1262,6 +1262,35 @@ describe('Stage Prompts Service', () => {
       const blocks = buildStagePrompt(1, createContext());
       expect(blocks.dynamicBlock).not.toContain('CONVERSATION TOPIC');
     });
+
+    it('uses confirmed topicFrame from the context bundle when explicit topicFrame is undefined', () => {
+      const blocks = buildStagePrompt(1, createContext({
+        contextBundle: {
+          ...mockContextBundle,
+          topicFrame: {
+            text: 'Trust around late-night texting',
+            confirmedAt: '2026-05-12T00:00:00.000Z',
+          },
+        },
+      }));
+
+      expect(blocks.dynamicBlock).toContain('CONVERSATION TOPIC: "Trust around late-night texting"');
+    });
+
+    it('does not use context bundle topicFrame when explicit topicFrame is null', () => {
+      const blocks = buildStagePrompt(1, createContext({
+        topicFrame: null,
+        contextBundle: {
+          ...mockContextBundle,
+          topicFrame: {
+            text: 'Trust around late-night texting',
+            confirmedAt: '2026-05-12T00:00:00.000Z',
+          },
+        },
+      }));
+
+      expect(blocks.dynamicBlock).not.toContain('CONVERSATION TOPIC');
+    });
   });
 
   describe('buildStagePrompt — Stage 1 witness cadence', () => {

--- a/backend/src/services/ai-orchestrator.ts
+++ b/backend/src/services/ai-orchestrator.ts
@@ -132,6 +132,8 @@ export interface OrchestratorResult {
 // User Preferences
 // ============================================================================
 
+const MIN_STAGE1_TURNS_BEFORE_FEEL_HEARD_CHECK = 5;
+
 /**
  * Get user's memory preferences from database.
  * Returns defaults if not set.
@@ -655,6 +657,9 @@ export async function orchestrateResponse(
       response = parsed.response;
       offerFeelHeardCheck = parsed.offerFeelHeardCheck;
       offerReadyToShare = parsed.offerReadyToShare;
+      if (context.stage === 1 && context.turnCount < MIN_STAGE1_TURNS_BEFORE_FEEL_HEARD_CHECK) {
+        offerFeelHeardCheck = false;
+      }
 
       // Draft is used for empathy (Stage 2) or topic frame (Stage 0).
       if (context.stage === 2) {

--- a/backend/src/services/context-assembler.ts
+++ b/backend/src/services/context-assembler.ts
@@ -10,6 +10,7 @@
 
 import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
+import { EmpathyStatus, SharedContentDeliveryStatus } from '@prisma/client';
 import {
   type MemoryIntentResult,
   type RetrievalDepth,
@@ -30,6 +31,41 @@ export interface ContextMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: string;
+}
+
+export interface StageHistoryMessage {
+  role: 'user' | 'assistant' | 'empathy_statement' | 'shared_context' | 'system';
+  content: string;
+  stage: number;
+  timestamp: string;
+}
+
+export interface PriorStageSummary {
+  stage: number;
+  lifecycleStatus?: string;
+  completedAt?: string;
+  userTurnCount: number;
+  assistantTurnCount: number;
+  highlights: StageHistoryMessage[];
+}
+
+export interface PriorStageSummaries {
+  stages: PriorStageSummary[];
+}
+
+export interface ConsentedShareStateItem {
+  kind: 'empathy_attempt' | 'additional_context';
+  direction: 'user_to_partner' | 'partner_to_user';
+  lifecycleStatus: string;
+  content?: string;
+  sharedAt?: string;
+  deliveredAt?: string;
+  revealedAt?: string;
+  validatedAt?: string;
+}
+
+export interface ConsentedShareState {
+  items: ConsentedShareStateItem[];
 }
 
 /**
@@ -146,6 +182,31 @@ export interface ContextBundle {
     gatesSatisfied: Record<string, unknown>;
   };
 
+  // Confirmed conversation topic. This is orientation context only; the
+  // confirmation timestamp on Session remains the source of truth.
+  topicFrame?: {
+    text: string;
+    confirmedAt: string;
+  };
+
+  // Condensed prior-stage context from this user's own lane only.
+  // StageProgress remains the gate source of truth; these summaries are only
+  // continuity context for what has already been said and persisted.
+  priorStageSummaries?: PriorStageSummaries;
+
+  // Typed consent/share lifecycle state for orientation only.
+  // Content is included only when owned by this user or delivered/revealed to
+  // them; StageProgress and lifecycle tables remain the gate source of truth.
+  consentedShareState?: ConsentedShareState;
+
+  // Full current-stage history for this user's own lane only.
+  // This is prompt orientation context, not a replacement for StageProgress or
+  // lifecycle tables when deciding gates.
+  currentStageHistory?: {
+    stage: number;
+    messages: StageHistoryMessage[];
+  };
+
   // User info
   userName: string;
   partnerName?: string;
@@ -209,8 +270,11 @@ export async function assembleContextBundle(
   // Note: buildInnerThoughtsContext depends on conversationContext, so it runs after.
   const turnBufferSize = getTurnBufferSize(stage, intent.intent);
 
-  const [conversationContext, emotionalThread, priorThemes, sessionSummary, userMemories, notableFacts, globalFacts, lastUserTurnAt] = await Promise.all([
+  const [conversationContext, currentStageHistory, priorStageSummaries, consentedShareState, emotionalThread, priorThemes, sessionSummary, userMemories, notableFacts, globalFacts, lastUserTurnAt] = await Promise.all([
     buildConversationContext(sessionId, userId, turnBufferSize, depth),
+    buildCurrentUserStageHistory(sessionId, userId, stage, depth),
+    buildPriorStageSummaries(sessionId, userId, stage, depth),
+    buildConsentedShareState(sessionId, userId, depth),
     buildEmotionalThread(sessionId, userId, depth),
     (depth === 'full' || depth === 'light')
       ? buildPriorThemes(sessionId, userId, session.relationshipId)
@@ -260,6 +324,15 @@ export async function assembleContextBundle(
       stage,
       gatesSatisfied,
     },
+    topicFrame: session.topicFrame && session.topicFrameConfirmedAt
+      ? {
+          text: session.topicFrame,
+          confirmedAt: session.topicFrameConfirmedAt.toISOString(),
+        }
+      : undefined,
+    priorStageSummaries,
+    consentedShareState,
+    currentStageHistory,
     userName,
     partnerName,
     intent,
@@ -310,6 +383,246 @@ async function buildConversationContext(
     content: m.content,
     timestamp: m.timestamp.toISOString(),
   }));
+}
+
+async function buildCurrentUserStageHistory(
+  sessionId: string,
+  userId: string,
+  stage: number,
+  depth: RetrievalDepth
+): Promise<ContextBundle['currentStageHistory'] | undefined> {
+  if (depth === 'none') return undefined;
+
+  const messages = await prisma.message.findMany({
+    where: {
+      sessionId,
+      stage,
+      OR: [
+        { senderId: userId },
+        { senderId: null, forUserId: userId },
+        { forUserId: userId, role: { in: ['EMPATHY_STATEMENT', 'SHARED_CONTEXT'] } },
+      ],
+    },
+    orderBy: { timestamp: 'asc' },
+    select: {
+      content: true,
+      role: true,
+      timestamp: true,
+      stage: true,
+    },
+  });
+
+  if (messages.length === 0) return undefined;
+
+  return {
+    stage,
+    messages: messages.map((message) => ({
+      role: mapStageHistoryRole(message.role),
+      content: message.content,
+      stage: message.stage,
+      timestamp: message.timestamp.toISOString(),
+    })),
+  };
+}
+
+function mapStageHistoryRole(role: string): StageHistoryMessage['role'] {
+  switch (role) {
+    case 'USER':
+      return 'user';
+    case 'AI':
+      return 'assistant';
+    case 'EMPATHY_STATEMENT':
+      return 'empathy_statement';
+    case 'SHARED_CONTEXT':
+      return 'shared_context';
+    default:
+      return 'system';
+  }
+}
+
+async function buildPriorStageSummaries(
+  sessionId: string,
+  userId: string,
+  currentStage: number,
+  depth: RetrievalDepth
+): Promise<ContextBundle['priorStageSummaries'] | undefined> {
+  if (depth === 'none' || currentStage <= 0) return undefined;
+
+  const [messages, progressRows] = await Promise.all([
+    prisma.message.findMany({
+      where: {
+        sessionId,
+        stage: { lt: currentStage },
+        OR: [
+          { senderId: userId },
+          { senderId: null, forUserId: userId },
+          { forUserId: userId, role: { in: ['EMPATHY_STATEMENT', 'SHARED_CONTEXT'] } },
+        ],
+      },
+      orderBy: [{ stage: 'asc' }, { timestamp: 'asc' }],
+      select: {
+        content: true,
+        role: true,
+        timestamp: true,
+        stage: true,
+      },
+    }),
+    prisma.stageProgress.findMany({
+      where: {
+        sessionId,
+        userId,
+        stage: { lt: currentStage },
+      },
+      orderBy: { stage: 'asc' },
+      select: {
+        stage: true,
+        status: true,
+        completedAt: true,
+      },
+    }),
+  ]);
+
+  if (messages.length === 0 && progressRows.length === 0) return undefined;
+
+  const byStage = new Map<number, PriorStageSummary>();
+  const ensureStage = (stage: number): PriorStageSummary => {
+    const existing = byStage.get(stage);
+    if (existing) return existing;
+    const summary: PriorStageSummary = {
+      stage,
+      userTurnCount: 0,
+      assistantTurnCount: 0,
+      highlights: [],
+    };
+    byStage.set(stage, summary);
+    return summary;
+  };
+
+  for (const progress of progressRows) {
+    const summary = ensureStage(progress.stage);
+    summary.lifecycleStatus = progress.status;
+    if (progress.completedAt) {
+      summary.completedAt = progress.completedAt.toISOString();
+    }
+  }
+
+  for (const message of messages) {
+    const summary = ensureStage(message.stage);
+    if (message.role === 'USER') {
+      summary.userTurnCount += 1;
+    } else if (message.role === 'AI') {
+      summary.assistantTurnCount += 1;
+    }
+
+    summary.highlights.push({
+      role: mapStageHistoryRole(message.role),
+      content: message.content,
+      stage: message.stage,
+      timestamp: message.timestamp.toISOString(),
+    });
+  }
+
+  const stages = [...byStage.values()]
+    .sort((a, b) => a.stage - b.stage)
+    .map((summary) => ({
+      ...summary,
+      highlights: summary.highlights.slice(-4),
+    }));
+
+  return stages.length > 0 ? { stages } : undefined;
+}
+
+async function buildConsentedShareState(
+  sessionId: string,
+  userId: string,
+  depth: RetrievalDepth
+): Promise<ContextBundle['consentedShareState'] | undefined> {
+  if (depth === 'none') return undefined;
+
+  const [empathyAttempts, shareOffers] = await Promise.all([
+    prisma.empathyAttempt.findMany({
+      where: { sessionId },
+      orderBy: { sharedAt: 'asc' },
+      select: {
+        sourceUserId: true,
+        content: true,
+        status: true,
+        sharedAt: true,
+        deliveredAt: true,
+        revealedAt: true,
+        validations: {
+          where: { validated: true },
+          select: { validatedAt: true },
+          orderBy: { validatedAt: 'asc' },
+          take: 1,
+        },
+      },
+    }),
+    prisma.reconcilerShareOffer.findMany({
+      where: {
+        result: { sessionId },
+        sharedContent: { not: null },
+        sharedAt: { not: null },
+      },
+      orderBy: { sharedAt: 'asc' },
+      select: {
+        userId: true,
+        status: true,
+        deliveryStatus: true,
+        sharedContent: true,
+        sharedAt: true,
+        deliveredAt: true,
+      },
+    }),
+  ]);
+
+  const items: ConsentedShareStateItem[] = [];
+
+  for (const attempt of empathyAttempts) {
+    const isOwnAttempt = attempt.sourceUserId === userId;
+    const isVisiblePartnerAttempt =
+      attempt.revealedAt !== null ||
+      attempt.status === EmpathyStatus.REVEALED ||
+      attempt.status === EmpathyStatus.VALIDATED;
+
+    items.push({
+      kind: 'empathy_attempt',
+      direction: isOwnAttempt ? 'user_to_partner' : 'partner_to_user',
+      lifecycleStatus: attempt.status,
+      ...(isOwnAttempt || isVisiblePartnerAttempt ? { content: attempt.content } : {}),
+      sharedAt: attempt.sharedAt.toISOString(),
+      ...(attempt.deliveredAt ? { deliveredAt: attempt.deliveredAt.toISOString() } : {}),
+      ...(attempt.revealedAt ? { revealedAt: attempt.revealedAt.toISOString() } : {}),
+      ...(attempt.validations[0]?.validatedAt ? { validatedAt: attempt.validations[0].validatedAt.toISOString() } : {}),
+    });
+  }
+
+  for (const offer of shareOffers) {
+    const isOwnShare = offer.userId === userId;
+    const isDeliveredToUser =
+      offer.deliveredAt !== null ||
+      offer.deliveryStatus === SharedContentDeliveryStatus.DELIVERED ||
+      offer.deliveryStatus === SharedContentDeliveryStatus.SEEN;
+
+    items.push({
+      kind: 'additional_context',
+      direction: isOwnShare ? 'user_to_partner' : 'partner_to_user',
+      lifecycleStatus: `${offer.status}/${offer.deliveryStatus}`,
+      ...(isOwnShare || isDeliveredToUser ? { content: offer.sharedContent ?? undefined } : {}),
+      ...(offer.sharedAt ? { sharedAt: offer.sharedAt.toISOString() } : {}),
+      ...(offer.deliveredAt ? { deliveredAt: offer.deliveredAt.toISOString() } : {}),
+    });
+  }
+
+  if (items.length === 0) return undefined;
+
+  items.sort((a, b) => {
+    const aTime = a.revealedAt ?? a.deliveredAt ?? a.sharedAt ?? '';
+    const bTime = b.revealedAt ?? b.deliveredAt ?? b.sharedAt ?? '';
+    return aTime.localeCompare(bTime);
+  });
+
+  return { items };
 }
 
 /**

--- a/backend/src/services/context-formatters.ts
+++ b/backend/src/services/context-formatters.ts
@@ -11,6 +11,9 @@ export interface ContextFormattingOptions {
  * in one logical place per direction of control.
  */
 const LONG_IDLE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+const STAGE_HISTORY_CONTENT_LIMIT = 360;
+const SHARE_STATE_CONTENT_LIMIT = 360;
+const PRIOR_STAGE_CONTENT_LIMIT = 240;
 
 /** Humanize an idle duration for inclusion in the prompt. */
 function formatIdleDuration(ms: number): string {
@@ -218,6 +221,36 @@ export function formatContextForPrompt(
     parts.push(...factLines);
   }
 
+  if (bundle.topicFrame?.text) {
+    parts.push('--- Conversation topic ---');
+    parts.push(`Confirmed topic: "${bundle.topicFrame.text}"`);
+    parts.push('Use this as orientation only. Stage gates still come from StageProgress and explicit product lifecycle state.');
+  }
+
+  if (bundle.priorStageSummaries?.stages.length) {
+    parts.push('--- Prior stage summaries (current user lane only) ---');
+    parts.push('Use this only for continuity. Stage gates still come from StageProgress and explicit product lifecycle state.');
+    for (const summary of bundle.priorStageSummaries.stages) {
+      parts.push(renderPriorStageSummary(summary));
+    }
+  }
+
+  if (bundle.consentedShareState?.items.length) {
+    parts.push('--- Consented partner/share state ---');
+    parts.push('Use this only for orientation. Stage gates still come from StageProgress and empathy/share/validation lifecycle state.');
+    for (const item of bundle.consentedShareState.items) {
+      parts.push(renderConsentedShareStateItem(item));
+    }
+  }
+
+  if (bundle.currentStageHistory?.messages.length) {
+    parts.push(`--- Current Stage ${bundle.currentStageHistory.stage} history (current user lane only) ---`);
+    parts.push('Use this only for continuity. Stage gates still come from StageProgress and explicit product lifecycle state.');
+    for (const message of bundle.currentStageHistory.messages) {
+      parts.push(`- ${renderStageHistoryRole(message.role)}: ${truncateStageHistoryContent(message.content)}`);
+    }
+  }
+
   if (bundle.innerThoughtsContext?.relevantReflections?.length) {
     parts.push('--- Private reflections (gentle reference) ---');
     for (const reflection of bundle.innerThoughtsContext.relevantReflections.slice(0, 2)) {
@@ -236,4 +269,69 @@ export function formatContextForPrompt(
   }
 
   return parts.filter((part) => part.trim().length > 0).join('\n');
+}
+
+function renderStageHistoryRole(role: NonNullable<ContextBundle['currentStageHistory']>['messages'][number]['role']): string {
+  switch (role) {
+    case 'user':
+      return 'User';
+    case 'assistant':
+      return 'AI';
+    case 'empathy_statement':
+      return 'Empathy statement';
+    case 'shared_context':
+      return 'Shared context';
+    default:
+      return 'System';
+  }
+}
+
+function truncateStageHistoryContent(content: string): string {
+  const compact = content.replace(/\s+/g, ' ').trim();
+  if (compact.length <= STAGE_HISTORY_CONTENT_LIMIT) return compact;
+  return `${compact.slice(0, STAGE_HISTORY_CONTENT_LIMIT - 1)}…`;
+}
+
+function renderPriorStageSummary(
+  summary: NonNullable<ContextBundle['priorStageSummaries']>['stages'][number]
+): string {
+  const status = summary.lifecycleStatus ? ` (${summary.lifecycleStatus}${summary.completedAt ? `; completed ${summary.completedAt}` : ''})` : '';
+  const lines = [
+    `Stage ${summary.stage}${status}: ${summary.userTurnCount} user turn(s), ${summary.assistantTurnCount} AI turn(s).`,
+  ];
+
+  for (const highlight of summary.highlights) {
+    lines.push(`  - ${renderStageHistoryRole(highlight.role)}: ${truncatePriorStageContent(highlight.content)}`);
+  }
+
+  return lines.join('\n');
+}
+
+function truncatePriorStageContent(content: string): string {
+  const compact = content.replace(/\s+/g, ' ').trim();
+  if (compact.length <= PRIOR_STAGE_CONTENT_LIMIT) return compact;
+  return `${compact.slice(0, PRIOR_STAGE_CONTENT_LIMIT - 1)}…`;
+}
+
+function renderConsentedShareStateItem(
+  item: NonNullable<ContextBundle['consentedShareState']>['items'][number]
+): string {
+  const direction = item.direction === 'user_to_partner' ? 'You shared' : 'Partner shared';
+  const kind = item.kind === 'empathy_attempt' ? 'empathy attempt' : 'additional context';
+  const timestamps = [
+    item.sharedAt ? `shared ${item.sharedAt}` : null,
+    item.deliveredAt ? `delivered ${item.deliveredAt}` : null,
+    item.revealedAt ? `revealed ${item.revealedAt}` : null,
+    item.validatedAt ? `validated ${item.validatedAt}` : null,
+  ].filter(Boolean);
+  const lifecycle = [item.lifecycleStatus, ...timestamps].join('; ');
+  const content = item.content ? `: ${truncateShareStateContent(item.content)}` : ' (content not yet visible to this user)';
+
+  return `- ${direction} ${kind} (${lifecycle})${content}`;
+}
+
+function truncateShareStateContent(content: string): string {
+  const compact = content.replace(/\s+/g, ' ').trim();
+  if (compact.length <= SHARE_STATE_CONTENT_LIMIT) return compact;
+  return `${compact.slice(0, SHARE_STATE_CONTENT_LIMIT - 1)}…`;
 }

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -1825,13 +1825,18 @@ The acknowledgment should feel like a natural transition, not a restart. Look at
  * Returns PromptBlocks with static (cacheable) and dynamic (per-turn) content.
  */
 export function buildStagePrompt(stage: number, context: PromptContext, options?: BuildStagePromptOptions): PromptBlocks {
+  const promptContext =
+    context.topicFrame === undefined && context.contextBundle.topicFrame?.text
+      ? { ...context, topicFrame: context.contextBundle.topicFrame.text }
+      : context;
+
   // Build post-share section if user just shared context with partner
-  const postShareSection = buildPostShareContextSection(context);
+  const postShareSection = buildPostShareContextSection(promptContext);
 
   // Stage transition: prepend a short injection to the dynamic block
   // (instead of replacing the entire prompt, which would lose modes/rules/readiness signals)
   const transitionInjection = options?.isStageTransition
-    ? buildTransitionInjection(stage, options.previousStage, context)
+    ? buildTransitionInjection(stage, options.previousStage, promptContext)
     : '';
 
   // Helper to combine dynamic parts with transition injection and post-share context
@@ -1846,8 +1851,8 @@ export function buildStagePrompt(stage: number, context: PromptContext, options?
     // Invited-session nudge — operational hint surfaced when an INVITED
     // Slack session is nearing its TTL. Goes at the END of the dynamic
     // block so it reads as a recent operational signal, not as framing.
-    if (context.invitedSessionNudge) {
-      dynamicBlock = `${dynamicBlock}\n\nOPERATIONAL NUDGE:\n${context.invitedSessionNudge}`;
+    if (promptContext.invitedSessionNudge) {
+      dynamicBlock = `${dynamicBlock}\n\nOPERATIONAL NUDGE:\n${promptContext.invitedSessionNudge}`;
     }
     // Append Slack formatting rules to the static block when the response will
     // render in a Slack DM. Keeping this in the static block preserves prompt
@@ -1861,35 +1866,35 @@ export function buildStagePrompt(stage: number, context: PromptContext, options?
 
   // Special case: Stage 0 invitation phase (before partner joins)
   if (stage === 0 && options?.isInvitationPhase) {
-    return finalize(buildInvitationPrompt(context));
+    return finalize(buildInvitationPrompt(promptContext));
   }
 
   // Special case: Onboarding mode (compact not yet signed)
   if (stage === 0 && options?.isOnboarding) {
-    return finalize(buildOnboardingPrompt(context));
+    return finalize(buildOnboardingPrompt(promptContext));
   }
 
   let blocks: PromptBlocks;
   switch (stage) {
     case 0:
     case 1:
-      blocks = buildStage1Prompt(context);
+      blocks = buildStage1Prompt(promptContext);
       break;
     case 2:
-      blocks = buildStage2Prompt(context);
+      blocks = buildStage2Prompt(promptContext);
       break;
     case 3:
-      blocks = buildStage3Prompt(context);
+      blocks = buildStage3Prompt(promptContext);
       break;
     case 4:
-      blocks = buildStage4Prompt(context);
+      blocks = buildStage4Prompt(promptContext);
       break;
     case 21: // Stage 2B: Informed Empathy
-      blocks = buildStage2BPrompt(context);
+      blocks = buildStage2BPrompt(promptContext);
       break;
     default:
       logger.warn(`[Stage Prompts] Unknown stage ${stage}, using Stage 1 prompt`);
-      blocks = buildStage1Prompt(context);
+      blocks = buildStage1Prompt(promptContext);
       break;
   }
 

--- a/docs/product/mwf-context-architecture-restart-progress.md
+++ b/docs/product/mwf-context-architecture-restart-progress.md
@@ -1,0 +1,317 @@
+# MWF Context Architecture Restart Progress
+
+Date: 2026-05-11
+Branch: `codex/context-architecture-restart-20260511`
+Worktree: `/tmp/mwf-context-architecture-restart`
+Base: `origin/main` at `5eddbfe4`
+
+## Scope
+
+This restart began from latest `main` and did not reuse the previous context branch. No Darryl/Shantam tuning or evaluation was run. Adam/Eve is now clean through Stage 2 using real CTA/API gates after reverting typed-chat sharing. Context improvements are being reintroduced incrementally with Adam/Eve DB verification after each increment.
+
+## Code Changes
+
+- `scripts/mwf_gold_loop.py`
+  - Load `backend/.env` for transcript extraction and DB inspection commands.
+  - Capture `db-stage-state.json` for each non-mock run.
+  - Add `db_stage_state_matches_stop_gate` hard invariant.
+  - Require Stage 2 stop gates to use DB `StageProgress`, `Message.stage`, and `EmpathyAttempt` lifecycle state instead of actor status or transcript text alone.
+  - Tighten Stage 2 actor handoff so `needs_partner` with `blocked_on` is not treated as a completed stop boundary.
+- `scripts/test_mwf_gold_loop.py`
+  - Add regression coverage for transcript/status passing while DB messages remain behind.
+  - Add coverage that Stage 2 needs real empathy lifecycle state, not actor status alone.
+  - Add pass coverage for valid Stage 2 `GATE_PENDING` plus `READY` attempts.
+  - Add coverage that Stage 2 partner waits resume the newly blocked partner, even when the other actor's prior status was also a partner wait.
+  - Add prompt coverage requiring actors to handle Stage 2 post-empathy share/context review prompts such as `Share this with <partner>? Review`.
+- `mobile/src/hooks/useChatUIState.ts`
+  - Treat `myAttempt.status === REFINING` as refinement mode even after `hasNewSharedContext` is cleared by viewing partner context, so the revised empathy review/resubmit panel can stay available.
+- `mobile/src/utils/chatUIState.ts`
+  - During Stage 2 refinement, hold optional share-suggestion panels so the required revised empathy review/resubmit CTA can surface.
+- `backend/src/services/context-assembler.ts` and `backend/src/services/context-formatters.ts`
+  - Add current-stage history for the current user's own lane as prompt continuity context.
+  - Label it explicitly as continuity-only context; stage gates still come from `StageProgress` and product lifecycle state.
+  - Add confirmed topic frame to the `ContextBundle` as orientation-only context. It is included only when `Session.topicFrameConfirmedAt` exists.
+  - Add typed consented partner/share lifecycle state from `EmpathyAttempt` and `ReconcilerShareOffer` rows.
+  - Label consented share state explicitly as orientation-only context; gates still come from `StageProgress` plus empathy/share/validation lifecycle state.
+  - Include shared content only when it is the current user's own content or has been delivered/revealed to the current user.
+  - Add prior-stage summaries from `Message.stage` and `StageProgress` for the current user's own lane only.
+  - Label prior-stage summaries explicitly as continuity-only context; stage gates still come from `StageProgress` and product lifecycle state.
+- `backend/src/services/stage-prompts.ts`
+  - Let stage prompts use confirmed topic frame from `contextBundle.topicFrame` when no explicit `topicFrame` is provided.
+  - Preserve explicit `topicFrame: null` as a suppression signal.
+- `backend/src/services/ai-orchestrator.ts`
+  - Add a Stage 1 minimum-turn guard before honoring model-requested feel-heard checks, so the visible felt-heard CTA cannot appear before enough substantive witness turns.
+  - This is state/turn-count gating, not chat text matching.
+- `backend/src/controllers/messages.ts`
+  - A typed Stage 2B share-confirmation persistence patch was tried and then reverted. Stage 2 sharing/resubmission must happen only through the review/share CTA/API path, not regex text matching in chat.
+  - Post-Stage-0 streaming prompts now pass topic frame only after `topicFrameConfirmedAt`, so unconfirmed topic drafts are not injected as durable context.
+
+## Verification
+
+- `python3 -m unittest scripts/test_mwf_gold_loop.py`: pass, 19 tests.
+- `python3 -m py_compile scripts/mwf_gold_loop.py scripts/test_mwf_gold_loop.py`: pass.
+- `npm --workspace mobile test -- --runTestsByPath src/utils/__tests__/chatUIState.test.ts --runInBand`: pass, 70 tests.
+- `npm --workspace backend run check`: pass.
+- `npm --workspace backend test -- --runTestsByPath src/services/__tests__/context-assembler.test.ts --runInBand`: pass, 20 tests.
+- `npm --workspace backend test -- --runTestsByPath src/services/__tests__/context-assembler.test.ts src/services/__tests__/stage-prompts.test.ts --runInBand`: pass, 127 tests.
+- `npm --workspace backend run check`: pass after confirmed-topic-frame increment.
+- `npm --workspace backend test -- --runTestsByPath src/services/__tests__/context-assembler.test.ts --runInBand`: pass, 26 tests after consented-share-state increment.
+- `npm --workspace backend run check`: pass after consented-share-state increment.
+- `npm --workspace backend test -- --runTestsByPath src/services/__tests__/context-assembler.test.ts --runInBand`: pass, 29 tests after prior-stage-summaries increment.
+- `npm --workspace backend run check`: pass after prior-stage-summaries increment.
+- `npm --workspace backend test -- --runTestsByPath src/services/__tests__/ai-orchestrator.test.ts --runInBand`: pass, 39 tests after Stage 1 felt-heard turn guard.
+- `npm --workspace backend test -- --runTestsByPath src/services/__tests__/stage-prompts.test.ts --runInBand`: pass, 105 tests after Stage 1 felt-heard turn guard.
+- `npm --workspace backend run check`: pass after Stage 1 felt-heard turn guard.
+
+## Adam/Eve Runs
+
+- `eval/runs/20260511-150503-adam-eve-iter-01`
+  - Baseline before harness patch.
+  - Initial transcript extraction failed because `DATABASE_URL` was not loaded for backend extractor.
+  - After re-running extraction/DB capture manually, DB showed both sides through Stage 1, but Stage 2 was incomplete.
+
+- `eval/runs/20260511-152602-adam-eve-iter-01`
+  - After transcript extraction and DB-state capture patch.
+  - Score: `3.0`, `eval_fail`.
+  - Hard invariant: `db_stage_state_matches_stop_gate`.
+  - DB evidence: Adam Stage 2 `IN_PROGRESS`, Eve Stage 2 `IN_PROGRESS`, Adam `EmpathyAttempt` `REFINING`.
+  - Orchestrator incorrectly moved to scoring after Eve said Adam still needed to revise.
+
+- `eval/runs/20260511-154427-adam-eve-iter-01`
+  - After Stage 2 handoff tightening.
+  - Score: `3.0`, `eval_fail`.
+  - Improvement: orchestrator resumed Adam after Eve shared context.
+  - Remaining blocker: actor loop ping-ponged at Stage 2 partner waits and still ended with DB Stage 2 incomplete.
+  - DB evidence: Adam Stage 2 `IN_PROGRESS`, Eve Stage 2 `IN_PROGRESS`, Adam `EmpathyAttempt` `REFINING`, Eve `EmpathyAttempt` `READY`, no validations.
+
+- `eval/runs/20260511-161106-adam-eve-iter-01`
+  - After initial reciprocal Stage 2 wait handling.
+  - Score: `3.0`, `eval_fail`.
+  - Improvement: orchestrator did not ping-pong to max actor turns. Adam shared his Stage 2 empathy attempt and returned `needs_partner` blocked on Eve; Eve completed Stage 1, shared her Stage 2 empathy/context, and returned `needs_partner` blocked on Adam.
+  - Follow-up finding: stopping on reciprocal Stage 2 partner waits was too early because Adam's status was stale from before Eve shared new context. The runner now resumes the newly blocked partner instead.
+  - Hard invariant: `db_stage_state_matches_stop_gate`.
+  - DB evidence: Adam Stage 0/1 `COMPLETED`, Eve Stage 0/1 `COMPLETED`, max `Message.stage` 2, Adam Stage 2 `IN_PROGRESS`, Eve Stage 2 `IN_PROGRESS`, Adam `EmpathyAttempt` `REFINING`, Eve `EmpathyAttempt` `READY`, no validations.
+  - Scorer found actor fidelity and MWF handling scoreable at 4/4 each, but `evaluation_scope.prompt_quality` remained `not_evaluable_for_prompt_quality` because the DB stop gate failed.
+
+- `eval/runs/20260511-163207-adam-eve-iter-01`
+  - After removing the premature reciprocal-wait stop.
+  - Score: `3.0`, `eval_fail`.
+  - Improvement: the loop continued after Eve shared and repeatedly handed control back to Adam.
+  - New blocker: Eve had a visible Stage 2 context-share/review prompt (`Share this with Adam? Review`) after submitting her empathy draft, but the actor initially stopped instead of handling it. Adam then remained on the old waiting UI (`Eve needs to complete her Stage 2 perspective-taking step`) while Eve later reported Adam needed to review/approve.
+  - Hard invariant: `db_stage_state_matches_stop_gate`.
+  - DB evidence: Adam Stage 2 `IN_PROGRESS`, Eve Stage 2 `IN_PROGRESS`, Adam `EmpathyAttempt` `AWAITING_SHARING`, Eve `EmpathyAttempt` `READY`, no reveals/validations.
+  - Follow-up patch: actor prompts now explicitly require handling Stage 2 post-empathy share/context review prompts before reporting wait or stage-limit status.
+
+- `eval/runs/20260511-165705-adam-eve-iter-01`
+  - After actor prompt tightening.
+  - Score: `3.0`, `eval_fail`.
+  - Improvement: both actors handled Stage 2 review surfaces more faithfully and Adam reached the refinement conversation after Eve shared context.
+  - New blocker: after Adam received Eve's shared context, the UI did not keep the true revised empathy resubmit panel reliably available once the shared-context notification was viewed. Adam typed readiness/confirmation in chat instead of completing the durable resubmit lifecycle.
+  - DB evidence: Adam `EmpathyAttempt` `REFINING`, Eve `EmpathyAttempt` `READY`, Stage 2 `IN_PROGRESS`.
+  - Follow-up patch: `useChatUIState` now derives refinement mode from `myAttempt.status === REFINING`, not only `hasNewSharedContext`.
+
+- `eval/runs/20260511-172244-adam-eve-iter-01`
+  - After mobile refinement-panel patch.
+  - Aborted/hung, not a valid baseline.
+  - Improvement: Adam reached the refinement UI and shared updated Stage 2 context.
+  - Blocker: the run got stuck behind an exchange-history bottom sheet overlay; controls were obscured and the actor could not complete the flow cleanly.
+  - Follow-up patch: gold actor prompts now treat exchange-history surfaces as diagnostic only and instruct actors to dismiss/reload if they block Stage 2 work.
+
+- `eval/runs/20260511-175041-adam-eve-iter-01`
+  - After exchange-history actor prompt patch.
+  - Score: `3.0`, `eval_fail`.
+  - Improvement: Stage 1 felt-heard gates passed for both actors, Eve shared her empathy/context, Adam received Eve's context, and actor fidelity/MWF handling both scored `4`.
+  - Hard invariants failed:
+    - `stage_limit_reached_correctly`: Adam ended `bug_blocked`.
+    - `db_stage_state_matches_stop_gate`: Adam `EmpathyAttempt` remained `REFINING`; Adam/Eve Stage 2 remained `IN_PROGRESS`.
+  - DB evidence:
+    - Adam attempt `cmp1xd03w005gpxx4v4gkhpp0`: `REFINING`, `revealedAt: null`, no validation.
+    - Eve attempt `cmp1xles000abpxx4sod5l89k`: `READY`, `revealedAt: null`, no validation.
+    - Adam had Stage 21 AI messages claiming the updated statement was shared, including `Your updated empathy statement has been shared with Eve.`, but persistence stayed behind.
+  - Product blocker: typed Stage 2B share confirmation could produce a "shared" AI reply without calling the durable resubmit lifecycle.
+  - Rejected approach: a backend typed-chat share confirmation patch was later reverted because gates must advance through real controls/CTAs, not regex chat matching.
+
+- `eval/runs/20260511-182243-adam-eve-iter-01`
+  - After mobile `REFINING` panel persistence and the now-reverted backend typed Stage 2B resubmit persistence.
+  - Score: `4.1`, `eval_pass`; target `4.0` reached.
+  - Hard invariants: pass; no failed invariant checks.
+  - DB evidence:
+    - Adam Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Eve Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Adam and Eve empathy attempts both `VALIDATED`; both revealed at `2026-05-12T01:46:04.283Z`.
+    - Max `Message.stage`: `21`, with Adam's Stage 2B revised empathy persisted as an `EMPATHY_STATEMENT` and follow-up acknowledgment at Stage 2.
+  - Flow evidence:
+    - Adam shared initial Stage 2 empathy.
+    - Eve shared empathy and additional context.
+    - Adam revised after Eve's context, submitted the updated version, and validated Eve's empathy.
+    - Eve validated Adam's updated empathy; app advanced both sides into Stage 3.
+  - Services cleanup: backend and web both stopped cleanly in `eval/runs/20260511-182239-adam-eve-services/cleanup.json`.
+
+- `eval/runs/20260511-185542-adam-eve-iter-01`
+  - After adding current-user current-stage history as prompt continuity context.
+  - Score: `3.75`, `eval_warn`; target `4.0` not reached.
+  - Hard invariants: pass; no failed invariant checks.
+  - DB evidence:
+    - Adam Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Eve Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Adam and Eve empathy attempts both `VALIDATED`; both revealed at `2026-05-12T02:12:57.884Z`.
+    - Max `Message.stage`: `21`.
+  - Follow-up user direction: revert regex/chat-based Stage 2B sharing and ensure gate movement only happens via clicked controls/CTAs.
+
+- `eval/runs/20260511-192128-adam-eve-iter-01`
+  - After reverting typed-chat Stage 2B sharing and requiring actors to use visible gate CTAs.
+  - Score: `2.8`, `eval_fail`; target `4.0` not reached.
+  - Hard invariants failed:
+    - `stage_limit_reached_correctly`: Adam ended `bug_blocked`.
+    - `db_stage_state_matches_stop_gate`: Adam `EmpathyAttempt` stayed `REFINING`; Adam/Eve Stage 2 stayed `IN_PROGRESS`.
+  - Product blocker: Adam received Eve's shared context and produced enough reflection for an updated empathy draft, but the visible review/resubmit CTA did not surface. The app had an optional context share suggestion competing for the same above-input slot, so Adam typed review/readiness in chat and the durable CTA/API lifecycle never completed.
+  - Follow-up patch: optional share suggestions are now hidden while the user is in Stage 2 `REFINING`, allowing the required empathy revision panel (`Revisit what you'll share`) to take the CTA slot.
+
+- `eval/runs/20260511-194717-adam-eve-iter-01`
+  - After the Stage 2 refinement CTA priority fix, with typed-chat Stage 2B sharing still reverted.
+  - Score: `4.0`, `eval_warn`; target `4.0` reached.
+  - Hard invariants: pass; no failed invariant checks.
+  - CTA-only flow evidence:
+    - Adam clicked the initial empathy draft review/share path.
+    - Eve clicked the empathy draft review/share path and the separate `Share This Version` context CTA.
+    - Adam received Eve's shared context, saw the required `Revisit what you'll share` review card, opened it, and clicked `Resubmit`.
+    - Adam validated Eve's empathy; Eve validated Adam's revised empathy.
+  - DB evidence:
+    - Adam Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Eve Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Adam and Eve empathy attempts both `VALIDATED`.
+    - Adam validation timestamp: `2026-05-12T03:05:25.956Z`; Eve validation timestamp: `2026-05-12T03:06:20.856Z`.
+    - Max message stage includes Stage 21 refinement messages, but durable `StageProgress` and `EmpathyAttempt` lifecycle state agree at the stop gate.
+  - Services cleanup: backend and web both stopped cleanly in `eval/runs/20260511-194713-adam-eve-services/cleanup.json`.
+
+- `eval/runs/20260511-201557-adam-eve-iter-01`
+  - After confirmed-topic-frame context increment.
+  - Score: `4.0`, `eval_warn`; target `4.0` reached.
+  - Hard invariants: pass; no failed invariant checks.
+  - CTA-only flow evidence:
+    - Adam clicked topic approval, invitation share, Stage 1 felt-heard, initial empathy review/share, Stage 2 revision review/resubmit, and Eve-empathy validation controls.
+    - Eve clicked Stage 1 felt-heard, empathy review/share, `Share This Version` for additional context, and Adam-empathy validation controls.
+    - No regex/chat-based Stage 2B persistence path was present or used.
+  - DB evidence:
+    - Adam Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Eve Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Adam and Eve empathy attempts both `VALIDATED`.
+    - Adam validation timestamp: `2026-05-12T03:39:13.597Z`; Eve validation timestamp: `2026-05-12T03:40:15.522Z`.
+    - Both attempts revealed at `2026-05-12T03:38:55.853Z`.
+  - Scorer notes:
+    - Actor fidelity and MWF handling both scored `4`.
+    - Improvement target: Stage 2 prompts sometimes ask what the partner needs "from you"; tighten this toward universal-person need framing without changing gates.
+    - Product/UI target: waiting/share-offer UI still has some accessibility/friction issues, but did not block the CTA lifecycle.
+  - Services cleanup: backend and web both stopped cleanly in `eval/runs/20260511-201553-adam-eve-services/cleanup.json`.
+
+- `eval/runs/20260511-205113-adam-eve-iter-01`
+  - After consented-share-state context increment.
+  - Score: `4.0`, `eval_warn`; target `4.0` reached.
+  - Hard invariants: pass; no failed invariant checks.
+  - CTA-only flow evidence:
+    - Adam clicked Stage 1 felt-heard, empathy draft review/share, revision review/resubmit after Eve's shared context, and Eve-empathy validation.
+    - Eve clicked Stage 1 felt-heard, empathy draft review/share, `Share This Version` for additional context, and Adam-empathy validation.
+    - No regex/chat-based Stage 2B persistence path was present or used.
+  - DB evidence:
+    - Adam Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Eve Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Adam and Eve empathy attempts both `VALIDATED`.
+    - Both attempts revealed at `2026-05-12T04:11:38.238Z`.
+    - Eve validated Adam at `2026-05-12T04:12:20.162Z`; Adam validated Eve at `2026-05-12T04:13:10.989Z`.
+  - Scorer notes:
+    - Actor fidelity and MWF handling both scored `4`.
+    - Improvement target: Adam's Stage 2 draft/refinement path over-smoothed his uncertainty by keeping a confident "not about me being enough" claim.
+    - Product/UI target: Eve saw a stale post-submit review/share panel after backend progress had continued.
+  - Services cleanup: backend and web both stopped cleanly in `eval/runs/20260511-205108-adam-eve-services/cleanup.json`.
+
+- `eval/runs/20260511-211928-adam-eve-iter-01`
+  - After prior-stage-summaries context increment.
+  - Score: `4.0`, `eval_warn`; target `4.0` reached.
+  - Hard invariants: pass; no failed invariant checks.
+  - CTA-only flow evidence:
+    - Adam clicked topic approval, invitation share, Stage 1 felt-heard, initial empathy review/share, revision review/resubmit after Eve's shared context, and Eve-empathy validation.
+    - Eve clicked Stage 1 felt-heard, empathy draft review/share, `Share This Version` for additional context, and Adam-empathy validation.
+    - No regex/chat-based Stage 2B persistence path was present or used; durable movement came through review/share/resubmit/validation CTAs and the existing API lifecycle.
+  - DB evidence:
+    - Adam Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Eve Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Adam and Eve empathy attempts both `VALIDATED`.
+    - Both attempts revealed at `2026-05-12T04:37:07.765Z`.
+    - Adam validated Eve at `2026-05-12T04:37:19.965Z`; Eve validated Adam at `2026-05-12T04:38:26.911Z`.
+  - Scorer notes:
+    - Actor fidelity and MWF handling both scored `4`.
+    - Improvement target: Adam's Stage 2 empathy synthesis partly imported Adam's fear that there may be no place for him instead of fully centering Eve's aliveness, shrinking, and need for truthful room.
+    - Product/UI target: after Adam validated Eve's empathy, the UI still showed a generic chat input while copy said Adam was held for Eve; waiting states should disable or clearly relabel the input as private Inner Thoughts.
+    - Prompt target: Eve received a share suggestion almost immediately after her first Stage 2 answer; it was helpful and consented, but the prompt should usually allow more resistance/curiosity before proposing shareable context.
+  - Services cleanup: backend and web both stopped cleanly in `eval/runs/20260511-211924-adam-eve-services/cleanup.json`.
+
+## James/Catherine Runs
+
+- `eval/runs/20260511-214326-james-catherine-iter-01`
+  - Cross-scenario validation after prior-stage-summaries context increment.
+  - Score: `3.75`, `eval_warn`; target `4.0` not reached.
+  - Hard invariants: pass; no failed invariant checks.
+  - CTA-only flow evidence:
+    - Catherine clicked topic approval/share invitation, Stage 1 felt-heard, empathy review/share, revised empathy review/resubmit after James's shared context, and James-empathy validation.
+    - James clicked Stage 0 ready, Stage 1 felt-heard, empathy review/share, `Share This Version` for context, and Catherine-empathy validation.
+    - No regex/chat-based Stage 2B persistence path was present or used; durable movement came through visible review/share/resubmit/validation CTAs and API lifecycle state.
+  - DB evidence:
+    - Catherine and James Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Catherine and James empathy attempts both `VALIDATED`.
+    - Both attempts revealed at `2026-05-12T04:57:14.258Z`.
+    - Catherine validated James at `2026-05-12T04:57:30.275Z`; James validated Catherine at `2026-05-12T04:58:22.405Z`.
+  - Scorer notes:
+    - Actor fidelity scored `4`.
+    - MWF handling scored `3` because Catherine advanced through the Stage 1 felt-heard gate immediately after MWF asked what years of self-abandonment had done to her, before she answered that deeper question.
+    - Eval-harness target: fix stage-specific transcript extraction; `catherine-stage2.md` omitted initial Stage 2 turns present in the full transcript, and the full transcript emitted stray `Stage 21` headings around revision/context-share events.
+    - Product/UI target: Catherine still had a generic textbox visible while waiting on James review; waiting states should disable or clearly relabel the input as private Inner Thoughts.
+  - Services cleanup: backend and web both stopped cleanly in `eval/runs/20260511-214322-james-catherine-services/cleanup.json`.
+
+- `eval/runs/20260511-220512-james-catherine-iter-01`
+  - After adding the Stage 1 minimum-turn guard for model-requested felt-heard checks.
+  - Score: `4.0`, `eval_warn`; target `4.0` reached.
+  - Hard invariants: pass; no failed invariant checks.
+  - CTA-only flow evidence:
+    - Catherine clicked topic/share invitation, Stage 1 felt-heard after additional witness turns, empathy review/share, revision review/resubmit after James's shared context and feedback, and James-empathy validation.
+    - James clicked Stage 0 ready, Stage 1 felt-heard after additional witness turns, empathy review/share, `Share This Version` for context, revision review/resubmit after Catherine's context, and Catherine-empathy validation.
+    - No regex/chat-based Stage 2B persistence path was present or used; durable movement came through visible review/share/resubmit/validation CTAs and API lifecycle state.
+  - DB evidence:
+    - Catherine and James Stage 0/1/2 `COMPLETED`, Stage 3 `IN_PROGRESS`.
+    - Catherine and James empathy attempts both `VALIDATED`.
+    - Both attempts revealed at `2026-05-12T05:37:54.916Z`.
+    - Catherine validated James at `2026-05-12T05:38:19.432Z`; James validated Catherine at `2026-05-12T05:39:02.868Z`.
+  - Scorer notes:
+    - Actor fidelity scored `4`.
+    - MWF handling scored `4`.
+    - Improvement target: review Stage 2 facilitator phrasing for repeated praise / rubric-shaped transitions.
+    - Improvement target: inspect Catherine-side review copy that may briefly misattribute the addressee during the review flow.
+  - Services cleanup: backend and web both stopped cleanly in `eval/runs/20260511-220508-james-catherine-services/cleanup.json`.
+
+## Current Status
+
+Adam/Eve and James/Catherine Stage 2 durable gates are clean through CTA/API lifecycle state:
+
+- The latest Adam/Eve CTA-only run completed Stage 2 for both users with score `4.0` and hard invariants passing.
+- The latest James/Catherine CTA-only run completed Stage 2 for both users with score `4.0` and hard invariants passing after the Stage 1 felt-heard turn guard.
+- Both `EmpathyAttempt` rows are `VALIDATED` in both latest scenario runs.
+- Stage 3 is `IN_PROGRESS` for both users after validation in both latest scenario runs.
+- No regex or typed-chat Stage 2B sharing path is present; progress moved through review/share/resubmit CTAs and the existing API lifecycle.
+- Current-stage history has been reintroduced as the first context increment.
+- Confirmed topic frame has been reintroduced as the second context increment.
+- Consented partner/share lifecycle state has been reintroduced as the third context increment and passed Adam/Eve gate verification.
+- Prior-stage summaries have been reintroduced as the fourth context increment and passed Adam/Eve gate verification.
+- Durable process facts decision: no separate durable-process-facts memory channel is being added. The needed process facts are already typed and auditable through `Session.topicFrameConfirmedAt`, `StageProgress`, `EmpathyAttempt`/share lifecycle rows, and `Message.stage`-scoped history. Prompt rendering labels all of these as orientation/continuity only, with gates still sourced from `StageProgress` and lifecycle tables.
+- Next broader-goal step is final audit before closing the restart goal.
+
+## Residual Risks
+
+- Per-stage transcript extraction can omit some Stage 2 context from the stage-specific artifact even when the full transcript has it.
+- One Adam Stage 1 reflection rendered malformed copy: `it doesnt feel likeand also this"`.
+- Stage 2 prompt wording sometimes says what the partner needs "from you"; this can drift toward partner-specific reassurance and should be tightened to universal-person need framing.
+- Adam's Stage 2 draft/refinement path can over-smooth his live uncertainty into too-confident empathy wording.
+- Waiting states can leave a generic chat input visible after validation even when copy says the user is being held for partner review.
+- Eve can see stale post-submit review/share or waiting copy after backend progress has already moved forward.
+- Stage 2 share suggestions can appear very early in a user's perspective-taking turn; keep monitoring whether this crowds out resistance before share consent.
+- UI/accessibility friction remains around share-offer/review surfaces, though the latest CTA-only run completed despite it.
+- James/Catherine now reaches the Stage 2 target, but scorer still recommends human review of formulaic Stage 2 praise / transition language.
+- Catherine-side Stage 2 review copy may briefly misattribute the addressee during review flow; inspect before broadening scenario scope.

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -285,7 +285,9 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     hasLiveProposedEmpathyStatement,
     empathyAlreadyConsented: empathyDraftData?.alreadyConsented ?? false,
     hasSharedEmpathyLocal,
-    isRefiningEmpathy: empathyStatusData?.hasNewSharedContext ?? false,
+    isRefiningEmpathy:
+      empathyStatusData?.hasNewSharedContext === true ||
+      empathyStatusData?.myAttempt?.status === 'REFINING',
     messageCountSinceSharedContext: empathyStatusData?.messageCountSinceSharedContext ?? 0,
     myAttemptContent: !!empathyStatusData?.myAttempt?.content,
     hasShareSuggestion: shareOfferData?.hasSuggestion ?? false,

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -223,6 +223,32 @@ describe('Above Input Panel Priority', () => {
     expect(result.shouldHideInput).toBe(false);
   });
 
+  it('prioritizes empathy revision review over optional share suggestion while refining', () => {
+    const inputs = createInputs({
+      myStage: Stage.PERSPECTIVE_STRETCH,
+      compactMySigned: true,
+      myProgress: { stage: Stage.PERSPECTIVE_STRETCH },
+      hasShareSuggestion: true,
+      shareOffer: { hasSuggestion: true },
+      hasRespondedToShareOfferLocal: false,
+      empathyAlreadyConsented: true,
+      empathyDraft: { alreadyConsented: true },
+      isRefiningEmpathy: true,
+      messageCountSinceSharedContext: 1,
+      hasEmpathyContent: true,
+      hasLiveProposedEmpathyStatement: true,
+      empathyStatus: {
+        hasNewSharedContext: true,
+        myAttemptStatus: 'REFINING',
+      },
+    });
+
+    const result = computeChatUIState(inputs);
+    expect(result.panels.showShareSuggestionPanel).toBe(false);
+    expect(result.panels.showEmpathyPanel).toBe(true);
+    expect(result.aboveInputPanel).toBe('empathy-statement');
+  });
+
   it('does not show share-suggestion panel after Stage 2', () => {
     const inputs = createInputs({
       myStage: Stage.NEED_MAPPING,

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -346,6 +346,7 @@ function computeShowShareSuggestionPanel(inputs: ChatUIStateInputs): boolean {
     sessionStatus,
     empathyAlreadyConsented,
     empathyDraft,
+    isRefiningEmpathy,
   } = inputs;
 
   if (sessionStatus === SessionStatus.RESOLVED) return false;
@@ -361,6 +362,12 @@ function computeShowShareSuggestionPanel(inputs: ChatUIStateInputs): boolean {
   // their own empathy attempt. Hold it until their own Stage 2 share is done
   // so the suggestion does not interrupt perspective-taking.
   const ownEmpathySubmitted = empathyAlreadyConsented || empathyDraft?.alreadyConsented === true;
+
+  // Optional context sharing must not block the required Stage 2 refinement
+  // review/resubmit path after the partner shares new context.
+  if (isRefiningEmpathy) {
+    return false;
+  }
 
   return hasShareSuggestion && ownEmpathySubmitted && !hasRespondedToShareOfferLocal;
 }

--- a/scripts/mwf_gold_loop.py
+++ b/scripts/mwf_gold_loop.py
@@ -346,6 +346,29 @@ def run_command(
             handle.close()
 
 
+def load_dotenv_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            values[key] = value
+    return values
+
+
+def backend_command_env() -> dict[str, str]:
+    env = dict(os.environ)
+    for key, value in load_dotenv_file(REPO_ROOT / "backend/.env").items():
+        env.setdefault(key, value)
+    return env
+
+
 def start_background_command(
     name: str,
     cmd: list[str],
@@ -933,11 +956,15 @@ Continue as {actor.character} until one of these happens:
 - the run is completed,
 - a product/state/browser bug blocks progress.
 
-If a visible Stage 1 "I feel heard" / feel-heard confirmation CTA is present for {actor.character}, either click it or give a clear in-character typed confirmation such as "I feel heard" / "Ready" when that is realistic. Do not report Stage 2 progress unless the UI actually moves past the Stage 1 gate.
+If a visible Stage 1 "I feel heard" / feel-heard confirmation CTA is present for {actor.character}, click the CTA. Do not type a chat message to satisfy a product gate. Do not report Stage 2 progress unless the UI actually moves past the Stage 1 gate.
 
 If a visible Stage 0 compact/getting-started screen is present for {actor.character}, including copy like "Ready to begin?" with a "Ready" CTA, click it and continue. The header may show the partner's name because the session is "with {partner.character}"; do not treat that alone as evidence that you are operating the partner side.
 
 If Stage {stop_after_stage} shows a visible share suggestion, context-share decision, validation card, proposal inventory, rank/select/submit controls, draft review, or text input for {actor.character}, treat it as legitimate in-stage work. Respond to that action before reporting "stage_limit_reached". In Stage 4, do not report "stage_limit_reached" merely after adding ideas; use it only after this assigned side has submitted selections or the stage is visibly closed for this side. If the visible next action belongs to {partner.character}, use "needs_partner" with "blocked_on": "{partner.side}".
+
+For Stage 2 specifically, a post-empathy prompt like "Share this with {partner.character}? Review", "Review what you'll share", "Share this version", or "Does this still feel true?" is a required context-share/review action for {actor.character}. Open the review, share/decline/refine in character, and only then report waiting or stage-limit status. Do not stop merely because an empathy attempt was submitted if a share/context review prompt remains visible.
+
+Exchange-history surfaces are diagnostic only. Do not open them to satisfy Stage 2. If exchange history is already open and it blocks controls, dismiss it or reload the page before deciding whether a real stage action remains.
 
 In Stage 4, do not keep adding ideas indefinitely just because the chat input remains visible. Once {actor.character} has contributed one or two concrete proposals or individual commitments and has made visible willingness selections for the current proposal inventory, stop and report `needs_partner` if closure buttons are still disabled because {partner.character}'s private selections, proposals, review, or closure are pending.
 
@@ -976,9 +1003,11 @@ Partner side: {partner.character}
 Stop after Stage {stop_after_stage}.
 
 Inspect the current in-app browser state, continue if {actor.character} has a legitimate action, and stop when blocked on {partner.character}, Stage {stop_after_stage} is reached, completed, or bug-blocked.
-If a visible Stage 1 "I feel heard" / feel-heard confirmation CTA is present for {actor.character}, either click it or give a clear in-character typed confirmation such as "I feel heard" / "Ready" when that is realistic. Do not report Stage 2 progress unless the UI actually moves past the Stage 1 gate.
+If a visible Stage 1 "I feel heard" / feel-heard confirmation CTA is present for {actor.character}, click the CTA. Do not type a chat message to satisfy a product gate. Do not report Stage 2 progress unless the UI actually moves past the Stage 1 gate.
 If a visible Stage 0 compact/getting-started screen is present for {actor.character}, including copy like "Ready to begin?" with a "Ready" CTA, click it and continue. The header may show the partner's name because the session is "with {partner.character}"; do not treat that alone as evidence that you are operating the partner side.
 If Stage {stop_after_stage} shows a visible share suggestion, context-share decision, validation card, proposal inventory, rank/select/submit controls, draft review, or text input for {actor.character}, handle that in-stage action before reporting "stage_limit_reached". In Stage 4, do not report "stage_limit_reached" merely after adding ideas; use it only after this assigned side has submitted selections or the stage is visibly closed for this side. If the visible next action belongs to {partner.character}, use "needs_partner" with "blocked_on": "{partner.side}".
+For Stage 2 specifically, a post-empathy prompt like "Share this with {partner.character}? Review", "Review what you'll share", "Share this version", or "Does this still feel true?" is a required context-share/review action for {actor.character}. Open the review, share/decline/refine in character, and only then report waiting or stage-limit status. Do not stop merely because an empathy attempt was submitted if a share/context review prompt remains visible.
+Exchange-history surfaces are diagnostic only. Do not open them to satisfy Stage 2. If exchange history is already open and it blocks controls, dismiss it or reload the page before deciding whether a real stage action remains.
 In Stage 4, do not keep adding ideas indefinitely just because the chat input remains visible. Once {actor.character} has contributed one or two concrete proposals or individual commitments and has made visible willingness selections for the current proposal inventory, stop and report `needs_partner` if closure buttons are still disabled because {partner.character}'s private selections, proposals, review, or closure are pending.
 For Stage 4 specifically, "stage_limit_reached" must have `"blocked_on": null`. If {actor.character} is waiting for {partner.character} to submit proposals, selections, review, or closure, report `"state": "needs_partner"` instead.
 Keep browser observations compact. Prefer `agent-browser ... snapshot -i` over full snapshots, and do not paste long prior transcript history into the final answer.
@@ -1266,12 +1295,11 @@ def actor_satisfies_stop_boundary(actor: Actor, stop_after_stage: int) -> bool:
         return False
     if status.state != "needs_partner" or stage < stop_after_stage:
         return False
-    # For Stage 0-2 regression gates, a partner-wait at the requested stage is
-    # a valid stop boundary: the product may still be doing privacy review or
-    # partner reveal work, but the assigned actor has reached the requested
-    # stage cap. Stage 4 remains stricter because proposal/selection closure has
-    # side-specific work that must not be cut short while blocked_on is set.
-    return not status.blocked_on or stop_after_stage < 4
+    # Stage 2 includes draft/share/reveal/validation work that can reopen the
+    # partner after both sides have entered the stage. A blocked partner wait is
+    # only a stop boundary for the early Stage 0/1 gates; later stages must
+    # clear the blocker before scoring.
+    return not status.blocked_on or stop_after_stage < 2
 
 
 def actor_has_unanswered_blocker(actors: dict[str, Actor], target_side: str, stop_after_stage: int = 0) -> bool:
@@ -1280,7 +1308,8 @@ def actor_has_unanswered_blocker(actors: dict[str, Actor], target_side: str, sto
         status = actor.status
         if not status or not status.blocked_on:
             continue
-        if str(status.blocked_on).lower() == target_side and actor.turns > target.turns:
+        target_has_had_chance = actor.turns >= target.turns if stop_after_stage == 2 else actor.turns > target.turns
+        if str(status.blocked_on).lower() == target_side and target_has_had_chance:
             if (
                 stop_after_stage < 4
                 and actor_satisfies_stop_boundary(actor, stop_after_stage)
@@ -1473,7 +1502,12 @@ def write_mock_transcripts(run_dir: Path, scenario: str, max_stage: int) -> list
 def extract_transcripts(session_id: str, run_dir: Path, scenario: str, max_stage: int) -> list[str]:
     output_dir = REPO_ROOT / "backend/scripts/transcripts"
     before = set(output_dir.glob(f"*{session_id[:8]}*.md")) if output_dir.exists() else set()
-    result = run_command(["npx", "tsx", "scripts/extract-session-transcripts.ts", session_id], cwd=REPO_ROOT / "backend", timeout=120)
+    result = run_command(
+        ["npx", "tsx", "scripts/extract-session-transcripts.ts", session_id],
+        cwd=REPO_ROOT / "backend",
+        timeout=120,
+        env=backend_command_env(),
+    )
     if result.returncode != 0:
         (run_dir / "transcript-extract-error.txt").write_text(result.stderr + "\n" + result.stdout, encoding="utf-8")
         return []
@@ -1488,6 +1522,92 @@ def extract_transcripts(session_id: str, run_dir: Path, scenario: str, max_stage
         copied.append(str(dest))
     stable = write_stage_transcript_artifacts((Path(path) for path in copied), target, scenario, max_stage)
     return stable or copied
+
+
+def capture_db_stage_state(session_id: str, run_dir: Path) -> dict[str, Any]:
+    script = r'''
+import "dotenv/config";
+import { PrismaClient } from "@prisma/client";
+
+(async () => {
+  const prisma = new PrismaClient();
+  const sessionId = process.argv[1];
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    include: {
+      relationship: { include: { members: { include: { user: true } } } },
+      stageProgress: { orderBy: [{ userId: "asc" }, { stage: "asc" }] },
+      messages: {
+        orderBy: { timestamp: "asc" },
+        select: { id: true, role: true, senderId: true, forUserId: true, stage: true, content: true, timestamp: true },
+      },
+      empathyAttempts: { include: { validations: true }, orderBy: [{ sourceUserId: "asc" }, { sharedAt: "asc" }] },
+    },
+  });
+  if (!session) {
+    console.log(JSON.stringify({ error: "session_not_found", sessionId }));
+    return;
+  }
+  const users = session.relationship.members.map((member) => member.user);
+  const userName = (id) => users.find((user) => user.id === id)?.name || id || null;
+  console.log(JSON.stringify({
+    session: { id: session.id, status: session.status },
+    users: users.map((user) => ({ id: user.id, name: user.name, email: user.email })),
+    stageProgress: session.stageProgress.map((row) => ({
+      userId: row.userId,
+      user: userName(row.userId),
+      stage: row.stage,
+      status: row.status,
+      completedAt: row.completedAt,
+      gates: row.gatesSatisfied,
+    })),
+    empathyAttempts: session.empathyAttempts.map((attempt) => ({
+      id: attempt.id,
+      sourceUserId: attempt.sourceUserId,
+      sourceUser: userName(attempt.sourceUserId),
+      status: attempt.status,
+      sharedAt: attempt.sharedAt,
+      revealedAt: attempt.revealedAt,
+      validations: attempt.validations.map((validation) => ({
+        userId: validation.userId,
+        user: userName(validation.userId),
+        validated: validation.validated,
+        validatedAt: validation.validatedAt,
+      })),
+    })),
+    messageStages: session.messages.map((message) => ({
+      id: message.id,
+      role: message.role,
+      stage: message.stage,
+      senderId: message.senderId,
+      sender: userName(message.senderId),
+      forUserId: message.forUserId,
+      forUser: userName(message.forUserId),
+      contentPrefix: String(message.content || "").slice(0, 180),
+    })),
+  }));
+  await prisma.$disconnect();
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+'''
+    result = run_command(
+        ["npx", "tsx", "-e", script, session_id],
+        cwd=REPO_ROOT / "backend",
+        timeout=120,
+        env=backend_command_env(),
+    )
+    if result.returncode != 0:
+        (run_dir / "db-stage-state-error.txt").write_text(result.stderr + "\n" + result.stdout, encoding="utf-8")
+        return {"status": "error", "error": result.stderr.strip() or result.stdout.strip()}
+    try:
+        state = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        (run_dir / "db-stage-state-error.txt").write_text(result.stdout, encoding="utf-8")
+        return {"status": "error", "error": "invalid_json", "raw": result.stdout}
+    (run_dir / "db-stage-state.json").write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return state
 
 
 CONTROL_TAG_RE = re.compile(
@@ -1758,6 +1878,85 @@ def check_stage_limit_reached(run_data: dict[str, Any], scenario: str, max_stage
         owner="eval_harness",
         dimension="actor_orchestration",
         details="Every scenario side must reach the requested stage limit, a completed state, or a no-action partner wait at the requested stop stage.",
+        evidence=evidence,
+    )
+
+
+def check_db_stage_state_matches_stop_gate(run_data: dict[str, Any], scenario: str, max_stage: int) -> dict[str, Any]:
+    evidence: list[str] = []
+    state = run_data.get("db_stage_state")
+    if not isinstance(state, dict) or state.get("status") == "error":
+        error = state.get("error") if isinstance(state, dict) else "missing db_stage_state"
+        evidence.append(f"db stage state unavailable: {error}")
+        return invariant_result(
+            "db_stage_state_matches_stop_gate",
+            False,
+            owner="eval_harness",
+            dimension="actor_orchestration",
+            details="Gold-loop gate evaluation must inspect DB StageProgress, Message.stage, and empathy lifecycle state instead of trusting actor transcript/status text alone.",
+            evidence=evidence,
+        )
+
+    users = {str(user.get("name", "")).lower(): str(user.get("id", "")) for user in state.get("users", []) if isinstance(user, dict)}
+    progress = state.get("stageProgress") if isinstance(state.get("stageProgress"), list) else []
+    messages = state.get("messageStages") if isinstance(state.get("messageStages"), list) else []
+    empathy_attempts = state.get("empathyAttempts") if isinstance(state.get("empathyAttempts"), list) else []
+    sides = scenario_sides(scenario)
+    side_ids = {side: users.get(side) for side in sides}
+    start = run_data.get("start") if isinstance(run_data.get("start"), dict) else {}
+    prior_stages = range(0, max_stage)
+    if str(start.get("mode") or "") == "target_stage":
+        prior_stages = range(0, 0)
+    for side, user_id in side_ids.items():
+        if not user_id:
+            evidence.append(f"{side}: missing DB user")
+            continue
+        for stage in prior_stages:
+            row = next((item for item in progress if item.get("userId") == user_id and item.get("stage") == stage), None)
+            if not row:
+                evidence.append(f"{side}: missing StageProgress stage {stage}")
+            elif row.get("status") != "COMPLETED":
+                evidence.append(f"{side}: StageProgress stage {stage} is {row.get('status')!r}, expected COMPLETED")
+        row = next((item for item in progress if item.get("userId") == user_id and item.get("stage") == max_stage), None)
+        if not row:
+            evidence.append(f"{side}: missing StageProgress stop stage {max_stage}")
+            continue
+        status = row.get("status")
+        gates = row.get("gates") if isinstance(row.get("gates"), dict) else {}
+        if max_stage == 1:
+            if status != "COMPLETED" or gates.get("feelHeardConfirmed") is not True:
+                evidence.append(f"{side}: Stage 1 DB gate incomplete: status={status!r} gates={gates!r}")
+        elif max_stage == 2:
+            attempts = [attempt for attempt in empathy_attempts if attempt.get("sourceUserId") == user_id]
+            if not attempts:
+                evidence.append(f"{side}: missing EmpathyAttempt for Stage 2")
+            else:
+                attempt = attempts[-1]
+                if attempt.get("status") not in {"READY", "REVEALED", "VALIDATED"}:
+                    evidence.append(f"{side}: EmpathyAttempt status {attempt.get('status')!r} is not a completed stop-gate state")
+            if status == "COMPLETED":
+                if gates.get("empathyValidated") is not True:
+                    evidence.append(f"{side}: Stage 2 marked COMPLETED without empathyValidated gate")
+            elif status != "GATE_PENDING":
+                evidence.append(f"{side}: Stage 2 DB status {status!r} is not GATE_PENDING or COMPLETED at stop gate")
+        elif status not in {"GATE_PENDING", "COMPLETED"}:
+            evidence.append(f"{side}: Stage {max_stage} DB status {status!r} is not GATE_PENDING or COMPLETED")
+
+    user_message_stages = [
+        int(message.get("stage"))
+        for message in messages
+        if message.get("role") in {"USER", "AI", "EMPATHY_STATEMENT", "SHARED_CONTEXT", "VALIDATION_FEEDBACK"}
+        and isinstance(message.get("stage"), int)
+    ]
+    if user_message_stages and max(user_message_stages) < max_stage:
+        evidence.append(f"highest Message.stage is {max(user_message_stages)}, below stop_after_stage {max_stage}")
+
+    return invariant_result(
+        "db_stage_state_matches_stop_gate",
+        not evidence,
+        owner="eval_harness",
+        dimension="actor_orchestration",
+        details="Gold-loop gate evaluation must inspect DB StageProgress, Message.stage, and empathy lifecycle state instead of trusting actor transcript/status text alone.",
         evidence=evidence,
     )
 
@@ -2069,6 +2268,7 @@ def run_invariant_checks(run_dir: Path, run_data: dict[str, Any], scenario: str,
     checks.append(check_no_internal_reconciler_analysis(transcripts))
     checks.append(check_partner_private_leakage(transcripts))
     checks.append(check_stage_limit_reached(run_data, scenario, max_stage))
+    checks.append(check_db_stage_state_matches_stop_gate(run_data, scenario, max_stage))
     checks.append(check_actor_operated_correct_side(run_data, scenario))
     checks.append(check_session_started_with_profile_initiator(run_data, scenario))
     checks.append(check_felt_heard_gate_after_witnessing(transcripts))
@@ -3449,6 +3649,8 @@ def run_iteration(
         run_data["transcripts"] = write_mock_transcripts(run_dir, args.scenario, args.stop_after_stage)
     else:
         run_data["transcripts"] = extract_transcripts(session_id, run_dir, args.scenario, args.stop_after_stage)
+    if not args.mock_actor:
+        run_data["db_stage_state"] = capture_db_stage_state(session_id, run_dir)
     write_run_json(run_dir, run_data)
 
     run_data["invariants"] = run_invariant_checks(run_dir, run_data, args.scenario, args.stop_after_stage)

--- a/scripts/test_mwf_gold_loop.py
+++ b/scripts/test_mwf_gold_loop.py
@@ -7,7 +7,9 @@ from mwf_gold_loop import (
     Actor,
     ActorStatus,
     actor_satisfies_stop_boundary,
+    build_actor_prompt,
     check_stage4_score_critical_content,
+    check_db_stage_state_matches_stop_gate,
     check_transcript_shared_context_blocks_labeled,
     check_transcript_side_stage_metadata,
     choose_next_actor,
@@ -36,7 +38,7 @@ class GoldLoopActorHandoffTest(unittest.TestCase):
 
         self.assertFalse(actor_satisfies_stop_boundary(actor, 4))
 
-    def test_stage2_partner_wait_satisfies_stop_boundary(self) -> None:
+    def test_stage2_partner_wait_does_not_satisfy_stop_boundary(self) -> None:
         actor = self.actor(
             "eve",
             ActorStatus(
@@ -48,7 +50,7 @@ class GoldLoopActorHandoffTest(unittest.TestCase):
             ),
         )
 
-        self.assertTrue(actor_satisfies_stop_boundary(actor, 2))
+        self.assertFalse(actor_satisfies_stop_boundary(actor, 2))
 
     def test_stage_limit_with_blocked_on_is_not_terminal(self) -> None:
         actor = self.actor(
@@ -110,18 +112,17 @@ class GoldLoopActorHandoffTest(unittest.TestCase):
 
         self.assertIs(next_actor, catherine)
 
-    def test_stage2_mutual_partner_wait_stops_loop(self) -> None:
+    def test_stage2_one_sided_partner_wait_resumes_blocked_partner(self) -> None:
         adam = self.actor(
             "adam",
             ActorStatus(
                 side="adam",
                 session_id="session-1",
                 stage=2,
-                state="needs_partner",
-                blocked_on="eve",
+                state="stage_limit_reached",
             ),
         )
-        adam.turns = 3
+        adam.turns = 1
         eve = self.actor(
             "eve",
             ActorStatus(
@@ -132,15 +133,163 @@ class GoldLoopActorHandoffTest(unittest.TestCase):
                 blocked_on="adam",
             ),
         )
-        eve.turns = 2
+        eve.turns = 1
 
         next_actor = choose_next_actor(
             {"adam": adam, "eve": eve},
-            last_side="adam",
+            last_side="eve",
             stop_after_stage=2,
         )
 
-        self.assertIsNone(next_actor)
+        self.assertIs(next_actor, adam)
+
+    def test_stage2_reciprocal_partner_wait_resumes_last_blocked_partner(self) -> None:
+        adam = self.actor(
+            "adam",
+            ActorStatus(
+                side="adam",
+                session_id="session-1",
+                stage=2,
+                state="needs_partner",
+                blocked_on="eve",
+            ),
+        )
+        adam.turns = 1
+        eve = self.actor(
+            "eve",
+            ActorStatus(
+                side="eve",
+                session_id="session-1",
+                stage=2,
+                state="needs_partner",
+                blocked_on="adam",
+            ),
+        )
+        eve.turns = 1
+
+        next_actor = choose_next_actor(
+            {"adam": adam, "eve": eve},
+            last_side="eve",
+            stop_after_stage=2,
+        )
+
+        self.assertIs(next_actor, adam)
+
+    def test_actor_prompt_requires_stage2_post_empathy_share_review(self) -> None:
+        adam = self.actor("adam")
+        eve = self.actor("eve")
+
+        prompt = build_actor_prompt(adam, eve, "session-1", 2, Path("/tmp/run"), "adam-eve")
+
+        self.assertIn('Share this with Eve? Review', prompt)
+        self.assertIn("Do not stop merely because an empathy attempt was submitted", prompt)
+
+    def test_actor_prompt_requires_clicking_gate_ctas_not_typed_chat(self) -> None:
+        adam = self.actor("adam")
+        eve = self.actor("eve")
+
+        prompt = build_actor_prompt(adam, eve, "session-1", 2, Path("/tmp/run"), "adam-eve")
+
+        self.assertIn("click the CTA", prompt)
+        self.assertIn("Do not type a chat message to satisfy a product gate", prompt)
+        self.assertNotIn("typed confirmation", prompt)
+        self.assertNotIn('such as "I feel heard" / "Ready"', prompt)
+
+    def test_db_stage_state_fails_when_messages_never_reach_claimed_stage(self) -> None:
+        run_data = {
+            "db_stage_state": {
+                "users": [
+                    {"id": "u-adam", "name": "Adam"},
+                    {"id": "u-eve", "name": "Eve"},
+                ],
+                "stageProgress": [
+                    {"userId": "u-adam", "stage": 0, "status": "COMPLETED", "gates": {"compactSigned": True}},
+                    {"userId": "u-eve", "stage": 0, "status": "COMPLETED", "gates": {"compactSigned": True}},
+                ],
+                "empathyAttempts": [],
+                "messageStages": [
+                    {"role": "USER", "stage": 0, "senderId": "u-adam", "contentPrefix": "Stage 2-looking chat text"},
+                    {"role": "AI", "stage": 0, "forUserId": "u-adam", "contentPrefix": "Next step: Walking in Their Shoes"},
+                ],
+            }
+        }
+
+        result = check_db_stage_state_matches_stop_gate(run_data, "adam-eve", 2)
+
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["severity"], "hard")
+        self.assertTrue(any("missing StageProgress stage 1" in item for item in result["evidence"]))
+        self.assertTrue(any("highest Message.stage is 0" in item for item in result["evidence"]))
+
+    def test_db_stage_state_requires_real_stage2_lifecycle_not_actor_status_only(self) -> None:
+        run_data = {
+            "status_history": [
+                {"side": "adam", "status": {"stage": 2, "state": "stage_limit_reached"}},
+                {"side": "eve", "status": {"stage": 2, "state": "needs_partner", "blocked_on": "adam"}},
+            ],
+            "db_stage_state": {
+                "users": [
+                    {"id": "u-adam", "name": "Adam"},
+                    {"id": "u-eve", "name": "Eve"},
+                ],
+                "stageProgress": [
+                    {"userId": "u-adam", "stage": 0, "status": "COMPLETED", "gates": {"compactSigned": True}},
+                    {"userId": "u-adam", "stage": 1, "status": "COMPLETED", "gates": {"feelHeardConfirmed": True}},
+                    {"userId": "u-adam", "stage": 2, "status": "IN_PROGRESS", "gates": {}},
+                    {"userId": "u-eve", "stage": 0, "status": "COMPLETED", "gates": {"compactSigned": True}},
+                    {"userId": "u-eve", "stage": 1, "status": "COMPLETED", "gates": {"feelHeardConfirmed": True}},
+                    {"userId": "u-eve", "stage": 2, "status": "IN_PROGRESS", "gates": {}},
+                ],
+                "empathyAttempts": [
+                    {"sourceUserId": "u-adam", "status": "HELD"},
+                    {"sourceUserId": "u-eve", "status": "AWAITING_SHARING"},
+                ],
+                "messageStages": [
+                    {"role": "USER", "stage": 2, "senderId": "u-adam", "contentPrefix": "I can see Eve's side."},
+                    {"role": "USER", "stage": 2, "senderId": "u-eve", "contentPrefix": "I can see Adam's side."},
+                ],
+            },
+        }
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            actor_result = run_invariant_checks(Path(tmp), run_data, "adam-eve", 2)
+            db_result = next(check for check in actor_result["checks"] if check["id"] == "db_stage_state_matches_stop_gate")
+
+        self.assertEqual(db_result["status"], "fail")
+        self.assertTrue(any("Stage 2 DB status 'IN_PROGRESS'" in item for item in db_result["evidence"]))
+        self.assertTrue(any("EmpathyAttempt status 'HELD'" in item for item in db_result["evidence"]))
+
+    def test_db_stage_state_accepts_stage2_gate_pending_with_ready_attempts(self) -> None:
+        run_data = {
+            "db_stage_state": {
+                "users": [
+                    {"id": "u-adam", "name": "Adam"},
+                    {"id": "u-eve", "name": "Eve"},
+                ],
+                "stageProgress": [
+                    {"userId": "u-adam", "stage": 0, "status": "COMPLETED", "gates": {"compactSigned": True}},
+                    {"userId": "u-adam", "stage": 1, "status": "COMPLETED", "gates": {"feelHeardConfirmed": True}},
+                    {"userId": "u-adam", "stage": 2, "status": "GATE_PENDING", "gates": {}},
+                    {"userId": "u-eve", "stage": 0, "status": "COMPLETED", "gates": {"compactSigned": True}},
+                    {"userId": "u-eve", "stage": 1, "status": "COMPLETED", "gates": {"feelHeardConfirmed": True}},
+                    {"userId": "u-eve", "stage": 2, "status": "GATE_PENDING", "gates": {}},
+                ],
+                "empathyAttempts": [
+                    {"sourceUserId": "u-adam", "status": "READY"},
+                    {"sourceUserId": "u-eve", "status": "READY"},
+                ],
+                "messageStages": [
+                    {"role": "USER", "stage": 2, "senderId": "u-adam", "contentPrefix": "I can see Eve's side."},
+                    {"role": "USER", "stage": 2, "senderId": "u-eve", "contentPrefix": "I can see Adam's side."},
+                ],
+            }
+        }
+
+        result = check_db_stage_state_matches_stop_gate(run_data, "adam-eve", 2)
+
+        self.assertEqual(result["status"], "pass")
 
     def test_later_partner_block_can_reopen_actor_that_reached_stage_limit(self) -> None:
         adam = self.actor(
@@ -353,6 +502,21 @@ class GoldLoopActorHandoffTest(unittest.TestCase):
             run_data = {
                 "start": {"mode": "target_stage", "target_stage": "NEED_MAPPING_COMPLETE"},
                 "transcripts": [str(adam_path), str(eve_path)],
+                "db_stage_state": {
+                    "users": [
+                        {"id": "u-adam", "name": "Adam"},
+                        {"id": "u-eve", "name": "Eve"},
+                    ],
+                    "stageProgress": [
+                        {"userId": "u-adam", "stage": 4, "status": "COMPLETED", "gates": {}},
+                        {"userId": "u-eve", "stage": 4, "status": "COMPLETED", "gates": {}},
+                    ],
+                    "empathyAttempts": [],
+                    "messageStages": [
+                        {"role": "USER", "stage": 4, "senderId": "u-adam", "contentPrefix": "Stage 4"},
+                        {"role": "USER", "stage": 4, "senderId": "u-eve", "contentPrefix": "Stage 4"},
+                    ],
+                },
                 "status_history": [
                     {"side": "adam", "status": {"side": "adam", "stage": 4, "state": "completed"}},
                     {"side": "eve", "status": {"side": "eve", "stage": 4, "state": "completed"}},

--- a/scripts/test_mwf_moment_eval.py
+++ b/scripts/test_mwf_moment_eval.py
@@ -145,7 +145,7 @@ class TestYamlParsing(unittest.TestCase):
                 self.assertIsInstance(entry.get("target_behaviors"), list)
                 self.assertIsInstance(entry.get("required_invariants"), list)
 
-    def test_gold_loop_actor_prompt_allows_realistic_typed_feel_heard_confirmation(self) -> None:
+    def test_gold_loop_actor_prompt_requires_clicking_feel_heard_cta(self) -> None:
         actor = gold_loop.Actor("Eve", "http://localhost:8082/session/test?e2e-user-id=eve")
         partner = gold_loop.Actor("Adam", "http://localhost:8082/session/test?e2e-user-id=adam")
 
@@ -161,8 +161,8 @@ class TestYamlParsing(unittest.TestCase):
 
         for text in (prompt, resume_prompt):
             self.assertIn('If a visible Stage 1 "I feel heard" / feel-heard confirmation CTA is present', text)
-            self.assertIn("either click it or give a clear in-character typed confirmation", text)
-            self.assertIn('"I feel heard" / "Ready"', text)
+            self.assertIn("click the CTA", text)
+            self.assertIn("Do not type a chat message to satisfy a product gate", text)
             self.assertIn("Do not report Stage 2 progress unless the UI actually moves past the Stage 1 gate", text)
 
     def test_gold_loop_uses_profile_initiator_separate_from_registry_order(self) -> None:


### PR DESCRIPTION
## Summary
- Fix the long-standing Stage 2 wall: when the partner shared context, the UI hid the Revisit/resubmit affordance and `EmpathyAttempt` stayed in `REFINING` forever. The fix is in `mobile/src/hooks/useChatUIState.ts` + `mobile/src/utils/chatUIState.ts` + a Stage 1 turn-count guard in `backend/src/services/ai-orchestrator.ts`. **No backend gate or chat-text intent detection** — Stage 2 movement still depends only on real review/share/resubmit/validation CTAs and their API lifecycle.
- Add the first round of context-architecture improvements: confirmed topic frame, current-user stage history, consented partner/share state, prior-stage summaries — assembled from existing `EmpathyAttempt` / `ReconcilerShareOffer` / `StageProgress` rows. Hidden partner content renders as "not yet visible"; no access is invented.
- Harden the gold-loop harness with `db-stage-state.json` capture and a `db_stage_state_matches_stop_gate` invariant so transcript-only passes can't mask a stuck DB lifecycle. New regression tests cover the stuck-stage failure modes.

## Verification
- **Adam/Eve**: four consecutive runs at `score=4.0`, `target_reached=True` via real CTA clicks. Both `EmpathyAttempt`s end `VALIDATED` in DB, mutual reveal completed.
- **James/Catherine**: `score=4.0`, `target_reached=True`. Stage 0/1/2 `COMPLETED` for both users; both empathy attempts `VALIDATED`.
- Hard invariants pass on both scenarios.
- `npm --workspace backend test --runTestsByPath src/services/__tests__/ai-orchestrator.test.ts`: pass (39 tests).
- `npm --workspace backend run check`: pass.
- `npm --workspace mobile run check`: pass.

Full per-run trail in `docs/product/mwf-context-architecture-restart-progress.md`.

## Test plan
- [ ] CI passes
- [ ] Spot-check an Adam/Eve Stage 2 cycle in dev: Revisit appears after partner shares, refined draft can be resubmitted via the button (never via chat text), reveal + validation fire and persist in DB
- [ ] Confirm Stage 1 felt-heard guard does not delay the gate inappropriately on a normal-pace conversation
- [ ] Confirm prompt context includes confirmed topic frame, prior-stage summaries, and consented partner/share state — and hides partner content marked "not yet visible"

🤖 Generated with [Claude Code](https://claude.com/claude-code) — work performed by [Codex](https://github.com/openai/codex) over a long autonomous run