### PR TITLE
fix: NativeAppBanner dismissal resets on page refresh

### DIFF
--- a/mobile/src/hooks/useNativeAppBannerDismissal.ts
+++ b/mobile/src/hooks/useNativeAppBannerDismissal.ts
@@ -1,26 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Platform } from 'react-native';
 
-const STORAGE_KEY = 'mwf.nativeAppBanner.dismissedAt';
-const DISMISSAL_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-
-function readDismissedAt(): number | null {
-  if (Platform.OS !== 'web' || typeof window === 'undefined') return null;
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = Number.parseInt(raw, 10);
-    return Number.isFinite(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-function isStillDismissed(dismissedAt: number | null): boolean {
-  if (dismissedAt === null) return false;
-  return Date.now() - dismissedAt < DISMISSAL_TTL_MS;
-}
-
 export function useNativeAppBannerDismissal(): {
   dismissed: boolean;
   dismiss: () => void;
@@ -31,18 +11,11 @@ export function useNativeAppBannerDismissal(): {
 
   useEffect(() => {
     if (Platform.OS !== 'web') return;
-    setDismissed(isStillDismissed(readDismissedAt()));
+    // Show the banner on every fresh page load.
+    setDismissed(false);
   }, []);
 
   const dismiss = useCallback(() => {
-    if (Platform.OS === 'web' && typeof window !== 'undefined') {
-      try {
-        window.localStorage.setItem(STORAGE_KEY, String(Date.now()));
-      } catch {
-        // localStorage can throw in private-mode Safari; fall through and
-        // dismiss in-memory so the current session at least respects the tap.
-      }
-    }
     setDismissed(true);
   }, []);
 


### PR DESCRIPTION
## Changes
- Fix: Replace `localStorage`-based 30-day dismissal persistence with pure React state
- Fix: Banner now reappears on every fresh page load, hidden only for the current page session
- Remove: Unused `STORAGE_KEY`, `DISMISSAL_TTL_MS`, `readDismissedAt()`, and `isStillDismissed()` helpers

Related to #581

## Provenance
- **Channel:** DM (Shantam)
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "The banner at the top of the web version of the app is not showing up for me. Is it because I already dismissed it? It should show up even if I dismissed it recently. I suppose it should stay hidden only as long as the page hasn't been refreshed."

## Docs updated
No doc changes needed — internal hook behavior change with no architectural impact.