### PR TITLE
Stage 4 Phase 5: three-orientation Tending check-in + five forward paths

### DIFF
--- a/backend/prisma/migrations/20260513020000_expand_tending_continue_choice/migration.sql
+++ b/backend/prisma/migrations/20260513020000_expand_tending_continue_choice/migration.sql
@@ -1,0 +1,31 @@
+-- Stage 4 Phase 5: introduce ContinueChoice enum with the five forward paths and
+-- remap legacy continueChoice string values onto the new enum.
+
+-- CreateEnum
+CREATE TYPE "ContinueChoice" AS ENUM (
+  'ANOTHER_ROUND',
+  'EXTEND',
+  'NEW_PROCESS',
+  'PARTIAL_CLOSURE',
+  'FULL_CLOSURE'
+);
+
+-- Remap historical string values BEFORE column type change so the USING clause is total.
+-- CONTINUE -> EXTEND, ADJUST -> ANOTHER_ROUND, CLOSE -> FULL_CLOSURE.
+-- Any unknown legacy value (e.g. NEW_PROCESS, OTHER_TRACK) maps to NULL — surface in followup if needed.
+UPDATE "TendingResponse"
+SET "continueChoice" = CASE "continueChoice"
+  WHEN 'CONTINUE'        THEN 'EXTEND'
+  WHEN 'ADJUST'          THEN 'ANOTHER_ROUND'
+  WHEN 'CLOSE'           THEN 'FULL_CLOSURE'
+  WHEN 'NEW_PROCESS'     THEN 'NEW_PROCESS'
+  WHEN 'ANOTHER_ROUND'   THEN 'ANOTHER_ROUND'
+  WHEN 'EXTEND'          THEN 'EXTEND'
+  WHEN 'PARTIAL_CLOSURE' THEN 'PARTIAL_CLOSURE'
+  WHEN 'FULL_CLOSURE'    THEN 'FULL_CLOSURE'
+  ELSE NULL
+END;
+
+ALTER TABLE "TendingResponse"
+  ALTER COLUMN "continueChoice" TYPE "ContinueChoice"
+  USING "continueChoice"::"ContinueChoice";

