### PR TITLE
fix: right-align shared context card for sender

### DIFF
--- a/mobile/src/components/ChatBubble.tsx
+++ b/mobile/src/components/ChatBubble.tsx
@@ -218,7 +218,11 @@ export function ChatBubble({
     if (isUser) return styles.userContainer;
     if (isSystem) return styles.systemContainer;
     if (isEmpathyStatement) return styles.empathyStatementContainer;
-    if (isSharedContext) return styles.sharedContextContainer;
+    if (isSharedContext) {
+      return message.sharedContentDirection === 'sent'
+        ? styles.sharedContextSentContainer
+        : styles.sharedContextContainer;
+    }
     if (isShareSuggestion) return styles.shareSuggestionContainer;
     return styles.aiContainer;
   };
@@ -516,6 +520,10 @@ const useStyles = () => {
     // Shared context: subtle container
     sharedContextContainer: {
       alignItems: 'flex-start',
+      marginVertical: t.spacing.md,
+    },
+    sharedContextSentContainer: {
+      alignItems: 'flex-end',
       marginVertical: t.spacing.md,
     },
     sharedContextBubble: {


### PR DESCRIPTION
## Changes
- Fix: shared context card now right-aligns (`flex-end`) when the current user is the sender, matching user message alignment
- The `sharedContentDirection` field was already computed and passed correctly — only the container style selection in `getContainerStyle()` was ignoring it

Related to #586

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam
- **Original message:** "If I shared it, it should be on the right side, not the left."

## Docs updated
No doc changes needed — one-line alignment fix in ChatBubble styles