### PR TITLE
Stage 4: explicit share/revise flow with symmetric reveal

### DIFF
--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -228,6 +228,32 @@ async function markStage4SelectionSubmitted(
   });
 }
 
+async function clearStage4SelectionSubmitted(
+  sessionId: string,
+  userId: string,
+  existingGates: Prisma.JsonValue | null | undefined
+): Promise<void> {
+  const next = {
+    ...((existingGates as Record<string, unknown> | null) || {}),
+  };
+  delete next.selectionSubmitted;
+  delete next.selectionSubmittedAt;
+
+  await prisma.stageProgress.update({
+    where: {
+      sessionId_userId_stage: { sessionId, userId, stage: 4 },
+    },
+    data: { gatesSatisfied: next as Prisma.InputJsonValue },
+  });
+}
+
+function hasSubmittedSelectionGate(
+  existingGates: Prisma.JsonValue | null | undefined
+): boolean {
+  const gates = existingGates as Record<string, unknown> | null | undefined;
+  return Boolean(gates && gates.selectionSubmitted === true);
+}
+
 function userIsSessionMember(session: Stage4MutableSession, userId: string): boolean {
   return session.relationship.members.some((member) => member.userId === userId);
 }
@@ -469,28 +495,160 @@ async function submitStage4SelectionsInternal(
     )
   );
 
-  await markStage4SelectionSubmitted(sessionId, userId, mutable.progress?.gatesSatisfied);
-
-  const partnerId = await getPartnerUserId(sessionId, userId);
-  const partnerSubmitted = partnerId
-    ? (await prisma.stage4ProposalSelection.count({ where: { sessionId, userId: partnerId } })) > 0
-    : false;
-
-  if (partnerId) {
-    await notifyPartner(sessionId, partnerId, 'session.strategies_updated', {
-      stage: 4,
-      submittedBy: userId,
-      change: 'stage4_selection_submitted',
-    });
+  // Per-tap selections are kept private until the user explicitly shares.
+  // If the user has already shared, persist the change but clear the gate so
+  // the partner doesn't see partially-revised stances mid-stream.
+  if (hasSubmittedSelectionGate(mutable.progress?.gatesSatisfied)) {
+    await clearStage4SelectionSubmitted(sessionId, userId, mutable.progress?.gatesSatisfied);
+    const partnerId = await getPartnerUserId(sessionId, userId);
+    if (partnerId) {
+      await notifyPartner(sessionId, partnerId, 'session.strategies_updated', {
+        stage: 4,
+        submittedBy: userId,
+        change: 'stage4_selection_revised',
+      });
+    }
   }
 
   const state = await buildStage4State(sessionId, userId);
+  const partnerId = await getPartnerUserId(sessionId, userId);
+  const partnerSubmitted = state.partnerSelectionStatus === 'SUBMITTED';
+
   successResponse(res, {
-    submitted: true,
+    submitted: state.mySelectionStatus === 'SUBMITTED',
     submittedAt: submittedAt.toISOString(),
     partnerSubmitted,
     state,
   });
+  void partnerId;
+}
+
+/**
+ * Mark the current user's Stage 4 selections as shared with their partner.
+ * Requires a selection on every active proposal.
+ * POST /sessions/:id/stage4/share-selections
+ */
+export async function shareStage4Selections(req: Request, res: Response): Promise<void> {
+  try {
+    const user = req.user;
+    if (!user) {
+      errorResponse(res, 'UNAUTHORIZED', 'Authentication required', 401);
+      return;
+    }
+
+    const { id: sessionId } = req.params;
+    const mutable = await getMutableStage4Session(sessionId, user.id);
+    if (!mutable) {
+      errorResponse(res, 'NOT_FOUND', 'Session not found', 404);
+      return;
+    }
+    if (mutable.session.status !== 'ACTIVE') {
+      errorResponse(res, 'SESSION_NOT_ACTIVE', 'Session is not active', 400);
+      return;
+    }
+    if (await prisma.stage4Closure.findUnique({ where: { sessionId } })) {
+      errorResponse(res, 'CONFLICT', 'Stage 4 is already closed', 409);
+      return;
+    }
+
+    // Stances are required only on shared proposals — individual commitments
+    // are one-sided so a stance from the non-owner isn't expected.
+    const [activeSharedProposals, mySelections] = await Promise.all([
+      prisma.strategyProposal.findMany({
+        where: {
+          sessionId,
+          status: Stage4ProposalStatus.ACTIVE,
+          kind: Stage4ProposalKind.SHARED_PROPOSAL,
+        },
+        select: { id: true },
+      }),
+      prisma.stage4ProposalSelection.findMany({
+        where: { sessionId, userId: user.id },
+        select: { proposalId: true },
+      }),
+    ]);
+
+    if (activeSharedProposals.length === 0) {
+      errorResponse(res, 'VALIDATION_ERROR', 'No shared proposals to share stances on yet', 400);
+      return;
+    }
+
+    const selectedIds = new Set(mySelections.map((s) => s.proposalId));
+    const missing = activeSharedProposals.filter((p) => !selectedIds.has(p.id));
+    if (missing.length > 0) {
+      errorResponse(
+        res,
+        'VALIDATION_ERROR',
+        'Take a stance on every shared proposal before sharing',
+        400
+      );
+      return;
+    }
+
+    await markStage4SelectionSubmitted(sessionId, user.id, mutable.progress?.gatesSatisfied);
+
+    const partnerId = await getPartnerUserId(sessionId, user.id);
+    if (partnerId) {
+      await notifyPartner(sessionId, partnerId, 'session.strategies_updated', {
+        stage: 4,
+        submittedBy: user.id,
+        change: 'stage4_selection_submitted',
+      });
+    }
+
+    const state = await buildStage4State(sessionId, user.id);
+    successResponse(res, { state });
+  } catch (error) {
+    logger.error('[shareStage4Selections] Error:', error);
+    errorResponse(res, 'INTERNAL_ERROR', 'Failed to share Stage 4 selections', 500);
+  }
+}
+
+/**
+ * Withdraw the current user's shared Stage 4 selections so they can revise.
+ * Partner immediately stops seeing them as shared.
+ * POST /sessions/:id/stage4/unshare-selections
+ */
+export async function unshareStage4Selections(req: Request, res: Response): Promise<void> {
+  try {
+    const user = req.user;
+    if (!user) {
+      errorResponse(res, 'UNAUTHORIZED', 'Authentication required', 401);
+      return;
+    }
+
+    const { id: sessionId } = req.params;
+    const mutable = await getMutableStage4Session(sessionId, user.id);
+    if (!mutable) {
+      errorResponse(res, 'NOT_FOUND', 'Session not found', 404);
+      return;
+    }
+    if (mutable.session.status !== 'ACTIVE') {
+      errorResponse(res, 'SESSION_NOT_ACTIVE', 'Session is not active', 400);
+      return;
+    }
+    if (await prisma.stage4Closure.findUnique({ where: { sessionId } })) {
+      errorResponse(res, 'CONFLICT', 'Stage 4 is already closed', 409);
+      return;
+    }
+
+    await clearStage4SelectionSubmitted(sessionId, user.id, mutable.progress?.gatesSatisfied);
+
+    const partnerId = await getPartnerUserId(sessionId, user.id);
+    if (partnerId) {
+      await notifyPartner(sessionId, partnerId, 'session.strategies_updated', {
+        stage: 4,
+        submittedBy: user.id,
+        change: 'stage4_selection_revised',
+      });
+    }
+
+    const state = await buildStage4State(sessionId, user.id);
+    successResponse(res, { state });
+  } catch (error) {
+    logger.error('[unshareStage4Selections] Error:', error);
+    errorResponse(res, 'INTERNAL_ERROR', 'Failed to revise Stage 4 selections', 500);
+  }
 }
 
 /**

--- a/backend/src/routes/__tests__/stage4.test.ts
+++ b/backend/src/routes/__tests__/stage4.test.ts
@@ -292,6 +292,9 @@ describe('Stage 4 API', () => {
           updatedAt: new Date('2026-05-06T10:02:00.000Z'),
         },
       ]);
+      (prisma.stageProgress.findMany as jest.Mock).mockResolvedValue([
+        { userId: mockPartnerId, stage: 4, gatesSatisfied: { selectionSubmitted: true } },
+      ]);
       (prisma.stage4NeedCoverage.findMany as jest.Mock).mockResolvedValue([]);
       (prisma.stage4Closure.findUnique as jest.Mock).mockResolvedValue(null);
       (prisma.agreement.findMany as jest.Mock).mockResolvedValue([]);
@@ -460,6 +463,10 @@ describe('Stage 4 API', () => {
           updatedAt: new Date('2026-05-06T10:03:00.000Z'),
         },
       ]);
+      (prisma.stageProgress.findMany as jest.Mock).mockResolvedValue([
+        { userId: mockUser.id, stage: 4, gatesSatisfied: { selectionSubmitted: true } },
+        { userId: mockPartnerId, stage: 4, gatesSatisfied: { selectionSubmitted: true } },
+      ]);
       (prisma.stage4NeedCoverage.findMany as jest.Mock).mockResolvedValue([]);
       (prisma.stage4Closure.findUnique as jest.Mock).mockResolvedValue(null);
       (prisma.agreement.findMany as jest.Mock).mockResolvedValue([]);
@@ -550,6 +557,9 @@ describe('Stage 4 API', () => {
           selectedAt: new Date('2026-05-06T10:04:00.000Z'),
           updatedAt: new Date('2026-05-06T10:04:00.000Z'),
         },
+      ]);
+      (prisma.stageProgress.findMany as jest.Mock).mockResolvedValue([
+        { userId: mockPartnerId, stage: 4, gatesSatisfied: { selectionSubmitted: true } },
       ]);
       (prisma.stage4NeedCoverage.findMany as jest.Mock).mockResolvedValue([]);
       (prisma.stage4Closure.findUnique as jest.Mock).mockResolvedValue(null);
@@ -895,30 +905,20 @@ describe('Stage 4 API', () => {
           }),
         })
       );
-      expect(prisma.stageProgress.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: {
-            gatesSatisfied: expect.objectContaining({
-              selectionSubmitted: true,
-            }),
-          },
-        })
-      );
-      expect(notifyPartner).toHaveBeenCalledWith(
-        mockSessionId,
-        mockPartnerId,
-        'session.strategies_updated',
-        expect.objectContaining({ change: 'stage4_selection_submitted' })
-      );
+      // Per-tap should NOT flip the selectionSubmitted gate — that's now an
+      // explicit "share" action.
+      expect(prisma.stageProgress.update).not.toHaveBeenCalled();
+      expect(notifyPartner).not.toHaveBeenCalled();
       expect(statusMock).toHaveBeenCalledWith(200);
       expect(jsonMock).toHaveBeenCalledWith(
         expect.objectContaining({
           success: true,
           data: expect.objectContaining({
-            submitted: true,
+            submitted: false,
             partnerSubmitted: false,
             state: expect.objectContaining({
               phase: Stage4Phase.SELECTION,
+              mySelectionStatus: 'NOT_STARTED',
               partnerSelectionStatus: 'NOT_STARTED',
             }),
           }),

--- a/backend/src/routes/stage4.ts
+++ b/backend/src/routes/stage4.ts
@@ -19,6 +19,8 @@ import {
   getStage4State,
   submitStage4ProposalSelection,
   submitStage4Selections,
+  shareStage4Selections,
+  unshareStage4Selections,
   closeStage4,
   proposeStrategy,
   submitRanking,
@@ -54,6 +56,22 @@ router.post(
   requireAuth,
   requireSessionAccess,
   asyncHandler(submitStage4Selections)
+);
+
+// Share current user's Stage 4 selections with their partner
+router.post(
+  '/sessions/:id/stage4/share-selections',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(shareStage4Selections)
+);
+
+// Withdraw current user's shared Stage 4 selections so they can revise
+router.post(
+  '/sessions/:id/stage4/unshare-selections',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(unshareStage4Selections)
 );
 
 // Close redesigned Stage 4 from willingness selections

--- a/backend/src/services/stage4-coverage.service.ts
+++ b/backend/src/services/stage4-coverage.service.ts
@@ -174,7 +174,7 @@ function classifyCoverage(
     return {
       status: 'OPEN',
       proposalIds: [],
-      note: 'Still open for Stage 4 discussion.',
+      note: 'Not yet addressed by a proposal.',
     };
   }
 

--- a/backend/src/services/stage4-state.ts
+++ b/backend/src/services/stage4-state.ts
@@ -219,24 +219,6 @@ function buildProposalCard(
   };
 }
 
-function requiresSharedSelection(proposal: Stage4ProposalRow): boolean {
-  return proposal.kind === Stage4ProposalKind.SHARED_PROPOSAL && proposal.status === Stage4ProposalStatus.ACTIVE;
-}
-
-function hasSelectionForEveryActiveSharedProposal(
-  userId: string | null,
-  proposals: Stage4ProposalRow[],
-  selections: Stage4SelectionRow[]
-): boolean {
-  if (!userId) return false;
-
-  const sharedProposalIds = proposals.filter(requiresSharedSelection).map((proposal) => proposal.id);
-  if (sharedProposalIds.length === 0) return false;
-
-  return sharedProposalIds.every((proposalId) =>
-    selections.some((selection) => selection.proposalId === proposalId && selection.userId === userId)
-  );
-}
 
 function hasSubmittedSelectionGate(progressRows: Stage4ProgressRow[], userId: string | null): boolean {
   if (!userId) return false;
@@ -407,16 +389,11 @@ export async function getStage4State(
   const mySelections = selections.filter((selection) => selection.userId === userId);
   const partnerSelections = selections.filter((selection) => selection.userId === partnerUserId);
   const activeProposals = proposals.filter((proposal) => proposal.status === Stage4ProposalStatus.ACTIVE);
-  const myActiveSharedSelectionComplete = hasSelectionForEveryActiveSharedProposal(userId, activeProposals, selections);
-  const partnerActiveSharedSelectionComplete = hasSelectionForEveryActiveSharedProposal(
-    partnerUserId,
-    activeProposals,
-    selections
-  );
-  const mySelectionSubmitted =
-    hasSubmittedSelectionGate(progressRows ?? [], userId) || myActiveSharedSelectionComplete;
-  const partnerSelectionSubmitted =
-    hasSubmittedSelectionGate(progressRows ?? [], partnerUserId) || partnerActiveSharedSelectionComplete;
+  // "Submitted" must be an explicit act now (POST /stage4/share-selections),
+  // not an implicit consequence of having decided on every proposal. Otherwise
+  // partners would see each others' stances mid-deliberation.
+  const mySelectionSubmitted = hasSubmittedSelectionGate(progressRows ?? [], userId);
+  const partnerSelectionSubmitted = hasSubmittedSelectionGate(progressRows ?? [], partnerUserId);
   const revealPartnerSelections = mySelectionSubmitted && partnerSelectionSubmitted;
   const proposalCards = activeProposals.map((proposal) =>
     buildProposalCard(proposal, userId, partnerUserId, selections, coverageRows, revealPartnerSelections)
@@ -469,6 +446,7 @@ export async function getStage4State(
           updatedAt: selection.updatedAt.toISOString(),
         }))
       : [],
+    mySelectionStatus: mySelectionSubmitted ? 'SUBMITTED' : 'NOT_STARTED',
     partnerSelectionStatus: partnerSelectionSubmitted ? 'SUBMITTED' : 'NOT_STARTED',
     outcome: closure
       ? {

--- a/mobile/src/components/Stage4RedesignPanel.tsx
+++ b/mobile/src/components/Stage4RedesignPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { Check, Clock, MinusCircle, Send, XCircle } from 'lucide-react-native';
+import { MinusCircle, Send, RotateCcw, Share2, XCircle } from 'lucide-react-native';
 import {
   GetStage4StateResponse,
   ProposalCardDTO,
@@ -18,7 +18,24 @@ interface Stage4RedesignPanelProps {
   partnerName?: string | null;
   isSelecting?: boolean;
   isClosing?: boolean;
+  isSharing?: boolean;
+  isRevising?: boolean;
+  /** Hide the inline footer — caller renders <Stage4RedesignFooter /> separately (e.g. sticky to the drawer). */
+  hideFooter?: boolean;
   onSelectProposal: (proposalId: string, decision: Stage4SelectionDecision) => void;