--- a/backend/prisma/migrations/20260513020100_add_tending_partial_closure/migration.sql
+++ b/backend/prisma/migrations/20260513020100_add_tending_partial_closure/migration.sql
@@ -1,0 +1,35 @@
+-- Stage 4 Phase 5: per-TendingEntry resolution table for the PARTIAL_CLOSURE path.
+
+-- CreateEnum
+CREATE TYPE "PartialClosureResolution" AS ENUM ('RESOLVED', 'CONTINUING');
+
+-- CreateTable
+CREATE TABLE "TendingResponsePartialClosure" (
+    "id" TEXT NOT NULL,
+    "tendingResponseId" TEXT NOT NULL,
+    "tendingEntryId" TEXT NOT NULL,
+    "resolution" "PartialClosureResolution" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TendingResponsePartialClosure_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TendingResponsePartialClosure_tendingResponseId_tendingEntr_key"
+  ON "TendingResponsePartialClosure"("tendingResponseId", "tendingEntryId");
+
+-- CreateIndex
+CREATE INDEX "TendingResponsePartialClosure_tendingEntryId_idx"
+  ON "TendingResponsePartialClosure"("tendingEntryId");
+
+-- AddForeignKey
+ALTER TABLE "TendingResponsePartialClosure"
+  ADD CONSTRAINT "TendingResponsePartialClosure_tendingResponseId_fkey"
+  FOREIGN KEY ("tendingResponseId") REFERENCES "TendingResponse"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TendingResponsePartialClosure"
+  ADD CONSTRAINT "TendingResponsePartialClosure_tendingEntryId_fkey"
+  FOREIGN KEY ("tendingEntryId") REFERENCES "TendingEntry"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260513020200_add_session_previous_session_id/migration.sql
+++ b/backend/prisma/migrations/20260513020200_add_session_previous_session_id/migration.sql
@@ -1,0 +1,12 @@
+-- Stage 4 Phase 5: Session lineage for the NEW_PROCESS check-in path.
+-- previousSessionId is nullable and self-referential (a fresh session can point back
+-- at the session whose Tending check-in chose NEW_PROCESS).
+
+ALTER TABLE "Session" ADD COLUMN "previousSessionId" TEXT;
+
+CREATE INDEX "Session_previousSessionId_idx" ON "Session"("previousSessionId");
+
+ALTER TABLE "Session"
+  ADD CONSTRAINT "Session_previousSessionId_fkey"
+  FOREIGN KEY ("previousSessionId") REFERENCES "Session"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -156,9 +156,15 @@ model Session {
   // Linked Inner Thoughts sessions for private reflection during partner session
   linkedInnerThoughts InnerWorkSession[] @relation("LinkedInnerThoughts")
 
+  // Stage 4 Phase 5: Tending check-in NEW_PROCESS path links forward to a fresh session
+  previousSession   Session?  @relation("SessionLineage", fields: [previousSessionId], references: [id], onDelete: SetNull)
+  previousSessionId String?
+  nextSessions      Session[] @relation("SessionLineage")
+
   @@index([relationshipId])
   @@index([status])
   @@index([type])
+  @@index([previousSessionId])
 }
 
 enum SessionType {
@@ -1161,7 +1167,8 @@ model TendingEntry {
   createdAt      DateTime           @default(now())
   updatedAt      DateTime           @updatedAt
 
-  responses TendingResponse[]
+  responses        TendingResponse[]
+  partialClosures  TendingResponsePartialClosure[]
 
   @@index([sessionId, status])
   @@index([agreementId])
@@ -1177,10 +1184,44 @@ model TendingResponse {
   userId         String
   status         String
   reflection     String?      @db.Text
-  continueChoice String?
+  continueChoice ContinueChoice?
   submittedAt    DateTime     @default(now())
 
+  // Stage 4 Phase 5: when continueChoice = PARTIAL_CLOSURE, per-entry resolutions
+  // are recorded against the originating response (one row per TendingEntry resolved).
+  partialClosures TendingResponsePartialClosure[]
+
   @@unique([tendingEntryId, userId])
+}
+
+// Stage 4 Phase 5: ContinueChoice — five forward paths at the end of a Tending check-in.
+enum ContinueChoice {
+  ANOTHER_ROUND     // Reset Stage 4 to inventory building; new experiments
+  EXTEND            // Keep current entries open with a new scheduledFor
+  NEW_PROCESS       // Create a fresh Session linked via previousSessionId; both users start at Stage 0
+  PARTIAL_CLOSURE   // Close some entries, continue others (per-TendingEntry granularity)
+  FULL_CLOSURE      // Mark all entries COMPLETED and move session to terminal state
+}
+
+enum PartialClosureResolution {
+  RESOLVED
+  CONTINUING
+}
+
+// Stage 4 Phase 5: Per-TendingEntry resolution recorded when a user picks PARTIAL_CLOSURE.
+// Scope decision: targets TendingEntry (not Agreement) so individual commitments can be
+// partially closed alongside shared agreements. See PR description for rationale.
+model TendingResponsePartialClosure {
+  id                String                    @id @default(cuid())
+  tendingResponse   TendingResponse           @relation(fields: [tendingResponseId], references: [id], onDelete: Cascade)
+  tendingResponseId String
+  tendingEntry      TendingEntry              @relation(fields: [tendingEntryId], references: [id], onDelete: Cascade)
+  tendingEntryId    String
+  resolution        PartialClosureResolution
+  createdAt         DateTime                  @default(now())
+
+  @@unique([tendingResponseId, tendingEntryId])
+  @@index([tendingEntryId])
 }
 
 model StrategyRanking {

--- a/backend/src/__tests__/prisma-schema.test.ts
+++ b/backend/src/__tests__/prisma-schema.test.ts
@@ -312,10 +312,10 @@ describe('Prisma Schema', () => {
         tendingEntry: { connect: { id: 'entry-id' } },
         user: { connect: { id: 'user-id' } },
         status: 'PARTLY',
-        continueChoice: 'ADJUST',
+        continueChoice: 'ANOTHER_ROUND',
       };
       expect(entryInput.type).toBe('SCHEDULED_SHARED_AGREEMENT_CHECKIN');
-      expect(responseInput.continueChoice).toBe('ADJUST');
+      expect(responseInput.continueChoice).toBe('ANOTHER_ROUND');
     });
 
     it('allows creating valid GlobalLibraryItem input', () => {

--- a/backend/src/controllers/tending.ts
+++ b/backend/src/controllers/tending.ts
@@ -6,16 +6,34 @@ import {
   createPassiveReentry,
   listTendingEntries,
   setIndividualEntryShare,
+  submitTendingCheckin,
   submitTendingResponse,
   TendingForbiddenError,
   TendingInvalidStateError,
   TendingNotFoundError,
 } from '../services/tending.service';
+import { ContinueChoice, PartialClosureResolution } from '@meet-without-fear/shared';
 
 const submitTendingResponseSchema = z.object({
   status: z.string().min(1).max(80),
   reflection: z.string().max(2000).optional(),
-  continueChoice: z.string().max(80).optional(),
+  continueChoice: z.nativeEnum(ContinueChoice).optional(),
+});
+
+const orientationSchema = z.object({
+  reflection: z.string().max(4000).default(''),
+  perEntryNotes: z.record(z.string(), z.string().max(2000)).optional(),
+});
+
+const submitTendingCheckinSchema = z.object({
+  orientations: z.object({
+    whatWorked: orientationSchema,
+    whereMoreSupport: orientationSchema,
+    whatComesNext: z.object({
+      continueChoice: z.nativeEnum(ContinueChoice),
+      partialClosure: z.record(z.string(), z.nativeEnum(PartialClosureResolution)).optional(),
+    }),
+  }),
 });
 
 const createTendingReentrySchema = z.object({
@@ -114,6 +132,45 @@ export async function postTendingEntryShare(req: Request, res: Response): Promis
 
 export async function postTendingEntryUnshare(req: Request, res: Response): Promise<void> {
   await handleShareToggle(req, res, false);
+}
+
+export async function postTendingCheckin(req: Request, res: Response): Promise<void> {
+  try {
+    const user = req.user;
+    if (!user) {
+      errorResponse(res, 'UNAUTHORIZED', 'Authentication required', 401);
+      return;
+    }
+
+    const parseResult = submitTendingCheckinSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      errorResponse(res, 'VALIDATION_ERROR', 'Invalid request body', 400, parseResult.error.issues);
+      return;
+    }
+
+    const result = await submitTendingCheckin({
+      sessionId: req.params.id,
+      userId: user.id,
+      orientations: parseResult.data.orientations,
+    });
+    successResponse(res, {
+      entries: result.entries,
+      newSessionId: result.newSessionId,
+      continueChoice: result.continueChoice,
+      nextScheduledFor: result.nextScheduledFor ? result.nextScheduledFor.toISOString() : null,
+    });
+  } catch (error) {
+    if (error instanceof TendingNotFoundError) {
+      errorResponse(res, 'NOT_FOUND', 'Session not found', 404);
+      return;
+    }
+    if (error instanceof TendingInvalidStateError) {
+      errorResponse(res, 'VALIDATION_ERROR', error.message, 400);
+      return;
+    }
+    logger.error('[postTendingCheckin] Error:', error);
+    errorResponse(res, 'INTERNAL_ERROR', 'Failed to submit Tending check-in', 500);
+  }
 }
 
 export async function postTendingReentry(req: Request, res: Response): Promise<void> {

--- a/backend/src/lib/__mocks__/prisma.ts
+++ b/backend/src/lib/__mocks__/prisma.ts
@@ -52,6 +52,7 @@ export const prisma = {
   stage4SubChatMessage: createMockModel(),
   tendingEntry: createMockModel(),
   tendingResponse: createMockModel(),
+  tendingResponsePartialClosure: createMockModel(),
   strategyProposalNeed: createMockModel(),
   emotionalExerciseCompletion: createMockModel(),
   globalLibraryItem: createMockModel(),

--- a/backend/src/routes/tending.ts
+++ b/backend/src/routes/tending.ts
@@ -3,6 +3,7 @@ import { requireAuth, requireSessionAccess } from '../middleware/auth';
 import { asyncHandler } from '../middleware/errors';
 import {
   getTendingEntries,
+  postTendingCheckin,
   postTendingEntryShare,
   postTendingEntryUnshare,
   postTendingReentry,
@@ -16,6 +17,13 @@ router.get(
   requireAuth,
   requireSessionAccess,
   asyncHandler(getTendingEntries)
+);
+
+router.post(
+  '/sessions/:id/tending/checkin',
+  requireAuth,
+  requireSessionAccess,
+  asyncHandler(postTendingCheckin)
 );
 
 router.post(

--- a/backend/src/services/__tests__/tending.service.test.ts
+++ b/backend/src/services/__tests__/tending.service.test.ts
@@ -8,10 +8,14 @@ import {
   scheduleIndividualCommitmentTendingEntries,
   scheduleSharedAgreementTendingEntries,
   setIndividualEntryShare,
+  submitTendingCheckin,
   submitTendingResponse,
   TendingForbiddenError,
+  TendingInvalidStateError,
 } from '../tending.service';
 import {
+  ContinueChoice,
+  PartialClosureResolution,
   TendingEntryScope,
   TendingEntryStatus,
   TendingEntryType,
@@ -94,7 +98,7 @@ describe('tending.service', () => {
             userId,
             status: 'WORKED',
             reflection: 'Better than last week',
-            continueChoice: 'CONTINUE',
+            continueChoice: ContinueChoice.EXTEND,
             submittedAt: new Date('2026-05-13T10:02:00.000Z'),
           },
           {
@@ -160,7 +164,7 @@ describe('tending.service', () => {
             userId,
             status: 'WORKED',
             reflection: 'Better',
-            continueChoice: 'CONTINUE',
+            continueChoice: ContinueChoice.EXTEND,
             submittedAt: new Date('2026-05-13T10:02:00.000Z'),
           },
         ],
@@ -173,7 +177,7 @@ describe('tending.service', () => {
       userId,
       status: 'WORKED',
       reflection: 'Better',
-      continueChoice: 'CONTINUE',
+      continueChoice: ContinueChoice.EXTEND,
     });
 
     expect(prisma.tendingResponse.upsert).toHaveBeenCalledWith(
@@ -431,5 +435,191 @@ describe('tending.service', () => {
         optedInShared: true,
       })
     ).rejects.toBeInstanceOf(TendingForbiddenError);
+  });
+
+  describe('submitTendingCheckin (Stage 4 Phase 5)', () => {
+    const baseOrientations = (
+      choice: ContinueChoice,
+      partialClosure?: Record<string, PartialClosureResolution>
+    ) => ({
+      whatWorked: { reflection: 'small wins' },
+      whereMoreSupport: { reflection: 'still hard' },
+      whatComesNext: { continueChoice: choice, partialClosure },
+    });
+
+    const openSharedEntry = (id: string) => ({
+      id,
+      sessionId,
+      agreementId: `agreement-${id}`,
+      type: TendingEntryType.SCHEDULED_SHARED_AGREEMENT_CHECKIN,
+      scope: TendingEntryScope.SHARED,
+      ownerUserId: null,
+      optedInShared: false,
+      status: TendingEntryStatus.OPEN,
+      scheduledFor: new Date('2026-05-13T10:00:00.000Z'),
+      openedAt: new Date('2026-05-13T10:00:00.000Z'),
+      completedAt: null,
+      summary: 'Check in',
+      createdAt: new Date('2026-05-06T10:00:00.000Z'),
+      updatedAt: new Date('2026-05-13T10:00:00.000Z'),
+      responses: [],
+    });
+
+    const stubSession = () => {
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue({
+        id: sessionId,
+        status: 'ACTIVE',
+        relationshipId: 'rel-1',
+        type: 'CONFLICT_RESOLUTION',
+        relationship: { members: [{ userId }, { userId: partnerId }] },
+      });
+    };
+
+    beforeEach(() => {
+      (prisma.tendingResponse.upsert as jest.Mock).mockImplementation((args: any) =>
+        Promise.resolve({ id: `resp-${args.where.tendingEntryId_userId.tendingEntryId}` })
+      );
+    });
+
+    it('rejects when there are no open entries', async () => {
+      stubSession();
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([]);
+      await expect(
+        submitTendingCheckin({
+          sessionId,
+          userId,
+          orientations: baseOrientations(ContinueChoice.EXTEND),
+        })
+      ).rejects.toBeInstanceOf(TendingInvalidStateError);
+    });
+
+    it('EXTEND reschedules every open entry and keeps the session active', async () => {
+      stubSession();
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([openSharedEntry('t1')]);
+      const result = await submitTendingCheckin({
+        sessionId,
+        userId,
+        orientations: baseOrientations(ContinueChoice.EXTEND),
+      });
+      expect(result.continueChoice).toBe(ContinueChoice.EXTEND);
+      expect(result.nextScheduledFor).toBeInstanceOf(Date);
+      expect(prisma.tendingEntry.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 't1' },
+          data: expect.objectContaining({ status: TendingEntryStatus.SCHEDULED }),
+        })
+      );
+      // Session should not be transitioned out of ACTIVE.
+      expect(prisma.session.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: 'RESOLVED' }) })
+      );
+    });
+
+    it('FULL_CLOSURE marks every open entry COMPLETED and resolves the session', async () => {
+      stubSession();
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([openSharedEntry('t1')]);
+      await submitTendingCheckin({
+        sessionId,
+        userId,
+        orientations: baseOrientations(ContinueChoice.FULL_CLOSURE),
+      });
+      expect(prisma.tendingEntry.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 't1' },
+          data: expect.objectContaining({ status: TendingEntryStatus.COMPLETED }),
+        })
+      );
+      expect(prisma.session.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: sessionId },
+          data: expect.objectContaining({ status: 'RESOLVED' }),
+        })
+      );
+    });
+
+    it('ANOTHER_ROUND clears stage 4 state and selectionSubmitted gates', async () => {
+      stubSession();
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([openSharedEntry('t1')]);
+      (prisma.stageProgress.findMany as jest.Mock).mockResolvedValue([
+        { id: 'sp-1', gatesSatisfied: { selectionSubmitted: true } },
+      ]);
+      await submitTendingCheckin({
+        sessionId,
+        userId,
+        orientations: baseOrientations(ContinueChoice.ANOTHER_ROUND),
+      });
+      expect(prisma.stage4Closure.deleteMany).toHaveBeenCalledWith({ where: { sessionId } });
+      expect(prisma.stage4ProposalSelection.deleteMany).toHaveBeenCalledWith({ where: { sessionId } });
+      expect(prisma.stageProgress.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'sp-1' },
+          data: expect.objectContaining({ gatesSatisfied: expect.not.objectContaining({ selectionSubmitted: true }) }),
+        })
+      );
+    });
+
+    it('NEW_PROCESS creates a fresh session linked back to the current one and resolves it', async () => {
+      stubSession();
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([openSharedEntry('t1')]);
+      (prisma.session.create as jest.Mock).mockResolvedValue({ id: 'session-2' });
+      const result = await submitTendingCheckin({
+        sessionId,
+        userId,
+        orientations: baseOrientations(ContinueChoice.NEW_PROCESS),
+      });
+      expect(result.newSessionId).toBe('session-2');
+      expect(prisma.session.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            relationshipId: 'rel-1',
+            previousSessionId: sessionId,
+            status: 'CREATED',
+          }),
+        })
+      );
+      expect(prisma.session.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: sessionId },
+          data: expect.objectContaining({ status: 'RESOLVED' }),
+        })
+      );
+    });
+
+    it('PARTIAL_CLOSURE closes RESOLVED entries and reschedules CONTINUING entries', async () => {
+      stubSession();
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([
+        openSharedEntry('t1'),
+        openSharedEntry('t2'),
+      ]);
+      const result = await submitTendingCheckin({
+        sessionId,
+        userId,
+        orientations: baseOrientations(ContinueChoice.PARTIAL_CLOSURE, {
+          t1: PartialClosureResolution.RESOLVED,
+          t2: PartialClosureResolution.CONTINUING,
+        }),
+      });
+      expect(result.continueChoice).toBe(ContinueChoice.PARTIAL_CLOSURE);
+      expect(prisma.tendingResponsePartialClosure.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            tendingEntryId: 't1',
+            resolution: PartialClosureResolution.RESOLVED,
+          }),
+        })
+      );
+      expect(prisma.tendingEntry.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 't1' },
+          data: expect.objectContaining({ status: TendingEntryStatus.COMPLETED }),
+        })
+      );
+      expect(prisma.tendingEntry.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 't2' },
+          data: expect.objectContaining({ status: TendingEntryStatus.SCHEDULED }),
+        })
+      );
+    });
   });
 });

