### PR TITLE
fix: stage color bars polish — sticky timing, centered text, spacing

### DIFF
--- a/mobile/src/components/ChatIndicator.tsx
+++ b/mobile/src/components/ChatIndicator.tsx
@@ -346,13 +346,15 @@ const useStyles = () => {
     stageChapterBar: {
       paddingVertical: 10,
       paddingHorizontal: 18,
-      marginVertical: 4,
+      marginTop: 16,
+      marginBottom: 4,
     },
     stageChapterText: {
       fontSize: 13,
       fontWeight: '700',
       letterSpacing: 0.8,
       textTransform: 'uppercase',
+      textAlign: 'center',
     },
     // Invitation sent: yellow/amber tint - separate line and text styles
     invitationSentLine: {

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -868,29 +868,32 @@ export function ChatInterface({
   } | null>(null);
 
   const viewabilityConfig = useRef({ itemVisiblePercentThreshold: 1 }).current;
+  const lastKnownStage = useRef<{ name: string; color: string } | null>(null);
 
   const onViewableItemsChanged = useCallback(({ viewableItems }: { viewableItems: Array<{ item: ChatListItem }> }) => {
-    // In an inverted list, the "topmost" visible item is the one with the highest
-    // index. Find the stage-chapter indicator among visible items that has the
-    // highest index — that corresponds to the oldest visible stage bar, which is
-    // visually at the top of the screen.
-    let topStage: { name: string; color: string } | null = null;
+    // Only show the sticky header when ALL inline stage bars have scrolled
+    // off-screen. Otherwise we get a duplicate (sticky + inline both visible).
+    const anyStageBarVisible = viewableItems.some(
+      (v) => isIndicator(v.item) && v.item.indicatorType === 'stage-chapter',
+    );
 
-    for (const v of viewableItems) {
-      if (isIndicator(v.item) && v.item.indicatorType === 'stage-chapter') {
-        topStage = {
-          name: v.item.metadata?.stageName || 'New Chapter',
-          color: v.item.metadata?.stageColor || '#8B9DC3',
-        };
+    if (anyStageBarVisible) {
+      // An inline bar is on screen — hide the sticky to avoid duplication
+      let latestStage: { name: string; color: string } | null = null;
+      for (const v of viewableItems) {
+        if (isIndicator(v.item) && v.item.indicatorType === 'stage-chapter') {
+          latestStage = {
+            name: v.item.metadata?.stageName || 'New Chapter',
+            color: v.item.metadata?.stageColor || '#8B9DC3',
+          };
+        }
       }
+      setCurrentStageMeta(null);
+      lastKnownStage.current = latestStage;
+    } else if (lastKnownStage.current) {
+      // No inline bar visible — show the sticky with the last known stage
+      setCurrentStageMeta(lastKnownStage.current);
     }
-
-    // Also check: if no stage-chapter is visible, derive from the topmost (oldest) visible message's context
-    // For now, only update when a stage bar is actually on screen
-    setCurrentStageMeta((prev) => {
-      if (topStage) return topStage;
-      return prev; // keep last known stage when scrolling between stages
-    });
   }, []);
 
   // ---------------------------------------------------------------------------
@@ -1008,6 +1011,7 @@ const useStyles = () => {
       fontWeight: '700',
       letterSpacing: 0.8,
       textTransform: 'uppercase',
+      textAlign: 'center',
     },
     flatList: {
       flex: 1,


### PR DESCRIPTION
## Summary

Three fixes for the stage color bars feature (#592) based on production feedback:

• *Sticky header shows too early* — now only appears when ALL inline stage bars have scrolled off-screen, preventing the duplicate-header issue where both sticky and inline bars were visible simultaneously
• *Text not centered* — both inline and sticky stage bar text is now center-aligned
• *Insufficient spacing* — added 16px top margin to inline stage bars for better visual separation from the previous section

## Provenance

- Channel: #bugs-and-requests
- Requester: Shantam (U0AD3TF2U7L)
- Thread: Color-coding stages discussion
- Screenshots: IMG_5161.png, IMG_5160.png showing the duplicate header and left-aligned text

## Docs updated

No doc changes needed — style/behavior fix only.

## Test plan

- [ ] Verify sticky header only appears when inline bar scrolls past the top
- [ ] Verify no duplicate headers visible at any scroll position
- [ ] Verify bar text is centered in both inline and sticky variants
- [ ] Verify adequate spacing above stage transition bars
- [ ] Test scrolling through a full multi-stage session

🤖 Generated with [Claude Code](https://claude.com/claude-code)