### PR TITLE
fix: remove raw session summary from re-entry context

### DIFF
--- a/backend/src/services/__tests__/tending.service.test.ts
+++ b/backend/src/services/__tests__/tending.service.test.ts
@@ -23,11 +23,6 @@ import {
 
 jest.mock('../../lib/prisma');
 jest.mock('../realtime');
-jest.mock('../conversation-summarizer', () => ({
-  getSessionSummary: jest.fn().mockResolvedValue({
-    summary: { text: 'They agreed to test a calmer planning rhythm.' },
-  }),
-}));
 
 describe('tending.service', () => {
   const sessionId = 'session-1';

--- a/backend/src/services/tending.service.ts
+++ b/backend/src/services/tending.service.ts
@@ -12,7 +12,6 @@ import {
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 import { publishSessionEvent } from './realtime';
-import { getSessionSummary } from './conversation-summarizer';
 
 type Tx = Prisma.TransactionClient;
 
@@ -351,7 +350,7 @@ export async function submitTendingResponse(args: {
 }
 
 async function buildReentrySummary(sessionId: string, userId: string, intent?: string): Promise<string> {
-  const [closure, sharedVessel, openNeeds, summaryData] = await Promise.all([
+  const [closure, sharedVessel, openNeeds] = await Promise.all([
     prisma.stage4Closure.findUnique({ where: { sessionId } }),
     prisma.sharedVessel.findUnique({
       where: { sessionId },
@@ -366,7 +365,6 @@ async function buildReentrySummary(sessionId: string, userId: string, intent?: s
       where: { sessionId, coverageStatus: { in: ['OPEN', 'PARTIAL'] } },
       orderBy: { updatedAt: 'desc' },
     }),
-    getSessionSummary(sessionId, userId).catch(() => null),
   ]);
 
   const individualIds = closure?.individualProposalIds ?? [];
@@ -390,7 +388,6 @@ async function buildReentrySummary(sessionId: string, userId: string, intent?: s
     openNeeds.length
       ? `Still-open needs: ${openNeeds.map((need) => need.needLabel).join('; ')}`
       : null,
-    summaryData ? `Session summary: ${summaryData.summary.text}` : null,
   ];
 
   return lines.filter(Boolean).join('\n');

--- a/mobile/src/components/TendingPanel.tsx
+++ b/mobile/src/components/TendingPanel.tsx
@@ -64,6 +64,31 @@ function formatDate(value: string | null): string {
   });
 }
 
+function parseSummaryLines(summary: string): Array<{ label: string; items: string[] }> {
+  const sections: Array<{ label: string; items: string[] }> = [];
+  for (const line of summary.split('\n')) {
+    if (!line || line === 'Passive Tending re-entry context.') continue;
+
+    let label: string;
+    let value: string;
+
+    if (line.startsWith('Stage 4 closed as ')) {
+      label = 'Closure';
+      const colonIdx = line.indexOf(': ', 'Stage 4 closed as '.length);
+      value = colonIdx >= 0 ? line.slice(colonIdx + 2) : line;
+    } else {
+      const colonIdx = line.indexOf(': ');
+      if (colonIdx < 0) continue;
+      label = line.slice(0, colonIdx);
+      value = line.slice(colonIdx + 2);
+    }
+
+    const items = value.includes('; ') ? value.split('; ') : [value];
+    sections.push({ label, items });
+  }
+  return sections;
+}
+
 function entryTitle(entry: TendingEntryDTO): string {
   if (entry.type === TendingEntryType.USER_INITIATED_REENTRY) {
     return 'Passive re-entry';
@@ -237,12 +262,17 @@ export function TendingPanel({
             </View>
           )}
 
-          {selectedEntry.summary && (
-            <View style={styles.contextBox}>
-              <Text style={styles.contextLabel}>Context</Text>
-              <Text style={styles.contextText}>{selectedEntry.summary}</Text>
-            </View>
-          )}
+          {selectedEntry.summary &&
+            parseSummaryLines(selectedEntry.summary).map((section, i) => (
+              <View key={i} style={styles.contextBox}>
+                <Text style={styles.contextLabel}>{section.label}</Text>
+                {section.items.map((item, j) => (
+                  <Text key={j} style={styles.contextText}>
+                    {section.items.length > 1 ? `\u2022 ${item}` : item}
+                  </Text>
+                ))}
+              </View>
+            ))}
 
           {canRespond(selectedEntry) ? (
             <View style={styles.responseArea}>

--- a/mobile/src/components/__tests__/TendingPanel.test.tsx
+++ b/mobile/src/components/__tests__/TendingPanel.test.tsx
@@ -140,4 +140,74 @@ describe('TendingPanel', () => {
 
     expect(defaultProps.onCreateReentry).toHaveBeenCalledWith('I want to revisit the open need.');
   });
+
+  describe('parseSummaryLines rendering', () => {
+    it('renders a standard Label: value line', () => {
+      render(
+        <TendingPanel
+          {...defaultProps}
+          entries={[{ ...openEntry, summary: 'Open needs: Trust and communication' }]}
+          agreements={[]}
+        />
+      );
+      expect(screen.getByText('Open needs')).toBeTruthy();
+      expect(screen.getByText('Trust and communication')).toBeTruthy();
+    });
+
+    it('renders Stage 4 closed as ... line with Closure label', () => {
+      render(
+        <TendingPanel
+          {...defaultProps}
+          entries={[{ ...openEntry, summary: 'Stage 4 closed as RESOLVED: Found common ground' }]}
+          agreements={[]}
+        />
+      );
+      expect(screen.getByText('Closure')).toBeTruthy();
+      expect(screen.getByText('Found common ground')).toBeTruthy();
+    });
+
+    it('renders a semicolon-delimited line as bullet items', () => {
+      render(
+        <TendingPanel
+          {...defaultProps}
+          entries={[{ ...openEntry, summary: 'Shared agreements: A; B; C' }]}
+          agreements={[]}
+        />
+      );
+      expect(screen.getByText('Shared agreements')).toBeTruthy();
+      expect(screen.getByText('\u2022 A')).toBeTruthy();
+      expect(screen.getByText('\u2022 B')).toBeTruthy();
+      expect(screen.getByText('\u2022 C')).toBeTruthy();
+    });
+
+    it('renders nothing for null summary', () => {
+      render(
+        <TendingPanel
+          {...defaultProps}
+          entries={[{ ...openEntry, summary: null }]}
+          agreements={[]}
+        />
+      );
+      expect(screen.queryByText('Open needs')).toBeNull();
+      expect(screen.queryByText('Closure')).toBeNull();
+    });
+
+    it('filters out the Passive Tending re-entry context. header line', () => {
+      render(
+        <TendingPanel
+          {...defaultProps}
+          entries={[
+            {
+              ...openEntry,
+              summary: 'Passive Tending re-entry context.\nOpen needs: Trust',
+            },
+          ]}
+          agreements={[]}
+        />
+      );
+      expect(screen.queryByText('Passive Tending re-entry context.')).toBeNull();
+      expect(screen.getByText('Open needs')).toBeTruthy();
+      expect(screen.getByText('Trust')).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
## Changes
- Remove: raw AI-generated session summary (`conversationSummary`) from passive re-entry context — it was designed for AI context continuity, not human consumption
- Remove: unused `getSessionSummary` import from tending service
- Fix: format remaining structured data in TendingPanel as separate labeled sections (closure, user intent, shared agreements, individual commitments, still-open needs) instead of a single text blob
- Add: bullet-point formatting when a section has multiple items (e.g. multiple agreements)

Related to #575

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L), confirmed by Darryl
- **Original message:** "Darryl and I finished a session and I tried the re-entry feature and it gave me this big long unformatted summary."

## Docs updated
No doc changes needed — the tending API doc (`docs/backend/api/tending.md`) already lists the correct context sources for re-entry without mentioning session summary.