--- a/backend/src/services/tending.service.ts
+++ b/backend/src/services/tending.service.ts
@@ -1,5 +1,8 @@
 import { Prisma } from '@prisma/client';
 import {
+  ContinueChoice,
+  PartialClosureResolution,
+  TendingCheckinOrientations,
   TendingEntryDTO,
   TendingEntryScope,
   TendingEntryStatus,
@@ -40,7 +43,7 @@ type TendingEntryWithResponses = {
     userId: string;
     status: string;
     reflection: string | null;
-    continueChoice: string | null;
+    continueChoice: ContinueChoice | null;
     submittedAt: Date;
   }>;
 };
@@ -280,7 +283,7 @@ export async function submitTendingResponse(args: {
   userId: string;
   status: string;
   reflection?: string;
-  continueChoice?: string;
+  continueChoice?: ContinueChoice;
 }): Promise<TendingEntryDTO> {
   const entry = await getEntryForUser(args.entryId, args.userId);
   if (entry.scope === TendingEntryScope.INDIVIDUAL && entry.ownerUserId !== args.userId) {
@@ -429,6 +432,257 @@ export async function publishPartnerInvolvingReentryChoice(args: {
     tendingEntryId: args.tendingEntryId,
     createdBy: args.userId,
   }, args.userId);
+}
+
+/**
+ * Stage 4 Phase 5 — submit the structured three-orientation check-in covering all
+ * currently-open Tending entries on a session in one shot. Returns the affected entries
+ * and metadata about the chosen forward path.
+ *
+ * Scope decision (documented in PR): partial-closure resolutions target TendingEntry
+ * rather than Agreement so individual commitments can be partially closed too.
+ */
+const DEFAULT_EXTENSION_DAYS = 28;
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date.getTime());
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+export type SubmitTendingCheckinResult = {
+  entries: TendingEntryDTO[];
+  newSessionId?: string;
+  continueChoice: ContinueChoice;
+  nextScheduledFor?: Date | null;
+};
+
+export async function submitTendingCheckin(args: {
+  sessionId: string;
+  userId: string;
+  orientations: TendingCheckinOrientations;
+  now?: Date;
+}): Promise<SubmitTendingCheckinResult> {
+  const now = args.now ?? new Date();
+  const session = await assertSessionMember(args.sessionId, args.userId);
+
+  const openEntries = (await prisma.tendingEntry.findMany({
+    where: {
+      sessionId: args.sessionId,
+      status: { in: [TendingEntryStatus.OPEN, TendingEntryStatus.PARTIAL] },
+      OR: [
+        { scope: TendingEntryScope.SHARED },
+        { scope: TendingEntryScope.INDIVIDUAL, ownerUserId: args.userId },
+      ],
+    },
+    include: { responses: true },
+  })) as TendingEntryWithResponses[];
+
+  if (openEntries.length === 0) {
+    throw new TendingInvalidStateError('No open Tending entries to check in on');
+  }
+
+  const choice = args.orientations.whatComesNext.continueChoice;
+  const reflection = [
+    args.orientations.whatWorked.reflection
+      ? `What worked: ${args.orientations.whatWorked.reflection}`
+      : null,
+    args.orientations.whereMoreSupport.reflection
+      ? `Where more support: ${args.orientations.whereMoreSupport.reflection}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  let nextScheduledFor: Date | null = null;
+  let newSessionId: string | undefined;
+
+  await prisma.$transaction(async (tx) => {
+    // 1) Persist a TendingResponse for each open entry that the user can respond to.
+    const responseIds: Record<string, string> = {};
+    for (const entry of openEntries) {
+      if (entry.scope === TendingEntryScope.INDIVIDUAL && entry.ownerUserId !== args.userId) {
+        continue;
+      }
+      const upserted = await tx.tendingResponse.upsert({
+        where: {
+          tendingEntryId_userId: {
+            tendingEntryId: entry.id,
+            userId: args.userId,
+          },
+        },
+        create: {
+          tendingEntryId: entry.id,
+          userId: args.userId,
+          status: 'CHECKIN',
+          reflection: reflection || null,
+          continueChoice: choice,
+          submittedAt: now,
+        },
+        update: {
+          status: 'CHECKIN',
+          reflection: reflection || null,
+          continueChoice: choice,
+          submittedAt: now,
+        },
+      });
+      responseIds[entry.id] = upserted.id;
+    }
+
+    // 2) Apply path-specific state transitions.
+    switch (choice) {
+      case ContinueChoice.ANOTHER_ROUND: {
+        // Reset Stage 4 to inventory building: clear closure, selections, gates.
+        // Preserve agreements as historical context.
+        await tx.stage4Closure.deleteMany({ where: { sessionId: args.sessionId } });
+        await tx.stage4ProposalSelection.deleteMany({ where: { sessionId: args.sessionId } });
+        await tx.stage4NeedCoverage.deleteMany({ where: { sessionId: args.sessionId } });
+        await tx.stage4NeedDeclination.deleteMany({ where: { sessionId: args.sessionId } });
+        // Clear selectionSubmitted gates on every member's stage-4 progress.
+        const progress = await tx.stageProgress.findMany({
+          where: { sessionId: args.sessionId, stage: 4 },
+        });
+        for (const row of progress) {
+          const gates = (row.gatesSatisfied as Record<string, unknown> | null) ?? {};
+          delete gates.selectionSubmitted;
+          await tx.stageProgress.update({
+            where: { id: row.id },
+            data: { gatesSatisfied: gates as Prisma.InputJsonValue },
+          });
+        }
+        // Close out current Tending entries so a fresh inventory cycle can run.
+        for (const entry of openEntries) {
+          await tx.tendingEntry.update({
+            where: { id: entry.id },
+            data: { status: TendingEntryStatus.COMPLETED, completedAt: now },
+          });
+        }
+        await tx.session.update({
+          where: { id: args.sessionId },
+          data: { status: 'ACTIVE' },
+        });
+        break;
+      }
+      case ContinueChoice.EXTEND: {
+        nextScheduledFor = addDays(now, DEFAULT_EXTENSION_DAYS);
+        for (const entry of openEntries) {
+          await tx.tendingEntry.update({
+            where: { id: entry.id },
+            data: {
+              status: TendingEntryStatus.SCHEDULED,
+              scheduledFor: nextScheduledFor,
+              openedAt: null,
+              completedAt: null,
+            },
+          });
+        }
+        break;
+      }
+      case ContinueChoice.NEW_PROCESS: {
+        // Create a new Session linked back to this one. Both users start at Stage 0.
+        const created = await tx.session.create({
+          data: {
+            relationshipId: session.relationshipId,
+            status: 'CREATED',
+            type: session.type,
+            previousSessionId: args.sessionId,
+          },
+        });
+        newSessionId = created.id;
+        // Mark current entries COMPLETED and the current session RESOLVED.
+        for (const entry of openEntries) {
+          await tx.tendingEntry.update({
+            where: { id: entry.id },
+            data: { status: TendingEntryStatus.COMPLETED, completedAt: now },
+          });
+        }
+        await tx.session.update({
+          where: { id: args.sessionId },
+          data: { status: 'RESOLVED', resolvedAt: now },
+        });
+        break;
+      }
+      case ContinueChoice.PARTIAL_CLOSURE: {
+        const resolutions = args.orientations.whatComesNext.partialClosure ?? {};
+        nextScheduledFor = addDays(now, DEFAULT_EXTENSION_DAYS);
+        for (const entry of openEntries) {
+          const resolution = resolutions[entry.id] ?? PartialClosureResolution.CONTINUING;
+          const responseId = responseIds[entry.id];
+          if (responseId) {
+            await tx.tendingResponsePartialClosure.upsert({
+              where: {
+                tendingResponseId_tendingEntryId: {
+                  tendingResponseId: responseId,
+                  tendingEntryId: entry.id,
+                },
+              },
+              create: {
+                tendingResponseId: responseId,
+                tendingEntryId: entry.id,
+                resolution,
+              },
+              update: { resolution },
+            });
+          }
+          if (resolution === PartialClosureResolution.RESOLVED) {
+            await tx.tendingEntry.update({
+              where: { id: entry.id },
+              data: { status: TendingEntryStatus.COMPLETED, completedAt: now },
+            });
+          } else {
+            await tx.tendingEntry.update({
+              where: { id: entry.id },
+              data: {
+                status: TendingEntryStatus.SCHEDULED,
+                scheduledFor: nextScheduledFor,
+                openedAt: null,
+                completedAt: null,
+              },
+            });
+          }
+        }
+        break;
+      }
+      case ContinueChoice.FULL_CLOSURE: {
+        for (const entry of openEntries) {
+          await tx.tendingEntry.update({
+            where: { id: entry.id },
+            data: { status: TendingEntryStatus.COMPLETED, completedAt: now },
+          });
+        }
+        await tx.session.update({
+          where: { id: args.sessionId },
+          data: { status: 'RESOLVED', resolvedAt: now },
+        });
+        break;
+      }
+      default:
+        throw new TendingInvalidStateError(`Unsupported continueChoice: ${choice as string}`);
+    }
+  });
+
+  try {
+    await publishSessionEvent(args.sessionId, 'notification.pending_action', {
+      kind: 'tending_checkin_submitted',
+      continueChoice: choice,
+      submittedBy: args.userId,
+      newSessionId,
+    }, args.userId);
+  } catch (error) {
+    logger.warn('[tending] Failed to publish check-in event', { sessionId: args.sessionId, error });
+  }
+
+  const refreshed = (await prisma.tendingEntry.findMany({
+    where: { id: { in: openEntries.map((e) => e.id) } },
+    include: { responses: true },
+  })) as TendingEntryWithResponses[];
+
+  return {
+    entries: refreshed.map((entry) => toEntryDTO(entry, args.userId)),
+    newSessionId,
+    continueChoice: choice,
+    nextScheduledFor,
+  };
 }
 
 export async function openDueTendingEntries(now = new Date()): Promise<{ opened: number; entryIds: string[] }> {

--- a/mobile/app/(auth)/session/[id]/_layout.tsx
+++ b/mobile/app/(auth)/session/[id]/_layout.tsx
@@ -51,6 +51,17 @@ export default function SessionLayout() {
           animation: 'slide_from_right',
         }}
       />
+      <Stack.Screen
+        name="tending-checkin"
+        options={{
+          title: 'Tending check-in',
+          headerShown: true,
+          headerStyle: { backgroundColor: palette.bg },
+          headerTintColor: palette.text,
+          headerTitleStyle: { color: palette.text, fontWeight: '600' },
+          presentation: 'modal',
+        }}
+      />
     </Stack>
   );
 }

--- a/mobile/app/(auth)/session/[id]/tending-checkin.tsx
+++ b/mobile/app/(auth)/session/[id]/tending-checkin.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from 'react';
+import { Alert, View, Text, StyleSheet } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { ContinueChoice } from '@meet-without-fear/shared';
+import { TendingCheckinScreen, TendingCheckinPayload } from '@/src/screens/TendingCheckinScreen';
+import { useTendingEntries, useSubmitTendingCheckin } from '@/src/hooks';
+import { colors } from '@/src/theme';
+
+/**
+ * Stage 4 Phase 5 — Tending check-in route.
+ *
+ * Hosts the three-orientation TendingCheckinScreen and handles post-submission
+ * routing per the chosen forward path.
+ */
+export default function TendingCheckinRoute() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const sessionId = typeof id === 'string' ? id : '';
+  const entriesQuery = useTendingEntries(sessionId || undefined);
+  const submit = useSubmitTendingCheckin();
+
+  const entries = useMemo(() => entriesQuery.data?.entries ?? [], [entriesQuery.data]);
+
+  const handleSubmit = (payload: TendingCheckinPayload) => {
+    submit.mutate(
+      {
+        sessionId,
+        orientations: payload,
+      },
+      {
+        onSuccess: (data) => {
+          switch (data.continueChoice) {
+            case ContinueChoice.ANOTHER_ROUND:
+              router.replace(`/session/${sessionId}`);
+              break;
+            case ContinueChoice.NEW_PROCESS:
+              if (data.newSessionId) {
+                router.replace(`/session/${data.newSessionId}`);
+              } else {
+                router.replace(`/session/${sessionId}`);
+              }
+              break;
+            case ContinueChoice.EXTEND: {
+              const when = data.nextScheduledFor
+                ? new Date(data.nextScheduledFor).toLocaleDateString()
+                : 'soon';
+              Alert.alert('Check-in scheduled', `Next check-in: ${when}`, [
+                { text: 'OK', onPress: () => router.replace(`/session/${sessionId}`) },
+              ]);
+              break;
+            }
+            case ContinueChoice.PARTIAL_CLOSURE: {
+              const when = data.nextScheduledFor
+                ? new Date(data.nextScheduledFor).toLocaleDateString()
+                : 'soon';
+              Alert.alert('Partial closure', `Continuing entries next check-in: ${when}`, [
+                { text: 'OK', onPress: () => router.replace(`/session/${sessionId}`) },
+              ]);
+              break;
+            }
+            case ContinueChoice.FULL_CLOSURE:
+              Alert.alert(
+                'Wrapped',
+                "This is wrapped. Whatever you've named here stays on record.",
+                [{ text: 'OK', onPress: () => router.replace(`/session/${sessionId}`) }]
+              );
+              break;
+          }
+        },
+        onError: (error) => {
+          Alert.alert('Could not submit', error.message ?? 'Please try again.');
+        },
+      }
+    );
+  };
+
+  if (entriesQuery.isLoading) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.muted}>Loading check-in…</Text>
+      </View>
+    );
+  }
+
+  if (!sessionId) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.muted}>Session not found.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <TendingCheckinScreen
+      entries={entries}
+      isSubmitting={submit.isPending}
+      onSubmit={handleSubmit}
+      onCancel={() => router.back()}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.bgPrimary },
+  muted: { color: colors.textMuted, fontSize: 14 },
+});

--- a/mobile/src/hooks/index.ts
+++ b/mobile/src/hooks/index.ts
@@ -143,6 +143,7 @@ export {
   useCloseStage4,
   useTendingEntries,
   useSubmitTendingResponse,
+  useSubmitTendingCheckin,
   useCreateTendingReentry,
   // Agreements
   useAgreements,

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -59,6 +59,8 @@ import {
   GetTendingEntriesResponse,
   SubmitTendingResponseRequest,
   SubmitTendingResponseResponse,
+  SubmitTendingCheckinRequest,
+  SubmitTendingCheckinResponse,
   CreateTendingReentryRequest,
   CreateTendingReentryResponse,
   AgreementDTO,
@@ -2374,6 +2376,36 @@ export function useSubmitTendingResponse(
           return { entries: [data.entry, ...withoutUpdated] };
         }
       );
+      queryClient.refetchQueries({ queryKey: stageKeys.tending(sessionId) });
+      queryClient.refetchQueries({ queryKey: stageKeys.stage4(sessionId) });
+    },
+    ...options,
+  });
+}
+
+/**
+ * Stage 4 Phase 5 — submit the three-orientation Tending check-in covering all
+ * open entries on a session.
+ */
+export function useSubmitTendingCheckin(
+  options?: Omit<
+    UseMutationOptions<
+      SubmitTendingCheckinResponse,
+      ApiClientError,
+      { sessionId: string } & SubmitTendingCheckinRequest
+    >,
+    'mutationFn'
+  >
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ sessionId, ...request }) => {
+      return post<SubmitTendingCheckinResponse, SubmitTendingCheckinRequest>(
+        `/sessions/${sessionId}/tending/checkin`,
+        request
+      );
+    },
+    onSuccess: (_data, { sessionId }) => {
       queryClient.refetchQueries({ queryKey: stageKeys.tending(sessionId) });
       queryClient.refetchQueries({ queryKey: stageKeys.stage4(sessionId) });
     },

--- a/mobile/src/screens/TendingCheckinScreen.tsx
+++ b/mobile/src/screens/TendingCheckinScreen.tsx
@@ -1,0 +1,351 @@
+import { useMemo, useState } from 'react';
+import { View, Text, TouchableOpacity, TextInput, ScrollView, StyleSheet } from 'react-native';
+import {
+  ContinueChoice,
+  PartialClosureResolution,
+  TendingEntryDTO,
+  TendingEntryScope,
+  TendingEntryStatus,
+} from '@meet-without-fear/shared';
+import { colors } from '@/theme';
+
+/**
+ * Stage 4 Phase 5 — Three-orientation Tending check-in.
+ *
+ * Sequential step navigation (back/next). Non-sequential navigation is the gold
+ * spec; this is documented as a follow-up in the phase plan.
+ */
+type Step = 'whatWorked' | 'whereMoreSupport' | 'whatComesNext';
+
+const STEP_ORDER: Step[] = ['whatWorked', 'whereMoreSupport', 'whatComesNext'];
+
+const PROMPTS: Record<Step, { title: string; subtitle: string; placeholder: string }> = {
+  whatWorked: {
+    title: 'What worked',
+    subtitle:
+      "Take a moment with each of these — what shifted, even a little? Wins worth naming, however small.",
+    placeholder: 'A win worth naming…',
+  },
+  whereMoreSupport: {
+    title: 'Where would more support help',
+    subtitle: "What's still feeling hard or stuck? No judgment — just naming it.",
+    placeholder: 'What still needs support…',
+  },
+  whatComesNext: {
+    title: 'What comes next',
+    subtitle: 'Where would you like to take it from here?',
+    placeholder: '',
+  },
+};
+
+const CHOICE_LABELS: Record<ContinueChoice, { label: string; subtitle: string }> = {
+  [ContinueChoice.ANOTHER_ROUND]: {
+    label: 'Try another round',
+    subtitle: "New experiments grounded in what you've learned",
+  },
+  [ContinueChoice.EXTEND]: {
+    label: 'Keep going',
+    subtitle: 'Current experiments still feel right — extend for another check-in',
+  },
+  [ContinueChoice.NEW_PROCESS]: {
+    label: 'Start a new process',
+    subtitle: 'Something significant shifted — start fresh from Stage 1',
+  },
+  [ContinueChoice.PARTIAL_CLOSURE]: {
+    label: 'Close some, continue others',
+    subtitle: 'Mark each agreement individually',
+  },
+  [ContinueChoice.FULL_CLOSURE]: {
+    label: 'Close fully',
+    subtitle: "You're ready to wrap this up",
+  },
+};
+
+const CHOICE_ORDER: ContinueChoice[] = [
+  ContinueChoice.ANOTHER_ROUND,
+  ContinueChoice.EXTEND,
+  ContinueChoice.NEW_PROCESS,
+  ContinueChoice.PARTIAL_CLOSURE,
+  ContinueChoice.FULL_CLOSURE,
+];
+
+export interface TendingCheckinPayload {
+  whatWorked: { reflection: string; perEntryNotes: Record<string, string> };
+  whereMoreSupport: { reflection: string; perEntryNotes: Record<string, string> };
+  whatComesNext: {
+    continueChoice: ContinueChoice;
+    partialClosure: Record<string, PartialClosureResolution>;
+  };
+}
+
+export interface TendingCheckinScreenProps {
+  entries: TendingEntryDTO[];
+  isSubmitting?: boolean;
+  onSubmit: (payload: TendingCheckinPayload) => void;
+  onCancel?: () => void;
+}
+
+function isRespondable(entry: TendingEntryDTO, currentUserId?: string): boolean {
+  if (entry.status !== TendingEntryStatus.OPEN && entry.status !== TendingEntryStatus.PARTIAL) {
+    return false;
+  }
+  if (entry.scope === TendingEntryScope.INDIVIDUAL && currentUserId && entry.ownerUserId !== currentUserId) {
+    return false;
+  }
+  return true;
+}
+
+export function TendingCheckinScreen({
+  entries,
+  isSubmitting = false,
+  onSubmit,
+  onCancel,
+}: TendingCheckinScreenProps) {
+  const respondable = useMemo(() => entries.filter((e) => isRespondable(e)), [entries]);
+
+  const [step, setStep] = useState<Step>('whatWorked');
+  const [whatWorked, setWhatWorked] = useState({ reflection: '', perEntryNotes: {} as Record<string, string> });
+  const [whereMore, setWhereMore] = useState({ reflection: '', perEntryNotes: {} as Record<string, string> });
+  const [choice, setChoice] = useState<ContinueChoice>(ContinueChoice.EXTEND);
+  const [partialClosure, setPartialClosure] = useState<Record<string, PartialClosureResolution>>({});
+
+  const stepIndex = STEP_ORDER.indexOf(step);
+  const isLast = stepIndex === STEP_ORDER.length - 1;
+
+  const goNext = () => {
+    if (isLast) {
+      onSubmit({
+        whatWorked,
+        whereMoreSupport: whereMore,
+        whatComesNext: { continueChoice: choice, partialClosure },
+      });
+      return;
+    }
+    setStep(STEP_ORDER[stepIndex + 1]);
+  };
+
+  const goBack = () => {
+    if (stepIndex === 0) {
+      onCancel?.();
+      return;
+    }
+    setStep(STEP_ORDER[stepIndex - 1]);
+  };
+
+  const renderEntryNotes = (
+    current: { reflection: string; perEntryNotes: Record<string, string> },
+    setCurrent: typeof setWhatWorked,
+    placeholder: string
+  ) => (
+    <>
+      {respondable.map((entry) => (
+        <View key={entry.id} style={styles.entryRow} testID={`tending-checkin-entry-${entry.id}`}>
+          <Text style={styles.entryTitle}>{entry.summary ?? 'Tending entry'}</Text>
+          <TextInput
+            value={current.perEntryNotes[entry.id] ?? ''}
+            onChangeText={(text) =>
+              setCurrent({
+                ...current,
+                perEntryNotes: { ...current.perEntryNotes, [entry.id]: text },
+              })
+            }
+            placeholder={placeholder}
+            placeholderTextColor={colors.textMuted}
+            style={styles.textInput}
+            multiline
+            accessibilityLabel={`Note for ${entry.summary ?? entry.id}`}
+          />
+        </View>
+      ))}
+      <Text style={styles.fieldLabel}>Overall reflection</Text>
+      <TextInput
+        value={current.reflection}
+        onChangeText={(text) => setCurrent({ ...current, reflection: text })}
+        placeholder={placeholder}
+        placeholderTextColor={colors.textMuted}
+        style={[styles.textInput, styles.reflectionInput]}
+        multiline
+        accessibilityLabel="Overall reflection"
+        testID="tending-checkin-reflection"
+      />
+    </>
+  );
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content} testID="tending-checkin-screen">
+      <View style={styles.stepper}>
+        {STEP_ORDER.map((s, i) => (
+          <View
+            key={s}
+            style={[styles.stepDot, i === stepIndex && styles.stepDotActive]}
+            testID={`tending-checkin-step-${s}`}
+          />
+        ))}
+      </View>
+      <Text style={styles.title}>{PROMPTS[step].title}</Text>
+      <Text style={styles.subtitle}>{PROMPTS[step].subtitle}</Text>
+
+      {step === 'whatWorked' && renderEntryNotes(whatWorked, setWhatWorked, PROMPTS.whatWorked.placeholder)}
+      {step === 'whereMoreSupport' &&
+        renderEntryNotes(whereMore, setWhereMore, PROMPTS.whereMoreSupport.placeholder)}
+
+      {step === 'whatComesNext' && (
+        <View>
+          {CHOICE_ORDER.map((c) => {
+            const selected = c === choice;
+            return (
+              <TouchableOpacity
+                key={c}
+                style={[styles.choiceCard, selected && styles.choiceCardSelected]}
+                onPress={() => setChoice(c)}
+                accessibilityRole="button"
+                accessibilityState={{ selected }}
+                testID={`tending-checkin-choice-${c}`}
+              >
+                <Text style={[styles.choiceLabel, selected && styles.choiceLabelSelected]}>
+                  {CHOICE_LABELS[c].label}
+                </Text>
+                <Text style={styles.choiceSubtitle}>{CHOICE_LABELS[c].subtitle}</Text>
+              </TouchableOpacity>
+            );
+          })}
+
+          {choice === ContinueChoice.PARTIAL_CLOSURE && (
+            <View style={styles.partialClosureBlock} testID="tending-checkin-partial-closure">
+              <Text style={styles.fieldLabel}>For each agreement</Text>
+              {respondable.map((entry) => {
+                const value = partialClosure[entry.id] ?? PartialClosureResolution.CONTINUING;
+                return (
+                  <View key={entry.id} style={styles.partialClosureRow}>
+                    <Text style={styles.entryTitle}>{entry.summary ?? 'Tending entry'}</Text>
+                    <View style={styles.partialClosureToggleRow}>
+                      {(
+                        [PartialClosureResolution.RESOLVED, PartialClosureResolution.CONTINUING] as const
+                      ).map((r) => {
+                        const sel = value === r;
+                        return (
+                          <TouchableOpacity
+                            key={r}
+                            style={[styles.toggleButton, sel && styles.toggleButtonSelected]}
+                            onPress={() => setPartialClosure({ ...partialClosure, [entry.id]: r })}
+                            accessibilityRole="button"
+                            accessibilityState={{ selected: sel }}
+                            testID={`tending-checkin-resolution-${entry.id}-${r}`}
+                          >
+                            <Text style={[styles.toggleText, sel && styles.toggleTextSelected]}>
+                              {r === PartialClosureResolution.RESOLVED ? 'Resolved' : 'Continuing'}
+                            </Text>
+                          </TouchableOpacity>
+                        );
+                      })}
+                    </View>
+                  </View>
+                );
+              })}
+            </View>
+          )}
+        </View>
+      )}
+
+      <View style={styles.navRow}>
+        <TouchableOpacity
+          style={styles.secondaryButton}
+          onPress={goBack}
+          accessibilityRole="button"
+          testID="tending-checkin-back"
+        >
+          <Text style={styles.secondaryButtonText}>{stepIndex === 0 ? 'Cancel' : 'Back'}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.primaryButton, isSubmitting && styles.disabled]}
+          onPress={goNext}
+          disabled={isSubmitting}
+          accessibilityRole="button"
+          testID={isLast ? 'tending-checkin-submit' : 'tending-checkin-next'}
+        >
+          <Text style={styles.primaryButtonText}>
+            {isLast ? (isSubmitting ? 'Submitting…' : 'Submit') : 'Next'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.bgPrimary },
+  content: { padding: 16, gap: 12 },
+  stepper: { flexDirection: 'row', gap: 8, marginBottom: 8 },
+  stepDot: {
+    flex: 1,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.border,
+  },
+  stepDotActive: { backgroundColor: colors.accent },
+  title: { fontSize: 20, fontWeight: '700', color: colors.textPrimary },
+  subtitle: { fontSize: 14, color: colors.textSecondary, lineHeight: 20, marginBottom: 8 },
+  fieldLabel: { fontSize: 13, fontWeight: '700', color: colors.textSecondary, marginTop: 12 },
+  entryRow: { gap: 6 },
+  entryTitle: { fontSize: 14, fontWeight: '600', color: colors.textPrimary },
+  textInput: {
+    minHeight: 48,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bgSecondary,
+    color: colors.textPrimary,
+    padding: 10,
+    fontSize: 14,
+    textAlignVertical: 'top',
+  },
+  reflectionInput: { minHeight: 72 },
+  choiceCard: {
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 12,
+    marginTop: 8,
+    backgroundColor: colors.bgSecondary,
+  },
+  choiceCardSelected: { borderColor: colors.accent, backgroundColor: colors.bgTertiary },
+  choiceLabel: { fontSize: 15, fontWeight: '700', color: colors.textPrimary },
+  choiceLabelSelected: { color: colors.accent },
+  choiceSubtitle: { fontSize: 13, color: colors.textSecondary, marginTop: 2 },
+  partialClosureBlock: { marginTop: 16, gap: 12 },
+  partialClosureRow: { gap: 6 },
+  partialClosureToggleRow: { flexDirection: 'row', gap: 8 },
+  toggleButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bgSecondary,
+  },
+  toggleButtonSelected: { borderColor: colors.accent, backgroundColor: colors.bgTertiary },
+  toggleText: { fontSize: 13, fontWeight: '600', color: colors.textSecondary },
+  toggleTextSelected: { color: colors.accent },
+  navRow: { flexDirection: 'row', justifyContent: 'space-between', gap: 12, marginTop: 16 },
+  primaryButton: {
+    flex: 1,
+    borderRadius: 8,
+    backgroundColor: colors.accent,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  primaryButtonText: { color: colors.textOnAccent, fontSize: 14, fontWeight: '700' },
+  secondaryButton: {
+    flex: 1,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingVertical: 12,
+    alignItems: 'center',
+    backgroundColor: colors.bgSecondary,
+  },
+  secondaryButtonText: { color: colors.textPrimary, fontSize: 14, fontWeight: '700' },
+  disabled: { opacity: 0.6 },
+});
+
+export default TendingCheckinScreen;

--- a/mobile/src/screens/__tests__/TendingCheckinScreen.test.tsx
+++ b/mobile/src/screens/__tests__/TendingCheckinScreen.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import {
+  ContinueChoice,
+  PartialClosureResolution,
+  TendingEntryDTO,
+  TendingEntryScope,
+  TendingEntryStatus,
+  TendingEntryType,
+} from '@meet-without-fear/shared';
+import { TendingCheckinScreen } from '../TendingCheckinScreen';
+
+const entry: TendingEntryDTO = {
+  id: 'tending-1',
+  sessionId: 'session-1',
+  agreementId: 'agreement-1',
+  type: TendingEntryType.SCHEDULED_SHARED_AGREEMENT_CHECKIN,
+  scope: TendingEntryScope.SHARED,
+  ownerUserId: null,
+  optedInShared: false,
+  status: TendingEntryStatus.OPEN,
+  scheduledFor: '2026-05-13T00:00:00.000Z',
+  openedAt: '2026-05-13T00:00:00.000Z',
+  completedAt: null,
+  summary: 'Check whether the shared next step helped.',
+  createdAt: '2026-05-06T00:00:00.000Z',
+  updatedAt: '2026-05-13T00:00:00.000Z',
+  myResponse: null,
+  responseCount: 0,
+};
+
+describe('TendingCheckinScreen', () => {
+  it('walks through three sequential steps and submits the payload', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId } = render(
+      <TendingCheckinScreen entries={[entry]} onSubmit={onSubmit} />
+    );
+
+    // Step 1 dot visible.
+    expect(getByTestId('tending-checkin-step-whatWorked')).toBeTruthy();
+    expect(getByTestId('tending-checkin-entry-tending-1')).toBeTruthy();
+    fireEvent.changeText(getByTestId('tending-checkin-reflection'), 'small wins');
+
+    // Step 2.
+    fireEvent.press(getByTestId('tending-checkin-next'));
+    fireEvent.changeText(getByTestId('tending-checkin-reflection'), 'still stuck');
+
+    // Step 3 — all five choices render.
+    fireEvent.press(getByTestId('tending-checkin-next'));
+    [
+      ContinueChoice.ANOTHER_ROUND,
+      ContinueChoice.EXTEND,
+      ContinueChoice.NEW_PROCESS,
+      ContinueChoice.PARTIAL_CLOSURE,
+      ContinueChoice.FULL_CLOSURE,
+    ].forEach((c) => {
+      expect(getByTestId(`tending-checkin-choice-${c}`)).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('tending-checkin-choice-FULL_CLOSURE'));
+    fireEvent.press(getByTestId('tending-checkin-submit'));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.whatComesNext.continueChoice).toBe(ContinueChoice.FULL_CLOSURE);
+    expect(payload.whatWorked.reflection).toBe('small wins');
+    expect(payload.whereMoreSupport.reflection).toBe('still stuck');
+  });
+
+  it('expands partial-closure into per-entry RESOLVED/CONTINUING toggles', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <TendingCheckinScreen entries={[entry]} onSubmit={onSubmit} />
+    );
+    fireEvent.press(getByTestId('tending-checkin-next'));
+    fireEvent.press(getByTestId('tending-checkin-next'));
+
+    expect(queryByTestId('tending-checkin-partial-closure')).toBeNull();
+    fireEvent.press(getByTestId('tending-checkin-choice-PARTIAL_CLOSURE'));
+    expect(getByTestId('tending-checkin-partial-closure')).toBeTruthy();
+    fireEvent.press(getByTestId('tending-checkin-resolution-tending-1-RESOLVED'));
+    fireEvent.press(getByTestId('tending-checkin-submit'));
+
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.whatComesNext.continueChoice).toBe(ContinueChoice.PARTIAL_CLOSURE);
+    expect(payload.whatComesNext.partialClosure['tending-1']).toBe(PartialClosureResolution.RESOLVED);
+  });
+});

--- a/shared/src/dto/strategy.ts
+++ b/shared/src/dto/strategy.ts
@@ -319,6 +319,47 @@ export interface SubmitTendingResponseResponse {
   entry: TendingEntryDTO;
 }
 
+// Stage 4 Phase 5: the five forward paths surfaced at a Tending check-in.
+export enum ContinueChoice {
+  ANOTHER_ROUND = 'ANOTHER_ROUND',
+  EXTEND = 'EXTEND',
+  NEW_PROCESS = 'NEW_PROCESS',
+  PARTIAL_CLOSURE = 'PARTIAL_CLOSURE',
+  FULL_CLOSURE = 'FULL_CLOSURE',
+}
+
+export enum PartialClosureResolution {
+  RESOLVED = 'RESOLVED',
+  CONTINUING = 'CONTINUING',
+}
+
+export interface TendingCheckinOrientationReflection {
+  reflection: string;
+  perEntryNotes?: Record<string, string>;
+}
+
+export interface TendingCheckinWhatComesNext {
+  continueChoice: ContinueChoice;
+  partialClosure?: Record<string, PartialClosureResolution>;
+}
+
+export interface TendingCheckinOrientations {
+  whatWorked: TendingCheckinOrientationReflection;
+  whereMoreSupport: TendingCheckinOrientationReflection;
+  whatComesNext: TendingCheckinWhatComesNext;
+}
+
+export interface SubmitTendingCheckinRequest {
+  orientations: TendingCheckinOrientations;
+}
+
+export interface SubmitTendingCheckinResponse {
+  entries: TendingEntryDTO[];
+  newSessionId?: string;
+  continueChoice: ContinueChoice;
+  nextScheduledFor?: string | null;
+}
+
 export interface CreateTendingReentryRequest {
   intent?: string;
 }


### PR DESCRIPTION
## Summary

Implements Phase 5 of `.planning/STAGE_4_GOLD_ALIGNMENT_PLAN.md` — restructures the Tending check-in flow to the gold-reference shape.

- **Three orientations** at check-in: *What worked* → *Where would more support help* → *What comes next* (sequential nav; non-sequential is a documented follow-up).
- **Five forward paths**: `ANOTHER_ROUND` / `EXTEND` / `NEW_PROCESS` / `PARTIAL_CLOSURE` / `FULL_CLOSURE`.
- **Per-`TendingEntry` partial closure** — see scope decision below.

## Scope decision

The partial-closure resolution table targets **`TendingEntry`**, not `Agreement`. Rationale: this lets individual commitments (which surface as `TendingEntry` rows of scope `INDIVIDUAL`) be partially closed alongside shared agreement check-ins. Aligns with the plan's stated recommendation.

## Schema changes

- New `ContinueChoice` enum with all 5 values. `TendingResponse.continueChoice` is now typed as that enum (was `String?`). Historical rows remapped: `CONTINUE → EXTEND`, `ADJUST → ANOTHER_ROUND`, `CLOSE → FULL_CLOSURE`.
- New `TendingResponsePartialClosure` join table (`tendingResponseId` × `tendingEntryId` → `RESOLVED | CONTINUING`).
- New `Session.previousSessionId` nullable self-FK for `NEW_PROCESS` lineage.

Migrations:
- `20260513020000_expand_tending_continue_choice`
- `20260513020100_add_tending_partial_closure`
- `20260513020200_add_session_previous_session_id`

## Backend

- `POST /sessions/:id/tending/checkin` (`submitTendingCheckin`) accepts the structured three-orientation payload and applies path-specific state transitions in a transaction:
  - `ANOTHER_ROUND`: clears Stage 4 closure, selections, need coverage, declinations, and `selectionSubmitted` gates; closes the current Tending entries; session stays `ACTIVE`. Agreements preserved as history.
  - `EXTEND`: reschedules every open entry +4 weeks.
  - `NEW_PROCESS`: creates a fresh `Session` with `previousSessionId = oldId`, marks old session `RESOLVED`, closes current entries.
  - `PARTIAL_CLOSURE`: per-entry `RESOLVED → COMPLETED` / `CONTINUING → SCHEDULED +4w`; persists rows in `TendingResponsePartialClosure`.
  - `FULL_CLOSURE`: closes every entry, session → `RESOLVED`, no friction.
- 6 new service tests assert each path's transitions plus empty-state rejection.

## Mobile

- New `TendingCheckinScreen` with three-step sequential navigation (Back/Cancel + Next/Submit), the five-path picker with the documented copy, and inline `RESOLVED`/`CONTINUING` toggles when `PARTIAL_CLOSURE` is selected.
- New route `(auth)/session/[id]/tending-checkin.tsx` hosting the screen and routing per choice:
  - `ANOTHER_ROUND` → back to session
  - `NEW_PROCESS` → navigate to the newly-created session
  - `EXTEND` / `PARTIAL_CLOSURE` → confirmation showing next check-in date
  - `FULL_CLOSURE` → dignified closure alert ("This is wrapped. Whatever you've named here stays on record.")
- New `useSubmitTendingCheckin` hook.
- Tests cover the three-step flow and the inline partial-closure expansion.

## Out of scope (deferred to Phase 6)

- AI conversation quality at each orientation.
- Listen-first mode before the check-in date is reached.
- Non-sequential step navigation.
- Surfacing `previousSessionId` lineage in the new session UI.

## Test plan

- [ ] Seed a session past the scheduled check-in date with shared + individual entries.
- [ ] Walk all three orientations end-to-end.
- [ ] For each of the 5 paths in separate sessions, verify the documented state transitions (Stage 4 reset, scheduledFor extension, lineage on new session, per-entry persistence, terminal closure).
- [x] `npm run check` passes across all workspaces.
- [x] `npm run test` passes across all workspaces (1339 backend / 670 mobile / 215 shared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)