### PR TITLE
fix: stop auto-opening activity drawer after sharing context (#584)

### DIFF
--- a/mobile/src/components/ActivityDrawer.tsx
+++ b/mobile/src/components/ActivityDrawer.tsx
@@ -340,6 +340,8 @@ export function ActivityDrawer({
   const isDragging = useRef(false);
   const currentSnap = useRef<'3q' | 'full'>('3q');
   const wasOpenedRef = useRef(visible);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   // Track the height above the FlatList (drag handle + header) so the
   // FlatList can be constrained to the visible area of the drawer.
@@ -395,9 +397,9 @@ export function ActivityDrawer({
     ]).start(() => {
       currentSnap.current = '3q';
       setIsMounted(false);
-      onClose();
+      onCloseRef.current();
     });
-  }, [drawerTranslate, backdropOpacity, onClose]);
+  }, [drawerTranslate, backdropOpacity]);
 
   // Trigger open/close animation when visible changes.
   useEffect(() => {

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -4218,10 +4218,8 @@ export function UnifiedSessionScreen({
           onShareComplete={() => {
             setRefinementOfferId(null);
             trackShareDraftSent(sessionId, (shareOfferData?.suggestion?.action ?? 'OFFER_OPTIONAL') as 'OFFER_SHARING' | 'OFFER_OPTIONAL', true);
-            // Open activity drawer to show updated share status
-            setActivityFocusTarget(null);
-            setShowActivityMenu(true);
-            // Refresh activity menu data
+            // Shared context now appears inline in chat — no need to auto-open the activity drawer.
+            // Refresh activity menu data so it's current if the user opens it later.
             queryClient.invalidateQueries({ queryKey: stageKeys.pendingActions(sessionId) });
             queryClient.invalidateQueries({ queryKey: stageKeys.shareOffer(sessionId) });
             queryClient.invalidateQueries({ queryKey: notificationKeys.badgeCount() });


### PR DESCRIPTION
## Changes
- Fix: Remove auto-open of "Between you and [partner]" activity drawer after sharing context — shared context now appears inline in chat, making the drawer auto-open redundant and jarring
- Fix: Stabilize ActivityDrawer's `closeDrawer` callback by storing `onClose` in a ref, preventing the open/close useEffect from re-triggering when the parent re-renders (root cause of the flicker)

Related to #584

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** I just shared this and the drawer "between me nd Darryl" opened and closedd like 3 times. How about we have it not open at all.

## Docs updated
No doc changes needed — behavior-only fix, no doc references to auto-open behavior exist.