### PR TITLE
Clean up dead Stage 4 refs after legacy StrategyPool removal

### DIFF
--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -587,12 +587,7 @@ export function UnifiedSessionScreen({
     needsRevealValidationItems,
     needsRevealValidationData,
     needsRevealValidatedByBoth,
-    strategyData,
-    strategyPhase,
-    strategies,
-    overlappingStrategies,
     agreements,
-    isGenerating,
     isSavingEmpathyDraft,
     isSharingEmpathy,
     isResubmittingEmpathy,
@@ -630,11 +625,7 @@ export function UnifiedSessionScreen({
     handleConsentToShareNeeds,
     handleValidateNeedsReveal,
     handleNeedsNotValidYet,
-    handleRequestMoreStrategies,
-    handleMarkReadyToRank,
-    handleSubmitRankings,
     handleConfirmAgreement,
-    handleCreateAgreementFromOverlap,
     handleResolveSession,
     handleRespondToShareOffer,
 
@@ -1765,16 +1756,12 @@ export function UnifiedSessionScreen({
     needsRevealValidatedByMe: (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsValidated === true,
     needsRevealValidatedByBoth: needsRevealValidatedByBoth,
     hasValidatedNeedsRevealLocal: completedActions.has('validated-needs'),
-    strategyPhase,
-    strategyReadiness: {
-      myReadyToRank: strategyData?.myReadyToRank === true ||
-        (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.readyToRank === true,
-      partnerReadyToRank: strategyData?.partnerReadyToRank === true ||
-        ((partnerProgress as { gatesSatisfied?: Record<string, unknown> } | undefined)?.gatesSatisfied)?.readyToRank === true,
-      canMarkReadyToRank: strategyData?.canMarkReadyToRank === true,
-      canRank: strategyData?.canRank === true,
-    },
-    overlappingStrategiesCount: overlappingStrategies?.length ?? 0,
+    // Legacy Stage 4 inputs: the strategy-pool-preview / overlap-preview cards
+    // are no longer emitted in renderInlineCard, but the hook still types them
+    // as required. Pass benign defaults until the hook's prop shape is cleaned
+    // up to drop them.
+    strategyPhase: 'COLLECTING',
+    overlappingStrategiesCount: 0,
     agreements: agreements?.map(a => ({
       agreedByMe: a.agreedByMe,
       agreedByPartner: a.agreedByPartner,
@@ -2417,7 +2404,6 @@ export function UnifiedSessionScreen({
       handleValidatePartnerEmpathy,
       handleConfirmAllNeeds,
       handleConsentToShareNeeds,
-      handleMarkReadyToRank,
       handleRespondToShareOffer,
       sendMessage,
       onStageComplete,
@@ -2425,10 +2411,9 @@ export function UnifiedSessionScreen({
     ]
   );
 
-  const transcriptInlineCards = useMemo(
-    () => inlineCards.filter((card) => card.type !== 'strategy-pool-preview'),
-    [inlineCards]
-  );
+  // 'strategy-pool-preview' is no longer emitted by useChatUIState now that the
+  // legacy StrategyPool path is gone. Pass inlineCards through directly.
+  const transcriptInlineCards = inlineCards;
 
   // -------------------------------------------------------------------------
   // Invitation URL for sharing (must be before early returns)
@@ -2789,19 +2774,12 @@ export function UnifiedSessionScreen({
   }, [
     activeOverlay,
     barometerValue,
-    strategies,
-    overlappingStrategies,
     agreements,
     sessionId,
-    isGenerating,
     styles,
     partnerName,
     handleBarometerChange,
-    handleRequestMoreStrategies,
-    handleMarkReadyToRank,
-    handleSubmitRankings,
     handleConfirmAgreement,
-    handleCreateAgreementFromOverlap,
     handleResolveSession,
     handleSignCompact,
     closeOverlay,


### PR DESCRIPTION
Follow-up to #558. Drops call-site refs to surfaces #558 already removed. Strictly noise reduction, no behavior change.

## What's dead and getting removed
**Destructured from `useUnifiedSession` but no longer consumed:** `strategyData`, `strategyPhase`, `strategies`, `overlappingStrategies`, `isGenerating`, `handleRequestMoreStrategies`, `handleMarkReadyToRank`, `handleSubmitRankings`, `handleCreateAgreementFromOverlap`.

**Stale dependency-array entries:** all of the above, plus a lingering `handleMarkReadyToRank` in `renderInlineCard`'s `useCallback` deps.

**`useChatUIState` input wiring:** `strategyReadiness` and `overlappingStrategies.count` were derived from removed data; dropped. The hook still types `strategyPhase` and `overlappingStrategiesCount` as required, so the call site passes benign defaults (`'COLLECTING'` and `0`) with a comment pointing at a follow-up to clean up the hook's prop shape.

**Redundant filter:** `transcriptInlineCards = inlineCards.filter(card => card.type !== 'strategy-pool-preview')` is now defensive against a card type the hook can no longer emit. Replaced with `transcriptInlineCards = inlineCards`.

## Verification
- `npm --workspace mobile run check`: pass
- `npm --workspace backend run check`: pass (untouched)
- `npm --workspace mobile run test` (chatUIState + SessionCompletion suites): 70 tests pass

## Test plan
- [ ] CI passes
- [ ] No behavior delta visible against a Stage 4 session — the GuidedActionPanel CTA, the slide-up drawer, and the agreement-preview card flow are all unchanged from #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)