### PR TITLE
Stage 4 Phase 2: pre-share needs-check gate

### DIFF
--- a/backend/prisma/migrations/20260512010000_add_stage4_need_declination/migration.sql
+++ b/backend/prisma/migrations/20260512010000_add_stage4_need_declination/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Stage4NeedDeclination" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "needId" TEXT NOT NULL,
+    "declinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Stage4NeedDeclination_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Stage4NeedDeclination_sessionId_idx" ON "Stage4NeedDeclination"("sessionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Stage4NeedDeclination_sessionId_userId_needId_key" ON "Stage4NeedDeclination"("sessionId", "userId", "needId");
+
+-- AddForeignKey
+ALTER TABLE "Stage4NeedDeclination" ADD CONSTRAINT "Stage4NeedDeclination_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -139,6 +139,7 @@ model Session {
   strategyRankings          StrategyRanking[]
   stage4ProposalSelections  Stage4ProposalSelection[]
   stage4NeedCoverages       Stage4NeedCoverage[]
+  stage4NeedDeclinations    Stage4NeedDeclination[]
   stage4Closure             Stage4Closure?
   tendingEntries            TendingEntry[]
   consentRecords            ConsentRecord[]
@@ -1048,6 +1049,18 @@ model Stage4NeedCoverage {
   updatedAt           DateTime @updatedAt
   createdAt           DateTime @default(now())
 
+  @@index([sessionId])
+}
+
+model Stage4NeedDeclination {
+  id         String   @id @default(cuid())
+  session    Session  @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId  String
+  userId     String
+  needId     String
+  declinedAt DateTime @default(now())
+
+  @@unique([sessionId, userId, needId])
   @@index([sessionId])
 }
 

--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -593,6 +593,65 @@ export async function shareStage4Selections(req: Request, res: Response): Promis
       return;
     }
 
+    // Gate: every open/partial need must be addressed by a willing-active
+    // proposal or explicitly declined ("leave for now") by this user.
+    const [openOrPartialNeeds, willingSelections, declinations] = await Promise.all([
+      prisma.stage4NeedCoverage.findMany({
+        where: {
+          sessionId,
+          coverageStatus: { in: ['OPEN', 'PARTIAL'] },
+        },
+        select: {
+          id: true,
+          needId: true,
+          coverageStatus: true,
+          coveringProposalIds: true,
+        },
+      }),
+      prisma.stage4ProposalSelection.findMany({
+        where: {
+          sessionId,
+          userId: user.id,
+          decision: Stage4SelectionDecision.WILLING,
+        },
+        select: { proposalId: true },
+      }),
+      prisma.stage4NeedDeclination.findMany({
+        where: { sessionId, userId: user.id },
+        select: { needId: true },
+      }),
+    ]);
+
+    const willingProposalIds = new Set(willingSelections.map((s) => s.proposalId));
+    const activeProposalIds = new Set(
+      (
+        await prisma.strategyProposal.findMany({
+          where: { sessionId, status: Stage4ProposalStatus.ACTIVE },
+          select: { id: true },
+        })
+      ).map((p) => p.id)
+    );
+    const declinedNeedIds = new Set(declinations.map((d) => d.needId));
+
+    const ungated = openOrPartialNeeds.filter((row) => {
+      const needIdentifier = row.needId ?? row.id;
+      if (declinedNeedIds.has(needIdentifier)) return false;
+      const hasWillingCover = row.coveringProposalIds.some(
+        (pid) => activeProposalIds.has(pid) && willingProposalIds.has(pid)
+      );
+      return !hasWillingCover;
+    });
+
+    if (ungated.length > 0) {
+      errorResponse(
+        res,
+        'VALIDATION_ERROR',
+        'Address or set aside every open need before sharing',
+        400
+      );
+      return;
+    }
+
     await markStage4SelectionSubmitted(sessionId, user.id, mutable.progress?.gatesSatisfied);
 
     const partnerId = await getPartnerUserId(sessionId, user.id);
