### PR TITLE
Stage 4 Phase 1: drop Discuss + new closure surface

### DIFF
--- a/backend/prisma/migrations/20260512000000_drop_stage4_needs_discussion/migration.sql
+++ b/backend/prisma/migrations/20260512000000_drop_stage4_needs_discussion/migration.sql
@@ -1,0 +1,17 @@
+-- Drop NEEDS_DISCUSSION from Stage4SelectionDecision enum.
+-- 1. Rewrite any existing selections using the removed value to NOT_WILLING.
+-- 2. Recreate the enum without NEEDS_DISCUSSION and swap it in.
+
+UPDATE "Stage4ProposalSelection"
+SET "decision" = 'NOT_WILLING'
+WHERE "decision" = 'NEEDS_DISCUSSION';
+
+ALTER TYPE "Stage4SelectionDecision" RENAME TO "Stage4SelectionDecision_old";
+
+CREATE TYPE "Stage4SelectionDecision" AS ENUM ('WILLING', 'NOT_WILLING');
+
+ALTER TABLE "Stage4ProposalSelection"
+  ALTER COLUMN "decision" TYPE "Stage4SelectionDecision"
+  USING ("decision"::text::"Stage4SelectionDecision");
+
+DROP TYPE "Stage4SelectionDecision_old";

