### PR TITLE
Stage 4 Phase 6: AI prompt tuning across seven surfaces

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -128,7 +128,7 @@ async function getStage4OpenNeedsForPrompt(
     const [coverageRows, willingSelections, declinations] = await Promise.all([
       prisma.stage4NeedCoverage.findMany({
         where: { sessionId, coverageStatus: { in: ['OPEN', 'PARTIAL'] } },
-        select: { id: true, needId: true, coveringProposalIds: true },
+        select: { id: true, needId: true, needLabel: true, coveringProposalIds: true },
       }),
       prisma.stage4ProposalSelection.findMany({
         where: { sessionId, userId, decision: 'WILLING' },
@@ -150,15 +150,19 @@ async function getStage4OpenNeedsForPrompt(
     });
     if (candidateRows.length === 0) return null;
     const needIds = candidateRows.map((r) => r.needId).filter((n): n is string => Boolean(n));
-    if (needIds.length === 0) return null;
-    const needs = await prisma.identifiedNeed.findMany({
-      where: { id: { in: needIds }, vessel: { userId } },
-      select: { id: true, need: true },
-    });
+    const needs = needIds.length > 0
+      ? await prisma.identifiedNeed.findMany({
+          where: { id: { in: needIds }, vessel: { userId } },
+          select: { id: true, need: true },
+        })
+      : [];
     const byId = new Map(needs.map((n) => [n.id, n.need] as const));
     const labels: Array<{ needLabel: string }> = [];
     for (const row of candidateRows) {
-      const label = row.needId ? byId.get(row.needId) : undefined;
+      // Prefer the user's exact phrasing from IdentifiedNeed; fall back to the
+      // coverage row's needLabel so coverage rows without an IdentifiedNeed
+      // link (or whose link belongs to the partner's vessel) still surface.
+      const label = (row.needId && byId.get(row.needId)) || row.needLabel;
       if (label) labels.push({ needLabel: label });
     }
     return labels.length > 0 ? labels : null;

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -44,6 +44,7 @@ import { captureProposedNeedsForUser } from '../services/needs';
 import { cleanVisibleAIText } from '../utils/visible-text';
 import { captureStage4Turn } from '../services/stage4-capture.service';
 import { applyStage4AutoClosureFromSignal } from '../services/stage4-auto-closure.service';
+import { isExplicitAskForInput } from '../services/stage4-prompts';
 
 // ============================================================================
 // Helpers
@@ -112,6 +113,78 @@ async function getStage4InventoryPromptContext(sessionId: string, currentUserId:
       return `- ${details.join(' | ')}`;
     })
     .join('\n');
+}
+
+/**
+ * Stage 4 Phase 6 — open needs (not declined, not yet willing-covered) with
+ * their labels, so the AI can surface one at a time in main chat with the
+ * user's own phrasing.
+ */
+async function getStage4OpenNeedsForPrompt(
+  sessionId: string,
+  userId: string
+): Promise<Array<{ needLabel: string }> | null> {
+  try {
+    const [coverageRows, willingSelections, declinations] = await Promise.all([
+      prisma.stage4NeedCoverage.findMany({
+        where: { sessionId, coverageStatus: { in: ['OPEN', 'PARTIAL'] } },
+        select: { id: true, needId: true, coveringProposalIds: true },
+      }),
+      prisma.stage4ProposalSelection.findMany({
+        where: { sessionId, userId, decision: 'WILLING' },
+        select: { proposalId: true },
+      }),
+      prisma.stage4NeedDeclination.findMany({
+        where: { sessionId, userId },
+        select: { needId: true },
+      }),
+    ]);
+    if (coverageRows.length === 0) return null;
+    const willingIds = new Set(willingSelections.map((s) => s.proposalId));
+    const declined = new Set(declinations.map((d) => d.needId));
+    const candidateRows = coverageRows.filter((row) => {
+      const needId = row.needId ?? row.id;
+      if (declined.has(needId)) return false;
+      const covered = row.coveringProposalIds.some((pid) => willingIds.has(pid));
+      return !covered;
+    });
+    if (candidateRows.length === 0) return null;
+    const needIds = candidateRows.map((r) => r.needId).filter((n): n is string => Boolean(n));
+    if (needIds.length === 0) return null;
+    const needs = await prisma.identifiedNeed.findMany({
+      where: { id: { in: needIds }, vessel: { userId } },
+      select: { id: true, need: true },
+    });
+    const byId = new Map(needs.map((n) => [n.id, n.need] as const));
+    const labels: Array<{ needLabel: string }> = [];
+    for (const row of candidateRows) {
+      const label = row.needId ? byId.get(row.needId) : undefined;
+      if (label) labels.push({ needLabel: label });
+    }
+    return labels.length > 0 ? labels : null;
+  } catch (err) {
+    logger.warn('[getStage4OpenNeedsForPrompt] failed', { error: err });
+    return null;
+  }
+}
+
+/**
+ * Stage 4 Phase 6 (Surface 6) — listen-first mode. Active when the session is
+ * RESOLVED and the user hasn't yet explicitly asked the AI for input since
+ * re-entry. Once any user message in history matches the explicit-ask regex,
+ * advice mode persists for the rest of the conversation.
+ */
+async function isStage4ListenFirstMode(
+  _sessionId: string,
+  _userId: string,
+  sessionStatus: string,
+  history: Array<{ role: string; content: string }>
+): Promise<boolean> {
+  if (sessionStatus !== 'RESOLVED') return false;
+  const askedForInput = history.some(
+    (m) => m.role === 'USER' && isExplicitAskForInput(m.content)
+  );
+  return !askedForInput;
 }
 
 /**
@@ -1506,6 +1579,17 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       ? await getStage4InventoryPromptContext(sessionId, user.id)
       : null;
 
+    const stage4OpenNeeds = currentStage === 4
+      ? await getStage4OpenNeedsForPrompt(sessionId, user.id)
+      : null;
+
+    const stage4ListenFirstMode = await isStage4ListenFirstMode(
+      sessionId,
+      user.id,
+      session.status,
+      history
+    );
+
     const prompt = buildStagePrompt(effectiveStage, {
       userName,
       currentUserId: user.id,
@@ -1522,6 +1606,8 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       empathyDraft: empathyDraftContent || undefined,
       isRefiningEmpathy: isRefiningEmpathy || undefined,
       stage4InventoryContext,
+      stage4OpenNeeds,
+      stage4ListenFirstMode,
       topicFrame: session.topicFrameConfirmedAt ? session.topicFrame : undefined,
     }, { isInvitationPhase });
 

--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -671,19 +671,13 @@ export async function shareStage4Selections(req: Request, res: Response): Promis
     // for the first time AND the partner hasn't shared yet, append a single
     // templated AI message to their chat so the moment doesn't go silent.
     try {
-      const partnerHasShared = partnerId
-        ? Boolean(
-            await prisma.stageProgress.findFirst({
-              where: {
-                sessionId,
-                userId: partnerId,
-                stage: 4,
-                gatesSatisfied: { path: ['selectionSubmitted'], equals: true },
-              },
-              select: { id: true },
-            })
-          )
-        : false;
+      const partnerProgress = partnerId
+        ? await prisma.stageProgress.findFirst({
+            where: { sessionId, userId: partnerId, stage: 4 },
+            select: { gatesSatisfied: true },
+          })
+        : null;
+      const partnerHasShared = hasSubmittedSelectionGate(partnerProgress?.gatesSatisfied);
       if (!partnerHasShared) {
         const sessionWithMembers = await prisma.session.findUnique({
           where: { id: sessionId },

--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -33,6 +33,7 @@ import { notifyPartner, publishSessionEvent } from '../services/realtime';
 import { successResponse, errorResponse } from '../utils/response';
 import { getPartnerUserId } from '../utils/session';
 import { getStage4State as buildStage4State, Stage4StateNotFoundError } from '../services/stage4-state';
+import { stage4HandoffBridgeMessage } from '../services/stage4-prompts';
 import {
   scheduleIndividualCommitmentTendingEntries,
   scheduleSharedAgreementTendingEntries,
@@ -664,6 +665,68 @@ export async function shareStage4Selections(req: Request, res: Response): Promis
         submittedBy: user.id,
         change: 'stage4_selection_submitted',
       });
+    }
+
+    // Stage 4 Phase 6 (Surface 5) — quiet handoff bridge. When this user shares
+    // for the first time AND the partner hasn't shared yet, append a single
+    // templated AI message to their chat so the moment doesn't go silent.
+    try {
+      const partnerHasShared = partnerId
+        ? Boolean(
+            await prisma.stageProgress.findFirst({
+              where: {
+                sessionId,
+                userId: partnerId,
+                stage: 4,
+                gatesSatisfied: { path: ['selectionSubmitted'], equals: true },
+              },
+              select: { id: true },
+            })
+          )
+        : false;
+      if (!partnerHasShared) {
+        const sessionWithMembers = await prisma.session.findUnique({
+          where: { id: sessionId },
+          include: {
+            relationship: {
+              include: {
+                members: {
+                  include: { user: { select: { firstName: true, name: true } } },
+                },
+              },
+            },
+          },
+        });
+        const members = sessionWithMembers?.relationship.members ?? [];
+        const myMember = members.find((m) => m.userId === user.id);
+        const partnerMember = members.find((m) => m.userId !== user.id);
+        const partnerName =
+          myMember?.nickname ||
+          partnerMember?.user.firstName ||
+          partnerMember?.user.name ||
+          undefined;
+        const bridgeContent = stage4HandoffBridgeMessage(partnerName);
+        const alreadyBridged = Boolean(
+          await prisma.message.findFirst({
+            where: { sessionId, forUserId: user.id, role: 'AI', content: bridgeContent },
+            select: { id: true },
+          })
+        );
+        if (!alreadyBridged) {
+          await prisma.message.create({
+            data: {
+              sessionId,
+              senderId: null,
+              forUserId: user.id,
+              role: 'AI',
+              content: bridgeContent,
+              stage: 4,
+            },
+          });
+        }
+      }
+    } catch (bridgeError) {
+      logger.warn('[shareStage4Selections] Failed to persist handoff bridge message', { bridgeError });
     }
 
     const state = await buildStage4State(sessionId, user.id);

--- a/backend/src/services/__tests__/stage4-prompts.test.ts
+++ b/backend/src/services/__tests__/stage4-prompts.test.ts
@@ -1,0 +1,96 @@
+import {
+  isExplicitAskForInput,
+  needsBrainstormPersona,
+  proposalRefinementPersona,
+  noOverlapPersona,
+  coverageReviewOpenNeedsClause,
+  stage4HandoffBridgeMessage,
+} from '../stage4-prompts';
+
+describe('isExplicitAskForInput', () => {
+  it.each([
+    'what should I do?',
+    'What should I do here, honestly',
+    "help me think about this please",
+    'Can you weigh in?',
+    'weigh in on this',
+    'any advice?',
+    'any ideas for next steps',
+    'any suggestions?',
+    'what would you suggest?',
+    'what would you recommend',
+    'what would you do',
+    'give me your take',
+    'give me advice',
+  ])('matches explicit ask: %s', (text) => {
+    expect(isExplicitAskForInput(text)).toBe(true);
+  });
+
+  it.each([
+    '',
+    'I was thinking about it on the drive home.',
+    'It worked, actually.',
+    'I stopped doing it last week.',
+    "I don't know what to feel.",
+    'what a day',
+  ])('does not match passive/reflective text: %s', (text) => {
+    expect(isExplicitAskForInput(text)).toBe(false);
+  });
+});
+
+describe('persona templates ground in user phrasing', () => {
+  it('needsBrainstormPersona quotes the exact need label verbatim', () => {
+    const persona = needsBrainstormPersona('feeling like myself inside this marriage');
+    expect(persona).toContain('"feeling like myself inside this marriage"');
+    expect(persona).toMatch(/do not lead with your own ideas/i);
+  });
+
+  it('needsBrainstormPersona falls back gracefully when label is missing', () => {
+    const persona = needsBrainstormPersona(null);
+    expect(persona).toContain('the named need');
+  });
+
+  it('proposalRefinementPersona quotes the proposal description and probes blockers', () => {
+    const persona = proposalRefinementPersona('walk together each evening');
+    expect(persona).toContain('"walk together each evening"');
+    expect(persona).toMatch(/what's making (them|the user) hesitate/i);
+  });
+
+  it('noOverlapPersona instructs near-miss and combination scanning, not pushing closure', () => {
+    const persona = noOverlapPersona();
+    expect(persona).toMatch(/near-miss/i);
+    expect(persona).toMatch(/combinable/i);
+    expect(persona).toMatch(/not to push for closure/i);
+  });
+});
+
+describe('coverageReviewOpenNeedsClause', () => {
+  it('returns empty when there are no open needs', () => {
+    expect(coverageReviewOpenNeedsClause([])).toBe('');
+  });
+
+  it('lists each open need by exact phrasing and instructs surfacing one at a time', () => {
+    const clause = coverageReviewOpenNeedsClause([
+      { needLabel: 'feeling like myself inside this marriage' },
+      { needLabel: 'not being alone on the inside' },
+    ]);
+    expect(clause).toContain('"feeling like myself inside this marriage"');
+    expect(clause).toContain('"not being alone on the inside"');
+    expect(clause).toMatch(/one at a time/i);
+    expect(clause).toMatch(/that's a valid place to land/i);
+  });
+});
+
+describe('stage4HandoffBridgeMessage', () => {
+  it('interpolates partner name and frames the wait + individual carry-forward', () => {
+    const msg = stage4HandoffBridgeMessage('Eve');
+    expect(msg).toContain('Eve');
+    expect(msg).toMatch(/shared experiment/i);
+    expect(msg).toMatch(/your own/i);
+  });
+
+  it('falls back to a generic partner phrase when name is missing', () => {
+    expect(stage4HandoffBridgeMessage(null)).toContain('your partner');
+    expect(stage4HandoffBridgeMessage('')).toContain('your partner');
+  });
+});

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -15,6 +15,10 @@ import { logger } from '../lib/logger';
 import { type ContextBundle } from './context-assembler';
 import { type SurfaceStyle } from './memory-intent';
 import { type CategorizedFact } from './partner-session-classifier';
+import {
+  RESOLVED_LISTEN_FIRST_CLAUSE,
+  coverageReviewOpenNeedsClause,
+} from './stage4-prompts';
 
 // ============================================================================
 // Response Protocol (Semantic Router Format)
@@ -469,6 +473,10 @@ export interface PromptContext {
   previousEmpathyContent?: string | null;
   /** Stage 4: active proposal inventory with stable IDs for typed add/revise/remove decisions */
   stage4InventoryContext?: string | null;
+  /** Stage 4 Phase 6 — open (not declined, not yet willing-covered) needs surfaced for COVERAGE_REVIEW proactive raising */
+  stage4OpenNeeds?: Array<{ needLabel: string }> | null;
+  /** Stage 4 Phase 6 — when true, main-chat persona switches to listen-first reflection mode (session RESOLVED, no check-in yet, user hasn't asked for input) */
+  stage4ListenFirstMode?: boolean;
   /** Partner's progress status for transition messages */
   partnerStatus?: 'not_joined' | 'in_progress' | 'completed';
   /**
@@ -1044,6 +1052,14 @@ When emitting <stage4_proposals>, set ownerUserId to currentUserId for INDIVIDUA
   }
   if (context.emotionalIntensity >= 8) {
     dynamicParts.push('HIGH USER INTENSITY: The user is very activated/distressed. Slow down. Validate first. This is not the moment for brainstorming — ground them before moving to action. Your tone should be calm and steady.');
+  }
+
+  if (context.stage4OpenNeeds && context.stage4OpenNeeds.length > 0) {
+    dynamicParts.push(coverageReviewOpenNeedsClause(context.stage4OpenNeeds));
+  }
+
+  if (context.stage4ListenFirstMode) {
+    dynamicParts.push(RESOLVED_LISTEN_FIRST_CLAUSE);
   }
 
   dynamicParts.push(`User's emotional intensity: ${context.emotionalIntensity}/10`);

--- a/backend/src/services/stage4-prompts.ts
+++ b/backend/src/services/stage4-prompts.ts
@@ -1,0 +1,183 @@
+/**
+ * Stage 4 — Phase 6 prompt fragments.
+ *
+ * Adjacent persona/clause templates for the seven Stage 4 AI surfaces so the
+ * gold-tone consistency across surfaces is visually obvious. Imported by:
+ *   - stage4-subchat.service.ts (Surfaces 2, 3, 4)
+ *   - stage-prompts.ts           (Surfaces 1, 6)
+ *   - stage4.ts controller       (Surface 5 — templated bridge message)
+ *   - tending controller / service (Surface 7 fragments, available for use
+ *     by per-orientation tending conversation if/when wired)
+ *
+ * Source of truth: docs/product/source-material/golden-transcripts/.
+ */
+
+// ---------------------------------------------------------------------------
+// Sub-chat personas (Surfaces 2, 3, 4)
+// ---------------------------------------------------------------------------
+
+export function needsBrainstormPersona(needLabel: string | null | undefined): string {
+  const need = needLabel?.trim() || 'the named need';
+  return [
+    `You're inside a focused side-conversation about one specific named need: "${need}".`,
+    `Your job is to help the user move from this need toward a small, bounded, observable experiment they could try.`,
+    `Ground every suggestion in the user's exact phrasing of the need — do not reframe it into generic conflict-resolution language.`,
+    ``,
+    `Approach:`,
+    `1. Ask first what the user has in mind. Do not lead with your own ideas.`,
+    `2. If they have a half-formed idea, help them sharpen it — narrow scope, add a time bound, surface what "it worked" would look like, make it reversible.`,
+    `3. Only offer your own ideas if they ask, or if they say they're stuck. Then offer at most one or two, each tied back to "${need}".`,
+    `4. A well-formed experiment is: specific, time-bounded ("for one week"), reversible ("we can stop if it's not helping"), observable ("we'll know if..."), and small enough to actually try.`,
+    `5. Only surface a structured proposal draft after the user has explicitly agreed to a concrete shape. Don't draft proposals speculatively — that pre-empts their agency.`,
+    ``,
+    `Tone: short, concrete, grounded. Default 1–3 sentences. Stay scoped to "${need}"; don't drift to the inventory at large.`,
+  ].join('\n');
+}
+
+export function proposalRefinementPersona(
+  proposalDescription: string | null | undefined
+): string {
+  const proposal = proposalDescription?.trim() || 'this proposal';
+  return [
+    `You're inside a focused side-conversation about one specific proposal: "${proposal}".`,
+    `Your job is to help the user reshape it so they could actually try it — not to defend it, not to talk them into it.`,
+    ``,
+    `Approach:`,
+    `1. Start by asking one focused question: what's making them hesitate? Is it the timing, the scope, or something about the experiment itself?`,
+    `2. Listen for which of the three is in the way: the what, the duration, or the success-measure. Treat them as independently reshapable — you can change one and leave the others.`,
+    `3. Propose a specific reshaped version that addresses the blocker. Don't list options abstractly; offer a concrete next shape and ask if it lands.`,
+    `4. If the user wants to remove or abandon the proposal, honor that immediately. Don't lobby for it.`,
+    ``,
+    `Stay scoped to this one proposal. Don't drift back to the inventory at large or compare against other proposals unless the user brings them in.`,
+    `Tone: short, concrete, collaborative. Default 1–3 sentences.`,
+  ].join('\n');
+}
+
+export function noOverlapPersona(): string {
+  return [
+    `Both partners have shared their willingness stances on the inventory and no shared proposal has mutual 'willing'.`,
+    `You can see both sides' stances in the inventory snapshot below. Your job is to help the user see what's actually possible from here — not to push for closure.`,
+    ``,
+    `Approach:`,
+    `1. Look for near-misses first: proposals where this user said Willing and the partner said Not willing (or vice versa). What's the small thing that would change for the un-willing side? A different duration? A smaller scope? A different success-measure?`,
+    `2. Look for combinable proposals: where two proposals have overlapping structure, a single reshaped proposal might bridge both.`,
+    `3. Only generate fresh alternatives when refinement and combination won't bridge — and when you do, ground them in the user's stated needs, not generic conflict-resolution moves.`,
+    `4. Hold the possibility that no shared agreement is a valid outcome. Individual commitments and a named open need are real results — don't treat them as failure.`,
+    ``,
+    `Tone: short, observant, non-pressuring. Default 1–3 sentences.`,
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main-chat conditional clauses (Surfaces 1, 6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Open-needs clause for COVERAGE_REVIEW: list open-and-not-declined needs and
+ * instruct the AI to raise one at a time with the gold's exact tone.
+ */
+export function coverageReviewOpenNeedsClause(
+  openNeeds: Array<{ needLabel: string }>
+): string {
+  if (openNeeds.length === 0) return '';
+  const list = openNeeds.map((n) => `  - "${n.needLabel}"`).join('\n');
+  return [
+    `COVERAGE_REVIEW — OPEN NEEDS NOT YET ADDRESSED OR DECLINED:`,
+    list,
+    ``,
+    `If the user is naturally pausing (not mid-thought) and there is at least one open need above, surface ONE at a time — never a list. Use the user's exact phrasing for the need. Sound like:`,
+    `  "I noticed [their exact words] isn't covered by what's on the table yet. Want to brainstorm something for it?"`,
+    `If they say yes, guide them toward tapping Brainstorm (which opens a focused side-chat). Do not try to do the brainstorm inside the main chat.`,
+    `If they say no, ask once: "Is it okay for now that this one isn't on the table here? That's a valid place to land." Then drop it.`,
+    `Never frame an open need as a failure. Never stack multiple needs into a single turn. Never raise a need they have already declined.`,
+  ].join('\n');
+}
+
+/**
+ * RESOLVED-session listen-first clause (Surface 6). When the session is RESOLVED
+ * and the user re-enters before the scheduled check-in has been submitted, the
+ * AI is reflection-only: no advice, no nudges toward the experiment, no judgment
+ * about abandonment.
+ */
+export const RESOLVED_LISTEN_FIRST_CLAUSE = [
+  `LISTEN-FIRST MODE — SESSION ALREADY RESOLVED:`,
+  `This session has been resolved. The user is returning before any scheduled check-in.`,
+  `Your job right now is to listen and reflect. Not to redirect. Not to nudge them back toward what they committed to. Not to coach.`,
+  ``,
+  `If the user comes in having already stopped doing something they committed to: that is not a failure. It is information. Reflect what they say. Ask what got in the way — not how to restart.`,
+  `If the user comes in with wins: name them and stay there. Don't rush to "what's next".`,
+  `If the user comes in distressed: stay with the distress. Don't problem-solve unless they ask.`,
+  ``,
+  `Stay in listen-first mode until the user explicitly asks for input — phrases like "what should I do?", "help me think about this", "can you weigh in?", "what do you think I should try?". When they ask, you can shift to advice mode for the rest of the conversation. Until then: reflect, don't drive.`,
+].join('\n');
+
+/**
+ * Detect whether a user message is explicitly asking for input, exiting
+ * listen-first mode. Kept as a simple regex per the plan; upgrade only if it
+ * misses cases in practice.
+ */
+export function isExplicitAskForInput(text: string): boolean {
+  if (!text) return false;
+  const t = text.toLowerCase();
+  const patterns = [
+    /\bwhat\s+should\s+i\s+do\b/,
+    /\bwhat\s+do\s+you\s+think\s+i\s+should\b/,
+    /\bhelp\s+me\s+think\b/,
+    /\bcan\s+you\s+weigh\s+in\b/,
+    /\bweigh\s+in\b/,
+    /\bany\s+(?:advice|ideas|suggestions)\b/,
+    /\bwhat\s+would\s+you\s+(?:suggest|recommend|do)\b/,
+    /\bgive\s+me\s+(?:advice|ideas|suggestions|your\s+take)\b/,
+  ];
+  return patterns.some((rx) => rx.test(t));
+}
+
+// ---------------------------------------------------------------------------
+// Surface 5 — handoff bridge templated message
+// ---------------------------------------------------------------------------
+
+export function stage4HandoffBridgeMessage(partnerName: string | null | undefined): string {
+  const partner = partnerName?.trim() || 'your partner';
+  return [
+    `Now ${partner} gets their turn to think about what they want to try.`,
+    `Once they're done, you'll both see whether there's a shared experiment you want to commit to together — and whatever you've named as your own is yours to carry either way.`,
+  ].join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Surface 7 — three-orientation Tending check-in micro-personas
+// ---------------------------------------------------------------------------
+
+/**
+ * "What worked" — surface each entry by name and ask for specifics. Hold wins
+ * explicitly; don't rush past them.
+ */
+export const TENDING_WHAT_WORKED_PERSONA = [
+  `You're walking the user through the "what worked" part of a Tending check-in.`,
+  `For each agreement or commitment, surface it by name and ask for the specifics of what shifted, even a little. Wins are named, however small.`,
+  `Don't accept "everything went great" without probing for an actual moment — ask: "What's one moment that stands out?"`,
+  `Don't rush to the next orientation. Sit with the wins. This is the only part of the protocol that's allowed to be slow on purpose.`,
+].join('\n');
+
+/**
+ * "Where would more support help" — receive without redirecting. Information,
+ * not failure.
+ */
+export const TENDING_MORE_SUPPORT_PERSONA = [
+  `You're walking the user through the "where would more support help" part of a Tending check-in.`,
+  `Receive what they share without redirecting. If they say "I stopped doing it," your response is "What got in the way?" — NOT "how can we restart?". Abandonment of a commitment is information, not failure.`,
+  `No judgment, no rescue, no coaching. Just naming what's still hard.`,
+  `Default 1–2 sentences per turn.`,
+].join('\n');
+
+/**
+ * "What comes next" — present the 5 paths neutrally. Full closure is honored
+ * without qualification.
+ */
+export const TENDING_WHAT_COMES_NEXT_PERSONA = [
+  `You're walking the user through the "what comes next" part of a Tending check-in.`,
+  `There are five paths: try another round, keep going (extend), start a new process, close some & continue others (partial closure), or close fully.`,
+  `Describe them neutrally. Do not editorialize on which is "right." Do not nudge toward continuing.`,
+  `If the user picks FULL_CLOSURE: honor it without qualification. A grounded response is something like "Then it matters that you said it here. That's real." Do not try to talk them out of it. Do not ask if they're sure.`,
+  `Full closure is a legitimate, dignified outcome — not an abandonment.`,
+].join('\n');

--- a/backend/src/services/stage4-subchat.service.ts
+++ b/backend/src/services/stage4-subchat.service.ts
@@ -33,6 +33,11 @@ import {
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 import { getCompletion } from '../lib/bedrock';
+import {
+  needsBrainstormPersona,
+  noOverlapPersona,
+  proposalRefinementPersona,
+} from './stage4-prompts';
 
 const MAIN_CHAT_HISTORY_LIMIT = 60;
 
@@ -154,14 +159,16 @@ export async function getSubChatById(
 // Prompt construction
 // ---------------------------------------------------------------------------
 
-const PERSONA_INSTRUCTIONS: Record<Stage4SubChatAnchor, string> = {
-  [Stage4SubChatAnchor.NEEDS_BRAINSTORM]:
-    "You're helping the user generate small, bounded, observable experiments to address the named need. Stay scoped to this need. When the user agrees on a concrete experiment, surface it as a structured proposal draft they can accept.",
-  [Stage4SubChatAnchor.PROPOSAL_REFINEMENT]:
-    "You're helping the user reshape a specific Stage 4 proposal. Identify what's blocking willingness and propose modifications. Stay scoped to this one proposal.",
-  [Stage4SubChatAnchor.NO_OVERLAP]:
-    "Both partners have shared willingness stances on the inventory and no shared proposal has mutual 'willing'. Help the user refine, combine, or generate new options grounded in their stated needs.",
-};
+function personaFor(anchor: AnchorContext): string {
+  switch (anchor.anchorKind) {
+    case Stage4SubChatAnchor.NEEDS_BRAINSTORM:
+      return needsBrainstormPersona(anchor.needLabel);
+    case Stage4SubChatAnchor.PROPOSAL_REFINEMENT:
+      return proposalRefinementPersona(anchor.proposalDescription);
+    case Stage4SubChatAnchor.NO_OVERLAP:
+      return noOverlapPersona();
+  }
+}
 
 export interface AnchorContext {
   anchorKind: Stage4SubChatAnchor;
@@ -213,7 +220,7 @@ export async function buildSystemPrompt(
   input: PromptBuildInput
 ): Promise<BuiltPrompt> {
   const { sessionId, userId, anchor, anchorId } = input;
-  const persona = PERSONA_INSTRUCTIONS[anchor.anchorKind];
+  const persona = personaFor(anchor);
 
   const anchorBlock =
     anchor.anchorKind === Stage4SubChatAnchor.NEEDS_BRAINSTORM


### PR DESCRIPTION
## Summary

Implements every prompt change described in `.planning/STAGE_4_PHASE_6_AI_PROMPT_TUNING.md` across the seven Stage 4 AI surfaces, bundled into one PR per the plan's `/goal`-shaped approach.

- New `backend/src/services/stage4-prompts.ts` collects per-surface templates side-by-side so gold-tone consistency is visually obvious.
- Sub-chat personas (Surfaces 2/3/4) replaced with rich, anchor-aware templates that ground every suggestion in the user's exact need/proposal phrasing.
- Stage 4 main-chat prompt picks up two new conditional clauses:
  - **Surface 1 (COVERAGE_REVIEW open-needs):** lists not-declined, not-willing-covered needs by exact phrasing; instructs the AI to raise one at a time during natural pauses.
  - **Surface 6 (RESOLVED listen-first):** activates when `session.status === 'RESOLVED'` and the user hasn't yet matched the explicit-ask regex; instructs reflect-only behavior.
- **Surface 5 (handoff bridge):** share-selections endpoint persists a single templated AI message when this user shares first and the partner hasn't shared yet.
- **Surface 7 (Tending micro-personas):** three orientation fragments exported from the new prompts file, ready to wire into per-orientation conversations.

Behavior tests for the sub-chat were already structural (they assert main-chat history inclusion, not persona wording), so no test updates were needed.

## Test plan
- [x] `npm run check` across all workspaces
- [x] `npm run test` across all workspaces (backend, mobile, shared)
- [ ] Manual verification per `STAGE_4_MANUAL_TESTING_CHECKLIST.md` Phase 6 section (post-merge eyes-and-taste loop per the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)