+  onShareSelections?: () => void;
+  onReviseSelections?: () => void;
+  onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason) => void;
+}
+
+interface Stage4RedesignFooterProps {
+  state: GetStage4StateResponse;
+  partnerName?: string | null;
+  isClosing?: boolean;
+  isSharing?: boolean;
+  isRevising?: boolean;
+  onShareSelections?: () => void;
+  onReviseSelections?: () => void;
   onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason) => void;
 }
 
@@ -33,27 +50,6 @@ const coverageLabels: Record<Stage4CoverageStatus, string> = {
   PARTIAL: 'Partly covered',
   OPEN: 'Open',
 };
-
-function phaseLabel(phase: Stage4Phase): string {
-  switch (phase) {
-    case Stage4Phase.INVENTORY_BUILDING:
-      return 'Building proposals';
-    case Stage4Phase.COVERAGE_REVIEW:
-      return 'Checking coverage';
-    case Stage4Phase.SELECTION:
-      return 'Choosing willingness';
-    case Stage4Phase.OUTCOME_REVIEW:
-      return 'Reviewing outcome';
-    case Stage4Phase.CLOSING:
-      return 'Closing';
-    case Stage4Phase.CLOSED_SHARED_AGREEMENT:
-      return 'Shared agreement';
-    case Stage4Phase.CLOSED_NO_SHARED_AGREEMENT:
-      return 'No shared agreement';
-    default:
-      return 'Stage 4';
-  }
-}
 
 function outcomeReasonLabel(reason: Stage4ClosureReason): string {
   switch (reason) {
@@ -76,24 +72,13 @@ function proposalKindLabel(kind: Stage4ProposalKind): string {
     : 'Shared proposal';
 }
 
-function DecisionBadge({
-  label,
-  decision,
-}: {
-  label: string;
-  decision?: Stage4SelectionDecision;
-}) {
-  const { palette } = useAppAppearance();
-  const styles = useMemo(() => makeStyles(palette), [palette]);
-
-  return (
-    <View style={styles.decisionBadge}>
-      <Text style={styles.decisionLabel}>{label}</Text>
-      <Text style={styles.decisionValue}>
-        {decision ? decisionLabels[decision] : 'Private'}
-      </Text>
-    </View>
-  );
+function partnerStateLabel(
+  partnerName: string | null,
+  decision?: Stage4SelectionDecision,
+): string {
+  const who = partnerName || 'They';
+  if (!decision) return `${who} hasn't shared their stance yet`;
+  return `${who}: ${decisionLabels[decision].toLowerCase()}`;
 }
 
 function ProposalCard({
@@ -104,16 +89,25 @@ function ProposalCard({
   onSelectProposal,
 }: {
   proposal: ProposalCardDTO;
-  partnerName?: string | null;
+  partnerName: string;
   isSelecting?: boolean;
   readOnly?: boolean;
   onSelectProposal: (proposalId: string, decision: Stage4SelectionDecision) => void;
 }) {
   const { palette } = useAppAppearance();
   const styles = useMemo(() => makeStyles(palette), [palette]);
-  const needsText = proposal.needsAddressed
-    .map((need) => `${need.label} (${coverageLabels[need.coverage]})`)
-    .join(', ');
+
+  const metaLines: string[] = [];
+  if (proposal.needsAddressed.length > 0) {
+    metaLines.push(
+      'Addresses: ' +
+        proposal.needsAddressed
+          .map((n) => `${n.label} (${coverageLabels[n.coverage].toLowerCase()})`)
+          .join(', '),
+    );
+  }
+  if (proposal.duration) metaLines.push(`Timing: ${proposal.duration}`);
+  if (proposal.measureOfSuccess) metaLines.push(`Success: ${proposal.measureOfSuccess}`);
 
   return (
     <View style={styles.proposalCard}>
@@ -124,25 +118,15 @@ function ProposalCard({
         )}
       </View>
       <Text style={styles.proposalDescription}>{proposal.description}</Text>
-      {needsText.length > 0 && (
-        <Text style={styles.proposalMeta}>Needs: {needsText}</Text>
-      )}
-      {proposal.duration && (
-        <Text style={styles.proposalMeta}>Timing: {proposal.duration}</Text>
-      )}
-      {proposal.measureOfSuccess && (
-        <Text style={styles.proposalMeta}>Success: {proposal.measureOfSuccess}</Text>
-      )}
 
-      <View style={styles.decisionRow}>
-        <DecisionBadge label="You" decision={proposal.myDecision} />
-        <DecisionBadge
-          label={partnerName || 'Partner'}
-          decision={proposal.partnerDecisionVisible}
-        />
-      </View>
+      {metaLines.map((line) => (
+        <Text key={line} style={styles.proposalMeta}>
+          {line}
+        </Text>
+      ))}
 
-      <View style={styles.selectionButtons}>
+      <Text style={styles.stanceLabel}>Your stance</Text>
+      <View style={styles.segmentedControl}>
         {[
           Stage4SelectionDecision.WILLING,
           Stage4SelectionDecision.NEEDS_DISCUSSION,
@@ -153,20 +137,33 @@ function ProposalCard({
           return (
             <TouchableOpacity
               key={decision}
-              style={[styles.selectionButton, selected && styles.selectionButtonSelected]}
+              style={[
+                styles.segment,
+                selected && styles.segmentSelected,
+                disabled && !selected && styles.segmentDisabled,
+              ]}
               onPress={() => onSelectProposal(proposal.id, decision)}
               disabled={disabled}
               accessibilityRole="button"
               accessibilityLabel={`${decisionLabels[decision]} for proposal`}
               accessibilityState={{ selected, disabled }}
             >
-              <Text style={[styles.selectionButtonText, selected && styles.selectionButtonTextSelected]}>
+              <Text
+                style={[
+                  styles.segmentText,
+                  selected && styles.segmentTextSelected,
+                ]}
+              >
                 {decisionLabels[decision]}
               </Text>
             </TouchableOpacity>
           );
         })}
       </View>
+
+      <Text style={styles.partnerState}>
+        {partnerStateLabel(partnerName, proposal.partnerDecisionVisible)}
+      </Text>
     </View>
   );
 }
@@ -193,10 +190,172 @@ function NeedRows({
           <View style={[styles.needDot, styles[`${tone}Dot`]]} />
           <View style={styles.needTextWrap}>
             <Text style={styles.needLabel}>{row.label}</Text>
-            {row.note && <Text style={styles.needNote}>{row.note}</Text>}
           </View>
         </View>
       ))}
+    </View>
+  );
+}
+
+export function Stage4RedesignFooter({
+  state,
+  partnerName,
+  isClosing = false,
+  isSharing = false,
+  isRevising = false,
+  onShareSelections,
+  onReviseSelections,
+  onCloseStage4,
+}: Stage4RedesignFooterProps) {
+  const { palette } = useAppAppearance();
+  const styles = useMemo(() => makeStyles(palette), [palette]);
+  const allProposals = [
+    ...state.inventory.sharedProposals,
+    ...state.inventory.individualCommitments,
+  ];
+  const mutualShared = state.inventory.sharedProposals.filter(
+    (proposal) =>
+      proposal.myDecision === Stage4SelectionDecision.WILLING &&
+      proposal.partnerDecisionVisible === Stage4SelectionDecision.WILLING,
+  );
+  const canCloseShared =
+    mutualShared.length > 0 && state.partnerSelectionStatus === 'SUBMITTED';
+  const canCloseNoShared =
+    (state.phase === Stage4Phase.OUTCOME_REVIEW ||
+      state.phase === Stage4Phase.SELECTION ||
+      state.phase === Stage4Phase.COVERAGE_REVIEW) &&
+    state.partnerSelectionStatus === 'SUBMITTED';
+  const showNoSharedClose =
+    state.phase === Stage4Phase.OUTCOME_REVIEW ||
+    state.phase === Stage4Phase.SELECTION ||
+    state.phase === Stage4Phase.COVERAGE_REVIEW;
+  const noSharedCloseDisabled = !canCloseNoShared || isClosing;
+  const mySelectionSubmitted = state.mySelectionStatus === 'SUBMITTED';
+  const partnerReady = state.partnerSelectionStatus === 'SUBMITTED';
+  const allMyDecisionsMade =
+    state.inventory.sharedProposals.length > 0 &&
+    state.inventory.sharedProposals.every((p) => Boolean(p.myDecision));
+  const who = partnerName || 'They';
+
+  if (state.outcome) return null;
+
+  if (allProposals.length === 0) {
+    return (
+      <View style={styles.footerContainer}>
+        <View style={styles.statusBlock}>
+          <Text style={styles.statusText}>
+            Proposals will appear here as your conversation develops them.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (!mySelectionSubmitted) {
+    const canShare = allMyDecisionsMade && !isSharing;
+    return (
+      <View style={styles.footerContainer}>
+        <View style={styles.actions}>
+          <TouchableOpacity
+            style={[styles.primaryButton, !canShare && styles.primaryButtonDisabled]}
+            onPress={() => {
+              if (canShare && onShareSelections) onShareSelections();
+            }}
+            disabled={!canShare}
+            accessibilityRole="button"
+            accessibilityLabel="Share my stances"
+            accessibilityState={{ disabled: !canShare }}
+            testID="stage4-share-selections"
+          >
+            <Share2 color={canShare ? palette.bg : palette.textFaint} size={17} />
+            <Text style={[styles.primaryButtonText, !canShare && styles.disabledButtonText]}>
+              {isSharing ? 'Sharing…' : `Share my stances with ${who}`}
+            </Text>
+          </TouchableOpacity>
+          {!allMyDecisionsMade && (
+            <Text style={styles.actionHint}>
+              Take a stance on every proposal first.
+            </Text>
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  if (!partnerReady) {
+    return (
+      <View style={styles.footerContainer}>
+        <View style={styles.actions}>
+          {onReviseSelections && (
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={() => {
+                if (!isRevising) onReviseSelections();
+              }}
+              disabled={isRevising}
+              accessibilityRole="button"
+              accessibilityLabel="Revise my stances"
+              testID="stage4-revise-selections"
+            >
+              <RotateCcw color={palette.text} size={17} />
+              <Text style={styles.secondaryButtonText}>
+                {isRevising ? 'Pulling back…' : 'Pull my stances back to revise'}
+              </Text>
+            </TouchableOpacity>
+          )}
+          <Text style={styles.actionHint}>
+            Hidden until {who} shares too — then you'll both see at once.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.footerContainer}>
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={[styles.primaryButton, !canCloseShared && styles.primaryButtonDisabled]}
+          onPress={() =>
+            onCloseStage4(
+              Stage4ClosureKind.SHARED_AGREEMENT,
+              Stage4ClosureReason.MUTUAL_SELECTION,
+            )
+          }
+          disabled={!canCloseShared || isClosing}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !canCloseShared || isClosing }}
+        >
+          <Send color={canCloseShared ? palette.bg : palette.textFaint} size={17} />
+          <Text style={[styles.primaryButtonText, !canCloseShared && styles.disabledButtonText]}>
+            Close with shared agreement
+          </Text>
+        </TouchableOpacity>
+        {showNoSharedClose && (
+          <TouchableOpacity
+            style={[styles.secondaryButton, noSharedCloseDisabled && styles.secondaryButtonDisabled]}
+            onPress={() =>
+              onCloseStage4(
+                Stage4ClosureKind.NO_SHARED_AGREEMENT,
+                Stage4ClosureReason.NO_OVERLAP,
+              )
+            }
+            disabled={noSharedCloseDisabled}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: noSharedCloseDisabled }}
+          >
+            <MinusCircle color={canCloseNoShared ? palette.text : palette.textFaint} size={17} />
+            <Text style={[styles.secondaryButtonText, noSharedCloseDisabled && styles.disabledButtonText]}>
+              Close without a shared agreement
+            </Text>
+          </TouchableOpacity>
+        )}
+        {!canCloseShared && (
+          <Text style={styles.actionHint}>
+            A shared agreement is available once you and {who} both say &ldquo;willing&rdquo; to the same proposal.
+          </Text>
+        )}
+      </View>
     </View>
   );
 }
@@ -206,11 +365,17 @@ export function Stage4RedesignPanel({
   partnerName,
   isSelecting = false,
   isClosing = false,
+  isSharing = false,
+  isRevising = false,
+  hideFooter = false,
   onSelectProposal,
+  onShareSelections,
+  onReviseSelections,
   onCloseStage4,
 }: Stage4RedesignPanelProps) {
   const { palette } = useAppAppearance();
   const styles = useMemo(() => makeStyles(palette), [palette]);
+  const partnerLabel = partnerName || 'Partner';
   const allProposals = [
     ...state.inventory.sharedProposals,
     ...state.inventory.individualCommitments,
@@ -233,22 +398,25 @@ export function Stage4RedesignPanel({
     state.phase === Stage4Phase.SELECTION ||
     state.phase === Stage4Phase.COVERAGE_REVIEW;
   const noSharedCloseDisabled = !canCloseNoShared || isClosing;
+  const mySelectionSubmitted = state.mySelectionStatus === 'SUBMITTED';
+  // Stances stay editable after sharing — changing one auto-unshares on the
+  // backend, so the partner never sees a stale stance. Only a finalized
+  // outcome locks them.
   const proposalSelectionsReadOnly = Boolean(state.outcome);
+
+  const coverageHasRows =
+    state.coverageAudit.covered.length > 0 ||
+    state.coverageAudit.partial.length > 0 ||
+    state.coverageAudit.open.length > 0;
 
   return (
     <View style={styles.container} testID="stage4-redesign-panel">
-      <View style={styles.card}>
-        <View style={styles.titleRow}>
-          <Text style={styles.title}>What comes next</Text>
-          <Text style={styles.phasePill}>{phaseLabel(state.phase)}</Text>
-        </View>
-        <Text style={styles.subtitle}>
-          Proposals are receipts from the conversation. Keep talking to add, revise, remove, or clarify them.
-        </Text>
-      </View>
+      <Text style={styles.intro}>
+        Proposals are receipts from your conversation. Keep talking to add, revise, or remove them.
+      </Text>
 
       <View style={styles.card}>
-        <Text style={styles.sectionTitle}>Proposal inventory</Text>
+        <Text style={styles.sectionTitle}>Proposals</Text>
         {allProposals.length === 0 ? (
           <Text style={styles.emptyText}>No proposals captured yet.</Text>
         ) : (
@@ -256,53 +424,28 @@ export function Stage4RedesignPanel({
             <ProposalCard
               key={proposal.id}
               proposal={proposal}
-              partnerName={partnerName}
+              partnerName={partnerLabel}
               isSelecting={isSelecting}
               readOnly={proposalSelectionsReadOnly}
               onSelectProposal={onSelectProposal}
             />
           ))
         )}
-        {state.inventory.unaddressedNeeds.length > 0 && (
-          <View style={styles.unaddressedBox}>
-            <Text style={styles.unaddressedTitle}>Still open</Text>
-            {state.inventory.unaddressedNeeds.map((need, index) => (
-              <Text key={need.id || `${need.label}-${index}`} style={styles.unaddressedNeed}>
-                {need.label}
-              </Text>
-            ))}
-          </View>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>How your needs are addressed</Text>
+        {coverageHasRows ? (
+          <>
+            <NeedRows title="Covered" rows={state.coverageAudit.covered} tone="covered" />
+            <NeedRows title="Partly addressed" rows={state.coverageAudit.partial} tone="partial" />
+            <NeedRows title="Not yet addressed" rows={state.coverageAudit.open} tone="open" />
+          </>
+        ) : (
+          <Text style={styles.emptyText}>
+            This will appear once your needs are mapped.
+          </Text>
         )}
-      </View>
-
-      <View style={styles.card}>
-        <Text style={styles.sectionTitle}>Needs coverage</Text>
-        <NeedRows title="Covered" rows={state.coverageAudit.covered} tone="covered" />
-        <NeedRows title="Partly covered" rows={state.coverageAudit.partial} tone="partial" />
-        <NeedRows title="Open" rows={state.coverageAudit.open} tone="open" />
-        {state.coverageAudit.covered.length === 0 &&
-          state.coverageAudit.partial.length === 0 &&
-          state.coverageAudit.open.length === 0 && (
-            <Text style={styles.emptyText}>Coverage will appear once Stage 3 needs are available.</Text>
-          )}
-      </View>
-
-      <View style={styles.card}>
-        <Text style={styles.sectionTitle}>Selection receipt</Text>
-        <View style={styles.receiptRow}>
-          <Check color={palette.success} size={18} />
-          <Text style={styles.receiptText}>
-            Your choices are saved proposal by proposal.
-          </Text>
-        </View>
-        <View style={styles.receiptRow}>
-          <Clock color={palette.textMuted} size={18} />
-          <Text style={styles.receiptText}>
-            {state.partnerSelectionStatus === 'SUBMITTED'
-              ? `${partnerName || 'Partner'} has submitted. Shared choices can now be reviewed.`
-              : `${partnerName || 'Partner'} choices stay private until they submit.`}
-          </Text>
-        </View>
       </View>
 
       {state.outcome && (
@@ -327,55 +470,138 @@ export function Stage4RedesignPanel({
         </View>
       )}
 
-      {!state.outcome && (
-        <View style={styles.actions}>
-          <TouchableOpacity
-            style={[styles.closeButton, !canCloseShared && styles.disabledButton]}
-            onPress={() =>
-              onCloseStage4(
-                Stage4ClosureKind.SHARED_AGREEMENT,
-                Stage4ClosureReason.MUTUAL_SELECTION
-              )
-            }
-            disabled={!canCloseShared || isClosing}
-            accessibilityRole="button"
-            accessibilityState={{ disabled: !canCloseShared || isClosing }}
-          >
-            <Send color={canCloseShared ? TEXT_ON_ACCENT : palette.textFaint} size={17} />
-            <Text style={[styles.closeButtonText, !canCloseShared && styles.disabledButtonText]}>
-              Close with shared agreement
-            </Text>
-          </TouchableOpacity>
+      {!hideFooter && !state.outcome && (() => {
+        const partnerReady = state.partnerSelectionStatus === 'SUBMITTED';
+        // Only shared proposals require a stance — individual commitments are
+        // one-sided so the partner doesn't have to take a position on them.
+        const allMyDecisionsMade =
+          state.inventory.sharedProposals.length > 0 &&
+          state.inventory.sharedProposals.every((p) => Boolean(p.myDecision));
+        const who = partnerName || 'They';
 
-          {showNoSharedClose && (
+        // (a) No proposals yet.
+        if (allProposals.length === 0) {
+          return (
+            <View style={styles.statusBlock}>
+              <Text style={styles.statusText}>
+                Proposals will appear here as your conversation develops them.
+              </Text>
+            </View>
+          );
+        }
+
+        // (b) I haven't shared yet → show Share CTA (disabled until every
+        // proposal has a stance) and an inline hint about what's missing.
+        if (!mySelectionSubmitted) {
+          const canShare = allMyDecisionsMade && !isSharing;
+          return (
+            <View style={styles.actions}>
+              <TouchableOpacity
+                style={[styles.primaryButton, !canShare && styles.primaryButtonDisabled]}
+                onPress={() => {
+                  if (canShare && onShareSelections) onShareSelections();
+                }}
+                disabled={!canShare}
+                accessibilityRole="button"
+                accessibilityLabel="Share my stances"
+                accessibilityState={{ disabled: !canShare }}
+                testID="stage4-share-selections"
+              >
+                <Share2 color={canShare ? palette.bg : palette.textFaint} size={17} />
+                <Text style={[styles.primaryButtonText, !canShare && styles.disabledButtonText]}>
+                  {isSharing ? 'Sharing…' : `Share my stances with ${who}`}
+                </Text>
+              </TouchableOpacity>
+              {!allMyDecisionsMade && (
+                <Text style={styles.actionHint}>
+                  Take a stance on every proposal first.
+                </Text>
+              )}
+            </View>
+          );
+        }
+
+        // (c) I've shared but partner hasn't → waiting state + Revise.
+        if (!partnerReady) {
+          return (
+            <View style={styles.actions}>
+              {onReviseSelections && (
+                <TouchableOpacity
+                  style={styles.secondaryButton}
+                  onPress={() => {
+                    if (!isRevising) onReviseSelections();
+                  }}
+                  disabled={isRevising}
+                  accessibilityRole="button"
+                  accessibilityLabel="Revise my stances"
+                  testID="stage4-revise-selections"
+                >
+                  <RotateCcw color={palette.text} size={17} />
+                  <Text style={styles.secondaryButtonText}>
+                    {isRevising ? 'Taking back…' : "I'm not ready yet"}
+                  </Text>
+                </TouchableOpacity>
+              )}
+              <View style={styles.statusBlock}>
+                <Text style={styles.statusText}>
+                  Hidden until {who} shares too — then you'll both see at once.
+                </Text>
+              </View>
+            </View>
+          );
+        }
+
+        // (d) Both shared → close buttons.
+        return (
+          <View style={styles.actions}>
             <TouchableOpacity
-              style={[styles.secondaryCloseButton, noSharedCloseDisabled && styles.disabledSecondaryButton]}
+              style={[styles.primaryButton, !canCloseShared && styles.primaryButtonDisabled]}
               onPress={() =>
                 onCloseStage4(
-                  Stage4ClosureKind.NO_SHARED_AGREEMENT,
-                  Stage4ClosureReason.NO_OVERLAP
+                  Stage4ClosureKind.SHARED_AGREEMENT,
+                  Stage4ClosureReason.MUTUAL_SELECTION
                 )
               }
-              disabled={noSharedCloseDisabled}
+              disabled={!canCloseShared || isClosing}
               accessibilityRole="button"
-              accessibilityState={{ disabled: noSharedCloseDisabled }}
+              accessibilityState={{ disabled: !canCloseShared || isClosing }}
             >
-              <MinusCircle color={canCloseNoShared ? palette.text : palette.textFaint} size={17} />
-              <Text style={[
-                styles.secondaryCloseButtonText,
-                noSharedCloseDisabled && styles.disabledButtonText,
-              ]}>
-                Close with no shared agreement
+              <Send color={canCloseShared ? palette.bg : palette.textFaint} size={17} />
+              <Text style={[styles.primaryButtonText, !canCloseShared && styles.disabledButtonText]}>
+                Close with shared agreement
               </Text>
             </TouchableOpacity>
-          )}
-          {showNoSharedClose && state.partnerSelectionStatus !== 'SUBMITTED' && (
-            <Text style={styles.actionHint}>
-              Available once both partners have made selections.
-            </Text>
-          )}
-        </View>
-      )}
+
+            {showNoSharedClose && (
+              <TouchableOpacity
+                style={[styles.secondaryButton, noSharedCloseDisabled && styles.secondaryButtonDisabled]}
+                onPress={() =>
+                  onCloseStage4(
+                    Stage4ClosureKind.NO_SHARED_AGREEMENT,
+                    Stage4ClosureReason.NO_OVERLAP
+                  )
+                }
+                disabled={noSharedCloseDisabled}
+                accessibilityRole="button"
+                accessibilityState={{ disabled: noSharedCloseDisabled }}
+              >
+                <MinusCircle color={canCloseNoShared ? palette.text : palette.textFaint} size={17} />
+                <Text style={[
+                  styles.secondaryButtonText,
+                  noSharedCloseDisabled && styles.disabledButtonText,
+                ]}>
+                  Close without a shared agreement
+                </Text>
+              </TouchableOpacity>
+            )}
+            {!canCloseShared && (
+              <Text style={styles.actionHint}>
+                A shared agreement is available once you and {who} both say &ldquo;willing&rdquo; to the same proposal.
+              </Text>
+            )}
+          </View>
+        );
+      })()}
 
       {state.phase === Stage4Phase.CLOSED_NO_SHARED_AGREEMENT && (
         <View style={styles.closedNote}>
@@ -391,54 +617,31 @@ export function Stage4RedesignPanel({
 
 type Palette = ReturnType<typeof useAppAppearance>['palette'];
 
-const TEXT_ON_ACCENT = '#0d0f12';
-const TEXT_ON_DANGER = '#ffffff';
-
 const makeStyles = (palette: Palette) => StyleSheet.create({
   container: {
-    padding: 16,
-    gap: 12,
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 16,
+    gap: 16,
   },
-  card: {
-    backgroundColor: palette.bgElev,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: palette.border,
-    padding: 14,
-  },
-  titleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: 10,
-  },
-  title: {
-    flex: 1,
-    color: palette.text,
-    fontSize: 18,
-    fontWeight: '700',
-  },
-  phasePill: {
-    color: TEXT_ON_ACCENT,
-    backgroundColor: palette.accent,
-    borderRadius: 999,
-    overflow: 'hidden',
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  subtitle: {
+  intro: {
     color: palette.textMuted,
     fontSize: 14,
     lineHeight: 20,
-    marginTop: 8,
+    paddingHorizontal: 4,
+  },
+  card: {
+    backgroundColor: palette.bgElev,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 14,
   },
   sectionTitle: {
     color: palette.text,
     fontSize: 16,
     fontWeight: '700',
-    marginBottom: 10,
+    marginBottom: 12,
   },
   emptyText: {
     color: palette.textMuted,
@@ -447,9 +650,7 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
   },
   proposalCard: {
     backgroundColor: palette.bgPane,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: palette.border,
+    borderRadius: 10,
     padding: 12,
     marginBottom: 10,
   },
@@ -463,6 +664,8 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
     color: palette.accentText,
     fontSize: 12,
     fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
   },
   ownerLabel: {
     color: palette.textMuted,
@@ -480,92 +683,71 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
     lineHeight: 18,
     marginTop: 6,
   },
-  decisionRow: {
-    flexDirection: 'row',
-    gap: 8,
-    marginTop: 10,
-  },
-  decisionBadge: {
-    flex: 1,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: palette.border,
-    padding: 8,
-  },
-  decisionLabel: {
+  stanceLabel: {
     color: palette.textMuted,
-    fontSize: 11,
+    fontSize: 12,
+    fontWeight: '600',
+    marginTop: 14,
+    marginBottom: 6,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  segmentedControl: {
+    flexDirection: 'row',
+    backgroundColor: palette.bgElev,
+    borderRadius: 10,
+    padding: 3,
+  },
+  segment: {
+    flex: 1,
+    paddingVertical: 9,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 8,
+  },
+  segmentSelected: {
+    backgroundColor: palette.accent,
+  },
+  segmentDisabled: {
+    opacity: 0.5,
+  },
+  segmentText: {
+    color: palette.text,
+    fontSize: 13,
     fontWeight: '600',
   },
-  decisionValue: {
-    color: palette.text,
-    fontSize: 13,
+  segmentTextSelected: {
+    color: palette.bg,
     fontWeight: '700',
-    marginTop: 2,
   },
-  selectionButtons: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 8,
-    marginTop: 10,
-  },
-  selectionButton: {
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: palette.border,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-  },
-  selectionButtonSelected: {
-    backgroundColor: palette.success,
-    borderColor: palette.success,
-  },
-  selectionButtonText: {
-    color: palette.text,
+  partnerState: {
+    color: palette.textMuted,
     fontSize: 12,
-    fontWeight: '700',
-  },
-  selectionButtonTextSelected: {
-    color: TEXT_ON_DANGER,
-  },
-  unaddressedBox: {
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: palette.warning,
-    padding: 10,
-    marginTop: 2,
-  },
-  unaddressedTitle: {
-    color: palette.warning,
-    fontSize: 13,
-    fontWeight: '700',
-    marginBottom: 6,
-  },
-  unaddressedNeed: {
-    color: palette.text,
-    fontSize: 13,
-    lineHeight: 18,
+    marginTop: 8,
+    fontStyle: 'italic',
   },
   coverageGroup: {
-    marginBottom: 10,
+    marginBottom: 12,
   },
   coverageTitle: {
     color: palette.textMuted,
-    fontSize: 13,
+    fontSize: 12,
     fontWeight: '700',
-    marginBottom: 6,
+    marginBottom: 8,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
   },
   needRow: {
     flexDirection: 'row',
     alignItems: 'flex-start',
-    gap: 8,
-    marginBottom: 7,
+    gap: 10,
+    marginBottom: 8,
   },
   needDot: {
-    width: 9,
-    height: 9,
-    borderRadius: 5,
-    marginTop: 5,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginTop: 6,
   },
   coveredDot: {
     backgroundColor: palette.success,
@@ -583,24 +765,6 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
     color: palette.text,
     fontSize: 14,
     lineHeight: 19,
-  },
-  needNote: {
-    color: palette.textMuted,
-    fontSize: 12,
-    lineHeight: 17,
-    marginTop: 2,
-  },
-  receiptRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: 8,
-    marginBottom: 8,
-  },
-  receiptText: {
-    flex: 1,
-    color: palette.text,
-    fontSize: 14,
-    lineHeight: 20,
   },
   outcomeReason: {
     color: palette.accentText,
@@ -630,49 +794,67 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
     lineHeight: 18,
     marginTop: 10,
   },
-  actions: {
-    gap: 8,
+  footerContainer: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 12,
+    borderTopWidth: 1,
+    borderTopColor: palette.border,
+    backgroundColor: palette.bgPane,
   },
-  closeButton: {
-    minHeight: 44,
-    borderRadius: 8,
+  actions: {
+    gap: 10,
+  },
+  statusBlock: {
+    backgroundColor: palette.bgElev,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 14,
+  },
+  statusText: {
+    color: palette.text,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  primaryButton: {
+    minHeight: 48,
+    borderRadius: 12,
     backgroundColor: palette.accent,
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',
     gap: 8,
-    paddingHorizontal: 12,
+    paddingHorizontal: 14,
   },
-  closeButtonText: {
-    color: TEXT_ON_ACCENT,
-    fontSize: 14,
-    fontWeight: '700',
-  },
-  disabledButton: {
+  primaryButtonDisabled: {
     backgroundColor: palette.chipBg,
   },
-  disabledButtonText: {
-    color: palette.textFaint,
+  primaryButtonText: {
+    color: palette.bg,
+    fontSize: 15,
+    fontWeight: '700',
   },
-  secondaryCloseButton: {
-    minHeight: 44,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: palette.border,
+  secondaryButton: {
+    minHeight: 48,
+    borderRadius: 12,
+    backgroundColor: palette.bgElev,
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',
     gap: 8,
-    paddingHorizontal: 12,
+    paddingHorizontal: 14,
   },
-  disabledSecondaryButton: {
-    borderColor: palette.border,
-    backgroundColor: palette.chipBg,
+  secondaryButtonDisabled: {
+    opacity: 0.6,
   },
-  secondaryCloseButtonText: {
+  secondaryButtonText: {
     color: palette.text,
-    fontSize: 14,
-    fontWeight: '700',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  disabledButtonText: {
+    color: palette.textFaint,
   },
   actionHint: {
     color: palette.textMuted,
@@ -684,7 +866,7 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-start',
     gap: 8,
-    borderRadius: 8,
+    borderRadius: 12,
     borderWidth: 1,
     borderColor: palette.warning,
     padding: 12,

--- a/mobile/src/components/WaitingBanner.tsx
+++ b/mobile/src/components/WaitingBanner.tsx
@@ -24,6 +24,8 @@ interface WaitingBannerProps {
   animationValue?: Animated.Value;
   /** Callback when user taps the breathing exercise link */
   onExercisePress?: () => void;
+  /** Optional action button (e.g. "Review"). Label comes from the status config; host wires the handler. */
+  onActionPress?: () => void;
   /** Test ID for testing */
   testID?: string;
 }
@@ -37,6 +39,7 @@ export function WaitingBanner({
   partnerName,
   animationValue,
   onExercisePress,
+  onActionPress,
   testID = 'waiting-banner',
 }: WaitingBannerProps) {
   const styles = useStyles();
@@ -95,6 +98,19 @@ export function WaitingBanner({
           <Text style={styles.subtext} testID={`${testID}-subtext`}>
             {config.bannerSubtext}
           </Text>
+        )}
+
+        {/* Inline action button (e.g. Review). Driven by config.actionLabel. */}
+        {config.actionLabel && onActionPress && (
+          <Pressable
+            onPress={onActionPress}
+            style={styles.actionButton}
+            testID={`${testID}-action`}
+            accessibilityRole="button"
+            accessibilityLabel={config.actionLabel}
+          >
+            <Text style={styles.actionButtonText}>{config.actionLabel}</Text>
+          </Pressable>
         )}
 
         {/* Breathing exercise link */}
@@ -165,6 +181,21 @@ const useStyles = () =>
       fontSize: t.typography.fontSize.sm,
       color: palette.accent,
       textDecorationLine: 'underline',
+      fontFamily: designFonts.sans,
+    },
+    actionButton: {
+      marginTop: t.spacing.sm,
+      minHeight: 44,
+      paddingHorizontal: t.spacing.lg,
+      borderRadius: 12,
+      backgroundColor: palette.accent,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    actionButtonText: {
+      fontSize: t.typography.fontSize.md,
+      color: palette.bg,
+      fontWeight: '700',
       fontFamily: designFonts.sans,
     },
   }));

--- a/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
+++ b/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
@@ -90,6 +90,7 @@ const baseState: GetStage4StateResponse = {
   },
   mySelections: [],
   partnerSelections: [],
+  mySelectionStatus: 'NOT_STARTED',
   partnerSelectionStatus: 'NOT_STARTED',
   outcome: null,
   tendingPreview: null,
@@ -110,10 +111,10 @@ describe('Stage4RedesignPanel', () => {
   it('renders proposal inventory and needs coverage cards', () => {
     render(<Stage4RedesignPanel {...defaultProps} />);
 
-    expect(screen.getByText('Proposal inventory')).toBeTruthy();
+    expect(screen.getByText('Proposals')).toBeTruthy();
     expect(screen.getByText('Take turns naming the impact before problem solving.')).toBeTruthy();
     expect(screen.getByText('I will pause when my voice gets sharp.')).toBeTruthy();
-    expect(screen.getByText('Needs coverage')).toBeTruthy();
+    expect(screen.getByText('How your needs are addressed')).toBeTruthy();
     expect(screen.getByText('Feeling heard')).toBeTruthy();
     expect(screen.getAllByText('Trust after conflict').length).toBeGreaterThan(0);
   });
@@ -121,8 +122,9 @@ describe('Stage4RedesignPanel', () => {
   it('keeps partner selections private before both submit', () => {
     render(<Stage4RedesignPanel {...defaultProps} />);
 
-    expect(screen.getByText('Eve choices stay private until they submit.')).toBeTruthy();
-    expect(screen.getAllByText('Private').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Eve hasn't shared their stance yet/i).length,
+    ).toBeGreaterThan(0);
   });
 
   it('submits proposal-level willingness selections', () => {
@@ -140,6 +142,7 @@ describe('Stage4RedesignPanel', () => {
     const state: GetStage4StateResponse = {
       ...baseState,
       phase: Stage4Phase.OUTCOME_REVIEW,
+      mySelectionStatus: 'SUBMITTED',
       partnerSelectionStatus: 'SUBMITTED',
       inventory: {
         ...baseState.inventory,
@@ -166,6 +169,7 @@ describe('Stage4RedesignPanel', () => {
     const state: GetStage4StateResponse = {
       ...baseState,
       phase: Stage4Phase.SELECTION,
+      mySelectionStatus: 'SUBMITTED',
       partnerSelectionStatus: 'SUBMITTED',
       inventory: {
         ...baseState.inventory,
@@ -197,40 +201,85 @@ describe('Stage4RedesignPanel', () => {
       Stage4ClosureReason.MUTUAL_SELECTION
     );
 
-    const noSharedButton = screen.getByText('Close with no shared agreement');
+    const noSharedButton = screen.getByText('Close without a shared agreement');
     expect(noSharedButton).not.toBeDisabled();
   });
 
-  it('renders close-without-agreement button as disabled before partner submits selections', () => {
+  it('shows the share CTA when stances are complete but not yet shared', () => {
+    render(<Stage4RedesignPanel {...defaultProps} />);
+
+    expect(screen.queryByText('Close without a shared agreement')).toBeNull();
+    expect(screen.queryByText('Close with shared agreement')).toBeNull();
+    expect(screen.getByText(/Share my stances with Eve/i)).toBeTruthy();
+  });
+
+  it('disables the share CTA until every proposal has a stance', () => {
     const state: GetStage4StateResponse = {
       ...baseState,
-      phase: Stage4Phase.OUTCOME_REVIEW,
-      partnerSelectionStatus: 'NOT_STARTED',
-      partnerSelections: [],
+      inventory: {
+        ...baseState.inventory,
+        sharedProposals: [
+          {
+            ...baseState.inventory.sharedProposals[0],
+            myDecision: undefined,
+          },
+        ],
+      },
     };
 
     render(<Stage4RedesignPanel {...defaultProps} state={state} />);
 
-    const closeButton = screen.getByText('Close with no shared agreement');
-    expect(closeButton).toBeDisabled();
-    expect(screen.getByText('Available once both partners have made selections.')).toBeTruthy();
-
-    fireEvent.press(closeButton);
-
-    expect(defaultProps.onCloseStage4).not.toHaveBeenCalled();
+    const share = screen.getByLabelText('Share my stances');
+    expect(share).toBeDisabled();
+    expect(screen.getByText(/Take a stance on every proposal first/i)).toBeTruthy();
   });
 
-  it('renders close-without-agreement button as enabled when partner has submitted selections', () => {
+  it('calls onShareSelections when the share CTA is pressed', () => {
+    const onShareSelections = jest.fn();
+    render(
+      <Stage4RedesignPanel {...defaultProps} onShareSelections={onShareSelections} />,
+    );
+
+    fireEvent.press(screen.getByLabelText('Share my stances'));
+    expect(onShareSelections).toHaveBeenCalled();
+  });
+
+  it('shows waiting state with revise CTA after sharing but before partner submits', () => {
+    const onReviseSelections = jest.fn();
+    const state: GetStage4StateResponse = {
+      ...baseState,
+      mySelectionStatus: 'SUBMITTED',
+      partnerSelectionStatus: 'NOT_STARTED',
+    };
+
+    render(
+      <Stage4RedesignPanel
+        {...defaultProps}
+        state={state}
+        onReviseSelections={onReviseSelections}
+      />,
+    );
+
+    expect(screen.queryByText('Close without a shared agreement')).toBeNull();
+    expect(screen.queryByText('Close with shared agreement')).toBeNull();
+    expect(screen.getByText(/Hidden until Eve shares too/i)).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Revise my stances'));
+    expect(onReviseSelections).toHaveBeenCalled();
+  });
+
+  it('renders close-without-agreement button as enabled when both have submitted selections', () => {
     const state: GetStage4StateResponse = {
       ...baseState,
       phase: Stage4Phase.OUTCOME_REVIEW,
+      mySelectionStatus: 'SUBMITTED',
       partnerSelectionStatus: 'SUBMITTED',
       partnerSelections: [],
     };
 
     render(<Stage4RedesignPanel {...defaultProps} state={state} />);
 
-    const closeButton = screen.getByText('Close with no shared agreement');
+    const closeButton = screen.getByText('Close without a shared agreement');
     expect(closeButton).not.toBeDisabled();
 
     fireEvent.press(closeButton);

--- a/mobile/src/config/waitingStatusConfig.ts
+++ b/mobile/src/config/waitingStatusConfig.ts
@@ -31,6 +31,8 @@ export interface WaitingStatusConfig {
   bannerSubtext?: string;
   /** Whether to show "Keep Chatting" action button */
   showKeepChattingAction: boolean;
+  /** Optional inline action button label (e.g. "Review"). The handler is wired by the host screen. */
+  actionLabel?: string;
 }
 
 // ============================================================================
@@ -240,6 +242,18 @@ export const WAITING_STATUS_CONFIG: Record<NonNullable<WaitingStatusState>, Wait
     showSpinner: false,
     showKeepChattingAction: false,
     bannerText: (p) => `${p} is reviewing the needs you both shared.`,
+  },
+
+  // Stage 4 (redesigned): I shared my willingness stances; partner hasn't yet.
+  'stage4-selections-pending': {
+    showBanner: true,
+    hideInput: true,
+    showInnerThoughts: false,
+    isActionRequired: false,
+    showSpinner: false,
+    showKeepChattingAction: false,
+    actionLabel: 'Review',
+    bannerText: (p) => `Hidden until ${p} shares too — then you'll both see at once.`,
   },
 
   // Stage 4: Waiting for partner to submit strategy rankings

--- a/mobile/src/hooks/index.ts
+++ b/mobile/src/hooks/index.ts
@@ -138,6 +138,8 @@ export {
   useStage4State,
   useSubmitStage4ProposalSelection,
   useSubmitStage4Selections,
+  useShareStage4Selections,
+  useUnshareStage4Selections,
   useCloseStage4,
   useTendingEntries,
   useSubmitTendingResponse,

--- a/mobile/src/hooks/useChatUIState.ts
+++ b/mobile/src/hooks/useChatUIState.ts
@@ -133,6 +133,13 @@ export interface UseChatUIStateProps {
     agreedByMe: boolean;
     agreedByPartner: boolean;
   }>;
+
+  // Stage 4 (redesigned): per-proposal willingness share status
+  stage4Selections?: {
+    mySelectionSubmitted: boolean;
+    partnerSelectionSubmitted: boolean;
+    hasOutcome: boolean;
+  };
 }
 
 /**
@@ -224,6 +231,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     strategyReadiness,
     overlappingStrategiesCount,
     agreements,
+    stage4Selections,
   } = props;
 
   // Track previous waiting status for transition detection
@@ -261,6 +269,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     strategyReadiness,
     overlappingStrategies: { count: overlappingStrategiesCount },
     agreements,
+    stage4Selections,
 
     // ChatUIStateInputs
     sessionStatus,
@@ -330,6 +339,7 @@ export function useChatUIState(props: UseChatUIStateProps): UseChatUIStateResult
     strategyReadiness,
     overlappingStrategiesCount,
     agreements,
+    stage4Selections,
     sessionStatus,
     isInviter,
     isLoading,

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -50,6 +50,7 @@ import {
   RevealOverlapResponse,
   MarkReadyResponse,
   GetStage4StateResponse,
+  Stage4SelectionDecision,
   SubmitStage4SelectionRequest,
   SubmitStage4SelectionsRequest,
   SubmitStage4SelectionsResponse,
@@ -2031,18 +2032,49 @@ export function useSubmitStage4ProposalSelection(
 ) {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<
+    SubmitStage4SelectionsResponse,
+    ApiClientError,
+    { sessionId: string; proposalId: string } & SubmitStage4SelectionRequest,
+    { previous: GetStage4StateResponse | undefined }
+  >({
+    ...options,
     mutationFn: async ({ sessionId, proposalId, ...request }) => {
       return post<SubmitStage4SelectionsResponse, SubmitStage4SelectionRequest>(
         `/sessions/${sessionId}/stage4/proposals/${proposalId}/selection`,
         request
       );
     },
+    onMutate: async ({ sessionId, proposalId, decision }) => {
+      const key = stageKeys.stage4(sessionId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<GetStage4StateResponse>(key);
+      if (previous) {
+        const patchProposal = <T extends { id: string; myDecision?: Stage4SelectionDecision }>(p: T): T =>
+          p.id === proposalId ? { ...p, myDecision: decision } : p;
+        queryClient.setQueryData<GetStage4StateResponse>(key, {
+          ...previous,
+          // Changing a stance after sharing pulls the share back so the
+          // partner never sees a stale value. Match the backend behavior.
+          mySelectionStatus: 'NOT_STARTED',
+          inventory: {
+            ...previous.inventory,
+            sharedProposals: previous.inventory.sharedProposals.map(patchProposal),
+            individualCommitments: previous.inventory.individualCommitments.map(patchProposal),
+          },
+        });
+      }
+      return { previous };
+    },
+    onError: (_err, { sessionId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(stageKeys.stage4(sessionId), context.previous);
+      }
+    },
     onSuccess: (data, { sessionId }) => {
       queryClient.setQueryData(stageKeys.stage4(sessionId), data.state);
       refreshStage4Caches(queryClient, sessionId);
     },
-    ...options,
   });
 }
 
@@ -2073,6 +2105,87 @@ export function useSubmitStage4Selections(
       refreshStage4Caches(queryClient, sessionId);
     },
     ...options,
+  });
+}
+
+/**
+ * Share the current user's Stage 4 selections with their partner.
+ * Requires every active proposal to have a stance.
+ */
+export function useShareStage4Selections() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { state: GetStage4StateResponse },
+    ApiClientError,
+    { sessionId: string },
+    { previous: GetStage4StateResponse | undefined }
+  >({
+    mutationFn: async ({ sessionId }) =>
+      post<{ state: GetStage4StateResponse }, Record<string, never>>(
+        `/sessions/${sessionId}/stage4/share-selections`,
+        {} as Record<string, never>
+      ),
+    onMutate: async ({ sessionId }) => {
+      const key = stageKeys.stage4(sessionId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<GetStage4StateResponse>(key);
+      if (previous) {
+        queryClient.setQueryData<GetStage4StateResponse>(key, {
+          ...previous,
+          mySelectionStatus: 'SUBMITTED',
+        });
+      }
+      return { previous };
+    },
+    onError: (_err, { sessionId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(stageKeys.stage4(sessionId), context.previous);
+      }
+    },
+    onSuccess: (data, { sessionId }) => {
+      queryClient.setQueryData(stageKeys.stage4(sessionId), data.state);
+      refreshStage4Caches(queryClient, sessionId);
+    },
+  });
+}
+
+/**
+ * Withdraw the current user's shared Stage 4 selections so they can revise.
+ */
+export function useUnshareStage4Selections() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { state: GetStage4StateResponse },
+    ApiClientError,
+    { sessionId: string },
+    { previous: GetStage4StateResponse | undefined }
+  >({
+    mutationFn: async ({ sessionId }) =>
+      post<{ state: GetStage4StateResponse }, Record<string, never>>(
+        `/sessions/${sessionId}/stage4/unshare-selections`,
+        {} as Record<string, never>
+      ),
+    onMutate: async ({ sessionId }) => {
+      const key = stageKeys.stage4(sessionId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<GetStage4StateResponse>(key);
+      if (previous) {
+        queryClient.setQueryData<GetStage4StateResponse>(key, {
+          ...previous,
+          mySelectionStatus: 'NOT_STARTED',
+        });
+      }
+      return { previous };
+    },
+    onError: (_err, { sessionId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(stageKeys.stage4(sessionId), context.previous);
+      }
+    },
+    onSuccess: (data, { sessionId }) => {
+      queryClient.setQueryData(stageKeys.stage4(sessionId), data.state);
+      refreshStage4Caches(queryClient, sessionId);
+    },
   });
 }
 

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -41,7 +41,7 @@ import { ShareTopicPanel } from '../components/ShareTopicPanel';
 import { WaitingRoom } from '../components/WaitingRoom';
 import { AgreementCard } from '../components/AgreementCard';
 import { SessionCompletionScreen } from '../components/SessionCompletionScreen';
-import { Stage4RedesignPanel } from '../components/Stage4RedesignPanel';
+import { Stage4RedesignPanel, Stage4RedesignFooter } from '../components/Stage4RedesignPanel';
 import { TendingPanel } from '../components/TendingPanel';
 // CuriosityCompactOverlay removed - now using inline approach
 import { CompactChatItem } from '../components/CompactChatItem';
@@ -72,6 +72,8 @@ import { useSharingStatus } from '../hooks/useSharingStatus';
 import { usePendingActions } from '../hooks/usePendingActions';
 import {
   useCloseStage4,
+  useShareStage4Selections,
+  useUnshareStage4Selections,
   useCreateTendingReentry,
   useNeedsComparison,
   useStage4State,
@@ -525,7 +527,7 @@ export function UnifiedSessionScreen({
   const { mutate: updateMood } = useUpdateMood();
   const queryClient = useQueryClient();
   const router = useRouter();
-  const { showError } = useToast();
+  const { showError, showWarning } = useToast();
 
   // Real-time presence tracking
 
@@ -1100,6 +1102,15 @@ export function UnifiedSessionScreen({
       if (eventName === 'session.strategies_updated') {
         console.log('[UnifiedSessionScreen] Strategies updated');
         refreshStage4RealtimeState();
+
+        // Partner pulled their stances back to revise → surface it so the
+        // partner doesn't wonder why their view "lost" data.
+        if ((data as { change?: string }).change === 'stage4_selection_revised') {
+          showWarning(
+            `${partnerName || 'Your other'} pulled their stances back`,
+            'You\'ll see them again when they re-share.',
+          );
+        }
       }
 
       if (eventName === 'partner.ranking_submitted') {
@@ -1444,6 +1455,8 @@ export function UnifiedSessionScreen({
       showError('Could not save that Stage 4 choice. Please try again.');
     },
   });
+  const shareStage4Selections = useShareStage4Selections();
+  const unshareStage4Selections = useUnshareStage4Selections();
   const closeStage4 = useCloseStage4({
     onSuccess: (response) => {
       if (response.outcome.kind === Stage4ClosureKind.SHARED_AGREEMENT) {
@@ -1479,6 +1492,27 @@ export function UnifiedSessionScreen({
     },
     [sessionId, submitStage4Selection]
   );
+  const handleShareStage4Selections = useCallback(() => {
+    shareStage4Selections.mutate(
+      { sessionId },
+      {
+        onError: (err) => {
+          const detail = err?.message || 'Please try again.';
+          showError('Could not share your stances', detail);
+        },
+      }
+    );
+  }, [shareStage4Selections, sessionId, showError]);
+  const handleReviseStage4Selections = useCallback(() => {
+    unshareStage4Selections.mutate(
+      { sessionId },
+      {
+        onError: () => {
+          showError('Could not unshare your stances. Please try again.');
+        },
+      }
+    );
+  }, [unshareStage4Selections, sessionId, showError]);
   const handleCloseRedesignedStage4 = useCallback(
     (kind: Stage4ClosureKind, reason: Stage4ClosureReason) => {
       closeStage4.mutate({
@@ -1766,6 +1800,13 @@ export function UnifiedSessionScreen({
       agreedByMe: a.agreedByMe,
       agreedByPartner: a.agreedByPartner,
     })),
+    stage4Selections: stage4State
+      ? {
+          mySelectionSubmitted: stage4State.mySelectionStatus === 'SUBMITTED',
+          partnerSelectionSubmitted: stage4State.partnerSelectionStatus === 'SUBMITTED',
+          hasOutcome: !!stage4State.outcome,
+        }
+      : undefined,
   });
 
   // -------------------------------------------------------------------------
@@ -2924,6 +2965,11 @@ export function UnifiedSessionScreen({
             partnerName={partnerName || 'your partner'}
             animationValue={waitingBannerAnim}
             onExercisePress={() => openOverlay('support-options')}
+            onActionPress={
+              waitingStatus === 'stage4-selections-pending'
+                ? () => setShowStage4Drawer(true)
+                : undefined
+            }
             testID="waiting-banner"
           />
         );
@@ -2933,18 +2979,60 @@ export function UnifiedSessionScreen({
         // Stage 4, surface the proposal-review entry point above the input so
         // the user always has a way to open the Stage 4 drawer.
         if (hasRedesignedStage4 && stage4State) {
-          const proposalCount =
-            stage4State.inventory.sharedProposals.length +
-            stage4State.inventory.individualCommitments.length;
+          const allProposals = [
+            ...stage4State.inventory.sharedProposals,
+            ...stage4State.inventory.individualCommitments,
+          ];
+          const proposalCount = allProposals.length;
           if (proposalCount === 0) return undefined;
+
+          const who = partnerName || 'them';
+          const mineSubmitted = stage4State.mySelectionStatus === 'SUBMITTED';
+          const partnerSubmitted = stage4State.partnerSelectionStatus === 'SUBMITTED';
+          const allStanced = allProposals.every((p) => Boolean(p.myDecision));
+          const hasMutualWilling = stage4State.inventory.sharedProposals.some(
+            (p) =>
+              p.myDecision === Stage4SelectionDecision.WILLING &&
+              p.partnerDecisionVisible === Stage4SelectionDecision.WILLING,
+          );
+
+          let title: string;
+          let subtitle: string;
+          let label: string;
+          if (stage4State.outcome) {
+            // Outcome already exists; chat surface doesn't need a CTA here.
+            return undefined;
+          } else if (!mineSubmitted && !allStanced) {
+            title =
+              proposalCount === 1 ? '1 proposal on the table' : `${proposalCount} proposals on the table`;
+            subtitle = 'Take a stance on each one when you’re ready.';
+            label = 'Review';
+          } else if (!mineSubmitted && allStanced) {
+            title = 'Ready to share your stances';
+            subtitle = `Open this to share them with ${who}.`;
+            label = 'Review & share';
+          } else if (mineSubmitted && !partnerSubmitted) {
+            title = `Waiting for ${who}`;
+            subtitle = `You'll know as soon as ${who} shares.`;
+            label = 'Review';
+          } else if (mineSubmitted && partnerSubmitted && hasMutualWilling) {
+            title = `You and ${who} agree on at least one proposal`;
+            subtitle = 'Open this to close with a shared agreement.';
+            label = 'Review & close';
+          } else {
+            title = `${who} has shared too`;
+            subtitle = 'No mutual “willing” yet — open this to see your options.';
+            label = 'Review';
+          }
+
           return (
             <GuidedActionPanel
               tone="review"
               eyebrow="What comes next"
-              title={proposalCount === 1 ? '1 proposal on the table' : `${proposalCount} proposals on the table`}
-              subtitle="Review the inventory and mark which proposals you're willing to try."
+              title={title}
+              subtitle={subtitle}
               primaryAction={{
-                label: 'Review',
+                label,
                 onPress: () => setShowStage4Drawer(true),
                 testID: 'stage4-review-button',
               }}
@@ -3180,7 +3268,11 @@ export function UnifiedSessionScreen({
               partnerName={partnerName}
               isSelecting={submitStage4Selection.isPending}
               isClosing={closeStage4.isPending}
+              isSharing={shareStage4Selections.isPending}
+              isRevising={unshareStage4Selections.isPending}
               onSelectProposal={handleStage4Selection}
+              onShareSelections={handleShareStage4Selections}
+              onReviseSelections={handleReviseStage4Selections}
               onCloseStage4={handleCloseRedesignedStage4}
             />
             {tendingPanel}
@@ -3361,7 +3453,10 @@ export function UnifiedSessionScreen({
           }
           // isInputDisabled prevents sending while API call is in progress
           isInputDisabled={isSending}
-          showEmotionSlider={!isInOnboardingUnsigned}
+          showEmotionSlider={
+            !isInOnboardingUnsigned &&
+            waitingStatus !== 'stage4-selections-pending'
+          }
           partnerName={partnerName}
           emotionValue={barometerValue}
           onEmotionChange={handleBarometerChange}
@@ -3685,18 +3780,12 @@ export function UnifiedSessionScreen({
         presentationStyle="pageSheet"
         onRequestClose={() => setShowStage4Drawer(false)}
       >
-        <SafeAreaView style={{ flex: 1, backgroundColor: styles.container.backgroundColor }} edges={['top', 'bottom']}>
+        <SafeAreaView style={styles.stage4DrawerSafeArea} edges={['top', 'bottom']}>
+          <View style={styles.stage4DrawerDragHandleArea}>
+            <View style={styles.stage4DrawerDragHandle} />
+          </View>
           <View style={styles.stage4DrawerHeader}>
             <Text style={styles.stage4DrawerTitle}>What comes next</Text>
-            <TouchableOpacity
-              style={styles.stage4DrawerCloseButton}
-              onPress={() => setShowStage4Drawer(false)}
-              accessibilityRole="button"
-              accessibilityLabel="Close Stage 4 review"
-              testID="stage4-drawer-close"
-            >
-              <Text style={styles.stage4DrawerCloseText}>✕</Text>
-            </TouchableOpacity>
           </View>
           <ScrollView contentContainerStyle={styles.stage4DrawerScroll}>
             {stage4State && (
@@ -3705,7 +3794,12 @@ export function UnifiedSessionScreen({
                 partnerName={partnerName}
                 isSelecting={submitStage4Selection.isPending}
                 isClosing={closeStage4.isPending}
+                isSharing={shareStage4Selections.isPending}
+                isRevising={unshareStage4Selections.isPending}
+                hideFooter
                 onSelectProposal={handleStage4Selection}
+                onShareSelections={handleShareStage4Selections}
+                onReviseSelections={handleReviseStage4Selections}
                 onCloseStage4={(kind, reason) => {
                   handleCloseRedesignedStage4(kind, reason);
                   setShowStage4Drawer(false);
@@ -3713,6 +3807,21 @@ export function UnifiedSessionScreen({
               />
             )}
           </ScrollView>
+          {stage4State && (
+            <Stage4RedesignFooter
+              state={stage4State}
+              partnerName={partnerName}
+              isClosing={closeStage4.isPending}
+              isSharing={shareStage4Selections.isPending}
+              isRevising={unshareStage4Selections.isPending}
+              onShareSelections={handleShareStage4Selections}
+              onReviseSelections={handleReviseStage4Selections}
+              onCloseStage4={(kind, reason) => {
+                handleCloseRedesignedStage4(kind, reason);
+                setShowStage4Drawer(false);
+              }}
+            />
+          )}
         </SafeAreaView>
       </Modal>
 
@@ -4597,17 +4706,30 @@ const useStyles = () => {
       zIndex: 100,
       elevation: 100,
     },
+    stage4DrawerSafeArea: {
+      flex: 1,
+      backgroundColor: palette.bgPane,
+    },
+    stage4DrawerDragHandleArea: {
+      paddingTop: 12,
+      paddingBottom: 8,
+      alignItems: 'center',
+    },
+    stage4DrawerDragHandle: {
+      width: 36,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: palette.borderStrong,
+    },
     stage4DrawerHeader: {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
       paddingHorizontal: 16,
-      paddingVertical: 12,
-      borderBottomWidth: 1,
-      borderBottomColor: palette.border,
+      paddingBottom: 8,
     },
     stage4DrawerTitle: {
-      fontSize: 20,
+      fontSize: 18,
       fontWeight: '700',
       color: palette.text,
     },
@@ -4615,7 +4737,7 @@ const useStyles = () => {
       width: 32,
       height: 32,
       borderRadius: 16,
-      backgroundColor: palette.bgPane,
+      backgroundColor: palette.bgElev,
       alignItems: 'center',
       justifyContent: 'center',
     },
@@ -4625,7 +4747,7 @@ const useStyles = () => {
       fontWeight: '600',
     },
     stage4DrawerScroll: {
-      paddingVertical: 8,
+      paddingBottom: 8,
     },
     closeOverlay: {
       position: 'absolute',

--- a/mobile/src/utils/getWaitingStatus.ts
+++ b/mobile/src/utils/getWaitingStatus.ts
@@ -28,6 +28,7 @@ export type WaitingStatusState =
   | 'needs-validation-pending' // Stage 3: Waiting for partner to confirm needs validation
   | 'partner-validating-needs' // Stage 3: User validated revealed needs, waiting for partner
   | 'ranking-pending' // Stage 4: Waiting for partner to submit ranking
+  | 'stage4-selections-pending' // Stage 4 (redesigned): User shared willingness stances, waiting for partner
   | 'strategy-readiness-pending' // Stage 4: User is ready to rank, waiting for partner readiness
   | 'partner-signed' // Partner has signed compact (transient)
   | 'partner-completed-witness' // Partner completed witness stage (transient)
@@ -115,6 +116,13 @@ export interface WaitingStatusInputs {
     agreedByMe: boolean;
     agreedByPartner: boolean;
   }>;
+
+  // Stage 4 (redesigned): per-proposal willingness share status
+  stage4Selections?: {
+    mySelectionSubmitted: boolean;
+    partnerSelectionSubmitted: boolean;
+    hasOutcome: boolean;
+  };
   sessionStatus?: string; // SessionStatus enum value
 }
 
@@ -326,6 +334,17 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
 
   if (strategyPhase === StrategyPhase.REVEALING && overlappingStrategies.count === 0) {
     return 'ranking-pending';
+  }
+
+  // Stage 4 redesign: I shared my willingness stances, partner hasn't yet.
+  if (
+    myStage === Stage.STRATEGIC_REPAIR &&
+    inputs.stage4Selections &&
+    inputs.stage4Selections.mySelectionSubmitted &&
+    !inputs.stage4Selections.partnerSelectionSubmitted &&
+    !inputs.stage4Selections.hasOutcome
+  ) {
+    return 'stage4-selections-pending';
   }
 
   // --- Priority 7: Stage 4 (Agreement Confirmation) ---

--- a/shared/src/dto/strategy.ts
+++ b/shared/src/dto/strategy.ts
@@ -324,6 +324,7 @@ export interface GetStage4StateResponse {
   coverageAudit: Stage4CoverageAuditDTO;
   mySelections: Stage4SelectionDTO[];
   partnerSelections: Stage4SelectionDTO[];
+  mySelectionStatus: 'NOT_STARTED' | 'SUBMITTED';
   partnerSelectionStatus: 'NOT_STARTED' | 'SUBMITTED';
   outcome: Stage4OutcomeDTO | null;
   tendingPreview: TendingPreviewDTO | null;


### PR DESCRIPTION
## Summary

Replaces the implicit "shared the moment you tap a stance" model in the redesigned Stage 4 "What comes next" drawer with an explicit Share gate that matches how earlier stages hand off between partners. Tapping Willing/Discuss/Not-willing now updates a private draft; users actively share with **Share my stances with X**, and either pull back with **I'm not ready yet** or change a stance (which auto-unshares).

The DTO grows a `mySelectionStatus` field. `buildStage4State` no longer auto-flips submitted-status based on completeness, so symmetric reveal (you both see at once) is finally real. Chat input + emotion slider hide via the standard `WaitingStatusState` machinery — same pipeline as needs-waiting-for-partner.

Drawer chrome: drag-handle header, sticky footer (extracted as `Stage4RedesignFooter` rendered outside the ScrollView), segmented stance control instead of look-alike pills, no more "Stage 4" leak in copy. Backend coverage note "Still open for Stage 4 discussion" → "Not yet addressed by a proposal."

Partner gets a transient toast when their counterpart pulls stances back, so vanishing data has an explanation.

## What's new

**Backend**
- `POST /sessions/:id/stage4/share-selections` — sets gate, requires a stance on every active shared proposal
- `POST /sessions/:id/stage4/unshare-selections` — clears gate, notifies partner with `change: 'stage4_selection_revised'`
- Per-tap selection endpoint no longer flips the gate; clears it if previously shared
- `GetStage4StateResponse.mySelectionStatus: 'NOT_STARTED' | 'SUBMITTED'`

**Mobile**
- `useShareStage4Selections` / `useUnshareStage4Selections` with optimistic cache updates
- New waiting state `stage4-selections-pending` in `WaitingStatusState`; banner gains optional `actionLabel` + `onActionPress`
- State-driven CTA copy above chat input ("Ready to share", "Waiting for Eve", "You and Eve agree on at least one proposal")
- Symmetric-reveal copy throughout: *"Hidden until Darryl shares too — then you'll both see at once."*

## Test plan
- [ ] Take stances on all proposals → Share CTA enables → tap → drawer flips to waiting, chat input + emotion slider hide
- [ ] In waiting state, tap **Review** in the banner → drawer opens; **I'm not ready yet** unshares; chat returns
- [ ] Change a stance in the drawer after sharing → mySelectionStatus reverts → Share CTA reappears
- [ ] Both share with at least one mutual Willing → close-with-shared-agreement enables
- [ ] Partner side: when other party pulls stances back, see warning toast and partner-decision visibility goes blank
- [ ] No "Stage 4" or "partner" wording leaks into user-facing copy
- [ ] `npm run check` and `npm run test` clean across workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)