@@ -609,6 +668,86 @@ export async function shareStage4Selections(req: Request, res: Response): Promis
   } catch (error) {
     logger.error('[shareStage4Selections] Error:', error);
     errorResponse(res, 'INTERNAL_ERROR', 'Failed to share Stage 4 selections', 500);
+  }
+}
+
+/**
+ * Mark a need as "leave for now" — explicitly declines to address it.
+ * POST /sessions/:id/stage4/needs/:needId/decline
+ */
+export async function declineStage4Need(req: Request, res: Response): Promise<void> {
+  try {
+    const user = req.user;
+    if (!user) {
+      errorResponse(res, 'UNAUTHORIZED', 'Authentication required', 401);
+      return;
+    }
+
+    const { id: sessionId, needId } = req.params;
+    const mutable = await getMutableStage4Session(sessionId, user.id);
+    if (!mutable) {
+      errorResponse(res, 'NOT_FOUND', 'Session not found', 404);
+      return;
+    }
+    if (mutable.session.status !== 'ACTIVE') {
+      errorResponse(res, 'SESSION_NOT_ACTIVE', 'Session is not active', 400);
+      return;
+    }
+    if (await prisma.stage4Closure.findUnique({ where: { sessionId } })) {
+      errorResponse(res, 'CONFLICT', 'Stage 4 is already closed', 409);
+      return;
+    }
+
+    await prisma.stage4NeedDeclination.upsert({
+      where: { sessionId_userId_needId: { sessionId, userId: user.id, needId } },
+      update: {},
+      create: { sessionId, userId: user.id, needId },
+    });
+
+    const state = await buildStage4State(sessionId, user.id);
+    successResponse(res, { state });
+  } catch (error) {
+    logger.error('[declineStage4Need] Error:', error);
+    errorResponse(res, 'INTERNAL_ERROR', 'Failed to decline need', 500);
+  }
+}
+
+/**
+ * Remove a "leave for now" declination — user changed their mind.
+ * DELETE /sessions/:id/stage4/needs/:needId/decline
+ */
+export async function undeclineStage4Need(req: Request, res: Response): Promise<void> {
+  try {
+    const user = req.user;
+    if (!user) {
+      errorResponse(res, 'UNAUTHORIZED', 'Authentication required', 401);
+      return;
+    }
+
+    const { id: sessionId, needId } = req.params;
+    const mutable = await getMutableStage4Session(sessionId, user.id);
+    if (!mutable) {
+      errorResponse(res, 'NOT_FOUND', 'Session not found', 404);
+      return;
+    }
+    if (mutable.session.status !== 'ACTIVE') {
+      errorResponse(res, 'SESSION_NOT_ACTIVE', 'Session is not active', 400);
+      return;
+    }
+    if (await prisma.stage4Closure.findUnique({ where: { sessionId } })) {
+      errorResponse(res, 'CONFLICT', 'Stage 4 is already closed', 409);
+      return;
+    }
+
+    await prisma.stage4NeedDeclination.deleteMany({
+      where: { sessionId, userId: user.id, needId },
+    });
+
+    const state = await buildStage4State(sessionId, user.id);
+    successResponse(res, { state });
+  } catch (error) {
+    logger.error('[undeclineStage4Need] Error:', error);
+    errorResponse(res, 'INTERNAL_ERROR', 'Failed to undecline need', 500);
   }
 }
 

--- a/backend/src/lib/__mocks__/prisma.ts
+++ b/backend/src/lib/__mocks__/prisma.ts
@@ -46,6 +46,7 @@ export const prisma = {
   stage4ProposalSelection: createMockModel(),
   stage4ProposalRevision: createMockModel(),
   stage4NeedCoverage: createMockModel(),
+  stage4NeedDeclination: createMockModel(),
   stage4Closure: createMockModel(),
   tendingEntry: createMockModel(),
   tendingResponse: createMockModel(),

--- a/backend/src/routes/__tests__/stage4.test.ts
+++ b/backend/src/routes/__tests__/stage4.test.ts
@@ -39,6 +39,9 @@ import {
   getStage4State,
   submitStage4ProposalSelection,
   submitStage4Selections,
+  shareStage4Selections,
+  declineStage4Need,
+  undeclineStage4Need,
   closeStage4,
   getStrategies,
   proposeStrategy,
@@ -2299,6 +2302,175 @@ describe('Stage 4 API', () => {
           error: expect.objectContaining({ code: 'NOT_FOUND' }),
         })
       );
+    });
+  });
+
+  describe('Stage 4 need declination', () => {
+    const needId = 'need-1';
+
+    function arrangeMutable() {
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue({
+        stage: 4,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: {},
+      });
+      (prisma.stage4Closure.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.strategyProposal.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.stage4ProposalSelection.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.stage4NeedCoverage.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.agreement.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.stage4NeedDeclination.findMany as jest.Mock).mockResolvedValue([]);
+    }
+
+    it('declines a need (POST decline) and returns updated state', async () => {
+      arrangeMutable();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId, needId },
+      });
+      const { res, statusMock } = createMockResponse();
+
+      await declineStage4Need(req as Request, res as Response);
+
+      expect(prisma.stage4NeedDeclination.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            sessionId_userId_needId: {
+              sessionId: mockSessionId,
+              userId: mockUser.id,
+              needId,
+            },
+          },
+          create: { sessionId: mockSessionId, userId: mockUser.id, needId },
+        })
+      );
+      expect(statusMock).toHaveBeenCalledWith(200);
+    });
+
+    it('undeclines a need (DELETE decline)', async () => {
+      arrangeMutable();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId, needId },
+      });
+      const { res, statusMock } = createMockResponse();
+
+      await undeclineStage4Need(req as Request, res as Response);
+
+      expect(prisma.stage4NeedDeclination.deleteMany).toHaveBeenCalledWith({
+        where: { sessionId: mockSessionId, userId: mockUser.id, needId },
+      });
+      expect(statusMock).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('POST /sessions/:id/stage4/share-selections', () => {
+    function arrangeForShare(opts: {
+      openCoverage?: Array<{
+        id: string;
+        needId: string | null;
+        coverageStatus: 'OPEN' | 'PARTIAL';
+        coveringProposalIds: string[];
+      }>;
+      willingProposalIds?: string[];
+      activeProposalIds?: string[];
+      declinedNeedIds?: string[];
+    }) {
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue({
+        stage: 4,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: {},
+      });
+      (prisma.stage4Closure.findUnique as jest.Mock).mockResolvedValue(null);
+      // first findMany: activeSharedProposals; second findMany inside gate: activeProposals (any)
+      (prisma.strategyProposal.findMany as jest.Mock)
+        .mockResolvedValueOnce(
+          (opts.activeProposalIds ?? ['prop-a']).map((id) => ({ id }))
+        )
+        .mockResolvedValueOnce(
+          (opts.activeProposalIds ?? ['prop-a']).map((id) => ({ id }))
+        );
+      (prisma.stage4ProposalSelection.findMany as jest.Mock)
+        // first call: mySelections used to ensure stance on all shared proposals
+        .mockResolvedValueOnce(
+          (opts.activeProposalIds ?? ['prop-a']).map((proposalId) => ({ proposalId }))
+        )
+        // second call: WILLING selections for gate
+        .mockResolvedValueOnce(
+          (opts.willingProposalIds ?? []).map((proposalId) => ({ proposalId }))
+        );
+      (prisma.stage4NeedCoverage.findMany as jest.Mock).mockResolvedValue(
+        opts.openCoverage ?? []
+      );
+      (prisma.stage4NeedDeclination.findMany as jest.Mock).mockResolvedValue(
+        (opts.declinedNeedIds ?? []).map((needId) => ({ needId }))
+      );
+      (prisma.agreement.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([]);
+    }
+
+    it('rejects when an open need is neither addressed-willing nor declined', async () => {
+      arrangeForShare({
+        openCoverage: [
+          {
+            id: 'cov-1',
+            needId: 'need-1',
+            coverageStatus: 'OPEN',
+            coveringProposalIds: [],
+          },
+        ],
+        willingProposalIds: ['prop-a'],
+        activeProposalIds: ['prop-a'],
+      });
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      await shareStage4Selections(req as Request, res as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({
+            code: 'VALIDATION_ERROR',
+            message: 'Address or set aside every open need before sharing',
+          }),
+        })
+      );
+    });
+
+    it('allows share when every open need is declined', async () => {
+      arrangeForShare({
+        openCoverage: [
+          {
+            id: 'cov-1',
+            needId: 'need-1',
+            coverageStatus: 'OPEN',
+            coveringProposalIds: [],
+          },
+        ],
+        willingProposalIds: ['prop-a'],
+        activeProposalIds: ['prop-a'],
+        declinedNeedIds: ['need-1'],
+      });
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+      });
+      const { res, statusMock } = createMockResponse();
+
+      await shareStage4Selections(req as Request, res as Response);
+
+      expect(prisma.stageProgress.update).toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(200);
     });
   });
 });

