### PR TITLE
Add PRIORITY-TICKETS.md for Tron Jenkins

### DIFF
--- a/PRIORITY-TICKETS.md
+++ b/PRIORITY-TICKETS.md
@@ -1,0 +1,25 @@
+# Priority Tickets
+
+Curated list of issues for external contributors (including Tron Jenkins) to prioritize.
+Updated by the team — check this file on each run.
+
+## How to use this file
+
+1. Pick the highest-priority unclaimed item you can handle
+2. Comment on the GitHub issue to claim it
+3. Open a PR referencing the issue number
+4. Once merged, the team will mark it done here
+
+## Active Priorities
+
+| # | Issue | Category | Priority | Notes |
+|---|-------|----------|----------|-------|
+| 1 | [#575](https://github.com/shantamg/meet-without-fear/issues/575) Re-entry summary: remove raw narrative + format structured data | Bug | High | UX concern — giant text blocks lose people |
+| 2 | [#553](https://github.com/shantamg/meet-without-fear/issues/553) Strategies list layout/UI issues (slider overlapping cards) | Bug | Medium | Visual bug in strategies view |
+| 3 | [#523](https://github.com/shantamg/meet-without-fear/issues/523) Missing AI framing message before partner feedback | Bug | Medium | Stage 3 Walking in Their Shoes |
+
+## Completed
+
+| # | Issue | Completed |
+|---|-------|-----------|
+| — | — | — |


### PR DESCRIPTION
## Changes
- Add: `PRIORITY-TICKETS.md` at repo root — curated priority list for external AI assistant (Tron Jenkins)
- Add: Initial seed of 3 high/medium-priority open bugs for Tron to pick up
- Add: Usage instructions and completed-items tracking section

Related to #576

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** "We have a new ai assistant named Tron Jenkins that will work with us. Ca we try out creating an MD file where we let Tron know what outstanding tickets he should prioritize working on?"

## Docs updated
No doc changes needed — new standalone file, not covered by existing docs