### PR TITLE
fix: open individual commitment check-ins in tending cron

### DIFF
--- a/backend/src/services/__tests__/tending.service.test.ts
+++ b/backend/src/services/__tests__/tending.service.test.ts
@@ -338,6 +338,18 @@ describe('tending.service', () => {
     const result = await openDueTendingEntries(new Date('2026-05-13T10:00:00.000Z'));
 
     expect(result).toEqual({ opened: 1, entryIds: ['tending-1'] });
+    expect(prisma.tendingEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          type: {
+            in: [
+              TendingEntryType.SCHEDULED_SHARED_AGREEMENT_CHECKIN,
+              TendingEntryType.SCHEDULED_INDIVIDUAL_COMMITMENT_CHECKIN,
+            ],
+          },
+        }),
+      })
+    );
     expect(prisma.tendingEntry.updateMany).toHaveBeenCalledWith({
       where: { id: 'tending-1', status: TendingEntryStatus.SCHEDULED },
       data: {

--- a/docs/backend/api/tending.md
+++ b/docs/backend/api/tending.md
@@ -4,7 +4,7 @@ sidebar_position: 12
 description: Post-resolution check-in and re-entry endpoints for follow-through on Stage 4 agreements.
 slug: /backend/api/tending
 created: 2026-05-06
-updated: 2026-05-13
+updated: 2026-05-14
 status: living
 ---
 # Tending API
@@ -16,7 +16,7 @@ Post-resolution check-in and re-entry endpoints. Tending surfaces after a sessio
 Three Tending entry types exist:
 
 - **Scheduled shared check-ins** (`SCHEDULED_SHARED_AGREEMENT_CHECKIN`) — created automatically for shared agreements when `Stage4Closure` is recorded. Visible to both session members. The cron script `backend/src/scripts/open-due-tending-entries.ts` opens them when their scheduled time arrives.
-- **Scheduled individual check-ins** (`SCHEDULED_INDIVIDUAL_COMMITMENT_CHECKIN`) — created for each user's individual commitments with `scope = INDIVIDUAL`. Only the owning user sees these by default; they can opt in to share with their partner via `POST tending/:entryId/share`.
+- **Scheduled individual check-ins** (`SCHEDULED_INDIVIDUAL_COMMITMENT_CHECKIN`) — created for each user's individual commitments with `scope = INDIVIDUAL`. Only the owning user sees these by default; they can opt in to share with their partner via `POST tending/:entryId/share`. The same cron script opens these when their scheduled time arrives.
 - **Passive re-entry** (`USER_INITIATED_REENTRY`) — created on demand when a user returns to a resolved session. Context is assembled from the Stage 4 closure summary, agreements, open needs, and individual commitments.
 
 ### Entry status lifecycle


### PR DESCRIPTION
## Changes
- Fix: `openDueTendingEntries()` now includes `SCHEDULED_INDIVIDUAL_COMMITMENT_CHECKIN` entries alongside shared agreement check-ins — individual commitments will be opened and notified when their scheduled date arrives
- Add: test coverage for individual commitment entries being opened by the cron
- Doc: update tending API doc to reflect that the cron opens both entry types

Related to #579

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** Why aren't individual agreements followed up on? I think they should be

## Docs updated
- `docs/backend/api/tending.md` — clarified that the cron script opens individual commitment check-ins too