--- a/backend/src/routes/stage4.ts
+++ b/backend/src/routes/stage4.ts
@@ -21,6 +21,8 @@ import {
   submitStage4Selections,
   shareStage4Selections,
   unshareStage4Selections,
+  declineStage4Need,
+  undeclineStage4Need,
   closeStage4,
   proposeStrategy,
   submitRanking,
@@ -64,6 +66,22 @@ router.post(
   requireAuth,
   requireSessionAccess,
   asyncHandler(shareStage4Selections)
+);
+
+// Mark a need as "leave for now"
+router.post(
+  '/sessions/:id/stage4/needs/:needId/decline',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(declineStage4Need)
+);
+
+// Remove a "leave for now" declination
+router.delete(
+  '/sessions/:id/stage4/needs/:needId/decline',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(undeclineStage4Need)
 );
 
 // Withdraw current user's shared Stage 4 selections so they can revise

--- a/backend/src/services/stage4-state.ts
+++ b/backend/src/services/stage4-state.ts
@@ -126,15 +126,20 @@ function getSourceLabel(
 function buildCoverageAudit(
   coverageRows: Stage4NeedCoverageRow[],
   userId: string,
-  partnerUserId: string | null
+  partnerUserId: string | null,
+  declinedNeedIds: Set<string>
 ): Stage4CoverageAuditDTO {
-  const rows = coverageRows.map((row): CoverageRowDTO => ({
-    id: row.needId ?? row.id,
-    label: row.needLabel,
-    source: getSourceLabel(row.sourceUserId, userId, partnerUserId),
-    coveringProposalIds: row.coveringProposalIds,
-    note: row.note,
-  }));
+  const rows = coverageRows.map((row): CoverageRowDTO => {
+    const rowNeedId = row.needId ?? row.id;
+    return {
+      id: rowNeedId,
+      label: row.needLabel,
+      source: getSourceLabel(row.sourceUserId, userId, partnerUserId),
+      coveringProposalIds: row.coveringProposalIds,
+      note: row.note,
+      userDeclinedToAddress: declinedNeedIds.has(rowNeedId),
+    };
+  });
 
   const byStatus = (status: string) =>
     rows.filter((_, index) => coverageRows[index].coverageStatus === status);
@@ -357,6 +362,7 @@ export async function getStage4State(
     agreements,
     tendingEntries,
     progressRows,
+    declinations,
   ] = await Promise.all([
     prisma.strategyProposal.findMany({
       where: { sessionId },
@@ -385,6 +391,10 @@ export async function getStage4State(
       where: { sessionId, stage: 4 },
       select: { userId: true, gatesSatisfied: true },
     }) as Promise<Stage4ProgressRow[]>,
+    prisma.stage4NeedDeclination.findMany({
+      where: { sessionId, userId },
+      select: { needId: true },
+    }) as Promise<{ needId: string }[]>,
   ]);
 
   const mySelections = selections.filter((selection) => selection.userId === userId);
@@ -430,7 +440,12 @@ export async function getStage4State(
       removedProposalCount: proposals.filter((proposal) => proposal.status === Stage4ProposalStatus.REMOVED).length,
       updatedAt: iso(latestInventoryUpdate) ?? new Date(0).toISOString(),
     },
-    coverageAudit: buildCoverageAudit(coverageRows, userId, partnerUserId),
+    coverageAudit: buildCoverageAudit(
+      coverageRows,
+      userId,
+      partnerUserId,
+      new Set(declinations.map((d) => d.needId))
+    ),
     mySelections: mySelections.map((selection): Stage4SelectionDTO => ({
       proposalId: selection.proposalId,
       decision: selection.decision,

--- a/mobile/src/components/ChatInput.tsx
+++ b/mobile/src/components/ChatInput.tsx
@@ -18,6 +18,10 @@ interface ChatInputProps {
   onVoicePress?: () => void;
   /** Content of a failed message to restore to the input field */
   failedMessage?: string | null;
+  /** Pre-fill the input with provided text and focus it (e.g. Stage 4 brainstorm seed). */
+  prefillText?: string | null;
+  /** Callback invoked once a prefill has been applied (so caller can clear). */
+  onPrefillConsumed?: () => void;
 }
 
 // ============================================================================
@@ -39,6 +43,8 @@ export function ChatInput({
   showCharacterCount = false,
   onVoicePress,
   failedMessage,
+  prefillText,
+  onPrefillConsumed,
 }: ChatInputProps) {
   const styles = useStyles();
   const { palette } = useAppAppearance();
@@ -54,6 +60,16 @@ export function ChatInput({
       setInput(failedMessage);
     }
   }, [failedMessage]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Pre-fill from external trigger (Stage 4 brainstorm stub).
+  useEffect(() => {
+    if (prefillText && prefillText.length > 0) {
+      justSentRef.current = false;
+      setInput(prefillText);
+      inputRef.current?.focus();
+      onPrefillConsumed?.();
+    }
+  }, [prefillText]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const canSend = input.trim().length > 0 && !disabled;
   const characterRatio = input.length / maxLength;

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -160,6 +160,10 @@ interface ChatInterfaceProps {
   onVoicePress?: () => void;
   /** Content of a failed message to restore to the input field */
   failedMessage?: string | null;
+  /** Pre-fill the input with provided text and focus it. */
+  prefillText?: string | null;
+  /** Callback invoked once a prefill has been applied. */
+  onPrefillConsumed?: () => void;
   /** ID of the last chat item the user has seen - used to show "New messages" separator */
   lastSeenChatItemId?: string | null;
   /** Server-backed timestamp from before this screen marked the session viewed. */
@@ -243,6 +247,8 @@ export function ChatInterface({
   onValidateNotQuite,
   onVoicePress,
   failedMessage,
+  prefillText,
+  onPrefillConsumed,
 }: ChatInterfaceProps) {
   const styles = useStyles();
   const flatListRef = useRef<FlatList<ChatListItem>>(null);
@@ -908,6 +914,8 @@ export function ChatInterface({
             disabled={disabled || isInputDisabled || isLoading}
             onVoicePress={onVoicePress}
             failedMessage={failedMessage}
+            prefillText={prefillText}
+            onPrefillConsumed={onPrefillConsumed}
           />
         )}
         {!isKeyboardVisible && renderAboveInput?.()}

--- a/mobile/src/components/Stage4RedesignPanel.tsx
+++ b/mobile/src/components/Stage4RedesignPanel.tsx
@@ -25,6 +25,9 @@ interface Stage4RedesignPanelProps {
   onSelectProposal: (proposalId: string, decision: Stage4SelectionDecision) => void;
   onShareSelections?: () => void;
   onReviseSelections?: () => void;
+  onBrainstormNeed?: (needLabel: string) => void;
+  onDeclineNeed?: (needId: string) => void;
+  onUndeclineNeed?: (needId: string) => void;
   onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason, checkInDate: string) => void;
 }
 
@@ -37,6 +40,23 @@ interface Stage4RedesignFooterProps {
   onShareSelections?: () => void;
   onReviseSelections?: () => void;
   onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason, checkInDate: string) => void;
+}
+
+/**
+ * True iff every OPEN or PARTIAL need is either covered by a proposal the user
+ * marked WILLING or explicitly declined ("leave for now") by the user.
+ */
+function allOpenNeedsAddressedOrDeclined(state: GetStage4StateResponse): boolean {
+  const willingProposalIds = new Set(
+    [...state.inventory.sharedProposals, ...state.inventory.individualCommitments]
+      .filter((p) => p.myDecision === Stage4SelectionDecision.WILLING)
+      .map((p) => p.id),
+  );
+  const rows = [...state.coverageAudit.open, ...state.coverageAudit.partial];
+  return rows.every((row) => {
+    if (row.userDeclinedToAddress) return true;
+    return row.coveringProposalIds.some((pid) => willingProposalIds.has(pid));
+  });
 }
 
 const decisionLabels: Record<Stage4SelectionDecision, string> = {
@@ -323,27 +343,76 @@ function NeedRows({
   title,
   rows,
   tone,
+  onBrainstormNeed,
+  onDeclineNeed,
+  onUndeclineNeed,
 }: {
   title: string;
   rows: GetStage4StateResponse['coverageAudit']['covered'];
   tone: 'covered' | 'partial' | 'open';
+  onBrainstormNeed?: (needLabel: string) => void;
+  onDeclineNeed?: (needId: string) => void;
+  onUndeclineNeed?: (needId: string) => void;
 }) {
   const { palette } = useAppAppearance();
   const styles = useMemo(() => makeStyles(palette), [palette]);
 
   if (rows.length === 0) return null;
 
+  const showActions = tone === 'open';
+
   return (
     <View style={styles.coverageGroup}>
       <Text style={styles.coverageTitle}>{title}</Text>
-      {rows.map((row, index) => (
-        <View key={row.id || `${row.label}-${index}`} style={styles.needRow}>
-          <View style={[styles.needDot, styles[`${tone}Dot`]]} />
-          <View style={styles.needTextWrap}>
-            <Text style={styles.needLabel}>{row.label}</Text>
+      {rows.map((row, index) => {
+        const declined = Boolean(row.userDeclinedToAddress);
+        const key = row.id || `${row.label}-${index}`;
+        return (
+          <View key={key} style={styles.needRow}>
+            <View style={[styles.needDot, styles[`${tone}Dot`]]} />
+            <View style={styles.needTextWrap}>
+              <Text style={[styles.needLabel, declined && styles.needLabelMuted]}>
+                {row.label}
+              </Text>
+              {showActions && row.id && (
+                declined ? (
+                  <TouchableOpacity
+                    onPress={() => onUndeclineNeed?.(row.id!)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Bring back ${row.label}`}
+                    testID={`stage4-need-undecline-${row.id}`}
+                  >
+                    <Text style={styles.needSetAside}>
+                      Set aside — tap to bring back
+                    </Text>
+                  </TouchableOpacity>
+                ) : (
+                  <View style={styles.needActions}>
+                    <TouchableOpacity
+                      onPress={() => onBrainstormNeed?.(row.label)}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Brainstorm with MWF about ${row.label}`}
+                      testID={`stage4-need-brainstorm-${row.id}`}
+                      style={styles.needActionButton}
+                    >
+                      <Text style={styles.needActionButtonText}>Brainstorm with MWF</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      onPress={() => onDeclineNeed?.(row.id!)}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Leave ${row.label} for now`}
+                      testID={`stage4-need-decline-${row.id}`}
+                      style={styles.needActionButton}
+                    >
+                      <Text style={styles.needActionButtonText}>Leave for now</Text>
+                    </TouchableOpacity>
+                  </View>
+                )
+              )}
+            </View>
           </View>
-        </View>
-      ))}
+        );
+      })}
     </View>
   );
 }
@@ -385,6 +454,7 @@ export function Stage4RedesignFooter({
   const allMyDecisionsMade =
     state.inventory.sharedProposals.length > 0 &&
     state.inventory.sharedProposals.every((p) => Boolean(p.myDecision));
+  const needsGated = allOpenNeedsAddressedOrDeclined(state);
   const who = partnerName || 'They';
 
   if (state.outcome) return null;
@@ -402,7 +472,7 @@ export function Stage4RedesignFooter({
   }
 
   if (!mySelectionSubmitted) {
-    const canShare = allMyDecisionsMade && !isSharing;
+    const canShare = allMyDecisionsMade && needsGated && !isSharing;
     return (
       <View style={styles.footerContainer}>
         <View style={styles.actions}>
@@ -425,6 +495,11 @@ export function Stage4RedesignFooter({
           {!allMyDecisionsMade && (
             <Text style={styles.actionHint}>
               Take a stance on every proposal first.
+            </Text>
+          )}
+          {allMyDecisionsMade && !needsGated && (
+            <Text style={styles.actionHint} testID="stage4-needs-gate-hint">
+              There are still needs unaddressed — brainstorm or set them aside first.
             </Text>
           )}
         </View>
@@ -486,6 +561,9 @@ export function Stage4RedesignPanel({
   onSelectProposal,
   onShareSelections,
   onReviseSelections,
+  onBrainstormNeed,
+  onDeclineNeed,
+  onUndeclineNeed,
   onCloseStage4,
 }: Stage4RedesignPanelProps) {
   const { palette } = useAppAppearance();
@@ -553,7 +631,14 @@ export function Stage4RedesignPanel({
           <>
             <NeedRows title="Covered" rows={state.coverageAudit.covered} tone="covered" />
             <NeedRows title="Partly addressed" rows={state.coverageAudit.partial} tone="partial" />
-            <NeedRows title="Not yet addressed" rows={state.coverageAudit.open} tone="open" />
+            <NeedRows
+              title="Not yet addressed"
+              rows={state.coverageAudit.open}
+              tone="open"
+              onBrainstormNeed={onBrainstormNeed}
+              onDeclineNeed={onDeclineNeed}
+              onUndeclineNeed={onUndeclineNeed}
+            />
           </>
         ) : (
           <Text style={styles.emptyText}>
@@ -605,9 +690,11 @@ export function Stage4RedesignPanel({
         }
 
         // (b) I haven't shared yet → show Share CTA (disabled until every
-        // proposal has a stance) and an inline hint about what's missing.
+        // proposal has a stance AND every open need is addressed-or-declined)
+        // with an inline hint about what's missing.
+        const needsGated = allOpenNeedsAddressedOrDeclined(state);
         if (!mySelectionSubmitted) {
-          const canShare = allMyDecisionsMade && !isSharing;
+          const canShare = allMyDecisionsMade && needsGated && !isSharing;
           return (
             <View style={styles.actions}>
               <TouchableOpacity
@@ -629,6 +716,11 @@ export function Stage4RedesignPanel({
               {!allMyDecisionsMade && (
                 <Text style={styles.actionHint}>
                   Take a stance on every proposal first.
+                </Text>
+              )}
+              {allMyDecisionsMade && !needsGated && (
+                <Text style={styles.actionHint} testID="stage4-needs-gate-hint-inline">
+                  There are still needs unaddressed — brainstorm or set them aside first.
                 </Text>
               )}
             </View>
@@ -840,6 +932,35 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
     color: palette.text,
     fontSize: 14,
     lineHeight: 19,
+  },
+  needLabelMuted: {
+    color: palette.textMuted,
+    textDecorationLine: 'line-through',
+  },
+  needActions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 6,
+  },
+  needActionButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: palette.border,
+    backgroundColor: palette.bgElev,
+  },
+  needActionButtonText: {
+    color: palette.text,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  needSetAside: {
+    color: palette.textMuted,
+    fontSize: 12,
+    fontStyle: 'italic',
+    marginTop: 4,
   },
   outcomeReason: {
     color: palette.accentText,

--- a/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
+++ b/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
@@ -281,8 +281,23 @@ describe('Stage4RedesignPanel', () => {
 
   it('calls onShareSelections when the share CTA is pressed', () => {
     const onShareSelections = jest.fn();
+    // Open need must be addressed-or-declined for the share gate to allow it.
+    const gatedState: GetStage4StateResponse = {
+      ...baseState,
+      coverageAudit: {
+        ...baseState.coverageAudit,
+        open: baseState.coverageAudit.open.map((row) => ({
+          ...row,
+          userDeclinedToAddress: true,
+        })),
+      },
+    };
     render(
-      <Stage4RedesignPanel {...defaultProps} onShareSelections={onShareSelections} />,
+      <Stage4RedesignPanel
+        {...defaultProps}
+        state={gatedState}
+        onShareSelections={onShareSelections}
+      />,
     );
 
     fireEvent.press(screen.getByLabelText('Share my stances'));
@@ -420,5 +435,77 @@ describe('Stage4RedesignPanel', () => {
 
     expect(screen.getByText('Shared agreement outcome')).toBeTruthy();
     expect(screen.getByText('Both people chose one shared experiment.')).toBeTruthy();
+  });
+
+  describe('Needs gate: brainstorm / leave-for-now', () => {
+    it('renders Brainstorm and Leave-for-now buttons for each open need', () => {
+      render(<Stage4RedesignPanel {...defaultProps} />);
+      expect(screen.getByTestId('stage4-need-brainstorm-coverage-2')).toBeTruthy();
+      expect(screen.getByTestId('stage4-need-decline-coverage-2')).toBeTruthy();
+    });
+
+    it('fires onBrainstormNeed with the need label when Brainstorm is tapped', () => {
+      const onBrainstormNeed = jest.fn();
+      render(
+        <Stage4RedesignPanel {...defaultProps} onBrainstormNeed={onBrainstormNeed} />
+      );
+      fireEvent.press(screen.getByTestId('stage4-need-brainstorm-coverage-2'));
+      expect(onBrainstormNeed).toHaveBeenCalledWith('Trust after conflict');
+    });
+
+    it('fires onDeclineNeed with the need id when Leave-for-now is tapped', () => {
+      const onDeclineNeed = jest.fn();
+      render(<Stage4RedesignPanel {...defaultProps} onDeclineNeed={onDeclineNeed} />);
+      fireEvent.press(screen.getByTestId('stage4-need-decline-coverage-2'));
+      expect(onDeclineNeed).toHaveBeenCalledWith('coverage-2');
+    });
+
+    it('renders the muted "Set aside" affordance when a need is declined', () => {
+      const declinedState: GetStage4StateResponse = {
+        ...baseState,
+        coverageAudit: {
+          ...baseState.coverageAudit,
+          open: baseState.coverageAudit.open.map((row) => ({
+            ...row,
+            userDeclinedToAddress: true,
+          })),
+        },
+      };
+      const onUndeclineNeed = jest.fn();
+      render(
+        <Stage4RedesignPanel
+          {...defaultProps}
+          state={declinedState}
+          onUndeclineNeed={onUndeclineNeed}
+        />
+      );
+      fireEvent.press(screen.getByTestId('stage4-need-undecline-coverage-2'));
+      expect(onUndeclineNeed).toHaveBeenCalledWith('coverage-2');
+    });
+
+    it('disables Share while any open need is neither addressed nor declined', () => {
+      // baseState has one open need with no covering proposal and no declination.
+      // sharedProposals[0] has myDecision = WILLING but it does not cover need-2.
+      render(<Stage4RedesignPanel {...defaultProps} />);
+      const share = screen.getByTestId('stage4-share-selections');
+      expect(share.props.accessibilityState?.disabled).toBe(true);
+      expect(screen.getByTestId('stage4-needs-gate-hint-inline')).toBeTruthy();
+    });
+
+    it('enables Share once every open need is declined', () => {
+      const gatedState: GetStage4StateResponse = {
+        ...baseState,
+        coverageAudit: {
+          ...baseState.coverageAudit,
+          open: baseState.coverageAudit.open.map((row) => ({
+            ...row,
+            userDeclinedToAddress: true,
+          })),
+        },
+      };
+      render(<Stage4RedesignPanel {...defaultProps} state={gatedState} />);
+      const share = screen.getByTestId('stage4-share-selections');
+      expect(share.props.accessibilityState?.disabled).toBe(false);
+    });
   });
 });

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -13,7 +13,7 @@ import {
   UseMutationOptions,
   InfiniteData,
 } from '@tanstack/react-query';
-import { get, post, ApiClientError } from '../lib/api';
+import { get, post, del, ApiClientError } from '../lib/api';
 import { useAuth } from './useAuth';
 import {
   // Response types
@@ -2173,6 +2173,101 @@ export function useUnshareStage4Selections() {
         queryClient.setQueryData<GetStage4StateResponse>(key, {
           ...previous,
           mySelectionStatus: 'NOT_STARTED',
+        });
+      }
+      return { previous };
+    },
+    onError: (_err, { sessionId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(stageKeys.stage4(sessionId), context.previous);
+      }
+    },
+    onSuccess: (data, { sessionId }) => {
+      queryClient.setQueryData(stageKeys.stage4(sessionId), data.state);
+      refreshStage4Caches(queryClient, sessionId);
+    },
+  });
+}
+
+/**
+ * Mark a Stage 4 need as "leave for now" — explicit declination to address it.
+ */
+export function useDeclineStage4Need() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { state: GetStage4StateResponse },
+    ApiClientError,
+    { sessionId: string; needId: string },
+    { previous: GetStage4StateResponse | undefined }
+  >({
+    mutationFn: async ({ sessionId, needId }) =>
+      post<{ state: GetStage4StateResponse }, Record<string, never>>(
+        `/sessions/${sessionId}/stage4/needs/${needId}/decline`,
+        {} as Record<string, never>
+      ),
+    onMutate: async ({ sessionId, needId }) => {
+      const key = stageKeys.stage4(sessionId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<GetStage4StateResponse>(key);
+      if (previous) {
+        const mark = (rows: typeof previous.coverageAudit.open) =>
+          rows.map((row) =>
+            row.id === needId ? { ...row, userDeclinedToAddress: true } : row
+          );
+        queryClient.setQueryData<GetStage4StateResponse>(key, {
+          ...previous,
+          coverageAudit: {
+            ...previous.coverageAudit,
+            open: mark(previous.coverageAudit.open),
+            partial: mark(previous.coverageAudit.partial),
+          },
+        });
+      }
+      return { previous };
+    },
+    onError: (_err, { sessionId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(stageKeys.stage4(sessionId), context.previous);
+      }
+    },
+    onSuccess: (data, { sessionId }) => {
+      queryClient.setQueryData(stageKeys.stage4(sessionId), data.state);
+      refreshStage4Caches(queryClient, sessionId);
+    },
+  });
+}
+
+/**
+ * Remove a "leave for now" declination — user changed their mind.
+ */
+export function useUndeclineStage4Need() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { state: GetStage4StateResponse },
+    ApiClientError,
+    { sessionId: string; needId: string },
+    { previous: GetStage4StateResponse | undefined }
+  >({
+    mutationFn: async ({ sessionId, needId }) =>
+      del<{ state: GetStage4StateResponse }>(
+        `/sessions/${sessionId}/stage4/needs/${needId}/decline`
+      ),
+    onMutate: async ({ sessionId, needId }) => {
+      const key = stageKeys.stage4(sessionId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<GetStage4StateResponse>(key);
+      if (previous) {
+        const unmark = (rows: typeof previous.coverageAudit.open) =>
+          rows.map((row) =>
+            row.id === needId ? { ...row, userDeclinedToAddress: false } : row
+          );
+        queryClient.setQueryData<GetStage4StateResponse>(key, {
+          ...previous,
+          coverageAudit: {
+            ...previous.coverageAudit,
+            open: unmark(previous.coverageAudit.open),
+            partial: unmark(previous.coverageAudit.partial),
+          },
         });
       }
       return { previous };

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -74,6 +74,8 @@ import {
   useCloseStage4,
   useShareStage4Selections,
   useUnshareStage4Selections,
+  useDeclineStage4Need,
+  useUndeclineStage4Need,
   useCreateTendingReentry,
   useNeedsComparison,
   useStage4State,
@@ -1457,6 +1459,8 @@ export function UnifiedSessionScreen({
   });
   const shareStage4Selections = useShareStage4Selections();
   const unshareStage4Selections = useUnshareStage4Selections();
+  const declineStage4Need = useDeclineStage4Need();
+  const undeclineStage4Need = useUndeclineStage4Need();
   const closeStage4 = useCloseStage4({
     onSuccess: (response) => {
       if (response.outcome.kind === Stage4ClosureKind.SHARED_AGREEMENT) {
@@ -1503,6 +1507,40 @@ export function UnifiedSessionScreen({
       }
     );
   }, [shareStage4Selections, sessionId, showError]);
+  // TODO(phase-3): The Brainstorm CTA on an unaddressed need currently just
+  // pre-fills the main chat input with a templated prompt. Phase 3 will rewire
+  // this into a dedicated sub-chat so the brainstorm doesn't pollute the main
+  // transcript.
+  const [stage4BrainstormPrefill, setStage4BrainstormPrefill] = useState<string | null>(null);
+  const handleBrainstormStage4Need = useCallback((needLabel: string) => {
+    setStage4BrainstormPrefill(`Let's brainstorm for "${needLabel}"`);
+  }, []);
+  const handleDeclineStage4Need = useCallback(
+    (needId: string) => {
+      declineStage4Need.mutate(
+        { sessionId, needId },
+        {
+          onError: () => {
+            showError('Could not set that aside. Please try again.');
+          },
+        }
+      );
+    },
+    [declineStage4Need, sessionId, showError]
+  );
+  const handleUndeclineStage4Need = useCallback(
+    (needId: string) => {
+      undeclineStage4Need.mutate(
+        { sessionId, needId },
+        {
+          onError: () => {
+            showError('Could not bring that back. Please try again.');
+          },
+        }
+      );
+    },
+    [undeclineStage4Need, sessionId, showError]
+  );
   const handleReviseStage4Selections = useCallback(() => {
     unshareStage4Selections.mutate(
       { sessionId },
@@ -3274,6 +3312,9 @@ export function UnifiedSessionScreen({
               onSelectProposal={handleStage4Selection}
               onShareSelections={handleShareStage4Selections}
               onReviseSelections={handleReviseStage4Selections}
+              onBrainstormNeed={handleBrainstormStage4Need}
+              onDeclineNeed={handleDeclineStage4Need}
+              onUndeclineNeed={handleUndeclineStage4Need}
               onCloseStage4={handleCloseRedesignedStage4}
             />
             {tendingPanel}
@@ -3448,6 +3489,8 @@ export function UnifiedSessionScreen({
           indicators={indicators}
           onSendMessage={sendMessageWithTracking}
           failedMessage={failedMessageContent}
+          prefillText={stage4BrainstormPrefill}
+          onPrefillConsumed={() => setStage4BrainstormPrefill(null)}
           // Cache-First: Ghost dots are derived from last message role in ChatInterface
           // isSending is still needed for brief moment during API call before optimistic message appears
           // isFetchingInitialMessage shows dots while fetching first AI message
@@ -3812,6 +3855,12 @@ export function UnifiedSessionScreen({
                 onSelectProposal={handleStage4Selection}
                 onShareSelections={handleShareStage4Selections}
                 onReviseSelections={handleReviseStage4Selections}
+                onBrainstormNeed={(needLabel) => {
+                  handleBrainstormStage4Need(needLabel);
+                  setShowStage4Drawer(false);
+                }}
+                onDeclineNeed={handleDeclineStage4Need}
+                onUndeclineNeed={handleUndeclineStage4Need}
                 onCloseStage4={(kind, reason, checkInDate) => {
                   handleCloseRedesignedStage4(kind, reason, checkInDate);
                   setShowStage4Drawer(false);

--- a/shared/src/dto/strategy.ts
+++ b/shared/src/dto/strategy.ts
@@ -227,6 +227,7 @@ export interface CoverageRowDTO {
   source: 'YOU' | 'PARTNER' | 'BOTH' | 'UNKNOWN';
   coveringProposalIds: string[];
   note: string | null;
+  userDeclinedToAddress?: boolean;
 }
 
 export interface Stage4CoverageAuditDTO {


### PR DESCRIPTION
## Summary

Implements Phase 2 of the Stage 4 Gold Alignment plan: a hard gate before sharing stances. Every named-but-unaddressed need must either be covered by a Willing'd active proposal OR explicitly marked "leave for now" by the user.

Plan: `.planning/STAGE_4_PHASE_2_NEEDS_CHECK_GATE.md`
Master plan: `.planning/STAGE_4_GOLD_ALIGNMENT_PLAN.md`

## Changes

- **Schema:** new `Stage4NeedDeclination` model + migration `add_stage4_need_declination` (`@@unique([sessionId, userId, needId])`).
- **Backend:**
  - `POST /sessions/:id/stage4/needs/:needId/decline` and `DELETE` counterpart.
  - `getStage4State` now includes `userDeclinedToAddress` on each coverage-audit row.
  - `shareStage4Selections` rejects with `VALIDATION_ERROR` ("Address or set aside every open need before sharing") when any open/partial need is neither covered by a WILLING active proposal nor declined.
- **Mobile:**
  - `useDeclineStage4Need` / `useUndeclineStage4Need` hooks with optimistic cache updates.
  - `Stage4RedesignPanel` renders **Brainstorm with MWF** + **Leave for now** on each open-need row, swapped for a muted "Set aside — tap to bring back" affordance when declined.
  - `Stage4RedesignFooter` and inline footer share derivation `allOpenNeedsAddressedOrDeclined`; share CTA is disabled with an inline hint until the gate is satisfied.
  - **Brainstorm stub:** pre-fills the main chat input with `Let's brainstorm for "${need.label}"` and focuses it (via new `prefillText`/`onPrefillConsumed` plumbing through `ChatInterface` → `ChatInput`). Marked `TODO(phase-3)` for sub-chat wiring.

## Test plan
- [x] Backend: new tests for decline/undecline endpoints + share-rejection when open needs are ungated. `npm run test` (backend) green.
- [x] Mobile: new panel cases for the brainstorm/leave buttons, the muted "Set aside" state, disabled Share state with hint, and enabled Share when every open need is declined. `npm run test` (mobile) green.
- [x] `npm run check` green across all workspaces.
- [ ] Manual UAT against a seeded Stage 4 session with mixed coverage (per the plan's "Verification beyond the goal" checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)