--- a/backend/prisma/migrations/20260512000100_add_stage4_closure_check_in_at/migration.sql
+++ b/backend/prisma/migrations/20260512000100_add_stage4_closure_check_in_at/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Stage4Closure" ADD COLUMN "checkInAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -973,7 +973,6 @@ enum Stage4ProposalStatus {
 enum Stage4SelectionDecision {
   WILLING
   NOT_WILLING
-  NEEDS_DISCUSSION
 }
 
 enum Stage4ClosureKind {
@@ -1062,6 +1061,7 @@ model Stage4Closure {
   sharedAgreementIds    String[]
   individualProposalIds String[]
   openNeedIds           String[]
+  checkInAt             DateTime?
   closedByUserId        String?
   closedAt              DateTime            @default(now())
   createdAt             DateTime            @default(now())

--- a/backend/src/__tests__/prisma-schema.test.ts
+++ b/backend/src/__tests__/prisma-schema.test.ts
@@ -179,7 +179,6 @@ describe('Prisma Schema', () => {
       expect(Stage4ProposalStatus.CONVERTED_TO_AGREEMENT).toBe('CONVERTED_TO_AGREEMENT');
       expect(Stage4SelectionDecision.WILLING).toBe('WILLING');
       expect(Stage4SelectionDecision.NOT_WILLING).toBe('NOT_WILLING');
-      expect(Stage4SelectionDecision.NEEDS_DISCUSSION).toBe('NEEDS_DISCUSSION');
       expect(Stage4ClosureKind.SHARED_AGREEMENT).toBe('SHARED_AGREEMENT');
       expect(Stage4ClosureKind.NO_SHARED_AGREEMENT).toBe('NO_SHARED_AGREEMENT');
       expect(Stage4ClosureReason.MUTUAL_SELECTION).toBe('MUTUAL_SELECTION');

--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -136,6 +136,14 @@ const closeStage4RequestSchema = z.object({
   kind: z.nativeEnum(Stage4ClosureKind).optional(),
   reason: z.nativeEnum(Stage4ClosureReason).optional(),
   summary: z.string().max(2000).optional(),
+  checkInDate: z
+    .string({ required_error: 'checkInDate is required' })
+    .min(1, 'checkInDate is required')
+    .refine((value) => !Number.isNaN(new Date(value).getTime()), {
+      message: 'checkInDate must be a valid ISO date string',
+    }),
+  // Optional, deprecated. Kept for backward compatibility — Phase 4 removes it.
+  // TODO(phase-4): remove followUpDatesByProposalId; checkInDate is the single source.
   followUpDatesByProposalId: z.record(z.string()).optional(),
 });
 
@@ -796,10 +804,12 @@ export async function closeStage4(req: Request, res: Response): Promise<void> {
         followUpDate: Date | null;
       }> = [];
 
+      const checkInAt = new Date(parseResult.data.checkInDate);
+
       if (closureKind === Stage4ClosureKind.SHARED_AGREEMENT) {
         for (const proposal of mutuallyWillingSharedProposals) {
-          const followUpDate = parseResult.data.followUpDatesByProposalId?.[proposal.id];
-          const parsedFollowUpDate = followUpDate ? new Date(followUpDate) : null;
+          const legacyFollowUp = parseResult.data.followUpDatesByProposalId?.[proposal.id];
+          const parsedFollowUpDate = legacyFollowUp ? new Date(legacyFollowUp) : checkInAt;
           const agreement = await tx.agreement.create({
             data: {
               sharedVesselId: sharedVessel.id,
@@ -852,6 +862,7 @@ export async function closeStage4(req: Request, res: Response): Promise<void> {
           sharedAgreementIds: createdAgreementIds,
           individualProposalIds,
           openNeedIds,
+          checkInAt,
           closedByUserId: user.id,
           closedAt: now,
         },

--- a/backend/src/routes/__tests__/stage4.test.ts
+++ b/backend/src/routes/__tests__/stage4.test.ts
@@ -457,7 +457,7 @@ describe('Stage 4 API', () => {
         {
           proposalId: mockStrategyIds[0],
           userId: mockPartnerId,
-          decision: Stage4SelectionDecision.NEEDS_DISCUSSION,
+          decision: Stage4SelectionDecision.NOT_WILLING,
           note: 'Timing is still unclear',
           selectedAt: new Date('2026-05-06T10:03:00.000Z'),
           updatedAt: new Date('2026-05-06T10:03:00.000Z'),
@@ -491,7 +491,7 @@ describe('Stage 4 API', () => {
               sharedProposals: [
                 expect.objectContaining({
                   myDecision: Stage4SelectionDecision.WILLING,
-                  partnerDecisionVisible: Stage4SelectionDecision.NEEDS_DISCUSSION,
+                  partnerDecisionVisible: Stage4SelectionDecision.NOT_WILLING,
                 }),
               ],
             }),
@@ -931,6 +931,7 @@ describe('Stage 4 API', () => {
         user: mockUser,
         params: { id: mockSessionId },
         body: {
+          checkInDate: '2026-05-13T10:00:00.000Z',
           followUpDatesByProposalId: {
             [mockStrategyIds[0]]: '2026-05-13T10:00:00.000Z',
           },
@@ -1090,7 +1091,7 @@ describe('Stage 4 API', () => {
       const req = createMockRequest({
         user: mockUser,
         params: { id: mockSessionId },
-        body: {},
+        body: { checkInDate: '2026-06-03T10:00:00.000Z' },
       });
       const { res, statusMock, jsonMock } = createMockResponse();
 
@@ -1231,6 +1232,7 @@ describe('Stage 4 API', () => {
         params: { id: mockSessionId },
         body: {
           kind: Stage4ClosureKind.SHARED_AGREEMENT,
+          checkInDate: '2026-06-03T10:00:00.000Z',
         },
       });
       const { res, statusMock, jsonMock } = createMockResponse();
@@ -1273,12 +1275,84 @@ describe('Stage 4 API', () => {
       );
     });
 
+    it('rejects close requests that omit checkInDate with VALIDATION_ERROR', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+        body: {},
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      await closeStage4(req as Request, res as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ code: 'VALIDATION_ERROR' }),
+        })
+      );
+      expect(prisma.stage4Closure.create).not.toHaveBeenCalled();
+    });
+
+    it('persists Stage4Closure.checkInAt from the request body', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+        body: { checkInDate: '2026-06-03T10:00:00.000Z' },
+      });
+      const { res } = createMockResponse();
+
+      (prisma.session.findFirst as jest.Mock)
+        .mockResolvedValueOnce(mockSession())
+        .mockResolvedValueOnce(mockSession());
+      (prisma.stageProgress.findFirst as jest.Mock)
+        .mockResolvedValueOnce({ stage: 4, status: 'IN_PROGRESS', gatesSatisfied: { selectionSubmitted: true } })
+        .mockResolvedValueOnce({ stage: 4, status: 'IN_PROGRESS', gatesSatisfied: { selectionSubmitted: true } });
+      (prisma.stage4Closure.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          kind: Stage4ClosureKind.NO_SHARED_AGREEMENT,
+          reason: Stage4ClosureReason.NO_OVERLAP,
+          summary: 'closed',
+          sharedAgreementIds: [],
+          individualProposalIds: [],
+          openNeedIds: [],
+          closedAt: new Date('2026-05-06T10:04:00.000Z'),
+          checkInAt: new Date('2026-06-03T10:00:00.000Z'),
+        });
+      (prisma.strategyProposal.findMany as jest.Mock)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      (prisma.stage4ProposalSelection.findMany as jest.Mock)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      (prisma.stage4NeedCoverage.findMany as jest.Mock)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      (prisma.sharedVessel.findUnique as jest.Mock).mockResolvedValue({ id: 'shared-vessel-1' });
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.agreement.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([]);
+
+      await closeStage4(req as Request, res as Response);
+
+      expect(prisma.stage4Closure.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            checkInAt: new Date('2026-06-03T10:00:00.000Z'),
+          }),
+        })
+      );
+    });
+
     it('closes a shared agreement when mutual willingness exists even if unrelated active fragments are unreviewed', async () => {
       const req = createMockRequest({
         user: mockUser,
         params: { id: mockSessionId },
         body: {
           kind: Stage4ClosureKind.SHARED_AGREEMENT,
+          checkInDate: '2026-06-03T10:00:00.000Z',
         },
       });
       const { res, statusMock, jsonMock } = createMockResponse();

--- a/backend/src/scripts/mwf-moment-real.ts
+++ b/backend/src/scripts/mwf-moment-real.ts
@@ -402,7 +402,7 @@ async function seedGenericMoment(moment: MomentPayload): Promise<SeedResult> {
             proposalId: created.id,
             sessionId: session.id,
             userId: selectedUser.id,
-            decision: choice === 'NOT_WILLING' ? 'NOT_WILLING' : choice === 'NEEDS_DISCUSSION' ? 'NEEDS_DISCUSSION' : 'WILLING',
+            decision: choice === 'NOT_WILLING' ? 'NOT_WILLING' : 'WILLING',
           },
         });
       }

--- a/backend/src/services/stage4-capture.service.ts
+++ b/backend/src/services/stage4-capture.service.ts
@@ -439,8 +439,6 @@ function extractSelection(text: string, userId: string, proposals: ProposalRow[]
   let decision: Stage4SelectionDecision | null = null;
   if (/\b(?:not willing|won't|do not want|don't want|no to)\b/i.test(text)) {
     decision = Stage4SelectionDecision.NOT_WILLING;
-  } else if (/\b(?:needs discussion|need to discuss|talk more|not sure yet)\b/i.test(text)) {
-    decision = Stage4SelectionDecision.NEEDS_DISCUSSION;
   } else if (/\b(?:willing|yes to|i can try|i'd try|i would try|works for me)\b/i.test(text)) {
     decision = Stage4SelectionDecision.WILLING;
   }

--- a/backend/src/services/stage4-state.ts
+++ b/backend/src/services/stage4-state.ts
@@ -64,6 +64,7 @@ type Stage4ClosureRow = {
   individualProposalIds: string[];
   openNeedIds: string[];
   closedAt: Date;
+  checkInAt: Date | null;
 };
 
 type Stage4ProgressRow = {
@@ -459,6 +460,7 @@ export async function getStage4State(
           individualCommitments: proposalCards.filter((proposal) => closedIndividualIds.has(proposal.id)),
           openNeeds: unaddressedNeeds.filter((need) => need.id && openNeedIds.has(need.id)),
           closedAt: closure.closedAt.toISOString(),
+          checkInAt: closure.checkInAt ? closure.checkInAt.toISOString() : null,
         }
       : null,
     tendingPreview: buildTendingPreview(closure, tendingEntries),

--- a/backend/src/testing/state-factory.ts
+++ b/backend/src/testing/state-factory.ts
@@ -2159,8 +2159,8 @@ export class StateFactory {
         ? [
             { proposalId: sharedCheckin.id, userId: userAId, decision: Stage4SelectionDecision.WILLING },
             { proposalId: sharedCheckin.id, userId: userBId, decision: Stage4SelectionDecision.WILLING },
-            { proposalId: sharedPause.id, userId: userAId, decision: Stage4SelectionDecision.NEEDS_DISCUSSION },
-            { proposalId: sharedPause.id, userId: userBId, decision: Stage4SelectionDecision.NEEDS_DISCUSSION },
+            { proposalId: sharedPause.id, userId: userAId, decision: Stage4SelectionDecision.NOT_WILLING },
+            { proposalId: sharedPause.id, userId: userBId, decision: Stage4SelectionDecision.NOT_WILLING },
             { proposalId: individualCommitment.id, userId: userAId, decision: Stage4SelectionDecision.WILLING },
           ]
         : targetStage === TargetStage.STAGE4_REDESIGN_NO_OVERLAP_SELECTIONS

--- a/mobile/src/components/SessionCompletionScreen.tsx
+++ b/mobile/src/components/SessionCompletionScreen.tsx
@@ -25,9 +25,21 @@ interface AgreementSummary {
   followUpDate: string | null;
 }
 
+interface IndividualCommitmentSummary {
+  id: string;
+  description: string;
+}
+
+interface OpenNeedSummary {
+  id: string;
+  label: string;
+}
+
 interface SessionCompletionScreenProps {
   partnerName: string;
   agreements: AgreementSummary[];
+  individualCommitments?: IndividualCommitmentSummary[];
+  openNeeds?: OpenNeedSummary[];
   tendingPanel?: ReactNode;
   onViewHistory: () => void;
   onReturnToSessions: () => void;
@@ -41,6 +53,8 @@ interface SessionCompletionScreenProps {
 export function SessionCompletionScreen({
   partnerName,
   agreements,
+  individualCommitments = [],
+  openNeeds = [],
   tendingPanel,
   onViewHistory,
   onReturnToSessions,
@@ -63,13 +77,13 @@ export function SessionCompletionScreen({
         </Text>
       </View>
 
-      {/* Agreements section */}
-      {agreements.length > 0 && (
-        <View style={styles.agreementsSection}>
-          <Text style={styles.sectionTitle}>
-            {agreements.length === 1 ? 'Your Next Step' : 'Your Next Steps'}
-          </Text>
-          {agreements.map((agreement) => (
+      {/* Shared experiments */}
+      <View style={styles.agreementsSection} testID="shared-experiments-section">
+        <Text style={styles.sectionTitle}>Shared experiments</Text>
+        {agreements.length === 0 ? (
+          <Text style={styles.emptyPlaceholder}>—</Text>
+        ) : (
+          agreements.map((agreement) => (
             <AgreementSummaryCard
               key={agreement.id}
               experiment={agreement.experiment}
@@ -78,9 +92,44 @@ export function SessionCompletionScreen({
               followUpDate={agreement.followUpDate}
               testID={`agreement-summary-${agreement.id}`}
             />
-          ))}
-        </View>
-      )}
+          ))
+        )}
+      </View>
+
+      {/* Individual commitments */}
+      <View style={styles.agreementsSection} testID="individual-commitments-section">
+        <Text style={styles.sectionTitle}>Individual commitments</Text>
+        {individualCommitments.length === 0 ? (
+          <Text style={styles.emptyPlaceholder}>—</Text>
+        ) : (
+          individualCommitments.map((commitment) => (
+            <View
+              key={commitment.id}
+              style={styles.bulletRow}
+              testID={`individual-commitment-${commitment.id}`}
+            >
+              <Text style={styles.bulletText}>{commitment.description}</Text>
+            </View>
+          ))
+        )}
+      </View>
+
+      {/* Named but not addressed */}
+      <View style={styles.agreementsSection} testID="open-needs-section">
+        <Text style={styles.sectionTitle}>Named but not addressed</Text>
+        {openNeeds.length === 0 ? (
+          <Text style={styles.emptyPlaceholder}>—</Text>
+        ) : (
+          openNeeds.map((need) => (
+            <View key={need.id} style={styles.bulletRow} testID={`open-need-${need.id}`}>
+              <Text style={styles.bulletText}>{need.label}</Text>
+            </View>
+          ))
+        )}
+        <Text style={styles.openNeedsCopy}>
+          These remain on record. Not a failure — just yours to hold beyond this.
+        </Text>
+      </View>
 
       {/* Reminder note */}
       {hasFollowUp && (
@@ -170,6 +219,27 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.5,
     marginBottom: 12,
+  },
+
+  emptyPlaceholder: {
+    color: colors.textMuted,
+    fontSize: 15,
+    paddingVertical: 4,
+  },
+  bulletRow: {
+    paddingVertical: 6,
+  },
+  bulletText: {
+    color: colors.textPrimary,
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  openNeedsCopy: {
+    color: colors.textMuted,
+    fontSize: 13,
+    fontStyle: 'italic',
+    marginTop: 10,
+    lineHeight: 18,
   },
 
   // Reminder

--- a/mobile/src/components/Stage4RedesignPanel.tsx
+++ b/mobile/src/components/Stage4RedesignPanel.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useMemo, useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 import { MinusCircle, Send, RotateCcw, Share2, XCircle } from 'lucide-react-native';
 import {
   GetStage4StateResponse,
@@ -25,7 +25,7 @@ interface Stage4RedesignPanelProps {
   onSelectProposal: (proposalId: string, decision: Stage4SelectionDecision) => void;
   onShareSelections?: () => void;
   onReviseSelections?: () => void;
-  onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason) => void;
+  onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason, checkInDate: string) => void;
 }
 
 interface Stage4RedesignFooterProps {
@@ -36,12 +36,11 @@ interface Stage4RedesignFooterProps {
   isRevising?: boolean;
   onShareSelections?: () => void;
   onReviseSelections?: () => void;
-  onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason) => void;
+  onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason, checkInDate: string) => void;
 }
 
 const decisionLabels: Record<Stage4SelectionDecision, string> = {
   [Stage4SelectionDecision.WILLING]: 'Willing',
-  [Stage4SelectionDecision.NEEDS_DISCUSSION]: 'Discuss',
   [Stage4SelectionDecision.NOT_WILLING]: 'Not willing',
 };
 
@@ -70,6 +69,159 @@ function proposalKindLabel(kind: Stage4ProposalKind): string {
   return kind === Stage4ProposalKind.INDIVIDUAL_COMMITMENT
     ? 'Individual commitment'
     : 'Shared proposal';
+}
+
+function defaultCheckInDate(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 28);
+  return date.toISOString().slice(0, 10);
+}
+
+const DATE_INPUT_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function CloseControls({
+  canCloseShared,
+  showNoSharedClose,
+  canCloseNoShared,
+  isClosing,
+  partnerName,
+  onCloseStage4,
+}: {
+  canCloseShared: boolean;
+  showNoSharedClose: boolean;
+  canCloseNoShared: boolean;
+  isClosing: boolean;
+  partnerName: string;
+  onCloseStage4: (
+    kind: Stage4ClosureKind,
+    reason: Stage4ClosureReason,
+    checkInDate: string,
+  ) => void;
+}) {
+  const { palette } = useAppAppearance();
+  const styles = useMemo(() => makeStyles(palette), [palette]);
+  const [pending, setPending] = useState<
+    | { kind: Stage4ClosureKind; reason: Stage4ClosureReason }
+    | null
+  >(null);
+  const [checkInDate, setCheckInDate] = useState<string>(defaultCheckInDate);
+  const noSharedCloseDisabled = !canCloseNoShared || isClosing;
+  const dateValid = DATE_INPUT_PATTERN.test(checkInDate.trim());
+
+  if (pending) {
+    const isShared = pending.kind === Stage4ClosureKind.SHARED_AGREEMENT;
+    return (
+      <View style={styles.actions}>
+        <Text style={styles.closeConfirmTitle}>
+          {isShared ? 'Close with shared agreement' : 'Close without a shared agreement'}
+        </Text>
+        <Text style={styles.closeConfirmCopy}>
+          {isShared
+            ? `Pick a check-in date. You'll both see this on the shared experiment.`
+            : `That's a valid place to land. Whatever you've named here stays on record.`}
+        </Text>
+        <Text style={styles.dateLabel}>Check-in date (YYYY-MM-DD)</Text>
+        <TextInput
+          style={styles.dateInput}
+          value={checkInDate}
+          onChangeText={setCheckInDate}
+          placeholder="YYYY-MM-DD"
+          placeholderTextColor={palette.textFaint}
+          autoCapitalize="none"
+          autoCorrect={false}
+          testID="stage4-close-check-in-date"
+          accessibilityLabel="Check-in date"
+        />
+        {!dateValid && (
+          <Text style={styles.actionHint}>Enter a date like 2026-06-09.</Text>
+        )}
+        <TouchableOpacity
+          style={[
+            styles.primaryButton,
+            (!dateValid || isClosing) && styles.primaryButtonDisabled,
+          ]}
+          onPress={() => {
+            if (!dateValid || isClosing) return;
+            onCloseStage4(pending.kind, pending.reason, checkInDate.trim());
+          }}
+          disabled={!dateValid || isClosing}
+          accessibilityRole="button"
+          accessibilityLabel="Confirm close"
+          accessibilityState={{ disabled: !dateValid || isClosing }}
+          testID="stage4-close-confirm"
+        >
+          <Send color={dateValid ? palette.bg : palette.textFaint} size={17} />
+          <Text
+            style={[
+              styles.primaryButtonText,
+              (!dateValid || isClosing) && styles.disabledButtonText,
+            ]}
+          >
+            {isClosing ? 'Closing…' : 'Confirm close'}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.secondaryButton}
+          onPress={() => setPending(null)}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel close"
+        >
+          <Text style={styles.secondaryButtonText}>Back</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.actions}>
+      <TouchableOpacity
+        style={[styles.primaryButton, !canCloseShared && styles.primaryButtonDisabled]}
+        onPress={() =>
+          setPending({
+            kind: Stage4ClosureKind.SHARED_AGREEMENT,
+            reason: Stage4ClosureReason.MUTUAL_SELECTION,
+          })
+        }
+        disabled={!canCloseShared || isClosing}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: !canCloseShared || isClosing }}
+      >
+        <Send color={canCloseShared ? palette.bg : palette.textFaint} size={17} />
+        <Text style={[styles.primaryButtonText, !canCloseShared && styles.disabledButtonText]}>
+          Close with shared agreement
+        </Text>
+      </TouchableOpacity>
+      {showNoSharedClose && (
+        <TouchableOpacity
+          style={[styles.secondaryButton, noSharedCloseDisabled && styles.secondaryButtonDisabled]}
+          onPress={() =>
+            setPending({
+              kind: Stage4ClosureKind.NO_SHARED_AGREEMENT,
+              reason: Stage4ClosureReason.NO_OVERLAP,
+            })
+          }
+          disabled={noSharedCloseDisabled}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: noSharedCloseDisabled }}
+        >
+          <MinusCircle color={canCloseNoShared ? palette.text : palette.textFaint} size={17} />
+          <Text
+            style={[
+              styles.secondaryButtonText,
+              noSharedCloseDisabled && styles.disabledButtonText,
+            ]}
+          >
+            Close without a shared agreement
+          </Text>
+        </TouchableOpacity>
+      )}
+      {!canCloseShared && (
+        <Text style={styles.actionHint}>
+          A shared agreement is available once you and {partnerName} both say &ldquo;willing&rdquo; to the same proposal.
+        </Text>
+      )}
+    </View>
+  );
 }
 
 function partnerStateLabel(
@@ -129,7 +281,6 @@ function ProposalCard({
       <View style={styles.segmentedControl}>
         {[
           Stage4SelectionDecision.WILLING,
-          Stage4SelectionDecision.NEEDS_DISCUSSION,
           Stage4SelectionDecision.NOT_WILLING,
         ].map((decision) => {
           const selected = proposal.myDecision === decision;
@@ -229,7 +380,6 @@ export function Stage4RedesignFooter({
     state.phase === Stage4Phase.OUTCOME_REVIEW ||
     state.phase === Stage4Phase.SELECTION ||
     state.phase === Stage4Phase.COVERAGE_REVIEW;
-  const noSharedCloseDisabled = !canCloseNoShared || isClosing;
   const mySelectionSubmitted = state.mySelectionStatus === 'SUBMITTED';
   const partnerReady = state.partnerSelectionStatus === 'SUBMITTED';
   const allMyDecisionsMade =
@@ -313,49 +463,14 @@ export function Stage4RedesignFooter({
 
   return (
     <View style={styles.footerContainer}>
-      <View style={styles.actions}>
-        <TouchableOpacity
-          style={[styles.primaryButton, !canCloseShared && styles.primaryButtonDisabled]}
-          onPress={() =>
-            onCloseStage4(
-              Stage4ClosureKind.SHARED_AGREEMENT,
-              Stage4ClosureReason.MUTUAL_SELECTION,
-            )
-          }
-          disabled={!canCloseShared || isClosing}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: !canCloseShared || isClosing }}
-        >
-          <Send color={canCloseShared ? palette.bg : palette.textFaint} size={17} />
-          <Text style={[styles.primaryButtonText, !canCloseShared && styles.disabledButtonText]}>
-            Close with shared agreement
-          </Text>
-        </TouchableOpacity>
-        {showNoSharedClose && (
-          <TouchableOpacity
-            style={[styles.secondaryButton, noSharedCloseDisabled && styles.secondaryButtonDisabled]}
-            onPress={() =>
-              onCloseStage4(
-                Stage4ClosureKind.NO_SHARED_AGREEMENT,
-                Stage4ClosureReason.NO_OVERLAP,
-              )
-            }
-            disabled={noSharedCloseDisabled}
-            accessibilityRole="button"
-            accessibilityState={{ disabled: noSharedCloseDisabled }}
-          >
-            <MinusCircle color={canCloseNoShared ? palette.text : palette.textFaint} size={17} />
-            <Text style={[styles.secondaryButtonText, noSharedCloseDisabled && styles.disabledButtonText]}>
-              Close without a shared agreement
-            </Text>
-          </TouchableOpacity>
-        )}
-        {!canCloseShared && (
-          <Text style={styles.actionHint}>
-            A shared agreement is available once you and {who} both say &ldquo;willing&rdquo; to the same proposal.
-          </Text>
-        )}
-      </View>
+      <CloseControls
+        canCloseShared={canCloseShared}
+        showNoSharedClose={showNoSharedClose}
+        canCloseNoShared={canCloseNoShared}
+        isClosing={isClosing}
+        partnerName={who}
+        onCloseStage4={onCloseStage4}
+      />
     </View>
   );
 }
@@ -397,7 +512,6 @@ export function Stage4RedesignPanel({
     state.phase === Stage4Phase.OUTCOME_REVIEW ||
     state.phase === Stage4Phase.SELECTION ||
     state.phase === Stage4Phase.COVERAGE_REVIEW;
-  const noSharedCloseDisabled = !canCloseNoShared || isClosing;
   const mySelectionSubmitted = state.mySelectionStatus === 'SUBMITTED';
   // Stances stay editable after sharing — changing one auto-unshares on the
   // backend, so the partner never sees a stale stance. Only a finalized
@@ -553,53 +667,14 @@ export function Stage4RedesignPanel({
 
         // (d) Both shared → close buttons.
         return (
-          <View style={styles.actions}>
-            <TouchableOpacity
-              style={[styles.primaryButton, !canCloseShared && styles.primaryButtonDisabled]}
-              onPress={() =>
-                onCloseStage4(
-                  Stage4ClosureKind.SHARED_AGREEMENT,
-                  Stage4ClosureReason.MUTUAL_SELECTION
-                )
-              }
-              disabled={!canCloseShared || isClosing}
-              accessibilityRole="button"
-              accessibilityState={{ disabled: !canCloseShared || isClosing }}
-            >
-              <Send color={canCloseShared ? palette.bg : palette.textFaint} size={17} />
-              <Text style={[styles.primaryButtonText, !canCloseShared && styles.disabledButtonText]}>
-                Close with shared agreement
-              </Text>
-            </TouchableOpacity>
-
-            {showNoSharedClose && (
-              <TouchableOpacity
-                style={[styles.secondaryButton, noSharedCloseDisabled && styles.secondaryButtonDisabled]}
-                onPress={() =>
-                  onCloseStage4(
-                    Stage4ClosureKind.NO_SHARED_AGREEMENT,
-                    Stage4ClosureReason.NO_OVERLAP
-                  )
-                }
-                disabled={noSharedCloseDisabled}
-                accessibilityRole="button"
-                accessibilityState={{ disabled: noSharedCloseDisabled }}
-              >
-                <MinusCircle color={canCloseNoShared ? palette.text : palette.textFaint} size={17} />
-                <Text style={[
-                  styles.secondaryButtonText,
-                  noSharedCloseDisabled && styles.disabledButtonText,
-                ]}>
-                  Close without a shared agreement
-                </Text>
-              </TouchableOpacity>
-            )}
-            {!canCloseShared && (
-              <Text style={styles.actionHint}>
-                A shared agreement is available once you and {who} both say &ldquo;willing&rdquo; to the same proposal.
-              </Text>
-            )}
-          </View>
+          <CloseControls
+            canCloseShared={canCloseShared}
+            showNoSharedClose={showNoSharedClose}
+            canCloseNoShared={canCloseNoShared}
+            isClosing={isClosing}
+            partnerName={who}
+            onCloseStage4={onCloseStage4}
+          />
         );
       })()}
 
@@ -861,6 +936,33 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
     fontSize: 12,
     lineHeight: 17,
     textAlign: 'center',
+  },
+  closeConfirmTitle: {
+    color: palette.text,
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  closeConfirmCopy: {
+    color: palette.textMuted,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  dateLabel: {
+    color: palette.textMuted,
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  dateInput: {
+    minHeight: 44,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: palette.border,
+    paddingHorizontal: 12,
+    color: palette.text,
+    fontSize: 15,
+    backgroundColor: palette.bgPane,
   },
   closedNote: {
     flexDirection: 'row',

--- a/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
+++ b/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
@@ -52,7 +52,7 @@ const baseState: GetStage4StateResponse = {
         duration: null,
         measureOfSuccess: null,
         status: Stage4ProposalStatus.ACTIVE,
-        myDecision: Stage4SelectionDecision.NEEDS_DISCUSSION,
+        myDecision: Stage4SelectionDecision.NOT_WILLING,
       },
     ],
     unaddressedNeeds: [
@@ -138,6 +138,17 @@ describe('Stage4RedesignPanel', () => {
     );
   });
 
+  it('offers only the two binary stance options per proposal', () => {
+    render(<Stage4RedesignPanel {...defaultProps} />);
+
+    const willing = screen.getAllByLabelText('Willing for proposal');
+    const notWilling = screen.getAllByLabelText('Not willing for proposal');
+
+    expect(willing.length).toBeGreaterThan(0);
+    expect(notWilling.length).toBeGreaterThan(0);
+    expect(screen.queryByText('Discuss')).toBeNull();
+  });
+
   it('enables shared-agreement closure only when mutual willingness is visible', () => {
     const state: GetStage4StateResponse = {
       ...baseState,
@@ -158,11 +169,46 @@ describe('Stage4RedesignPanel', () => {
     render(<Stage4RedesignPanel {...defaultProps} state={state} />);
 
     fireEvent.press(screen.getByText('Close with shared agreement'));
+    // Pressing the close button only opens the check-in step — it must not
+    // call onCloseStage4 yet, because checkInDate is required.
+    expect(defaultProps.onCloseStage4).not.toHaveBeenCalled();
+
+    fireEvent.press(screen.getByTestId('stage4-close-confirm'));
 
     expect(defaultProps.onCloseStage4).toHaveBeenCalledWith(
       Stage4ClosureKind.SHARED_AGREEMENT,
-      Stage4ClosureReason.MUTUAL_SELECTION
+      Stage4ClosureReason.MUTUAL_SELECTION,
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)
     );
+  });
+
+  it('blocks the confirm-close CTA when the check-in date is empty', () => {
+    const state: GetStage4StateResponse = {
+      ...baseState,
+      phase: Stage4Phase.OUTCOME_REVIEW,
+      mySelectionStatus: 'SUBMITTED',
+      partnerSelectionStatus: 'SUBMITTED',
+      inventory: {
+        ...baseState.inventory,
+        sharedProposals: [
+          {
+            ...baseState.inventory.sharedProposals[0],
+            partnerDecisionVisible: Stage4SelectionDecision.WILLING,
+          },
+        ],
+      },
+    };
+
+    render(<Stage4RedesignPanel {...defaultProps} state={state} />);
+
+    fireEvent.press(screen.getByText('Close with shared agreement'));
+    fireEvent.changeText(screen.getByTestId('stage4-close-check-in-date'), '');
+
+    const confirm = screen.getByTestId('stage4-close-confirm');
+    expect(confirm).toBeDisabled();
+
+    fireEvent.press(confirm);
+    expect(defaultProps.onCloseStage4).not.toHaveBeenCalled();
   });
 
   it('enables shared-agreement closure when mutual willingness exists even if other active fragments are unreviewed', () => {
@@ -195,14 +241,13 @@ describe('Stage4RedesignPanel', () => {
     expect(closeButton).not.toBeDisabled();
 
     fireEvent.press(closeButton);
+    fireEvent.press(screen.getByTestId('stage4-close-confirm'));
 
     expect(defaultProps.onCloseStage4).toHaveBeenCalledWith(
       Stage4ClosureKind.SHARED_AGREEMENT,
-      Stage4ClosureReason.MUTUAL_SELECTION
+      Stage4ClosureReason.MUTUAL_SELECTION,
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)
     );
-
-    const noSharedButton = screen.getByText('Close without a shared agreement');
-    expect(noSharedButton).not.toBeDisabled();
   });
 
   it('shows the share CTA when stances are complete but not yet shared', () => {
@@ -283,10 +328,12 @@ describe('Stage4RedesignPanel', () => {
     expect(closeButton).not.toBeDisabled();
 
     fireEvent.press(closeButton);
+    fireEvent.press(screen.getByTestId('stage4-close-confirm'));
 
     expect(defaultProps.onCloseStage4).toHaveBeenCalledWith(
       Stage4ClosureKind.NO_SHARED_AGREEMENT,
-      Stage4ClosureReason.NO_OVERLAP
+      Stage4ClosureReason.NO_OVERLAP,
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)
     );
   });
 
@@ -302,6 +349,7 @@ describe('Stage4RedesignPanel', () => {
         individualCommitments: [],
         openNeeds: baseState.inventory.unaddressedNeeds,
         closedAt: '2026-05-06T00:00:00.000Z',
+        checkInAt: '2026-06-03T00:00:00.000Z',
       },
     };
 
@@ -324,6 +372,7 @@ describe('Stage4RedesignPanel', () => {
         individualCommitments: [],
         openNeeds: baseState.inventory.unaddressedNeeds,
         closedAt: '2026-05-06T00:00:00.000Z',
+        checkInAt: '2026-06-03T00:00:00.000Z',
       },
     };
 
@@ -363,6 +412,7 @@ describe('Stage4RedesignPanel', () => {
         individualCommitments: [],
         openNeeds: [],
         closedAt: '2026-05-06T00:00:00.000Z',
+        checkInAt: '2026-06-03T00:00:00.000Z',
       },
     };
 

--- a/mobile/src/hooks/__tests__/useStages.test.ts
+++ b/mobile/src/hooks/__tests__/useStages.test.ts
@@ -1097,7 +1097,7 @@ describe('useStages', () => {
             selections: [
               {
                 proposalId: 'proposal-1',
-                decision: Stage4SelectionDecision.NEEDS_DISCUSSION,
+                decision: Stage4SelectionDecision.NOT_WILLING,
               },
             ],
           });
@@ -1107,7 +1107,7 @@ describe('useStages', () => {
           selections: [
             {
               proposalId: 'proposal-1',
-              decision: Stage4SelectionDecision.NEEDS_DISCUSSION,
+              decision: Stage4SelectionDecision.NOT_WILLING,
             },
           ],
         });

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1514,11 +1514,12 @@ export function UnifiedSessionScreen({
     );
   }, [unshareStage4Selections, sessionId, showError]);
   const handleCloseRedesignedStage4 = useCallback(
-    (kind: Stage4ClosureKind, reason: Stage4ClosureReason) => {
+    (kind: Stage4ClosureKind, reason: Stage4ClosureReason, checkInDate: string) => {
       closeStage4.mutate({
         sessionId,
         kind,
         reason,
+        checkInDate,
       });
     },
     [closeStage4, sessionId]
@@ -3311,6 +3312,17 @@ export function UnifiedSessionScreen({
             measureOfSuccess: a.measureOfSuccess,
             followUpDate: a.followUpDate,
           }))}
+          individualCommitments={
+            stage4State?.outcome?.individualCommitments.map((c) => ({
+              id: c.id,
+              description: c.description,
+            })) ?? []
+          }
+          openNeeds={
+            stage4State?.outcome?.openNeeds
+              .filter((n): n is typeof n & { id: string } => Boolean(n.id))
+              .map((n) => ({ id: n.id, label: n.label })) ?? []
+          }
           tendingPanel={tendingPanel}
           onViewHistory={() => setViewingResolvedHistory(true)}
           onReturnToSessions={() => onNavigateBack?.()}
@@ -3800,8 +3812,8 @@ export function UnifiedSessionScreen({
                 onSelectProposal={handleStage4Selection}
                 onShareSelections={handleShareStage4Selections}
                 onReviseSelections={handleReviseStage4Selections}
-                onCloseStage4={(kind, reason) => {
-                  handleCloseRedesignedStage4(kind, reason);
+                onCloseStage4={(kind, reason, checkInDate) => {
+                  handleCloseRedesignedStage4(kind, reason, checkInDate);
                   setShowStage4Drawer(false);
                 }}
               />
@@ -3816,8 +3828,8 @@ export function UnifiedSessionScreen({
               isRevising={unshareStage4Selections.isPending}
               onShareSelections={handleShareStage4Selections}
               onReviseSelections={handleReviseStage4Selections}
-              onCloseStage4={(kind, reason) => {
-                handleCloseRedesignedStage4(kind, reason);
+              onCloseStage4={(kind, reason, checkInDate) => {
+                handleCloseRedesignedStage4(kind, reason, checkInDate);
                 setShowStage4Drawer(false);
               }}
             />

--- a/shared/src/dto/strategy.ts
+++ b/shared/src/dto/strategy.ts
@@ -252,6 +252,7 @@ export interface Stage4OutcomeDTO {
   individualCommitments: ProposalCardDTO[];
   openNeeds: UnaddressedNeedDTO[];
   closedAt: string;
+  checkInAt: string | null;
 }
 
 export interface TendingPreviewDTO {
@@ -354,6 +355,9 @@ export interface CloseStage4Request {
   kind?: Stage4ClosureKind;
   reason?: Stage4ClosureReason;
   summary?: string;
+  /** ISO date string. Used as the followUpDate for any generated Agreement rows. */
+  checkInDate: string;
+  /** @deprecated Phase 4 removes this — checkInDate is the single source. */
   followUpDatesByProposalId?: Record<string, string>;
 }
 

--- a/shared/src/enums.ts
+++ b/shared/src/enums.ts
@@ -145,7 +145,6 @@ export enum Stage4ProposalStatus {
 export enum Stage4SelectionDecision {
   WILLING = 'WILLING',
   NOT_WILLING = 'NOT_WILLING',
-  NEEDS_DISCUSSION = 'NEEDS_DISCUSSION',
 }
 
 export enum Stage4ClosureKind {


### PR DESCRIPTION
## Summary

Implements Areas A (Drop Discuss) and F (Closure surface) from `.planning/STAGE_4_GOLD_ALIGNMENT_PLAN.md`, completing the goal-shaped checklist in `.planning/STAGE_4_PHASE_1_DROP_DISCUSS_AND_CLOSURE.md`.

- **Binary stance.** `NEEDS_DISCUSSION` removed from the `Stage4SelectionDecision` enum, schema, capture regex, segmented control, fixtures, and tests. New Prisma migration `drop_stage4_needs_discussion` rewrites any existing selections to `NOT_WILLING` and then drops the enum value.
- **Check-in date is required to close.** `closeStage4` now rejects requests missing `checkInDate` with `VALIDATION_ERROR` and persists it as `Stage4Closure.checkInAt`. Any agreements created during shared-agreement closure use this date as their `followUpDate`. Legacy `followUpDatesByProposalId` is kept as a Phase-4 fallback.
- **Closure surface — "A Path Forward".** `SessionCompletionScreen` always renders three sections (Shared experiments / Individual commitments / Named but not addressed). Empty sections show a `—` placeholder. The open-needs copy is verbatim gold: *"These remain on record. Not a failure — just yours to hold beyond this."*
- **No-shared close copy.** Replaces "are you sure?" friction with *"That's a valid place to land. Whatever you've named here stays on record."*

## Completion checklist

1. ✅ `grep -r NEEDS_DISCUSSION shared/src backend/src mobile/src` returns nothing.
2. ✅ Migration `20260512000000_drop_stage4_needs_discussion` applied locally; `migrate status` reports up to date.
3. ✅ `npm run check` passes across all workspaces.
4. ✅ `npm run test` passes (mobile 649, backend 1317, shared 215).
5. ✅ `Stage4RedesignPanel.test.tsx` adds binary-stance and check-in-required tests; the existing close-flow tests are updated to go through the new confirm step.
6. ✅ Backend test rejects close without `checkInDate` with `VALIDATION_ERROR`.
7. ✅ Backend test asserts `Stage4Closure.checkInAt` is persisted from the request body.
8. ⚠️ No UI screenshots attached — covered by component tests; happy to capture once a seeded pair-session is available.
9. ✅ This PR.
10. ✅ No new TS errors over `main`; pre-existing `★` warnings unchanged.

## Test plan

- [ ] Open a seeded Stage 4 session in two browsers and confirm the segmented control shows two options.
- [ ] Reach close-with-shared-agreement; confirm the check-in date picker appears and the Confirm CTA blocks submission with an empty date.
- [ ] Confirm `SessionCompletionScreen` shows all three sections with the gold copy.
- [ ] Replay against a `NO_SHARED_AGREEMENT` closure; confirm the dignified copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)