### PR TITLE
docs: incremental audit 2026-05-13 — Stage 4 Phase 1-6 doc sync

### DIFF
--- a/docs/backend/api/stage-4.md
+++ b/docs/backend/api/stage-4.md
@@ -3,7 +3,7 @@ title: "Stage 4 API: Strategic Repair"
 sidebar_position: 11
 description: Endpoints for collaborative strategy proposal, willingness selection, agreement documentation, and Tending check-ins.
 slug: /backend/api/stage-4
-updated: 2026-05-09
+updated: 2026-05-13
 ---
 # Stage 4 API: Strategic Repair
 
@@ -15,7 +15,7 @@ Stage 4 is **sequential** (unlike stages 1-3 which are parallel). Both users mus
 
 > **Two flows coexist in the codebase.**
 >
-> The **redesigned flow** (primary) uses a willingness-selection model: proposals are AI-captured, both users indicate willingness (WILLING / NOT_WILLING / NEEDS_DISCUSSION) per proposal, then stage 4 closes explicitly via `POST /stage4/close`. See [Stage 4 Redesign endpoints](#stage-4-redesign-primary-flow) below.
+> The **redesigned flow** (primary) uses a willingness-selection model: proposals are AI-captured, both users indicate willingness (WILLING / NOT_WILLING) per proposal, then stage 4 closes explicitly via `POST /stage4/close`. See [Stage 4 Redesign endpoints](#stage-4-redesign-primary-flow) below.
 >
 > The **legacy flow** (vestigial) used private ranking followed by overlap reveal. Its endpoints (`/strategies/rank`, `/strategies/overlap`, `/strategies/ready`) remain in the router for backward compatibility but are not the primary resolution path.
 
@@ -47,13 +47,50 @@ GET /api/v1/sessions/:id/stage4
 ```typescript
 interface GetStage4StateResponse {
   phase: Stage4Phase;
-  proposals: ProposalCardDTO[];
+  inventory: ProposalInventoryDTO;
   coverageAudit: Stage4CoverageAuditDTO;
   mySelections: Stage4SelectionDTO[];
-  partnerSelectionsSubmitted: boolean;
-  closure: Stage4ClosureDTO | null;
-  agreements: AgreementDTO[];
+  partnerSelections: Stage4SelectionDTO[];  // visible after both users share
+  mySelectionStatus: 'NOT_SUBMITTED' | 'SUBMITTED' | 'SHARED';
+  partnerSelectionStatus: 'NOT_SUBMITTED' | 'SUBMITTED' | 'SHARED';
+  outcome: Stage4OutcomeDTO | null;
   tendingPreview: TendingPreviewDTO | null;
+}
+
+interface ProposalInventoryDTO {
+  sharedProposals: ProposalCardDTO[];
+  individualCommitments: ProposalCardDTO[];
+  unaddressedNeeds: UnaddressedNeedDTO[];
+}
+
+interface ProposalCardDTO {
+  id: string;
+  kind: Stage4ProposalKind;   // SHARED_PROPOSAL | INDIVIDUAL_COMMITMENT
+  description: string;
+  ownerLabel: 'You' | string;  // partner display name for partner-owned proposals
+  needsAddressed: ProposalNeedCoverageDTO[];
+  duration: string | null;
+  measureOfSuccess: string | null;
+  status: Stage4ProposalStatus; // ACTIVE | REVISED | REMOVED | CONVERTED_TO_AGREEMENT
+  myDecision: Stage4SelectionDecision | null;
+  partnerDecisionVisible: Stage4SelectionDecision | null;  // null until partner shares
+}
+
+interface ProposalNeedCoverageDTO {
+  needLabel: string;
+  coverageStatus: 'COVERED' | 'PARTIAL' | 'OPEN';
+}
+
+interface UnaddressedNeedDTO {
+  needId: string;
+  needLabel: string;
+  sourceUserId: string;
+  declinedAt: string | null;  // set when user marks "leave for now"
+}
+
+enum Stage4SelectionDecision {
+  WILLING     = 'WILLING',
+  NOT_WILLING = 'NOT_WILLING',
 }
 
 enum Stage4Phase {
@@ -64,22 +101,6 @@ enum Stage4Phase {
   CLOSING                    = 'CLOSING',
   CLOSED_SHARED_AGREEMENT    = 'CLOSED_SHARED_AGREEMENT',
   CLOSED_NO_SHARED_AGREEMENT = 'CLOSED_NO_SHARED_AGREEMENT',
-}
-
-interface ProposalCardDTO {
-  id: string;
-  description: string;
-  needsAddressed: string[];
-  duration: string | null;
-  kind: Stage4ProposalKind;   // SHARED_PROPOSAL | INDIVIDUAL_COMMITMENT
-  status: Stage4ProposalStatus; // ACTIVE | REVISED | REMOVED | CONVERTED_TO_AGREEMENT
-  mySelection: Stage4SelectionDecision | null;
-}
-
-enum Stage4SelectionDecision {
-  WILLING          = 'WILLING',
-  NOT_WILLING      = 'NOT_WILLING',
-  NEEDS_DISCUSSION = 'NEEDS_DISCUSSION',
 }
 ```
 
@@ -103,11 +124,8 @@ interface SubmitStage4ProposalSelectionRequest {
 #### Response
 
 ```typescript
-interface SubmitStage4ProposalSelectionResponse {
-  proposalId: string;
-  decision: Stage4SelectionDecision;
-  note: string | null;
-}
+// Returns the full updated GetStage4StateResponse
+type SubmitStage4ProposalSelectionResponse = GetStage4StateResponse;
 ```
 
 Gate link: sets `selectionSubmitted` on `StageProgress.gatesSatisfied` after the caller submits decisions.
@@ -137,7 +155,9 @@ interface SubmitStage4SelectionsRequest {
 ```typescript
 interface SubmitStage4SelectionsResponse {
   submitted: boolean;
-  count: number;
+  submittedAt: string;
+  partnerSubmitted: boolean;
+  state: GetStage4StateResponse;
 }
 ```
 
@@ -157,10 +177,10 @@ POST /api/v1/sessions/:id/stage4/close
 
 ```typescript
 interface CloseStage4Request {
+  checkInDate: string;               // REQUIRED. ISO 8601 date — single follow-up date for all tending entries
   kind?: Stage4ClosureKind;          // Overrides computed kind if provided
   reason?: Stage4ClosureReason;
   summary?: string;                  // max 2000 chars
-  followUpDatesByProposalId?: Record<string, string>;  // proposalId → ISO 8601 date
 }
 
 enum Stage4ClosureKind {
@@ -180,11 +200,158 @@ enum Stage4ClosureReason {
 
 ```typescript
 interface CloseStage4Response {
-  closure: Stage4ClosureDTO;
-  agreements: AgreementDTO[];
-  sessionResolved: boolean;
+  closed: boolean;
+  closedAt: string;
+  outcome: Stage4OutcomeDTO;
+  state: GetStage4StateResponse;
+}
+
+interface Stage4OutcomeDTO {
+  kind: Stage4ClosureKind;
+  reason: Stage4ClosureReason;
+  sharedAgreements: AgreementDTO[];
+  individualCommitments: ProposalCardDTO[];
+  checkInAt: string | null;
 }
 ```
+
+---
+
+### Share Selections
+
+Publishes the caller's willingness decisions to their partner. Before sharing, decisions are private. Once shared, the partner can see your stances on each proposal. Enables symmetric reveal.
+
+```
+POST /api/v1/sessions/:id/stage4/share-selections
+```
+
+Returns the full `GetStage4StateResponse` with updated `mySelectionStatus: 'SHARED'`.
+
+---
+
+### Unshare Selections
+
+Withdraws the caller's shared selections (allowed while partner has not yet shared).
+
+```
+POST /api/v1/sessions/:id/stage4/unshare-selections
+```
+
+Returns the full `GetStage4StateResponse` with updated `mySelectionStatus: 'SUBMITTED'`.
+
+---
+
+### Decline / Undecline a Need
+
+Mark a need as "leave for now" instead of forcing full coverage before closure.
+
+```
+POST /api/v1/sessions/:id/stage4/needs/:needId/decline
+DELETE /api/v1/sessions/:id/stage4/needs/:needId/decline
+```
+
+Both return the full `GetStage4StateResponse`.
+
+---
+
+### Open Sub-Chat
+
+Open a guided AI sub-chat anchored to a specific context (needs brainstorm, proposal refinement, or no-overlap recovery). The sub-chat uses a persona tuned to the anchor kind.
+
+```
+POST /api/v1/sessions/:id/stage4/subchat
+```
+
+#### Request Body
+
+```typescript
+interface OpenStage4SubChatRequest {
+  anchorKind: Stage4SubChatAnchor;
+  anchorId?: string;  // proposalId for PROPOSAL_REFINEMENT; needId for NEEDS_BRAINSTORM
+}
+
+enum Stage4SubChatAnchor {
+  NEEDS_BRAINSTORM    = 'NEEDS_BRAINSTORM',     // Brainstorm proposals for an unaddressed need
+  PROPOSAL_REFINEMENT = 'PROPOSAL_REFINEMENT',  // Refine an existing proposal
+  NO_OVERLAP          = 'NO_OVERLAP',           // Guided recovery when no mutual willing proposals exist
+}
+```
+
+#### Response
+
+```typescript
+interface OpenStage4SubChatResponse {
+  subChat: Stage4SubChatDTO;
+}
+
+interface Stage4SubChatDTO {
+  id: string;
+  anchorKind: Stage4SubChatAnchor;
+  anchorId: string | null;
+  status: Stage4SubChatStatus;   // ACTIVE | RESOLVED
+  messages: Stage4SubChatMessageDTO[];
+  createdAt: string;
+  resolvedAt: string | null;
+}
+
+interface Stage4SubChatMessageDTO {
+  id: string;
+  role: 'USER' | 'AI';
+  content: string;
+  proposalDraft?: Stage4ProposalDraft;  // AI-surfaced candidate proposal
+  createdAt: string;
+}
+
+interface Stage4ProposalDraft {
+  description: string;
+  kind: Stage4ProposalKind;
+  duration: string | null;
+  measureOfSuccess: string | null;
+}
+
+enum Stage4SubChatStatus {
+  ACTIVE   = 'ACTIVE',
+  RESOLVED = 'RESOLVED',
+}
+```
+
+---
+
+### Send Sub-Chat Message
+
+```
+POST /api/v1/sessions/:id/stage4/subchat/:subChatId/messages
+```
+
+#### Request Body
+
+```typescript
+interface SendStage4SubChatMessageRequest {
+  content: string;  // max 2000 chars
+}
+```
+
+Returns the updated `Stage4SubChatDTO`.
+
+---
+
+### Resolve Sub-Chat
+
+Accept a proposal draft from the sub-chat (optionally modified) and apply it to the main proposal inventory.
+
+```
+POST /api/v1/sessions/:id/stage4/subchat/:subChatId/resolve
+```
+
+#### Request Body
+
+```typescript
+interface ResolveStage4SubChatRequest {
+  acceptedDraft?: Stage4ProposalDraft;  // omit to resolve without creating a proposal
+}
+```
+
+Returns `{ subChat: Stage4SubChatDTO; state: GetStage4StateResponse }`.
 
 ---
 
@@ -651,11 +818,12 @@ Stage 4 uses these caller-side gate markers on `StageProgress.gatesSatisfied`:
 | Gate | Flow | Requirement |
 |------|------|-------------|
 | `selectionSubmitted` | Redesign (primary) | Caller posted `/stage4/proposals/:id/selection` or `/stage4/selections` |
+| `shareSelectionSubmitted` | Redesign (primary) | Caller posted `/stage4/share-selections` |
 | `readyToRank` | Legacy | Caller posted `/strategies/ready` after contributing at least one strategy |
 | `rankingSubmitted` | Legacy | Caller posted `/strategies/rank` after both users were ready |
 | `agreementCreated` | Legacy | Set by generic `/stages/advance` gate table; not used by redesign closure |
 
-In the redesigned flow, session resolution is driven by `POST /stage4/close`. The `selectionSubmitted` gate is the primary prerequisite checked before closure is allowed. `readyToRank` and `rankingSubmitted` are set but not consulted by `closeStage4`.
+In the redesigned flow, session resolution is driven by `POST /stage4/close`. The caller must have submitted AND shared their selections (`shareSelectionSubmitted`) before closure is allowed. `readyToRank` and `rankingSubmitted` are set but not consulted by `closeStage4`.
 
 In the legacy flow, session resolves when every `Agreement` row is fully confirmed by both partners.
 
@@ -668,9 +836,10 @@ flowchart TD
     Enter[Enter Stage 4] --> Inventory[AI captures proposals from conversation]
     Inventory --> Coverage[Coverage audit: which needs are addressed?]
     Coverage --> Select[Each user submits willingness per proposal]
-    Select --> BothSelected{Both submitted selections?}
-    BothSelected -->|No| Wait[Wait for partner]
-    BothSelected -->|Yes| Review[Outcome review: shared willing proposals visible]
+    Select --> Share[POST /stage4/share-selections]
+    Share --> BothShared{Both shared selections?}
+    BothShared -->|No| Wait[Wait for partner]
+    BothShared -->|Yes| Review[Outcome review: symmetric reveal of willing proposals]
     Review --> Close[POST /stage4/close]
     Close --> SharedAgree{Mutual WILLING overlap?}
     SharedAgree -->|Yes| CLOSED_SHARED[CLOSED_SHARED_AGREEMENT: Agreements created, Tending scheduled]

--- a/docs/backend/api/tending.md
+++ b/docs/backend/api/tending.md
@@ -4,7 +4,7 @@ sidebar_position: 12
 description: Post-resolution check-in and re-entry endpoints for follow-through on Stage 4 agreements.
 slug: /backend/api/tending
 created: 2026-05-06
-updated: 2026-05-06
+updated: 2026-05-13
 status: living
 ---
 # Tending API
@@ -13,10 +13,11 @@ Post-resolution check-in and re-entry endpoints. Tending surfaces after a sessio
 
 ## Overview
 
-Two Tending flows exist:
+Three Tending entry types exist:
 
-- **Scheduled check-ins** (`SCHEDULED_SHARED_AGREEMENT_CHECKIN`) — created automatically when `Stage4Closure` records agreements with a `followUpDate`. The cron script `backend/src/scripts/open-due-tending-entries.ts` opens them when their scheduled time arrives.
-- **Passive re-entry** (`USER_INITIATED_REENTRY`) — created on demand when a user returns to a resolved session and wants to reconnect with its outcomes. Context is assembled from the Stage 4 closure summary, agreements, open needs, and individual commitments.
+- **Scheduled shared check-ins** (`SCHEDULED_SHARED_AGREEMENT_CHECKIN`) — created automatically for shared agreements when `Stage4Closure` is recorded. Visible to both session members. The cron script `backend/src/scripts/open-due-tending-entries.ts` opens them when their scheduled time arrives.
+- **Scheduled individual check-ins** (`SCHEDULED_INDIVIDUAL_COMMITMENT_CHECKIN`) — created for each user's individual commitments with `scope = INDIVIDUAL`. Only the owning user sees these by default; they can opt in to share with their partner via `POST tending/:entryId/share`.
+- **Passive re-entry** (`USER_INITIATED_REENTRY`) — created on demand when a user returns to a resolved session. Context is assembled from the Stage 4 closure summary, agreements, open needs, and individual commitments.
 
 ### Entry status lifecycle
 
@@ -47,27 +48,46 @@ interface TendingEntryDTO {
   id: string;
   type: TendingEntryType;
   status: TendingEntryStatus;
+  scope: TendingEntryScope;       // SHARED | INDIVIDUAL
+  ownerUserId: string | null;     // Set for INDIVIDUAL entries; null for SHARED
+  optedInShared: boolean;         // INDIVIDUAL entry owner has shared with partner
   scheduledFor: string | null;    // ISO 8601; null for re-entry
   openedAt: string | null;
   completedAt: string | null;
   summary: string | null;         // Context assembled at creation time
   myResponse: TendingResponseDTO | null;
   responseCount: number;          // How many partners have responded
+  createdAt: string;
+  updatedAt: string;
+}
+
+enum TendingEntryScope {
+  SHARED     = 'SHARED',
+  INDIVIDUAL = 'INDIVIDUAL',
 }
 
 interface TendingResponseDTO {
   id: string;
   tendingEntryId: string;
   userId: string;
-  status: string;                 // e.g. "WORKED", "PARTLY", "DID_NOT_WORK"
+  status: string;                         // e.g. "WORKED", "PARTLY", "DID_NOT_WORK"
   reflection: string | null;
-  continueChoice: string | null;  // e.g. "CONTINUE", "ADJUST", "CLOSE"
+  continueChoice: ContinueChoice | null;  // Five structured forward paths
   submittedAt: string;
 }
 
+enum ContinueChoice {
+  ANOTHER_ROUND   = 'ANOTHER_ROUND',   // Reset Stage 4 to inventory building
+  EXTEND          = 'EXTEND',          // Keep entries SCHEDULED with new follow-up date (28 days)
+  NEW_PROCESS     = 'NEW_PROCESS',     // Create a fresh Session linked via previousSessionId; both users restart at Stage 0
+  PARTIAL_CLOSURE = 'PARTIAL_CLOSURE', // Resolve some entries, continue others (per-TendingEntry granularity)
+  FULL_CLOSURE    = 'FULL_CLOSURE',    // Mark all entries COMPLETED, move session to RESOLVED
+}
+
 enum TendingEntryType {
-  SCHEDULED_SHARED_AGREEMENT_CHECKIN = 'SCHEDULED_SHARED_AGREEMENT_CHECKIN',
-  USER_INITIATED_REENTRY             = 'USER_INITIATED_REENTRY',
+  SCHEDULED_SHARED_AGREEMENT_CHECKIN      = 'SCHEDULED_SHARED_AGREEMENT_CHECKIN',
+  SCHEDULED_INDIVIDUAL_COMMITMENT_CHECKIN = 'SCHEDULED_INDIVIDUAL_COMMITMENT_CHECKIN',
+  USER_INITIATED_REENTRY                  = 'USER_INITIATED_REENTRY',
 }
 
 enum TendingEntryStatus {
@@ -94,9 +114,9 @@ POST /api/v1/sessions/:id/tending/:entryId/responses
 
 ```typescript
 interface SubmitTendingResponseRequest {
-  status: string;             // Required; max 80 chars. e.g. "WORKED", "PARTLY", "DID_NOT_WORK"
-  reflection?: string;        // Optional; max 2000 chars
-  continueChoice?: string;    // Optional; max 80 chars. e.g. "CONTINUE", "ADJUST", "CLOSE"
+  status: string;                    // Required; max 80 chars. e.g. "WORKED", "PARTLY", "DID_NOT_WORK"
+  reflection?: string;               // Optional; max 2000 chars
+  continueChoice?: ContinueChoice;   // Optional; one of the five ContinueChoice enum values
 }
 ```
 
@@ -153,6 +173,83 @@ interface CreateTendingReentryResponse {
 
 ---
 
+## Structured Three-Orientation Check-in
+
+The primary unified endpoint for tending responses. Handles all open entries in one atomic transaction with structured three-part input.
+
+```
+POST /api/v1/sessions/:id/tending/checkin
+```
+
+### Request Body
+
+```typescript
+interface SubmitTendingCheckinRequest {
+  orientations: {
+    whatWorked: {
+      reflection: string;                          // max 2000 chars
+      perEntryNotes?: Record<string, string>;      // entryId → note
+    };
+    whereMoreSupport: {
+      reflection: string;                          // max 2000 chars
+      perEntryNotes?: Record<string, string>;
+    };
+    whatComesNext: {
+      continueChoice: ContinueChoice;
+      partialClosure?: Record<string, PartialClosureResolution>;  // entryId → resolution (PARTIAL_CLOSURE path only)
+    };
+  };
+}
+
+enum PartialClosureResolution {
+  RESOLVED   = 'RESOLVED',
+  CONTINUING = 'CONTINUING',
+}
+```
+
+### Response
+
+```typescript
+interface SubmitTendingCheckinResponse {
+  entries: TendingEntryDTO[];
+  newSessionId?: string;            // Populated when continueChoice = NEW_PROCESS
+  continueChoice: ContinueChoice;
+  nextScheduledFor?: string | null; // ISO 8601; populated when continueChoice = EXTEND
+}
+```
+
+### Behavior by ContinueChoice
+
+| Choice | Effect |
+|--------|--------|
+| `ANOTHER_ROUND` | Clears Stage 4 closure, selections, and need coverage — resets to inventory building |
+| `EXTEND` | Keeps all entries SCHEDULED with a new follow-up date (28 days from now) |
+| `NEW_PROCESS` | Creates a new Session linked via `previousSessionId`; both users begin at Stage 0 |
+| `PARTIAL_CLOSURE` | Resolves entries marked RESOLVED; entries marked CONTINUING stay SCHEDULED |
+| `FULL_CLOSURE` | All entries → COMPLETED; session → RESOLVED |
+
+---
+
+## Share / Unshare an Individual Entry
+
+Allows the owner of an `INDIVIDUAL`-scope entry to share or unshare it with their partner.
+
+```
+POST /api/v1/sessions/:id/tending/:entryId/share
+POST /api/v1/sessions/:id/tending/:entryId/unshare
+```
+
+### Preconditions
+
+- Entry must have `scope = INDIVIDUAL`.
+- Caller must be the entry owner (`ownerUserId`).
+
+### Response
+
+Returns the updated `TendingEntryDTO`.
+
+---
+
 ## Scheduled Entry Opening (Cron)
 
 The script `backend/src/scripts/open-due-tending-entries.ts` is run by cron. It:
@@ -178,7 +275,7 @@ See [Prisma Schema: Tending](../data-model/prisma-schema.md#tending) for the ful
 | `NOT_FOUND` | 404 | Session or entry not found |
 | `VALIDATION_ERROR` | 400 | Entry is not in a state that accepts responses (e.g. SCHEDULED) |
 | `UNAUTHORIZED` | 401 | Missing auth |
-| `FORBIDDEN` | 403 | Caller is not a session member |
+| `FORBIDDEN` | 403 | Caller is not a session member; or caller is not the owner of an INDIVIDUAL entry |
 
 ---
 

--- a/docs/backend/data-model/prisma-schema.md
+++ b/docs/backend/data-model/prisma-schema.md
@@ -3,7 +3,7 @@ title: Prisma Schema
 sidebar_position: 1
 description: Core Vessel Architecture tables plus pointers to the rest of the Prisma schema (Inner Work, reconciler, memory, needs/people, telemetry).
 slug: /backend/data-model/prisma-schema
-updated: "2026-05-11"
+updated: "2026-05-13"
 ---
 # Prisma Schema
 
@@ -101,6 +101,9 @@ model Session {
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
   resolvedAt     DateTime?
+  previousSessionId String?   // Links to the prior session when ContinueChoice = NEW_PROCESS
+  previousSession   Session?  @relation("SessionLineage", fields: [previousSessionId], references: [id])
+  nextSessions      Session[] @relation("SessionLineage")
 
   // Explicit topic frame (3-5 word neutral description, e.g., "Tuesday pickup disagreement")
   topicFrame            String?
@@ -662,6 +665,7 @@ model StrategyProposal {
   rankings    StrategyRanking[]
   selections  Stage4ProposalSelection[]
   revisions   Stage4ProposalRevision[]
+  needLinks   StrategyProposalNeed[]
 }
 
 enum StrategySource {
@@ -705,7 +709,6 @@ model Stage4ProposalSelection {
 enum Stage4SelectionDecision {
   WILLING
   NOT_WILLING
-  NEEDS_DISCUSSION
 }
 ```
 
@@ -766,6 +769,7 @@ model Stage4Closure {
   openNeedIds          String[]
   closedByUserId       String
   closedAt             DateTime @default(now())
+  checkInAt            DateTime?  // Scheduled follow-up date for all tending entries
   createdAt            DateTime @default(now())
 }
 
@@ -837,25 +841,37 @@ Post-resolution check-in and re-entry models. Created when Stage 4 closes with a
 
 ```prisma
 model TendingEntry {
-  id           String   @id @default(cuid())
-  session      Session  @relation(fields: [sessionId], references: [id])
-  sessionId    String
-  agreement    Agreement? @relation(fields: [agreementId], references: [id])
-  agreementId  String?
-  type         TendingEntryType
-  status       TendingEntryStatus @default(SCHEDULED)
-  scheduledFor DateTime?
-  openedAt     DateTime?
-  completedAt  DateTime?
-  summary      String?  @db.Text   // Context assembled at creation
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id             String             @id @default(cuid())
+  session        Session            @relation(fields: [sessionId], references: [id])
+  sessionId      String
+  agreement      Agreement?         @relation(fields: [agreementId], references: [id])
+  agreementId    String?
+  type           TendingEntryType
+  status         TendingEntryStatus @default(SCHEDULED)
+  scope          TendingEntryScope  @default(SHARED)  // SHARED or INDIVIDUAL
+  ownerUserId    String?            // Set for INDIVIDUAL entries; null for SHARED
+  optedInShared  Boolean            @default(false)   // INDIVIDUAL owner can share with partner
+  scheduledFor   DateTime?
+  openedAt       DateTime?
+  completedAt    DateTime?
+  summary        String?            @db.Text   // Context assembled at creation
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
 
-  responses    TendingResponse[]
+  responses      TendingResponse[]
+  partialClosures TendingResponsePartialClosure[]
+
+  @@index([sessionId, scope, ownerUserId])
+}
+
+enum TendingEntryScope {
+  SHARED
+  INDIVIDUAL
 }
 
 enum TendingEntryType {
   SCHEDULED_SHARED_AGREEMENT_CHECKIN
+  SCHEDULED_INDIVIDUAL_COMMITMENT_CHECKIN
   USER_INITIATED_REENTRY
 }
 
@@ -875,15 +891,112 @@ One response per entry/user (enforced by upsert in the service).
 
 ```prisma
 model TendingResponse {
-  id             String   @id @default(cuid())
-  tendingEntry   TendingEntry @relation(fields: [tendingEntryId], references: [id])
+  id             String        @id @default(cuid())
+  tendingEntry   TendingEntry  @relation(fields: [tendingEntryId], references: [id])
   tendingEntryId String
-  user           User     @relation(fields: [userId], references: [id])
+  user           User          @relation(fields: [userId], references: [id])
   userId         String
-  status         String   // e.g. "WORKED", "PARTLY", "DID_NOT_WORK"
-  reflection     String?  @db.Text
-  continueChoice String?  // e.g. "CONTINUE", "ADJUST", "CLOSE"
-  submittedAt    DateTime @default(now())
+  status         String        // e.g. "WORKED", "PARTLY", "DID_NOT_WORK"
+  reflection     String?       @db.Text
+  continueChoice ContinueChoice?  // Structured forward path enum (see ContinueChoice below)
+  submittedAt    DateTime      @default(now())
+
+  partialClosures TendingResponsePartialClosure[]
+}
+
+enum ContinueChoice {
+  ANOTHER_ROUND    // Reset Stage 4 to inventory building
+  EXTEND           // Reschedule entries 28 days out
+  NEW_PROCESS      // Create linked Session; both users restart at Stage 0
+  PARTIAL_CLOSURE  // Resolve some entries, continue others
+  FULL_CLOSURE     // Mark all entries COMPLETED; session → RESOLVED
+}
+```
+
+### TendingResponsePartialClosure
+
+Tracks per-entry resolution when `ContinueChoice = PARTIAL_CLOSURE`.
+
+```prisma
+model TendingResponsePartialClosure {
+  id               String          @id @default(cuid())
+  tendingResponse  TendingResponse @relation(fields: [tendingResponseId], references: [id])
+  tendingResponseId String
+  tendingEntry     TendingEntry    @relation(fields: [tendingEntryId], references: [id])
+  tendingEntryId   String
+  resolution       PartialClosureResolution  // RESOLVED or CONTINUING
+  createdAt        DateTime        @default(now())
+
+  @@unique([tendingResponseId, tendingEntryId])
+}
+
+enum PartialClosureResolution {
+  RESOLVED
+  CONTINUING
+}
+```
+
+---
+
+## Stage 4 Sub-Chat
+
+Guided AI sub-conversations anchored to proposal refinement, needs brainstorming, or no-overlap recovery.
+
+### Stage4SubChat
+
+```prisma
+model Stage4SubChat {
+  id         String             @id @default(cuid())
+  session    Session            @relation(fields: [sessionId], references: [id])
+  sessionId  String
+  user       User               @relation(fields: [userId], references: [id])
+  userId     String
+  anchorKind Stage4SubChatAnchor
+  anchorId   String?            // proposalId for PROPOSAL_REFINEMENT; needId for NEEDS_BRAINSTORM
+  status     Stage4SubChatStatus @default(ACTIVE)
+  createdAt  DateTime           @default(now())
+  resolvedAt DateTime?
+
+  messages   Stage4SubChatMessage[]
+}
+
+model Stage4SubChatMessage {
+  id         String      @id @default(cuid())
+  subChat    Stage4SubChat @relation(fields: [subChatId], references: [id])
+  subChatId  String
+  role       MessageRole
+  content    String      @db.Text
+  createdAt  DateTime    @default(now())
+}
+
+enum Stage4SubChatAnchor {
+  NEEDS_BRAINSTORM     // Brainstorm proposals for an unaddressed need
+  PROPOSAL_REFINEMENT  // Refine an existing proposal
+  NO_OVERLAP           // Guided recovery when no mutual willing proposals
+}
+
+enum Stage4SubChatStatus {
+  ACTIVE
+  RESOLVED
+}
+```
+
+---
+
+## Need–Proposal Linkage
+
+### StrategyProposalNeed
+
+Junction table linking proposals to identified needs. Created when `stage4-prompts.ts` populates the `needLinks` relation.
+
+```prisma
+model StrategyProposalNeed {
+  proposal   StrategyProposal @relation(fields: [proposalId], references: [id])
+  proposalId String
+  needId     String
+  createdAt  DateTime         @default(now())
+
+  @@id([proposalId, needId])
 }
 ```
 

--- a/docs/backend/prompts/index.md
+++ b/docs/backend/prompts/index.md
@@ -38,7 +38,7 @@ Meet Without Fear uses Claude models via AWS Bedrock:
 | [Stage 2: Perspective](./stage-2-perspective.md) | 2 | Building empathy guess; also hosts the `MIRROR` mode (redirect judgment) and other internal modes as branches of `buildStage2Prompt` |
 | Stage 2B: Informed Empathy | 21 (internal code) | Refining empathy after receiving partner's shared context (`buildStage2BPrompt`) |
 | [Stage 3: What Matters](./stage-3-needs.md) | 3 | User-driven self-reflection on what truly matters; AI redirects other-focused answers back to the user's own needs (lives inside `buildStage3Prompt`) |
-| [Stage 4: Strategic Repair](./stage-4-repair.md) | 4 | Collaborative strategy creation |
+| [Stage 4: Strategic Repair](./stage-4-repair.md) | 4 | Collaborative strategy creation — seven surfaces: main chat (Surface 1), needs brainstorm subchat (2), proposal refinement subchat (3), no-overlap subchat (4), handoff bridge (5), listen-first for RESOLVED re-entry (6), tending check-in (7) |
 
 ### Cross-Stage
 
@@ -47,6 +47,8 @@ Meet Without Fear uses Claude models via AWS Bedrock:
 | [Emotional Support](./emotional-support.md) | All | Responding to high intensity |
 
 > **Mirror Intervention** is **not** a standalone prompt — it's the `MIRROR` mode inside `buildStage2Prompt`, selected when a user slips into blame. The linked `mirror-intervention.md` page describes the behavior but the code lives in `stage-prompts.ts`.
+
+> **Stage 4 — Seven Surfaces**: Unlike stages 0–3 which each have a single prompt, Stage 4 uses seven distinct surfaces defined in `backend/src/services/stage4-prompts.ts`. Surface 1 (main chat) uses `buildStage4Prompt()` from `stage-prompts.ts` with two conditional dynamic clauses: `coverageReviewOpenNeedsClause()` (lists open needs when in COVERAGE_REVIEW phase) and `RESOLVED_LISTEN_FIRST_CLAUSE` (reflection-only mode when session is RESOLVED). Surfaces 2–4 are sub-chat personas for guided proposal work. Surface 5 is a templated handoff bridge message. Surface 6 is listen-first mode. Surface 7 contains three tending check-in micro-personas.
 
 ### Utility
 

--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -2,7 +2,7 @@
 title: Chat Interface
 sidebar_position: 3
 description: The primary conversation interface where users interact with the AI.
-updated: 2026-05-10
+updated: 2026-05-13
 status: living
 ---
 # Chat Interface
@@ -187,21 +187,31 @@ flowchart TB
     subgraph RepairChat[Strategic Repair View]
         Header4[Stage 4: Moving Forward]
 
+        subgraph Chat4[Main Chat - Surface 1]
+            AI41[AI facilitates guided proposal work]
+            User41[User responds / brainstorms needs]
+        end
+
         subgraph ProposalArea[Proposals]
-            YourProp[Your proposal: Daily check-in]
-            TheirProp[Their proposal: Weekly date]
-            PropStatus[Awaiting response]
+            YourProp[Your proposal linked to open need]
+            PropResponse[Willing / Not willing]
         end
 
-        subgraph AgreedArea[Agreements]
-            Agreed1[Agreed: 10-min daily conversation]
+        subgraph SubChatDrawer[Sub-Chat Drawer - Surfaces 2-4]
+            SC1[Needs brainstorm subchat]
+            SC2[Proposal refinement subchat]
+            SC3[No-overlap subchat]
         end
 
-        subgraph Chat4[Negotiation]
-            AI41[AI facilitates discussion]
+        subgraph TendingArea[Tending Check-In - Surface 7]
+            Tending[How are you tending to yourself?]
         end
     end
 ```
+
+**Sub-chat drawer pattern**: Surfaces 2–4 open as a bottom drawer (guided sub-chat) layered over the main chat. Each sub-chat has its own AI persona and is dismissed when the user completes the guided flow, returning them to the main chat (Surface 1) with any generated content (needs list, refined proposal, etc.) carried forward.
+
+**Proposal responses use two options only**: "Willing" / "Not willing" — there is no "Discuss" / `NEEDS_DISCUSSION` option in the UI.
 
 ## Session entry flow
 


### PR DESCRIPTION
## Changes
- Fix: `stage-4.md` — drop `NEEDS_DISCUSSION` enum value, update `GetStage4StateResponse` / `ProposalCardDTO` structures, require `checkInDate` in `CloseStage4Request`, document 8 new endpoints (share-selections, need-decline, subchat CRUD), add `shareSelectionSubmitted` gate, update flow diagram
- Fix: `tending.md` — add `ContinueChoice` enum (5 forward paths), INDIVIDUAL scope fields, new `/tending/checkin` endpoint, share/unshare individual entry endpoints, `SCHEDULED_INDIVIDUAL_COMMITMENT_CHECKIN` entry type
- Fix: `prisma-schema.md` — remove `NEEDS_DISCUSSION`, Session lineage field, TendingEntry scope fields, 4 new models, `Stage4Closure.checkInAt`
- Fix: `prompts/index.md` — document Stage 4 seven-surface architecture
- Fix: `chat-interface.md` — update Stage 4 wireframe to redesigned flow

## Provenance
- **Channel:** cron / nightly incremental audit
- **Requested by:** automated scheduler (audit-docs)
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** audit-docs incremental

## Docs updated
- `docs/backend/api/stage-4.md`
- `docs/backend/api/tending.md`
- `docs/backend/data-model/prisma-schema.md`
- `docs/backend/prompts/index.md`
- `docs/mobile/wireframes/chat-interface.md`