### PR TITLE
[codex] Fix chat sticky headers and keyboard composer

### DIFF
--- a/mobile/app/(auth)/design-system.tsx
+++ b/mobile/app/(auth)/design-system.tsx
@@ -338,7 +338,7 @@ function ChatSection({ styles, palette }: { styles: ReturnType<typeof makeStyles
         <SessionChatHeader
           partnerName="Sam"
           partnerOnline
-          stageName="Walking in Their Shoes"
+          conversationTopic="Feeling stuck about household responsibilities"
           leftActionIcon="menu"
           onBackPress={() => {}}
           onPress={() => {}}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { useFonts } from 'expo-font';
 import * as Sentry from '@sentry/react-native';
 import * as SplashScreen from 'expo-splash-screen';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Platform, StyleSheet, View } from 'react-native';
 
@@ -136,25 +137,27 @@ function AppShell({ includeMixpanel = true }: { includeMixpanel?: boolean }) {
       <View style={[styles.webFrame, { backgroundColor: palette.bg }]}>
         <NativeAppBanner />
         <GestureHandlerRootView style={[styles.container, { backgroundColor: palette.bg }]}>
-          <SafeAreaProvider>
-            <SessionDrawerProvider>
-              <ToastProvider>
-                {includeMixpanel && <MixpanelInitializer />}
-                <Stack
-                  screenOptions={{
-                    headerShown: false,
-                    gestureEnabled: false,
-                    contentStyle: { backgroundColor: palette.bg },
-                  }}
-                >
-                  <Stack.Screen name="(public)" />
-                  <Stack.Screen name="(auth)" />
-                  <Stack.Screen name="+not-found" options={{ headerShown: true }} />
-                </Stack>
-                <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
-              </ToastProvider>
-            </SessionDrawerProvider>
-          </SafeAreaProvider>
+          <KeyboardProvider>
+            <SafeAreaProvider>
+              <SessionDrawerProvider>
+                <ToastProvider>
+                  {includeMixpanel && <MixpanelInitializer />}
+                  <Stack
+                    screenOptions={{
+                      headerShown: false,
+                      gestureEnabled: false,
+                      contentStyle: { backgroundColor: palette.bg },
+                    }}
+                  >
+                    <Stack.Screen name="(public)" />
+                    <Stack.Screen name="(auth)" />
+                    <Stack.Screen name="+not-found" options={{ headerShown: true }} />
+                  </Stack>
+                  <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
+                </ToastProvider>
+              </SessionDrawerProvider>
+            </SafeAreaProvider>
+          </KeyboardProvider>
         </GestureHandlerRootView>
       </View>
     </View>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -5,11 +5,11 @@ import { useFonts } from 'expo-font';
 import * as Sentry from '@sentry/react-native';
 import * as SplashScreen from 'expo-splash-screen';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Platform, StyleSheet, View } from 'react-native';
 
 import { APP_MAX_WIDTH, AppearanceProvider, useAppAppearance } from '@/src/theme';
+import { KeyboardControllerProvider } from '@/src/utils/keyboardController';
 import { SessionDrawerProvider } from '@/src/hooks/useSessionDrawer';
 import { useInvitationLink } from '@/src/hooks/useInvitation';
 import { QueryProvider } from '@/src/providers/QueryProvider';
@@ -137,7 +137,7 @@ function AppShell({ includeMixpanel = true }: { includeMixpanel?: boolean }) {
       <View style={[styles.webFrame, { backgroundColor: palette.bg }]}>
         <NativeAppBanner />
         <GestureHandlerRootView style={[styles.container, { backgroundColor: palette.bg }]}>
-          <KeyboardProvider>
+          <KeyboardControllerProvider>
             <SafeAreaProvider>
               <SessionDrawerProvider>
                 <ToastProvider>
@@ -157,7 +157,7 @@ function AppShell({ includeMixpanel = true }: { includeMixpanel?: boolean }) {
                 </ToastProvider>
               </SessionDrawerProvider>
             </SafeAreaProvider>
-          </KeyboardProvider>
+          </KeyboardControllerProvider>
         </GestureHandlerRootView>
       </View>
     </View>

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -101,6 +101,11 @@ jest.mock('react-native/src/private/specs_DEPRECATED/modules/NativeDeviceInfo', 
 // Mock NativeEventEmitter
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
 
+// Mock native keyboard controller used for interactive keyboard tracking.
+jest.mock('react-native-keyboard-controller', () =>
+  require('react-native-keyboard-controller/jest')
+);
+
 // Mock UIManager for React Native 0.79+
 jest.mock('react-native/Libraries/ReactNative/UIManager', () => ({
   ...jest.requireActual('react-native/Libraries/ReactNative/UIManager'),

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -66,6 +66,7 @@
     "react-native-audio-record": "^0.2.2",
     "react-native-drawer-layout": "^4.2.1",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-keyboard-controller": "^1.21.7",
     "react-native-reanimated": "4.1.6",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/mobile/src/components/ChatBubble.tsx
+++ b/mobile/src/components/ChatBubble.tsx
@@ -90,6 +90,8 @@ export function ChatBubble({
   const hasAnimatedRef = useRef(false);
   const hasStartedRef = useRef(false);
   const animationIdentityRef = useRef(animationIdentity ?? message.id);
+  const userEntrancePlayedRef = useRef(false);
+  const userEntranceAnim = useRef(new Animated.Value(1)).current;
 
   // Determine if this message type uses fade-in animation (non-AI, non-USER animated messages)
   const willAnimate = !isUser && !isAI && enableTypewriter && !message.skipTypewriter;
@@ -105,7 +107,9 @@ export function ChatBubble({
     animationIdentityRef.current = currentAnimationIdentity;
     hasAnimatedRef.current = false;
     hasStartedRef.current = false;
+    userEntrancePlayedRef.current = false;
     fadeAnim.setValue(1);
+    userEntranceAnim.setValue(1);
   }
 
   // Store callbacks in refs to avoid re-triggering animation
@@ -118,6 +122,11 @@ export function ChatBubble({
 
   // Determine if we should use typewriter effect (AI messages only)
   const shouldUseTypewriter = isAI && enableTypewriter && !message.skipTypewriter && !hasAnimatedRef.current;
+  const shouldAnimateUserEntrance =
+    isUser &&
+    enableTypewriter &&
+    !message.skipTypewriter &&
+    (message.status === 'sending' || message.id.startsWith('optimistic-user-'));
 
   // Determine if we should use fade-in effect (non-AI, non-USER messages that should animate)
   const shouldUseFadeIn = !isUser && !isAI && enableTypewriter && !message.skipTypewriter && !hasAnimatedRef.current;
@@ -156,6 +165,20 @@ export function ChatBubble({
       });
     }
   }, [shouldUseFadeIn, isNextToAnimate, fadeAnim]);
+
+  useEffect(() => {
+    if (!shouldAnimateUserEntrance || userEntrancePlayedRef.current) {
+      return;
+    }
+
+    userEntrancePlayedRef.current = true;
+    userEntranceAnim.setValue(0);
+    Animated.timing(userEntranceAnim, {
+      toValue: 1,
+      duration: 220,
+      useNativeDriver: true,
+    }).start();
+  }, [shouldAnimateUserEntrance, userEntranceAnim]);
 
   // Call onStart when typewriter begins - use effect to avoid setState during render
   // Only starts when this message is next in the animation queue (onAnimationStart is provided)
@@ -345,6 +368,18 @@ export function ChatBubble({
         return <Animated.View style={{ opacity: fadeAnim }}>{content}</Animated.View>;
       }
       return content;
+    }
+
+    if (isUser && shouldAnimateUserEntrance) {
+      const translateY = userEntranceAnim.interpolate({
+        inputRange: [0, 1],
+        outputRange: [14, 0],
+      });
+      return (
+        <Animated.View style={{ opacity: userEntranceAnim, transform: [{ translateY }] }}>
+          <Text style={getTextStyle()}>{message.content}</Text>
+        </Animated.View>
+      );
     }
 
     // Use typewriter effect for new AI messages - animates word-by-word at consistent pace

--- a/mobile/src/components/ChatBubble.tsx
+++ b/mobile/src/components/ChatBubble.tsx
@@ -88,7 +88,6 @@ export function ChatBubble({
   const shouldAnimateUserEntrance =
     isUser &&
     enableTypewriter &&
-    !message.skipTypewriter &&
     (message.status === 'sending' || message.id.startsWith('optimistic-user-'));
 
   // Track if this specific message instance has completed animation

--- a/mobile/src/components/ChatBubble.tsx
+++ b/mobile/src/components/ChatBubble.tsx
@@ -200,23 +200,6 @@ export function ChatBubble({
     return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   };
 
-  const getStatusText = (status: MessageDeliveryStatus): string => {
-    switch (status) {
-      case 'sending':
-        return 'Sending...';
-      case 'streaming':
-        return 'Responding...';
-      case 'sent':
-        return 'Sent';
-      case 'delivered':
-        return 'Delivered';
-      case 'read':
-        return 'Read';
-      case 'error':
-        return 'Failed to send';
-    }
-  };
-
   const getSharedContentStatusText = (status: SharedContentDeliveryStatus | undefined): string => {
     switch (status) {
       case 'sending':
@@ -422,18 +405,6 @@ export function ChatBubble({
         {showTimestamp && (
           <Text style={[styles.time, isSystem && styles.systemTime]}>
             {formatTime(message.timestamp)}
-          </Text>
-        )}
-        {isUser && message.status && (
-          <Text
-            style={[
-              styles.statusText,
-              message.status === 'sending' && styles.statusSending,
-              message.status === 'read' && styles.statusRead,
-              message.status === 'error' && styles.statusError,
-            ]}
-          >
-            {getStatusText(message.status)}
           </Text>
         )}
       </View>
@@ -649,20 +620,6 @@ const useStyles = () => {
     },
     systemTime: {
       textAlign: 'center',
-    },
-    statusText: {
-      fontSize: t.typography.fontSize.xs,
-      color: palette.textFaint,
-      fontFamily: designFonts.sans,
-    },
-    statusSending: {
-      fontStyle: 'italic',
-    },
-    statusRead: {
-      color: palette.accent,
-    },
-    statusError: {
-      color: palette.danger,
     },
   }));
 };

--- a/mobile/src/components/ChatBubble.tsx
+++ b/mobile/src/components/ChatBubble.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useCallback } from 'react';
-import { View, Text, Animated } from 'react-native';
+import { View, Text, Animated, Easing } from 'react-native';
 import { MessageRole, SharedContentDeliveryStatus } from '@meet-without-fear/shared';
 import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
@@ -175,7 +175,8 @@ export function ChatBubble({
     userEntranceAnim.setValue(0);
     Animated.timing(userEntranceAnim, {
       toValue: 1,
-      duration: 220,
+      duration: 360,
+      easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();
   }, [shouldAnimateUserEntrance, userEntranceAnim]);
@@ -356,7 +357,7 @@ export function ChatBubble({
     if (isUser && shouldAnimateUserEntrance) {
       const translateY = userEntranceAnim.interpolate({
         inputRange: [0, 1],
-        outputRange: [14, 0],
+        outputRange: [28, 0],
       });
       return (
         <Animated.View style={{ opacity: userEntranceAnim, transform: [{ translateY }] }}>

--- a/mobile/src/components/ChatBubble.tsx
+++ b/mobile/src/components/ChatBubble.tsx
@@ -36,6 +36,10 @@ interface ChatBubbleProps {
   onAnimationStart?: () => void;
   /** Callback when animation completes */
   onAnimationComplete?: () => void;
+  /** Callback as typewriter/fade progress changes layout */
+  onAnimationProgress?: () => void;
+  /** Stable identity for animation state when a temporary message id is reconciled. */
+  animationIdentity?: string;
   /** Whether speech is currently playing for this message */
   isSpeaking?: boolean;
   /** Callback when speaker button is pressed */
@@ -63,6 +67,8 @@ export function ChatBubble({
   enableTypewriter = true,
   onAnimationStart,
   onAnimationComplete,
+  onAnimationProgress,
+  animationIdentity,
   isSpeaking = false,
   onSpeakerPress,
   hideSpeaker = false,
@@ -83,7 +89,7 @@ export function ChatBubble({
   // Track if this specific message instance has completed animation
   const hasAnimatedRef = useRef(false);
   const hasStartedRef = useRef(false);
-  const messageIdRef = useRef(message.id);
+  const animationIdentityRef = useRef(animationIdentity ?? message.id);
 
   // Determine if this message type uses fade-in animation (non-AI, non-USER animated messages)
   const willAnimate = !isUser && !isAI && enableTypewriter && !message.skipTypewriter;
@@ -92,9 +98,11 @@ export function ChatBubble({
   // Always start at 1 (visible) — the fade-in effect sets to 0 and animates when triggered
   const fadeAnim = useRef(new Animated.Value(1)).current;
 
-  // Reset animation state if message ID changes
-  if (messageIdRef.current !== message.id) {
-    messageIdRef.current = message.id;
+  // Reset animation state if the animation identity changes. The display id
+  // can change when a streaming placeholder is reconciled to its persisted id.
+  const currentAnimationIdentity = animationIdentity ?? message.id;
+  if (animationIdentityRef.current !== currentAnimationIdentity) {
+    animationIdentityRef.current = currentAnimationIdentity;
     hasAnimatedRef.current = false;
     hasStartedRef.current = false;
     fadeAnim.setValue(1);
@@ -103,8 +111,10 @@ export function ChatBubble({
   // Store callbacks in refs to avoid re-triggering animation
   const onStartRef = useRef(onAnimationStart);
   const onCompleteRef = useRef(onAnimationComplete);
+  const onProgressRef = useRef(onAnimationProgress);
   onStartRef.current = onAnimationStart;
   onCompleteRef.current = onAnimationComplete;
+  onProgressRef.current = onAnimationProgress;
 
   // Determine if we should use typewriter effect (AI messages only)
   const shouldUseTypewriter = isAI && enableTypewriter && !message.skipTypewriter && !hasAnimatedRef.current;
@@ -346,7 +356,9 @@ export function ChatBubble({
           style={getTextStyle()}
           wordDelay={40}
           fadeDuration={120}
+          completeWhenCaughtUp={message.status !== 'streaming'}
           onComplete={handleComplete}
+          onProgress={() => onProgressRef.current?.()}
         />
       );
     }

--- a/mobile/src/components/ChatBubble.tsx
+++ b/mobile/src/components/ChatBubble.tsx
@@ -85,13 +85,18 @@ export function ChatBubble({
   const isShareSuggestion = (message.role as string) === 'SHARE_SUGGESTION';
   const isAI = !isUser && !isSystem && !isEmpathyStatement && !isSharedContext && !isShareSuggestion;
   const isIntervention = message.isIntervention ?? false;
+  const shouldAnimateUserEntrance =
+    isUser &&
+    enableTypewriter &&
+    !message.skipTypewriter &&
+    (message.status === 'sending' || message.id.startsWith('optimistic-user-'));
 
   // Track if this specific message instance has completed animation
   const hasAnimatedRef = useRef(false);
   const hasStartedRef = useRef(false);
   const animationIdentityRef = useRef(animationIdentity ?? message.id);
   const userEntrancePlayedRef = useRef(false);
-  const userEntranceAnim = useRef(new Animated.Value(1)).current;
+  const userEntranceAnim = useRef(new Animated.Value(shouldAnimateUserEntrance ? 0 : 1)).current;
 
   // Determine if this message type uses fade-in animation (non-AI, non-USER animated messages)
   const willAnimate = !isUser && !isAI && enableTypewriter && !message.skipTypewriter;
@@ -109,7 +114,7 @@ export function ChatBubble({
     hasStartedRef.current = false;
     userEntrancePlayedRef.current = false;
     fadeAnim.setValue(1);
-    userEntranceAnim.setValue(1);
+    userEntranceAnim.setValue(shouldAnimateUserEntrance ? 0 : 1);
   }
 
   // Store callbacks in refs to avoid re-triggering animation
@@ -122,11 +127,6 @@ export function ChatBubble({
 
   // Determine if we should use typewriter effect (AI messages only)
   const shouldUseTypewriter = isAI && enableTypewriter && !message.skipTypewriter && !hasAnimatedRef.current;
-  const shouldAnimateUserEntrance =
-    isUser &&
-    enableTypewriter &&
-    !message.skipTypewriter &&
-    (message.status === 'sending' || message.id.startsWith('optimistic-user-'));
 
   // Determine if we should use fade-in effect (non-AI, non-USER messages that should animate)
   const shouldUseFadeIn = !isUser && !isAI && enableTypewriter && !message.skipTypewriter && !hasAnimatedRef.current;
@@ -172,7 +172,6 @@ export function ChatBubble({
     }
 
     userEntrancePlayedRef.current = true;
-    userEntranceAnim.setValue(0);
     Animated.timing(userEntranceAnim, {
       toValue: 1,
       duration: 360,
@@ -354,18 +353,6 @@ export function ChatBubble({
       return content;
     }
 
-    if (isUser && shouldAnimateUserEntrance) {
-      const translateY = userEntranceAnim.interpolate({
-        inputRange: [0, 1],
-        outputRange: [28, 0],
-      });
-      return (
-        <Animated.View style={{ opacity: userEntranceAnim, transform: [{ translateY }] }}>
-          <Text style={getTextStyle()}>{message.content}</Text>
-        </Animated.View>
-      );
-    }
-
     // Use typewriter effect for new AI messages - animates word-by-word at consistent pace
     // This normalizes display speed regardless of how fast streaming arrives
     if (shouldUseTypewriter) {
@@ -386,9 +373,17 @@ export function ChatBubble({
     return <Text style={getTextStyle()}>{message.content}</Text>;
   };
 
+  const userEntranceTranslateY = userEntranceAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [36, 0],
+  });
+  const containerAnimationStyle = shouldAnimateUserEntrance
+    ? { opacity: userEntranceAnim, transform: [{ translateY: userEntranceTranslateY }] }
+    : null;
+
   return (
-    <View
-      style={[styles.container, getContainerStyle()]}
+    <Animated.View
+      style={[styles.container, getContainerStyle(), containerAnimationStyle]}
       testID={`chat-bubble-${message.id}`}
     >
       <View style={[styles.bubble, isAI && styles.aiBubbleContainer, getBubbleStyle()]}>
@@ -409,7 +404,7 @@ export function ChatBubble({
           </Text>
         )}
       </View>
-    </View>
+    </Animated.View>
   );
 }
 

--- a/mobile/src/components/ChatIndicator.tsx
+++ b/mobile/src/components/ChatIndicator.tsx
@@ -346,8 +346,6 @@ const useStyles = () => {
     stageChapterBar: {
       paddingVertical: 10,
       paddingHorizontal: 18,
-      marginTop: 16,
-      marginBottom: 4,
     },
     stageChapterText: {
       fontSize: 13,

--- a/mobile/src/components/ChatInput.tsx
+++ b/mobile/src/components/ChatInput.tsx
@@ -10,7 +10,10 @@ import { designFonts, useAppAppearance } from '../theme';
 
 interface ChatInputProps {
   onSend: (message: string) => void;
+  /** Disables sending. The text field can remain editable to avoid keyboard jumps. */
   disabled?: boolean;
+  /** Disables editing the text field itself. */
+  inputDisabled?: boolean;
   placeholder?: string;
   maxLength?: number;
   showCharacterCount?: boolean;
@@ -38,6 +41,7 @@ const CHARACTER_WARNING_THRESHOLD = 0.8;
 export function ChatInput({
   onSend,
   disabled = false,
+  inputDisabled = false,
   placeholder = 'Type a message...',
   maxLength = DEFAULT_MAX_LENGTH,
   showCharacterCount = false,
@@ -123,7 +127,7 @@ export function ChatInput({
           placeholderTextColor={palette.textFaint}
           multiline
           maxLength={maxLength}
-          editable={!disabled}
+          editable={!inputDisabled}
           testID="chat-input"
         />
         {showCharacterCount && (

--- a/mobile/src/components/ChatInput.tsx
+++ b/mobile/src/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { View, TextInput, TouchableOpacity, Text, Platform, Keyboard, type TextInput as TextInputType } from 'react-native';
+import { View, TextInput, TouchableOpacity, Text, Platform, type TextInput as TextInputType } from 'react-native';
 import { ArrowUp, Mic } from 'lucide-react-native';
 import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
@@ -91,9 +91,6 @@ export function ChatInput({
     inputRef.current?.clear();
     try {
       onSend(message);
-      requestAnimationFrame(() => {
-        Keyboard.dismiss();
-      });
     } finally {
       // Reset flag after a short delay to allow autocorrect events to be ignored.
       // Must be in finally block so the flag is always cleared even if onSend throws.

--- a/mobile/src/components/ChatInput.tsx
+++ b/mobile/src/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { View, TextInput, TouchableOpacity, Text, Platform, type TextInput as TextInputType } from 'react-native';
+import { View, TextInput, TouchableOpacity, Text, Platform, Keyboard, type TextInput as TextInputType } from 'react-native';
 import { ArrowUp, Mic } from 'lucide-react-native';
 import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
@@ -91,6 +91,9 @@ export function ChatInput({
     inputRef.current?.clear();
     try {
       onSend(message);
+      requestAnimationFrame(() => {
+        Keyboard.dismiss();
+      });
     } finally {
       // Reset flag after a short delay to allow autocorrect events to be ignored.
       // Must be in finally block so the flag is always cleared even if onSend throws.

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -214,7 +214,6 @@ interface ChatInterfaceProps {
 const DEFAULT_EMPTY_TITLE = 'Start the Conversation';
 const DEFAULT_EMPTY_MESSAGE =
   "Share what's on your mind. I'm here to listen and help you work through it.";
-const DEFAULT_IOS_COMPOSER_SPACER_HEIGHT = 164;
 
 const seenAnimatedItemIdsByScope = new Map<string, Set<string>>();
 let localAnimationScopeCounter = 0;
@@ -977,7 +976,7 @@ export function ChatInterface({
     // the user was already reading at the bottom.
     if (!isLoadingHistoryRef.current || !snapshot) {
       scrollMetricsRef.current.contentHeight = height;
-      if ((isNearBottomRef.current || shouldStickToBottomRef.current) && !(Platform.OS === 'ios' && isKeyboardVisible)) {
+      if (isNearBottomRef.current || shouldStickToBottomRef.current) {
         scrollToBottom(false);
       }
       return;
@@ -998,14 +997,14 @@ export function ChatInterface({
       historyLoadSnapshotRef.current = null;
       isLoadingHistoryRef.current = false;
     }
-  }, [isKeyboardVisible, scrollToBottom]);
+  }, [scrollToBottom]);
 
   const handleListLayout = useCallback((event: LayoutChangeEvent) => {
     scrollMetricsRef.current.layoutHeight = event.nativeEvent.layout.height;
-    if ((isNearBottomRef.current || shouldStickToBottomRef.current) && !(Platform.OS === 'ios' && isKeyboardVisible)) {
+    if (isNearBottomRef.current || shouldStickToBottomRef.current) {
       scrollToBottom(false);
     }
-  }, [isKeyboardVisible, scrollToBottom]);
+  }, [scrollToBottom]);
 
   const handleEndReached = useCallback(() => {
     if (hasMore && !isLoadingMore && onLoadMore) {
@@ -1058,10 +1057,7 @@ export function ChatInterface({
       style={styles.bottomContainer}
       onLayout={(event) => {
         if (Platform.OS === 'ios') {
-          const nextHeight = Math.ceil(event.nativeEvent.layout.height);
-          setBottomContainerHeight((currentHeight) => (
-            Math.abs(currentHeight - nextHeight) > 2 ? nextHeight : currentHeight
-          ));
+          setBottomContainerHeight(event.nativeEvent.layout.height);
         }
       }}
     >
@@ -1101,9 +1097,7 @@ export function ChatInterface({
         stickyHeaderIndices={stickyHeaderIndices}
         contentContainerStyle={[
           styles.messageList,
-          Platform.OS === 'ios' && {
-            paddingBottom: Math.max(bottomContainerHeight, DEFAULT_IOS_COMPOSER_SPACER_HEIGHT),
-          },
+          Platform.OS === 'ios' && bottomContainerHeight > 0 && { paddingBottom: bottomContainerHeight },
           listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
         ]}
         ListHeaderComponent={renderLoadingHeader}

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -10,6 +10,7 @@ import {
   ActivityIndicator,
   NativeSyntheticEvent,
   NativeScrollEvent,
+  LayoutChangeEvent,
 } from 'react-native';
 import type { MessageDTO, SharedContentDeliveryStatus } from '@meet-without-fear/shared';
 import { MessageRole } from '@meet-without-fear/shared';
@@ -22,7 +23,7 @@ import { EmpathyValidationCard } from './EmpathyValidationCard';
 import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
 import { useSpeech, useAutoSpeech } from '../hooks/useSpeech';
-import { isPreRegisteredAnimatedId } from '../utils/animationBridge';
+import { getAnimationIdentity, isPreRegisteredAnimatedId } from '../utils/animationBridge';
 
 // ============================================================================
 // Types
@@ -99,6 +100,25 @@ function isCustomCard(item: ChatListItem): item is ChatCustomCardItem {
 
 function isCustomEmptyState(item: ChatListItem): item is CustomEmptyStateItem {
   return 'type' in item && item.type === 'custom-empty-state';
+}
+
+function getSameMomentSortRank(item: ChatListItem): number {
+  if (isIndicator(item)) {
+    switch (item.indicatorType) {
+      case 'invitation-sent':
+      case 'invitation-accepted':
+      case 'feel-heard':
+        return 0;
+      case 'stage-chapter':
+        return 1;
+      default:
+        return 1;
+    }
+  }
+
+  if (isValidationCard(item)) return 3;
+  if (isCustomCard(item)) return 3;
+  return 2;
 }
 
 interface ChatInterfaceProps {
@@ -254,6 +274,15 @@ export function ChatInterface({
 }: ChatInterfaceProps) {
   const styles = useStyles();
   const flatListRef = useRef<FlatList<ChatListItem>>(null);
+  const scrollMetricsRef = useRef({
+    offset: 0,
+    contentHeight: 0,
+    layoutHeight: 0,
+  });
+  const isNearBottomRef = useRef(true);
+  const shouldStickToBottomRef = useRef(true);
+  const scrollRetryTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const scrollRetryAnimationFrameRef = useRef<number | null>(null);
   const localAnimationScopeRef = useRef<string | null>(null);
   if (localAnimationScopeRef.current === null) {
     localAnimationScopeRef.current = createLocalAnimationScope();
@@ -268,18 +297,61 @@ export function ChatInterface({
     seenAnimatedItemIdsRef.current = getSeenAnimatedItemIds(animationScope);
   }
 
+  const scrollToBottom = useCallback((animated: boolean) => {
+    scrollRetryTimeoutsRef.current.forEach(clearTimeout);
+    scrollRetryTimeoutsRef.current = [];
+    if (scrollRetryAnimationFrameRef.current !== null) {
+      cancelAnimationFrame(scrollRetryAnimationFrameRef.current);
+    }
+
+    const run = () => {
+      const { contentHeight, layoutHeight } = scrollMetricsRef.current;
+      const maxOffset = Math.max(0, contentHeight - layoutHeight);
+
+      if (contentHeight > 0 && layoutHeight > 0) {
+        flatListRef.current?.scrollToOffset({ offset: maxOffset, animated });
+        return;
+      }
+
+      flatListRef.current?.scrollToEnd({ animated });
+    };
+
+    scrollRetryAnimationFrameRef.current = requestAnimationFrame(run);
+    scrollRetryTimeoutsRef.current = [
+      setTimeout(run, 40),
+      setTimeout(run, 120),
+      setTimeout(run, 260),
+      setTimeout(run, 500),
+      setTimeout(run, 800),
+    ];
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      scrollRetryTimeoutsRef.current.forEach(clearTimeout);
+      if (scrollRetryAnimationFrameRef.current !== null) {
+        cancelAnimationFrame(scrollRetryAnimationFrameRef.current);
+      }
+    };
+  }, []);
+
   useEffect(() => {
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
 
-    const showSub = Keyboard.addListener(showEvent, () => setIsKeyboardVisible(true));
+    const showSub = Keyboard.addListener(showEvent, () => {
+      setIsKeyboardVisible(true);
+      if (isNearBottomRef.current || shouldStickToBottomRef.current) {
+        scrollToBottom(false);
+      }
+    });
     const hideSub = Keyboard.addListener(hideEvent, () => setIsKeyboardVisible(false));
 
     return () => {
       showSub.remove();
       hideSub.remove();
     };
-  }, []);
+  }, [scrollToBottom]);
 
   // ---------------------------------------------------------------------------
   // Cache-First Architecture: Derive "waiting for AI" from last message role
@@ -312,6 +384,13 @@ export function ChatInterface({
   // 2. Cache-First behavior (deriving from last message role)
   const showTypingIndicator = isLoading || isWaitingForAI;
 
+  useEffect(() => {
+    if (showTypingIndicator && (isNearBottomRef.current || shouldStickToBottomRef.current)) {
+      shouldStickToBottomRef.current = true;
+      scrollToBottom(false);
+    }
+  }, [showTypingIndicator, scrollToBottom]);
+
   // Track the ID of the chat item currently being animated.
   const [animatingItemId, setAnimatingItemId] = useState<string | null>(null);
 
@@ -325,8 +404,11 @@ export function ChatInterface({
   const animatedItemIdsRef = useRef<Set<string>>(new Set());
 
   const markItemAnimationSeen = useCallback((itemId: string) => {
+    const animationIdentity = getAnimationIdentity(itemId);
     animatedItemIdsRef.current.add(itemId);
+    animatedItemIdsRef.current.add(animationIdentity);
     seenAnimatedItemIdsRef.current.add(itemId);
+    seenAnimatedItemIdsRef.current.add(animationIdentity);
   }, []);
 
   // STABLE SORT: Ensure order never flip-flops if timestamps are identical
@@ -334,36 +416,42 @@ export function ChatInterface({
     // 1. Combine messages, indicators, and validation cards
     const items: ChatListItem[] = [...messages, ...indicators, ...(validationCards || []), ...(customCards || [])];
 
-    // 2. Sort Newest First (standard chat sort)
+    // 2. Sort Oldest First so native sticky headers own the visual start of
+    // each section. New messages are kept at the bottom via explicit scroll.
     items.sort((a, b) => {
       const aTime = 'timestamp' in a && a.timestamp ? new Date(a.timestamp).getTime() : 0;
       const bTime = 'timestamp' in b && b.timestamp ? new Date(b.timestamp).getTime() : 0;
-      // Primary sort: Time (newest first) - with 1 second tolerance for items created in sequence
-      const timeDiff = bTime - aTime;
-      if (Math.abs(timeDiff) > 1000) return timeDiff;
+      // Primary sort: Time (oldest first). Chat messages must keep exact
+      // chronological order; otherwise a fast AI reply can land before the
+      // user message that triggered it and get suppressed by the animation
+      // queue's "user already replied" guard.
+      const timeDiff = aTime - bTime;
 
-      // For items within 1 second: indicators should appear ABOVE messages at the same time
-      // (older position = higher index in the sorted array)
+      const rankDiff = getSameMomentSortRank(a) - getSameMomentSortRank(b);
+      if (Math.abs(timeDiff) <= 1000 && rankDiff !== 0) return rankDiff;
+      if (timeDiff !== 0) return timeDiff;
+
+      // For items within 1 second: indicators should appear above messages at
+      // the same time.
       const aIsIndicator = isIndicator(a);
       const bIsIndicator = isIndicator(b);
-      if (aIsIndicator && !bIsIndicator) return 1; // a (indicator) comes after b (message) in array = appears higher
-      if (bIsIndicator && !aIsIndicator) return -1; // b (indicator) comes after a (message) in array = appears higher
+      if (aIsIndicator && !bIsIndicator) return -1;
+      if (bIsIndicator && !aIsIndicator) return 1;
 
       // Validation cards should appear BELOW messages at the same time
-      // (newer position = lower index in the sorted array)
       const aIsValidation = isValidationCard(a);
       const bIsValidation = isValidationCard(b);
-      if (aIsValidation && !bIsValidation) return -1; // validation card appears after/below message
-      if (bIsValidation && !aIsValidation) return 1;
+      if (aIsValidation && !bIsValidation) return 1;
+      if (bIsValidation && !aIsValidation) return -1;
 
       // Custom cards should appear below the prompt/message that introduced them.
       const aIsCustomCard = isCustomCard(a);
       const bIsCustomCard = isCustomCard(b);
-      if (aIsCustomCard && !bIsCustomCard) return -1;
-      if (bIsCustomCard && !aIsCustomCard) return 1;
+      if (aIsCustomCard && !bIsCustomCard) return 1;
+      if (bIsCustomCard && !aIsCustomCard) return -1;
 
       // Fallback: ID comparison for stability
-      return b.id.localeCompare(a.id);
+      return a.id.localeCompare(b.id);
     });
 
     // 3. Inject Compact Item (Custom Empty State)
@@ -372,11 +460,7 @@ export function ChatInterface({
     // - New sessions (no indicators): Compact appears as first item
     // - Accepted invitations (with indicators): Compact appears below indicators
     if (customEmptyState && messages.length === 0) {
-      // Unshift adds to Index 0.
-      // In an INVERTED list, Index 0 is the Visual BOTTOM (closest to input).
-      // For new sessions: Compact is the only item (appears at bottom)
-      // For accepted invitations: Compact appears below the "ACCEPTED INVITATION" indicator
-      items.unshift({
+      items.push({
         type: 'custom-empty-state',
         id: 'custom-empty-state-item',
       });
@@ -384,11 +468,6 @@ export function ChatInterface({
 
     return items;
   }, [messages, indicators, validationCards, customCards, customEmptyState, lastSeenChatItemId, lastViewedAt]);
-
-  const scrollMetricsRef = useRef({
-    offset: 0,
-    contentHeight: 0,
-  });
 
   // Track when we're actively loading history to prevent scroll interference
   const isLoadingHistoryRef = useRef(false);
@@ -408,7 +487,7 @@ export function ChatInterface({
       return;
     }
 
-    const newestItem = listItems[0];
+    const newestItem = listItems[listItems.length - 1];
     if (!newestItem) return;
 
     const currentTimestamp = 'timestamp' in newestItem && newestItem.timestamp
@@ -420,23 +499,23 @@ export function ChatInterface({
     // Update ref immediately
     newestMessageTimestampRef.current = currentTimestamp;
 
-    // If this is the very first load (previous is 0), no special scroll needed
-    // Let the inverted FlatList naturally show content at the bottom
+    // If this is the very first load, jump to the bottom after layout.
     if (previousTimestamp === 0) {
+      shouldStickToBottomRef.current = true;
+      scrollToBottom(false);
       return;
     }
 
     // If the new message is NEWER than what we saw before, it's a new chat message
     // SCROLL TO BOTTOM
     if (currentTimestamp > previousTimestamp) {
-      setTimeout(() => {
-        flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
-      }, 100);
+      shouldStickToBottomRef.current = true;
+      scrollToBottom(true);
     }
 
     // If currentTimestamp === previousTimestamp, we just loaded history
     // DO NOT SCROLL - the newest message hasn't changed
-  }, [listItems]);
+  }, [listItems, scrollToBottom]);
 
   // Snapshot boundary: captures all message IDs present on first meaningful render.
   // Messages in the snapshot render instantly. Messages not in the snapshot may animate.
@@ -488,7 +567,7 @@ export function ChatInterface({
   }, [listItems, lastSeenChatItemId]);
 
   const isAtOrBeforeSeenBoundary = useCallback((item: ChatListItem, index: number) => {
-    if (lastSeenItemIndex >= 0 && index >= lastSeenItemIndex) {
+    if (lastSeenItemIndex >= 0 && index <= lastSeenItemIndex) {
       return true;
     }
 
@@ -504,23 +583,26 @@ export function ChatInterface({
 
   const shouldAnimateItem = useCallback((item: ChatListItem, index: number) => {
     if (isIndicator(item) || isValidationCard(item) || isCustomEmptyState(item)) return false;
-    if (animatedItemIdsRef.current.has(item.id)) return false;
-    if (seenAnimatedItemIdsRef.current.has(item.id)) return false;
-    if (isPreRegisteredAnimatedId(item.id)) return false;
-    if (isAtOrBeforeSeenBoundary(item, index)) return false;
+    const animationIdentity = getAnimationIdentity(item.id);
+    if (animatedItemIdsRef.current.has(item.id) || animatedItemIdsRef.current.has(animationIdentity)) return false;
+    if (seenAnimatedItemIdsRef.current.has(item.id) || seenAnimatedItemIdsRef.current.has(animationIdentity)) return false;
+    if (isPreRegisteredAnimatedId(item.id) || isPreRegisteredAnimatedId(animationIdentity)) return false;
 
     if (isCustomCard(item)) {
+      if (isAtOrBeforeSeenBoundary(item, index)) return false;
       return item.animate === true;
     }
 
     const message = item as ChatMessage;
     if (message.role === MessageRole.USER) return false;
     if (message.id.startsWith('optimistic-')) return false;
+    const wasPresentAtMount = mountSnapshotIdsRef.current.has(message.id);
+    if (wasPresentAtMount && isAtOrBeforeSeenBoundary(item, index)) return false;
 
     // If the user has already replied after this assistant/system message,
     // the message must be visible immediately. It is no longer a live pending
     // animation candidate, and hiding it leaves blank transcript gaps.
-    for (let i = index - 1; i >= 0; i--) {
+    for (let i = index + 1; i < listItems.length; i++) {
       const laterItem = listItems[i];
       if (isIndicator(laterItem) || isValidationCard(laterItem) || isCustomEmptyState(laterItem) || isCustomCard(laterItem)) continue;
       if ((laterItem as ChatMessage).role === MessageRole.USER) {
@@ -576,16 +658,16 @@ export function ChatInterface({
   const nextAnimatableMessageId = useMemo(() => {
     if (animatingItemId !== null) return null;
 
-    // listItems is sorted newest first (descending by timestamp)
-    // Iterate from the END (oldest) to find the oldest animatable message
-    for (let i = listItems.length - 1; i >= 0; i--) {
+    // listItems is sorted oldest first. Iterate forward to animate in
+    // chronological order.
+    for (let i = 0; i < listItems.length; i++) {
       const item = listItems[i];
       if (!shouldAnimateItem(item, i)) continue;
 
       // Skip if a user message exists after this AI message chronologically
       // (user already saw and responded — no need to animate)
       let hasUserResponseAfter = false;
-      for (let j = i - 1; j >= 0; j--) {
+      for (let j = i + 1; j < listItems.length; j++) {
         const laterItem = listItems[j];
         if (isIndicator(laterItem) || isValidationCard(laterItem) || isCustomEmptyState(laterItem) || isCustomCard(laterItem)) continue;
         if ((laterItem as ChatMessage).role === MessageRole.USER) {
@@ -594,7 +676,7 @@ export function ChatInterface({
         }
       }
       if (hasUserResponseAfter) continue;
-      return item.id;
+      return getAnimationIdentity(item.id);
     }
     return null;
   }, [listItems, animatingItemId, shouldAnimateItem]);
@@ -604,17 +686,29 @@ export function ChatInterface({
   // button-only actions from replaying older visible messages one by one.
   useEffect(() => {
     if (animatingItemId !== null) {
-      const animatingIndex = listItems.findIndex((item) => item.id === animatingItemId);
+      const animatingIndex = listItems.findIndex((item) => getAnimationIdentity(item.id) === animatingItemId);
       const animatingItem = animatingIndex >= 0 ? listItems[animatingIndex] : null;
-      if (!animatingItem || !shouldAnimateItem(animatingItem, animatingIndex)) {
-        markItemAnimationSeen(animatingItemId);
+
+      if (animatingItem && !isIndicator(animatingItem) && !isValidationCard(animatingItem) && !isCustomEmptyState(animatingItem) && !isCustomCard(animatingItem)) {
+        const message = animatingItem as ChatMessage;
+        const hasUserResponseAfter = listItems.slice(animatingIndex + 1).some((laterItem) => {
+          if (isIndicator(laterItem) || isValidationCard(laterItem) || isCustomEmptyState(laterItem) || isCustomCard(laterItem)) return false;
+          return (laterItem as ChatMessage).role === MessageRole.USER;
+        });
+
+        if (message.status !== 'streaming' && hasUserResponseAfter) {
+          markItemAnimationSeen(animatingItemId);
+          setAnimatingItemId(null);
+        }
+      } else if (!animatingItem) {
         setAnimatingItemId(null);
       }
     }
 
     listItems.forEach((item, index) => {
       if (isIndicator(item) || isValidationCard(item) || isCustomEmptyState(item)) return;
-      if (item.id === nextAnimatableMessageId || item.id === animatingItemId) return;
+      const animationIdentity = getAnimationIdentity(item.id);
+      if (animationIdentity === nextAnimatableMessageId || animationIdentity === animatingItemId) return;
 
       if (isCustomCard(item)) {
         if (item.animate === true && !shouldAnimateItem(item, index)) {
@@ -636,7 +730,12 @@ export function ChatInterface({
   useEffect(() => {
     const isAnimating = animatingItemId !== null;
     onTypewriterStateChange?.(isAnimating);
-  }, [animatingItemId, onTypewriterStateChange]);
+
+    if (isAnimating && (isNearBottomRef.current || shouldStickToBottomRef.current)) {
+      shouldStickToBottomRef.current = true;
+      scrollToBottom(false);
+    }
+  }, [animatingItemId, onTypewriterStateChange, scrollToBottom]);
 
   const renderItem: ListRenderItem<ChatListItem> = useCallback(({ item }) => {
     // 1. Render Custom Empty State (Compact)
@@ -685,7 +784,8 @@ export function ChatInterface({
     if (isCustomCard(item)) {
       const itemIndex = listItems.findIndex((listItem) => listItem.id === item.id);
       const shouldAnimate = itemIndex >= 0 ? shouldAnimateItem(item, itemIndex) : false;
-      const isNextAnimatable = item.id === nextAnimatableMessageId;
+      const animationIdentity = getAnimationIdentity(item.id);
+      const isNextAnimatable = animationIdentity === nextAnimatableMessageId;
 
       return (
         <>
@@ -704,15 +804,16 @@ export function ChatInterface({
     // 5. Render Messages
     // At this point, item must be a ChatMessage (we've already handled indicators, validation cards, custom cards, and custom empty state)
     const message = item as ChatMessage;
+    const animationIdentity = getAnimationIdentity(message.id);
     
     const itemIndex = listItems.findIndex((listItem) => listItem.id === message.id);
-    const isCurrentlyAnimating = message.id === animatingItemId;
+    const isCurrentlyAnimating = animationIdentity === animatingItemId;
     const isAIMessage = message.role !== MessageRole.USER;
 
     const shouldAnimateTypewriter = itemIndex >= 0 ? shouldAnimateItem(message, itemIndex) : false;
 
     // Track animation for the next message in queue (oldest unanimatied)
-    const isNextAnimatable = message.id === nextAnimatableMessageId;
+    const isNextAnimatable = animationIdentity === nextAnimatableMessageId;
 
     const bubbleMessage: ChatBubbleMessage = {
       id: message.id,
@@ -730,7 +831,14 @@ export function ChatInterface({
       <>
         <ChatBubble
           message={bubbleMessage}
-          onAnimationStart={isNextAnimatable ? () => setAnimatingItemId(message.id) : undefined}
+          animationIdentity={animationIdentity}
+          onAnimationStart={isNextAnimatable ? () => setAnimatingItemId(animationIdentity) : undefined}
+          onAnimationProgress={() => {
+            if (isNearBottomRef.current || shouldStickToBottomRef.current) {
+              shouldStickToBottomRef.current = true;
+              scrollToBottom(false);
+            }
+          }}
           onAnimationComplete={(isNextAnimatable || isCurrentlyAnimating) ? () => {
             markItemAnimationSeen(message.id);
             setAnimatingItemId(null);
@@ -743,20 +851,28 @@ export function ChatInterface({
         {renderMessageExtra?.(message)}
       </>
     );
-  }, [listItems, shouldAnimateItem, nextAnimatableMessageId, animatingItemId, onTypewriterComplete, isSpeaking, currentId, handleSpeakerPress, customEmptyState, styles, partnerName, renderMessageExtra, onContextSharedPress, onValidateAccurate, onValidateNotQuite, markItemAnimationSeen]);
+  }, [listItems, shouldAnimateItem, nextAnimatableMessageId, animatingItemId, onTypewriterComplete, isSpeaking, currentId, handleSpeakerPress, customEmptyState, styles, partnerName, renderMessageExtra, onContextSharedPress, onValidateAccurate, onValidateNotQuite, markItemAnimationSeen, scrollToBottom]);
 
-  const keyExtractor = useCallback((item: ChatListItem) => item.id, []);
+  const keyExtractor = useCallback((item: ChatListItem) => getAnimationIdentity(item.id), []);
 
-  // In inverted list: Header is visually at BOTTOM (Typing Indicator)
+  // Footer is visually at the bottom (Typing Indicator)
   // We always render a container with minHeight to prevent layout shift
   // when the indicator disappears and the AI message appears
   const renderHeader = useCallback(() => {
     return (
-      <View style={styles.typingIndicatorContainer}>
+      <View
+        style={styles.typingIndicatorContainer}
+        onLayout={() => {
+          if (isNearBottomRef.current || shouldStickToBottomRef.current) {
+            shouldStickToBottomRef.current = true;
+            scrollToBottom(false);
+          }
+        }}
+      >
         {showTypingIndicator && <TypingIndicator />}
       </View>
     );
-  }, [showTypingIndicator, styles]);
+  }, [showTypingIndicator, styles, scrollToBottom]);
 
   // Memoize the empty state element (not a callback!) to prevent remounts
   // NOTE: styles are excluded from deps because useStyles() creates new refs each render
@@ -783,8 +899,8 @@ export function ChatInterface({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showTypingIndicator, emptyStateTitle, emptyStateMessage, customEmptyState]);
 
-  // In inverted list: Footer is visually at TOP (Loading Spinner)
-  const renderFooter = useCallback(() => {
+  // Header is visually at the top (Loading Spinner)
+  const renderLoadingHeader = useCallback(() => {
     if (!isLoadingMore) return null;
     return (
       <View style={styles.loadingMore}>
@@ -795,18 +911,19 @@ export function ChatInterface({
 
   const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+    const distanceFromBottom = Math.max(
+      0,
+      contentSize.height - layoutMeasurement.height - contentOffset.y,
+    );
+    const isNearBottom = distanceFromBottom < 80;
+
     scrollMetricsRef.current = {
       offset: contentOffset.y,
       contentHeight: contentSize.height,
+      layoutHeight: layoutMeasurement.height,
     };
-
-    // Detect overscroll (rubber band past oldest content in inverted list)
-    const maxOffset = Math.max(0, contentSize.height - layoutMeasurement.height);
-    const overscrolled = contentOffset.y > maxOffset + 5;
-    if (overscrolled !== isOverscrolledRef.current) {
-      isOverscrolledRef.current = overscrolled;
-      if (overscrolled) setCurrentStageMeta(null);
-    }
+    isNearBottomRef.current = isNearBottom;
+    shouldStickToBottomRef.current = isNearBottom;
   }, []);
 
   const handleContentSizeChange = useCallback((_width: number, height: number) => {
@@ -815,8 +932,13 @@ export function ChatInterface({
     // Always keep scroll metrics updated
     scrollMetricsRef.current.contentHeight = height;
 
-    // If we're not in history loading mode, nothing to restore
+    // If we're not in history loading mode, keep the bottom pinned only when
+    // the user was already reading at the bottom.
     if (!isLoadingHistoryRef.current || !snapshot) {
+      scrollMetricsRef.current.contentHeight = height;
+      if (isNearBottomRef.current || shouldStickToBottomRef.current) {
+        scrollToBottom(false);
+      }
       return;
     }
 
@@ -835,7 +957,14 @@ export function ChatInterface({
       historyLoadSnapshotRef.current = null;
       isLoadingHistoryRef.current = false;
     }
-  }, []);
+  }, [scrollToBottom]);
+
+  const handleListLayout = useCallback((event: LayoutChangeEvent) => {
+    scrollMetricsRef.current.layoutHeight = event.nativeEvent.layout.height;
+    if (isNearBottomRef.current || shouldStickToBottomRef.current) {
+      scrollToBottom(false);
+    }
+  }, [scrollToBottom]);
 
   const handleEndReached = useCallback(() => {
     if (hasMore && !isLoadingMore && onLoadMore) {
@@ -867,89 +996,21 @@ export function ChatInterface({
     }
   }, [isLoadingMore]);
 
-  // ---------------------------------------------------------------------------
-  // Sticky Stage Header: shows the current stage at the top of the chat
-  // ---------------------------------------------------------------------------
-  const [currentStageMeta, setCurrentStageMeta] = useState<{
-    name: string;
-    color: string;
-  } | null>(null);
-
-  // Use a high threshold so the sticky appears as soon as the inline bar
-  // starts going behind the header (not after it's fully off-screen).
-  const viewabilityConfig = useRef({ itemVisiblePercentThreshold: 95 }).current;
-  const stageBarsRef = useRef<Array<{ index: number; name: string; color: string }>>([]);
-  const isOverscrolledRef = useRef(false);
-
-  // Pre-compute stage bar positions whenever the list changes
-  useEffect(() => {
-    const bars: Array<{ index: number; name: string; color: string }> = [];
-    listItems.forEach((item, index) => {
+  const stickyHeaderIndices = useMemo(() => {
+    // VirtualizedList counts ListHeaderComponent as scroll child 0, so data
+    // rows are offset by one when passed through stickyHeaderIndices.
+    const listHeaderOffset = 1;
+    return listItems.reduce<number[]>((indices, item, index) => {
       if (isIndicator(item) && item.indicatorType === 'stage-chapter') {
-        bars.push({
-          index,
-          name: item.metadata?.stageName || 'New Chapter',
-          color: item.metadata?.stageColor || '#8B9DC3',
-        });
+        indices.push(index + listHeaderOffset);
       }
-    });
-    stageBarsRef.current = bars;
+      return indices;
+    }, []);
   }, [listItems]);
-
-  const onViewableItemsChanged = useCallback(({ viewableItems }: { viewableItems: Array<{ item: ChatListItem; index: number | null }> }) => {
-    // Suppress sticky during overscroll (rubber band effect)
-    if (isOverscrolledRef.current) {
-      setCurrentStageMeta(null);
-      return;
-    }
-
-    const visibleIndices = new Set<number>();
-    for (const v of viewableItems) {
-      if (v.index != null) visibleIndices.add(v.index);
-    }
-
-    const bars = stageBarsRef.current;
-
-    // In an inverted FlatList, higher data index = higher on screen.
-    // A bar that scrolled off the TOP has a high index and is NOT visible.
-    // Find the non-visible bar with the highest index.
-    let stickyBar: { index: number; name: string; color: string } | null = null;
-    for (const bar of bars) {
-      if (!visibleIndices.has(bar.index)) {
-        if (!stickyBar || bar.index > stickyBar.index) {
-          stickyBar = bar;
-        }
-      }
-    }
-
-    if (stickyBar) {
-      // Only show if there are visible items BELOW this bar on screen
-      // (lower index = lower on screen in inverted list).
-      // This prevents showing the sticky for bars that scrolled off the BOTTOM.
-      const hasContentBelow = viewableItems.some(
-        (v) => v.index != null && v.index < stickyBar!.index,
-      );
-      setCurrentStageMeta(
-        hasContentBelow ? { name: stickyBar.name, color: stickyBar.color } : null,
-      );
-    } else {
-      // All bars visible or no bars exist — no sticky needed
-      setCurrentStageMeta(null);
-    }
-  }, []);
 
   // ---------------------------------------------------------------------------
   // New Activity Pill: floating indicator for off-screen new items
   // ---------------------------------------------------------------------------
-
-  /** Pick white or dark text based on background luminance. */
-  const getContrastText = useCallback((hex: string): string => {
-    const r = parseInt(hex.slice(1, 3), 16);
-    const g = parseInt(hex.slice(3, 5), 16);
-    const b = parseInt(hex.slice(5, 7), 16);
-    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-    return luminance > 0.55 ? '#1a1815' : '#ffffff';
-  }, []);
 
   return (
     <KeyboardAvoidingView
@@ -957,46 +1018,30 @@ export function ChatInterface({
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       keyboardVerticalOffset={keyboardVerticalOffset}
     >
-      {/* Sticky stage header overlay */}
-      {currentStageMeta && listItems.length > 0 && (
-        <View
-          style={[styles.stickyStageHeader, { backgroundColor: currentStageMeta.color }]}
-          pointerEvents="none"
-        >
-          <Text style={[styles.stickyStageText, { color: getContrastText(currentStageMeta.color) }]}>
-            {currentStageMeta.name}
-          </Text>
-        </View>
-      )}
       <FlatList
         ref={flatListRef}
-        inverted
         data={listItems}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
         style={styles.flatList}
-        viewabilityConfig={viewabilityConfig}
-        onViewableItemsChanged={onViewableItemsChanged}
-        // Stabilizer: maintains position when spinners appear/disappear
-        maintainVisibleContentPosition={{
-          minIndexForVisible: 0,
-        }}
+        stickyHeaderIndices={stickyHeaderIndices}
         contentContainerStyle={[
           styles.messageList,
           listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
         ]}
-        ListHeaderComponent={
+        ListHeaderComponent={renderLoadingHeader}
+        ListFooterComponent={
           <>
             {renderBelowChat?.()}
             {renderHeader?.()}
           </>
         }
-        ListFooterComponent={renderFooter}
         ListEmptyComponent={emptyStateElement}
         showsVerticalScrollIndicator={false}
         testID="chat-message-list"
-        onEndReached={handleEndReached}
-        onEndReachedThreshold={0.2}
+        onStartReached={handleEndReached}
+        onStartReachedThreshold={0.2}
+        onLayout={handleListLayout}
         onScroll={handleScroll}
         scrollEventThrottle={16}
         onContentSizeChange={handleContentSizeChange}
@@ -1039,22 +1084,6 @@ const useStyles = () => {
       flex: 1,
       backgroundColor: palette.bg,
     },
-    stickyStageHeader: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      zIndex: 10,
-      paddingVertical: 6,
-      paddingHorizontal: 18,
-    },
-    stickyStageText: {
-      fontSize: 12,
-      fontWeight: '700',
-      letterSpacing: 0.8,
-      textTransform: 'uppercase',
-      textAlign: 'center',
-    },
     flatList: {
       flex: 1,
     },
@@ -1069,11 +1098,9 @@ const useStyles = () => {
     },
     customMessageListEmpty: {
       flexGrow: 1,
-      // In inverted list, flex-end aligns to visual TOP
-      justifyContent: 'flex-end',
+      justifyContent: 'flex-start',
     },
     loadingMore: {
-      // In inverted list, this appears at visual TOP
       paddingVertical: t.spacing.xl,
       alignItems: 'center',
     },
@@ -1093,8 +1120,6 @@ const useStyles = () => {
     },
     emptyState: {
       flex: 1,
-      // Counter-flip the inverted list for empty state text
-      transform: [{ scaleY: -1 }],
       justifyContent: 'center',
       alignItems: 'center',
       paddingHorizontal: t.spacing['3xl'],
@@ -1102,9 +1127,6 @@ const useStyles = () => {
     },
     customEmptyState: {
       flex: 1,
-      // Counter-flip the inverted list for empty state content
-      transform: [{ scaleY: -1 }],
-      // Start content at the top (in flipped view this is flex-start)
       justifyContent: 'flex-start',
     },
     emptyStateTitle: {

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -11,7 +11,6 @@ import {
   NativeScrollEvent,
   LayoutChangeEvent,
 } from 'react-native';
-import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import type { MessageDTO, SharedContentDeliveryStatus } from '@meet-without-fear/shared';
 import { MessageRole } from '@meet-without-fear/shared';
 import { ChatBubble, ChatBubbleMessage, MessageDeliveryStatus } from './ChatBubble';
@@ -24,6 +23,7 @@ import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
 import { useSpeech, useAutoSpeech } from '../hooks/useSpeech';
 import { getAnimationIdentity, isPreRegisteredAnimatedId } from '../utils/animationBridge';
+import { KeyboardAwareAvoidingView } from '../utils/keyboardController';
 
 // ============================================================================
 // Types
@@ -1039,7 +1039,7 @@ export function ChatInterface({
   // ---------------------------------------------------------------------------
 
   return (
-    <KeyboardAvoidingView
+    <KeyboardAwareAvoidingView
       style={styles.container}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       keyboardVerticalOffset={keyboardVerticalOffset}
@@ -1098,7 +1098,7 @@ export function ChatInterface({
         {!isKeyboardVisible && renderAboveInput?.()}
         {!isKeyboardVisible && renderBelowInput?.()}
       </View>
-    </KeyboardAvoidingView>
+    </KeyboardAwareAvoidingView>
   );
 }
 

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -1060,6 +1060,7 @@ export function ChatInterface({
           <ChatInput
             onSend={onSendMessage}
             disabled={disabled || isInputDisabled || isLoading}
+            inputDisabled={disabled || isLoading}
             onVoicePress={onVoicePress}
             failedMessage={failedMessage}
             prefillText={prefillText}

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   FlatList,
   Keyboard,
+  InputAccessoryView,
   Platform,
   ListRenderItem,
   ActivityIndicator,
@@ -23,7 +24,7 @@ import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
 import { useSpeech, useAutoSpeech } from '../hooks/useSpeech';
 import { getAnimationIdentity, isPreRegisteredAnimatedId } from '../utils/animationBridge';
-import { KeyboardAwareAvoidingView } from '../utils/keyboardController';
+import { hasLinkedKeyboardController, KeyboardAwareAvoidingView } from '../utils/keyboardController';
 
 // ============================================================================
 // Types
@@ -213,6 +214,7 @@ interface ChatInterfaceProps {
 const DEFAULT_EMPTY_TITLE = 'Start the Conversation';
 const DEFAULT_EMPTY_MESSAGE =
   "Share what's on your mind. I'm here to listen and help you work through it.";
+const DEFAULT_IOS_COMPOSER_SPACER_HEIGHT = 164;
 
 const seenAnimatedItemIdsByScope = new Map<string, Set<string>>();
 let localAnimationScopeCounter = 0;
@@ -419,6 +421,8 @@ export function ChatInterface({
 
   // Track the ID of the chat item currently being animated.
   const [animatingItemId, setAnimatingItemId] = useState<string | null>(null);
+  const [bottomContainerHeight, setBottomContainerHeight] = useState(0);
+  const useIOSAccessoryComposer = Platform.OS === 'ios' && !hasLinkedKeyboardController();
 
   // Speech functionality
   const { isSpeaking, currentId, toggle: toggleSpeech } = useSpeech();
@@ -962,7 +966,7 @@ export function ChatInterface({
     // the user was already reading at the bottom.
     if (!isLoadingHistoryRef.current || !snapshot) {
       scrollMetricsRef.current.contentHeight = height;
-      if (isNearBottomRef.current || shouldStickToBottomRef.current) {
+      if ((isNearBottomRef.current || shouldStickToBottomRef.current) && !(useIOSAccessoryComposer && isKeyboardVisible)) {
         scrollToBottom(false);
       }
       return;
@@ -983,14 +987,14 @@ export function ChatInterface({
       historyLoadSnapshotRef.current = null;
       isLoadingHistoryRef.current = false;
     }
-  }, [scrollToBottom]);
+  }, [isKeyboardVisible, scrollToBottom, useIOSAccessoryComposer]);
 
   const handleListLayout = useCallback((event: LayoutChangeEvent) => {
     scrollMetricsRef.current.layoutHeight = event.nativeEvent.layout.height;
-    if (isNearBottomRef.current || shouldStickToBottomRef.current) {
+    if ((isNearBottomRef.current || shouldStickToBottomRef.current) && !(useIOSAccessoryComposer && isKeyboardVisible)) {
       scrollToBottom(false);
     }
-  }, [scrollToBottom]);
+  }, [isKeyboardVisible, scrollToBottom, useIOSAccessoryComposer]);
 
   const handleEndReached = useCallback(() => {
     if (hasMore && !isLoadingMore && onLoadMore) {
@@ -1038,12 +1042,44 @@ export function ChatInterface({
   // New Activity Pill: floating indicator for off-screen new items
   // ---------------------------------------------------------------------------
 
-  return (
-    <KeyboardAwareAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={keyboardVerticalOffset}
+  const bottomControls = (
+    <View
+      style={styles.bottomContainer}
+      onLayout={(event) => {
+        if (!useIOSAccessoryComposer) return;
+        const nextHeight = Math.ceil(event.nativeEvent.layout.height);
+        setBottomContainerHeight((currentHeight) => (
+          Math.abs(currentHeight - nextHeight) > 2 ? nextHeight : currentHeight
+        ));
+      }}
     >
+      {showEmotionSlider && onEmotionChange && (
+        <EmotionSlider
+          value={emotionValue}
+          onChange={onEmotionChange}
+          onHighEmotion={onHighEmotion}
+          compact={compactEmotionSlider}
+          testID="chat-emotion-slider"
+        />
+      )}
+      {!hideInput && (
+        <ChatInput
+          onSend={onSendMessage}
+          disabled={disabled || isInputDisabled || isLoading}
+          inputDisabled={disabled || isLoading}
+          onVoicePress={onVoicePress}
+          failedMessage={failedMessage}
+          prefillText={prefillText}
+          onPrefillConsumed={onPrefillConsumed}
+        />
+      )}
+      {!isKeyboardVisible && renderAboveInput?.()}
+      {!isKeyboardVisible && renderBelowInput?.()}
+    </View>
+  );
+
+  const chatContent = (
+    <>
       <FlatList
         ref={flatListRef}
         data={listItems}
@@ -1053,6 +1089,9 @@ export function ChatInterface({
         stickyHeaderIndices={stickyHeaderIndices}
         contentContainerStyle={[
           styles.messageList,
+          useIOSAccessoryComposer && {
+            paddingBottom: Math.max(bottomContainerHeight, DEFAULT_IOS_COMPOSER_SPACER_HEIGHT),
+          },
           listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
         ]}
         ListHeaderComponent={renderLoadingHeader}
@@ -1074,30 +1113,29 @@ export function ChatInterface({
         scrollEventThrottle={16}
         onContentSizeChange={handleContentSizeChange}
       />
-      <View style={styles.bottomContainer}>
-        {showEmotionSlider && onEmotionChange && (
-          <EmotionSlider
-            value={emotionValue}
-            onChange={onEmotionChange}
-            onHighEmotion={onHighEmotion}
-            compact={compactEmotionSlider}
-            testID="chat-emotion-slider"
-          />
-        )}
-        {!hideInput && (
-          <ChatInput
-            onSend={onSendMessage}
-            disabled={disabled || isInputDisabled || isLoading}
-            inputDisabled={disabled || isLoading}
-            onVoicePress={onVoicePress}
-            failedMessage={failedMessage}
-            prefillText={prefillText}
-            onPrefillConsumed={onPrefillConsumed}
-          />
-        )}
-        {!isKeyboardVisible && renderAboveInput?.()}
-        {!isKeyboardVisible && renderBelowInput?.()}
+      {useIOSAccessoryComposer ? (
+        <InputAccessoryView>
+          {bottomControls}
+        </InputAccessoryView>
+      ) : bottomControls}
+    </>
+  );
+
+  if (useIOSAccessoryComposer) {
+    return (
+      <View style={styles.container}>
+        {chatContent}
       </View>
+    );
+  }
+
+  return (
+    <KeyboardAwareAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={keyboardVerticalOffset}
+    >
+      {chatContent}
     </KeyboardAwareAvoidingView>
   );
 }

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -359,8 +359,8 @@ export function ChatInterface({
   // If the last message is from USER, we're waiting for AI response → show typing indicator
   // If the last message is from AI/SYSTEM, response has arrived → hide typing indicator
   // This eliminates the need for a separate waitingForAIResponse boolean state
-  const isWaitingForAI = useMemo(() => {
-    if (messages.length === 0) return false;
+  const newestChatFlowMessage = useMemo(() => {
+    if (messages.length === 0) return null;
     // Find the newest message by timestamp among chat-flow roles (USER/AI).
     // Synthetic messages (EMPATHY_STATEMENT, SHARED_CONTEXT, etc.) may be
     // appended at the end of the array but have older timestamps — using
@@ -375,21 +375,45 @@ export function ChatInterface({
         newest = m;
       }
     }
-    return newest?.role === MessageRole.USER;
+    return newest;
   }, [messages]);
+  const isWaitingForAI = newestChatFlowMessage?.role === MessageRole.USER;
+  const shouldDelayTypingIndicator =
+    isWaitingForAI &&
+    !isLoading &&
+    (newestChatFlowMessage?.status === 'sending' || newestChatFlowMessage?.id.startsWith('optimistic-user-'));
 
   // Combined loading state: explicit isLoading OR derived from last message
   // This allows both:
   // 1. Legacy behavior (passing isLoading for initial fetch, confirmation, etc.)
   // 2. Cache-First behavior (deriving from last message role)
   const showTypingIndicator = isLoading || isWaitingForAI;
+  const [showDelayedTypingIndicator, setShowDelayedTypingIndicator] = useState(false);
 
   useEffect(() => {
-    if (showTypingIndicator && (isNearBottomRef.current || shouldStickToBottomRef.current)) {
+    if (!showTypingIndicator) {
+      setShowDelayedTypingIndicator(false);
+      return;
+    }
+
+    if (!shouldDelayTypingIndicator) {
+      setShowDelayedTypingIndicator(true);
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      setShowDelayedTypingIndicator(true);
+    }, 420);
+
+    return () => clearTimeout(timeoutId);
+  }, [showTypingIndicator, shouldDelayTypingIndicator]);
+
+  useEffect(() => {
+    if (showDelayedTypingIndicator && (isNearBottomRef.current || shouldStickToBottomRef.current)) {
       shouldStickToBottomRef.current = true;
       scrollToBottom(false);
     }
-  }, [showTypingIndicator, scrollToBottom]);
+  }, [showDelayedTypingIndicator, scrollToBottom]);
 
   // Track the ID of the chat item currently being animated.
   const [animatingItemId, setAnimatingItemId] = useState<string | null>(null);
@@ -869,16 +893,16 @@ export function ChatInterface({
           }
         }}
       >
-        {showTypingIndicator && <TypingIndicator />}
+        {showDelayedTypingIndicator && <TypingIndicator />}
       </View>
     );
-  }, [showTypingIndicator, styles, scrollToBottom]);
+  }, [showDelayedTypingIndicator, styles, scrollToBottom]);
 
   // Memoize the empty state element (not a callback!) to prevent remounts
   // NOTE: styles are excluded from deps because useStyles() creates new refs each render
   // but the actual style values are stable (theme-based)
   const emptyStateElement = useMemo(() => {
-    if (showTypingIndicator) return null;
+    if (showDelayedTypingIndicator) return null;
     // Use custom empty state if provided (e.g., onboarding compact)
     // Custom empty state starts at the top (flex-start) instead of centered
     if (customEmptyState) {
@@ -897,7 +921,7 @@ export function ChatInterface({
       </View>
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showTypingIndicator, emptyStateTitle, emptyStateMessage, customEmptyState]);
+  }, [showDelayedTypingIndicator, emptyStateTitle, emptyStateMessage, customEmptyState]);
 
   // Header is visually at the top (Loading Spinner)
   const renderLoadingHeader = useCallback(() => {

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -214,6 +214,7 @@ interface ChatInterfaceProps {
 const DEFAULT_EMPTY_TITLE = 'Start the Conversation';
 const DEFAULT_EMPTY_MESSAGE =
   "Share what's on your mind. I'm here to listen and help you work through it.";
+const DEFAULT_IOS_COMPOSER_SPACER_HEIGHT = 164;
 
 const seenAnimatedItemIdsByScope = new Map<string, Set<string>>();
 let localAnimationScopeCounter = 0;
@@ -976,7 +977,7 @@ export function ChatInterface({
     // the user was already reading at the bottom.
     if (!isLoadingHistoryRef.current || !snapshot) {
       scrollMetricsRef.current.contentHeight = height;
-      if (isNearBottomRef.current || shouldStickToBottomRef.current) {
+      if ((isNearBottomRef.current || shouldStickToBottomRef.current) && !(Platform.OS === 'ios' && isKeyboardVisible)) {
         scrollToBottom(false);
       }
       return;
@@ -997,14 +998,14 @@ export function ChatInterface({
       historyLoadSnapshotRef.current = null;
       isLoadingHistoryRef.current = false;
     }
-  }, [scrollToBottom]);
+  }, [isKeyboardVisible, scrollToBottom]);
 
   const handleListLayout = useCallback((event: LayoutChangeEvent) => {
     scrollMetricsRef.current.layoutHeight = event.nativeEvent.layout.height;
-    if (isNearBottomRef.current || shouldStickToBottomRef.current) {
+    if ((isNearBottomRef.current || shouldStickToBottomRef.current) && !(Platform.OS === 'ios' && isKeyboardVisible)) {
       scrollToBottom(false);
     }
-  }, [scrollToBottom]);
+  }, [isKeyboardVisible, scrollToBottom]);
 
   const handleEndReached = useCallback(() => {
     if (hasMore && !isLoadingMore && onLoadMore) {
@@ -1057,7 +1058,10 @@ export function ChatInterface({
       style={styles.bottomContainer}
       onLayout={(event) => {
         if (Platform.OS === 'ios') {
-          setBottomContainerHeight(event.nativeEvent.layout.height);
+          const nextHeight = Math.ceil(event.nativeEvent.layout.height);
+          setBottomContainerHeight((currentHeight) => (
+            Math.abs(currentHeight - nextHeight) > 2 ? nextHeight : currentHeight
+          ));
         }
       }}
     >
@@ -1097,7 +1101,9 @@ export function ChatInterface({
         stickyHeaderIndices={stickyHeaderIndices}
         contentContainerStyle={[
           styles.messageList,
-          Platform.OS === 'ios' && bottomContainerHeight > 0 && { paddingBottom: bottomContainerHeight },
+          Platform.OS === 'ios' && {
+            paddingBottom: Math.max(bottomContainerHeight, DEFAULT_IOS_COMPOSER_SPACER_HEIGHT),
+          },
           listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
         ]}
         ListHeaderComponent={renderLoadingHeader}

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -1038,7 +1038,14 @@ export function ChatInterface({
   // New Activity Pill: floating indicator for off-screen new items
   // ---------------------------------------------------------------------------
 
-  const bottomControls = (
+  const auxiliaryControls = !isKeyboardVisible ? (
+    <>
+      {renderAboveInput?.()}
+      {renderBelowInput?.()}
+    </>
+  ) : null;
+
+  const composerControls = (
     <View style={styles.bottomContainer}>
       {showEmotionSlider && onEmotionChange && (
         <EmotionSlider
@@ -1060,8 +1067,6 @@ export function ChatInterface({
           onPrefillConsumed={onPrefillConsumed}
         />
       )}
-      {!isKeyboardVisible && renderAboveInput?.()}
-      {!isKeyboardVisible && renderBelowInput?.()}
     </View>
   );
 
@@ -1109,8 +1114,9 @@ export function ChatInterface({
           {messageList}
         </KeyboardAwareAvoidingView>
         <KeyboardStickyComposer>
-          {bottomControls}
+          {composerControls}
         </KeyboardStickyComposer>
+        {auxiliaryControls}
       </View>
     );
   }
@@ -1122,7 +1128,8 @@ export function ChatInterface({
       keyboardVerticalOffset={keyboardVerticalOffset}
     >
       {messageList}
-      {bottomControls}
+      {composerControls}
+      {auxiliaryControls}
     </KeyboardAwareAvoidingView>
   );
 }

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -281,8 +281,6 @@ export function ChatInterface({
   });
   const isNearBottomRef = useRef(true);
   const shouldStickToBottomRef = useRef(true);
-  const dragStartOffsetRef = useRef<number | null>(null);
-  const dragStartedNearBottomRef = useRef(false);
   const scrollRetryTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const scrollRetryAnimationFrameRef = useRef<number | null>(null);
   const localAnimationScopeRef = useRef<string | null>(null);
@@ -950,22 +948,6 @@ export function ChatInterface({
     };
     isNearBottomRef.current = isNearBottom;
     shouldStickToBottomRef.current = isNearBottom;
-
-    if (
-      isKeyboardVisible &&
-      dragStartedNearBottomRef.current &&
-      dragStartOffsetRef.current !== null &&
-      contentOffset.y < dragStartOffsetRef.current - 24
-    ) {
-      Keyboard.dismiss();
-      dragStartOffsetRef.current = null;
-      dragStartedNearBottomRef.current = false;
-    }
-  }, [isKeyboardVisible]);
-
-  const handleScrollBeginDrag = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    dragStartOffsetRef.current = event.nativeEvent.contentOffset.y;
-    dragStartedNearBottomRef.current = isNearBottomRef.current;
   }, []);
 
   const handleContentSizeChange = useCallback((_width: number, height: number) => {
@@ -1086,7 +1068,6 @@ export function ChatInterface({
         onStartReached={handleEndReached}
         onStartReachedThreshold={0.2}
         onLayout={handleListLayout}
-        onScrollBeginDrag={handleScrollBeginDrag}
         onScroll={handleScroll}
         scrollEventThrottle={16}
         onContentSizeChange={handleContentSizeChange}

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -281,6 +281,8 @@ export function ChatInterface({
   });
   const isNearBottomRef = useRef(true);
   const shouldStickToBottomRef = useRef(true);
+  const dragStartOffsetRef = useRef<number | null>(null);
+  const dragStartedNearBottomRef = useRef(false);
   const scrollRetryTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const scrollRetryAnimationFrameRef = useRef<number | null>(null);
   const localAnimationScopeRef = useRef<string | null>(null);
@@ -948,10 +950,22 @@ export function ChatInterface({
     };
     isNearBottomRef.current = isNearBottom;
     shouldStickToBottomRef.current = isNearBottom;
-  }, []);
 
-  const handleScrollBeginDrag = useCallback(() => {
-    Keyboard.dismiss();
+    if (
+      isKeyboardVisible &&
+      dragStartedNearBottomRef.current &&
+      dragStartOffsetRef.current !== null &&
+      contentOffset.y < dragStartOffsetRef.current - 24
+    ) {
+      Keyboard.dismiss();
+      dragStartOffsetRef.current = null;
+      dragStartedNearBottomRef.current = false;
+    }
+  }, [isKeyboardVisible]);
+
+  const handleScrollBeginDrag = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    dragStartOffsetRef.current = event.nativeEvent.contentOffset.y;
+    dragStartedNearBottomRef.current = isNearBottomRef.current;
   }, []);
 
   const handleContentSizeChange = useCallback((_width: number, height: number) => {

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   FlatList,
   Keyboard,
-  KeyboardAvoidingView,
   Platform,
   ListRenderItem,
   ActivityIndicator,
@@ -12,6 +11,7 @@ import {
   NativeScrollEvent,
   LayoutChangeEvent,
 } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import type { MessageDTO, SharedContentDeliveryStatus } from '@meet-without-fear/shared';
 import { MessageRole } from '@meet-without-fear/shared';
 import { ChatBubble, ChatBubbleMessage, MessageDeliveryStatus } from './ChatBubble';
@@ -339,31 +339,19 @@ export function ChatInterface({
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
 
-    const scheduleKeyboardLayout = (event: Parameters<typeof Keyboard.scheduleLayoutAnimation>[0]) => {
-      if (Platform.OS === 'ios') {
-        Keyboard.scheduleLayoutAnimation(event);
-      }
-    };
-
-    const showSub = Keyboard.addListener(showEvent, (event) => {
-      scheduleKeyboardLayout(event);
+    const showSub = Keyboard.addListener(showEvent, () => {
       setIsKeyboardVisible(true);
       if (isNearBottomRef.current || shouldStickToBottomRef.current) {
         scrollToBottom(false);
       }
     });
-    const hideSub = Keyboard.addListener(hideEvent, (event) => {
-      scheduleKeyboardLayout(event);
+    const hideSub = Keyboard.addListener(hideEvent, () => {
       setIsKeyboardVisible(false);
     });
-    const changeFrameSub = Platform.OS === 'ios'
-      ? Keyboard.addListener('keyboardWillChangeFrame', scheduleKeyboardLayout)
-      : null;
 
     return () => {
       showSub.remove();
       hideSub.remove();
-      changeFrameSub?.remove();
     };
   }, [scrollToBottom]);
 

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -23,7 +23,7 @@ import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
 import { useSpeech, useAutoSpeech } from '../hooks/useSpeech';
 import { getAnimationIdentity, isPreRegisteredAnimatedId } from '../utils/animationBridge';
-import { KeyboardAwareAvoidingView } from '../utils/keyboardController';
+import { hasLinkedKeyboardController, KeyboardAwareAvoidingView, KeyboardStickyComposer } from '../utils/keyboardController';
 
 // ============================================================================
 // Types
@@ -1038,66 +1038,91 @@ export function ChatInterface({
   // New Activity Pill: floating indicator for off-screen new items
   // ---------------------------------------------------------------------------
 
+  const bottomControls = (
+    <View style={styles.bottomContainer}>
+      {showEmotionSlider && onEmotionChange && (
+        <EmotionSlider
+          value={emotionValue}
+          onChange={onEmotionChange}
+          onHighEmotion={onHighEmotion}
+          compact={compactEmotionSlider}
+          testID="chat-emotion-slider"
+        />
+      )}
+      {!hideInput && (
+        <ChatInput
+          onSend={onSendMessage}
+          disabled={disabled || isInputDisabled || isLoading}
+          inputDisabled={disabled || isLoading}
+          onVoicePress={onVoicePress}
+          failedMessage={failedMessage}
+          prefillText={prefillText}
+          onPrefillConsumed={onPrefillConsumed}
+        />
+      )}
+      {!isKeyboardVisible && renderAboveInput?.()}
+      {!isKeyboardVisible && renderBelowInput?.()}
+    </View>
+  );
+
+  const messageList = (
+    <FlatList
+      ref={flatListRef}
+      data={listItems}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      style={styles.flatList}
+      stickyHeaderIndices={stickyHeaderIndices}
+      contentContainerStyle={[
+        styles.messageList,
+        listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
+      ]}
+      ListHeaderComponent={renderLoadingHeader}
+      ListFooterComponent={
+        <>
+          {renderBelowChat?.()}
+          {renderHeader?.()}
+        </>
+      }
+      ListEmptyComponent={emptyStateElement}
+      showsVerticalScrollIndicator={false}
+      keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
+      keyboardShouldPersistTaps="handled"
+      testID="chat-message-list"
+      onStartReached={handleEndReached}
+      onStartReachedThreshold={0.2}
+      onLayout={handleListLayout}
+      onScroll={handleScroll}
+      scrollEventThrottle={16}
+      onContentSizeChange={handleContentSizeChange}
+    />
+  );
+
+  if (Platform.OS === 'ios' && hasLinkedKeyboardController()) {
+    return (
+      <View style={styles.container}>
+        <KeyboardAwareAvoidingView
+          style={styles.flatListContainer}
+          behavior="height"
+          keyboardVerticalOffset={keyboardVerticalOffset}
+        >
+          {messageList}
+        </KeyboardAwareAvoidingView>
+        <KeyboardStickyComposer>
+          {bottomControls}
+        </KeyboardStickyComposer>
+      </View>
+    );
+  }
+
   return (
     <KeyboardAwareAvoidingView
       style={styles.container}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       keyboardVerticalOffset={keyboardVerticalOffset}
     >
-      <FlatList
-        ref={flatListRef}
-        data={listItems}
-        keyExtractor={keyExtractor}
-        renderItem={renderItem}
-        style={styles.flatList}
-        stickyHeaderIndices={stickyHeaderIndices}
-        contentContainerStyle={[
-          styles.messageList,
-          listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
-        ]}
-        ListHeaderComponent={renderLoadingHeader}
-        ListFooterComponent={
-          <>
-            {renderBelowChat?.()}
-            {renderHeader?.()}
-          </>
-        }
-        ListEmptyComponent={emptyStateElement}
-        showsVerticalScrollIndicator={false}
-        keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
-        keyboardShouldPersistTaps="handled"
-        testID="chat-message-list"
-        onStartReached={handleEndReached}
-        onStartReachedThreshold={0.2}
-        onLayout={handleListLayout}
-        onScroll={handleScroll}
-        scrollEventThrottle={16}
-        onContentSizeChange={handleContentSizeChange}
-      />
-      <View style={styles.bottomContainer}>
-        {showEmotionSlider && onEmotionChange && (
-          <EmotionSlider
-            value={emotionValue}
-            onChange={onEmotionChange}
-            onHighEmotion={onHighEmotion}
-            compact={compactEmotionSlider}
-            testID="chat-emotion-slider"
-          />
-        )}
-        {!hideInput && (
-          <ChatInput
-            onSend={onSendMessage}
-            disabled={disabled || isInputDisabled || isLoading}
-            inputDisabled={disabled || isLoading}
-            onVoicePress={onVoicePress}
-            failedMessage={failedMessage}
-            prefillText={prefillText}
-            onPrefillConsumed={onPrefillConsumed}
-          />
-        )}
-        {!isKeyboardVisible && renderAboveInput?.()}
-        {!isKeyboardVisible && renderBelowInput?.()}
-      </View>
+      {messageList}
+      {bottomControls}
     </KeyboardAwareAvoidingView>
   );
 }
@@ -1115,6 +1140,10 @@ const useStyles = () => {
     },
     flatList: {
       flex: 1,
+    },
+    flatListContainer: {
+      flex: 1,
+      backgroundColor: palette.bg,
     },
     messageList: {
       paddingVertical: 18,

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   FlatList,
   Keyboard,
-  InputAccessoryView,
   Platform,
   ListRenderItem,
   ActivityIndicator,
@@ -24,7 +23,7 @@ import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
 import { useSpeech, useAutoSpeech } from '../hooks/useSpeech';
 import { getAnimationIdentity, isPreRegisteredAnimatedId } from '../utils/animationBridge';
-import { hasLinkedKeyboardController, KeyboardAwareAvoidingView } from '../utils/keyboardController';
+import { KeyboardAwareAvoidingView } from '../utils/keyboardController';
 
 // ============================================================================
 // Types
@@ -214,7 +213,6 @@ interface ChatInterfaceProps {
 const DEFAULT_EMPTY_TITLE = 'Start the Conversation';
 const DEFAULT_EMPTY_MESSAGE =
   "Share what's on your mind. I'm here to listen and help you work through it.";
-const DEFAULT_IOS_COMPOSER_SPACER_HEIGHT = 164;
 
 const seenAnimatedItemIdsByScope = new Map<string, Set<string>>();
 let localAnimationScopeCounter = 0;
@@ -421,8 +419,6 @@ export function ChatInterface({
 
   // Track the ID of the chat item currently being animated.
   const [animatingItemId, setAnimatingItemId] = useState<string | null>(null);
-  const [bottomContainerHeight, setBottomContainerHeight] = useState(0);
-  const useIOSAccessoryComposer = Platform.OS === 'ios' && !hasLinkedKeyboardController();
 
   // Speech functionality
   const { isSpeaking, currentId, toggle: toggleSpeech } = useSpeech();
@@ -966,7 +962,7 @@ export function ChatInterface({
     // the user was already reading at the bottom.
     if (!isLoadingHistoryRef.current || !snapshot) {
       scrollMetricsRef.current.contentHeight = height;
-      if ((isNearBottomRef.current || shouldStickToBottomRef.current) && !(useIOSAccessoryComposer && isKeyboardVisible)) {
+      if (isNearBottomRef.current || shouldStickToBottomRef.current) {
         scrollToBottom(false);
       }
       return;
@@ -987,14 +983,14 @@ export function ChatInterface({
       historyLoadSnapshotRef.current = null;
       isLoadingHistoryRef.current = false;
     }
-  }, [isKeyboardVisible, scrollToBottom, useIOSAccessoryComposer]);
+  }, [scrollToBottom]);
 
   const handleListLayout = useCallback((event: LayoutChangeEvent) => {
     scrollMetricsRef.current.layoutHeight = event.nativeEvent.layout.height;
-    if ((isNearBottomRef.current || shouldStickToBottomRef.current) && !(useIOSAccessoryComposer && isKeyboardVisible)) {
+    if (isNearBottomRef.current || shouldStickToBottomRef.current) {
       scrollToBottom(false);
     }
-  }, [isKeyboardVisible, scrollToBottom, useIOSAccessoryComposer]);
+  }, [scrollToBottom]);
 
   const handleEndReached = useCallback(() => {
     if (hasMore && !isLoadingMore && onLoadMore) {
@@ -1042,44 +1038,12 @@ export function ChatInterface({
   // New Activity Pill: floating indicator for off-screen new items
   // ---------------------------------------------------------------------------
 
-  const bottomControls = (
-    <View
-      style={styles.bottomContainer}
-      onLayout={(event) => {
-        if (!useIOSAccessoryComposer) return;
-        const nextHeight = Math.ceil(event.nativeEvent.layout.height);
-        setBottomContainerHeight((currentHeight) => (
-          Math.abs(currentHeight - nextHeight) > 2 ? nextHeight : currentHeight
-        ));
-      }}
+  return (
+    <KeyboardAwareAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={keyboardVerticalOffset}
     >
-      {showEmotionSlider && onEmotionChange && (
-        <EmotionSlider
-          value={emotionValue}
-          onChange={onEmotionChange}
-          onHighEmotion={onHighEmotion}
-          compact={compactEmotionSlider}
-          testID="chat-emotion-slider"
-        />
-      )}
-      {!hideInput && (
-        <ChatInput
-          onSend={onSendMessage}
-          disabled={disabled || isInputDisabled || isLoading}
-          inputDisabled={disabled || isLoading}
-          onVoicePress={onVoicePress}
-          failedMessage={failedMessage}
-          prefillText={prefillText}
-          onPrefillConsumed={onPrefillConsumed}
-        />
-      )}
-      {!isKeyboardVisible && renderAboveInput?.()}
-      {!isKeyboardVisible && renderBelowInput?.()}
-    </View>
-  );
-
-  const chatContent = (
-    <>
       <FlatList
         ref={flatListRef}
         data={listItems}
@@ -1089,9 +1053,6 @@ export function ChatInterface({
         stickyHeaderIndices={stickyHeaderIndices}
         contentContainerStyle={[
           styles.messageList,
-          useIOSAccessoryComposer && {
-            paddingBottom: Math.max(bottomContainerHeight, DEFAULT_IOS_COMPOSER_SPACER_HEIGHT),
-          },
           listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
         ]}
         ListHeaderComponent={renderLoadingHeader}
@@ -1113,29 +1074,30 @@ export function ChatInterface({
         scrollEventThrottle={16}
         onContentSizeChange={handleContentSizeChange}
       />
-      {useIOSAccessoryComposer ? (
-        <InputAccessoryView>
-          {bottomControls}
-        </InputAccessoryView>
-      ) : bottomControls}
-    </>
-  );
-
-  if (useIOSAccessoryComposer) {
-    return (
-      <View style={styles.container}>
-        {chatContent}
+      <View style={styles.bottomContainer}>
+        {showEmotionSlider && onEmotionChange && (
+          <EmotionSlider
+            value={emotionValue}
+            onChange={onEmotionChange}
+            onHighEmotion={onHighEmotion}
+            compact={compactEmotionSlider}
+            testID="chat-emotion-slider"
+          />
+        )}
+        {!hideInput && (
+          <ChatInput
+            onSend={onSendMessage}
+            disabled={disabled || isInputDisabled || isLoading}
+            inputDisabled={disabled || isLoading}
+            onVoicePress={onVoicePress}
+            failedMessage={failedMessage}
+            prefillText={prefillText}
+            onPrefillConsumed={onPrefillConsumed}
+          />
+        )}
+        {!isKeyboardVisible && renderAboveInput?.()}
+        {!isKeyboardVisible && renderBelowInput?.()}
       </View>
-    );
-  }
-
-  return (
-    <KeyboardAwareAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={keyboardVerticalOffset}
-    >
-      {chatContent}
     </KeyboardAwareAvoidingView>
   );
 }

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -1062,6 +1062,8 @@ export function ChatInterface({
         }
         ListEmptyComponent={emptyStateElement}
         showsVerticalScrollIndicator={false}
+        keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
+        keyboardShouldPersistTaps="handled"
         testID="chat-message-list"
         onStartReached={handleEndReached}
         onStartReachedThreshold={0.2}

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -1106,13 +1106,9 @@ export function ChatInterface({
   if (Platform.OS === 'ios' && hasLinkedKeyboardController()) {
     return (
       <View style={styles.container}>
-        <KeyboardAwareAvoidingView
-          style={styles.flatListContainer}
-          behavior="height"
-          keyboardVerticalOffset={keyboardVerticalOffset}
-        >
+        <View style={styles.flatListContainer}>
           {messageList}
-        </KeyboardAwareAvoidingView>
+        </View>
         <KeyboardStickyComposer>
           {composerControls}
         </KeyboardStickyComposer>

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -5,6 +5,7 @@ import {
   FlatList,
   Keyboard,
   KeyboardAvoidingView,
+  InputAccessoryView,
   Platform,
   ListRenderItem,
   ActivityIndicator,
@@ -431,6 +432,7 @@ export function ChatInterface({
 
   // Track the ID of the chat item currently being animated.
   const [animatingItemId, setAnimatingItemId] = useState<string | null>(null);
+  const [bottomContainerHeight, setBottomContainerHeight] = useState(0);
 
   // Speech functionality
   const { isSpeaking, currentId, toggle: toggleSpeech } = useSpeech();
@@ -1050,12 +1052,42 @@ export function ChatInterface({
   // New Activity Pill: floating indicator for off-screen new items
   // ---------------------------------------------------------------------------
 
-  return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={keyboardVerticalOffset}
+  const bottomControls = (
+    <View
+      style={styles.bottomContainer}
+      onLayout={(event) => {
+        if (Platform.OS === 'ios') {
+          setBottomContainerHeight(event.nativeEvent.layout.height);
+        }
+      }}
     >
+      {showEmotionSlider && onEmotionChange && (
+        <EmotionSlider
+          value={emotionValue}
+          onChange={onEmotionChange}
+          onHighEmotion={onHighEmotion}
+          compact={compactEmotionSlider}
+          testID="chat-emotion-slider"
+        />
+      )}
+      {!hideInput && (
+        <ChatInput
+          onSend={onSendMessage}
+          disabled={disabled || isInputDisabled || isLoading}
+          inputDisabled={disabled || isLoading}
+          onVoicePress={onVoicePress}
+          failedMessage={failedMessage}
+          prefillText={prefillText}
+          onPrefillConsumed={onPrefillConsumed}
+        />
+      )}
+      {!isKeyboardVisible && renderAboveInput?.()}
+      {!isKeyboardVisible && renderBelowInput?.()}
+    </View>
+  );
+
+  const chatContent = (
+    <>
       <FlatList
         ref={flatListRef}
         data={listItems}
@@ -1065,6 +1097,7 @@ export function ChatInterface({
         stickyHeaderIndices={stickyHeaderIndices}
         contentContainerStyle={[
           styles.messageList,
+          Platform.OS === 'ios' && bottomContainerHeight > 0 && { paddingBottom: bottomContainerHeight },
           listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
         ]}
         ListHeaderComponent={renderLoadingHeader}
@@ -1086,30 +1119,29 @@ export function ChatInterface({
         scrollEventThrottle={16}
         onContentSizeChange={handleContentSizeChange}
       />
-      <View style={styles.bottomContainer}>
-        {showEmotionSlider && onEmotionChange && (
-          <EmotionSlider
-            value={emotionValue}
-            onChange={onEmotionChange}
-            onHighEmotion={onHighEmotion}
-            compact={compactEmotionSlider}
-            testID="chat-emotion-slider"
-          />
-        )}
-        {!hideInput && (
-          <ChatInput
-            onSend={onSendMessage}
-            disabled={disabled || isInputDisabled || isLoading}
-            inputDisabled={disabled || isLoading}
-            onVoicePress={onVoicePress}
-            failedMessage={failedMessage}
-            prefillText={prefillText}
-            onPrefillConsumed={onPrefillConsumed}
-          />
-        )}
-        {!isKeyboardVisible && renderAboveInput?.()}
-        {!isKeyboardVisible && renderBelowInput?.()}
+      {Platform.OS === 'ios' ? (
+        <InputAccessoryView>
+          {bottomControls}
+        </InputAccessoryView>
+      ) : bottomControls}
+    </>
+  );
+
+  if (Platform.OS === 'ios') {
+    return (
+      <View style={styles.container}>
+        {chatContent}
       </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={undefined}
+      keyboardVerticalOffset={keyboardVerticalOffset}
+    >
+      {chatContent}
     </KeyboardAvoidingView>
   );
 }

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -11,6 +11,7 @@ import {
   NativeScrollEvent,
   LayoutChangeEvent,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { MessageDTO, SharedContentDeliveryStatus } from '@meet-without-fear/shared';
 import { MessageRole } from '@meet-without-fear/shared';
 import { ChatBubble, ChatBubbleMessage, MessageDeliveryStatus } from './ChatBubble';
@@ -273,6 +274,7 @@ export function ChatInterface({
   onPrefillConsumed,
 }: ChatInterfaceProps) {
   const styles = useStyles();
+  const safeAreaInsets = useSafeAreaInsets();
   const flatListRef = useRef<FlatList<ChatListItem>>(null);
   const scrollMetricsRef = useRef({
     offset: 0,
@@ -1109,7 +1111,7 @@ export function ChatInterface({
         <View style={styles.flatListContainer}>
           {messageList}
         </View>
-        <KeyboardStickyComposer>
+        <KeyboardStickyComposer offset={{ opened: safeAreaInsets.bottom }}>
           {composerControls}
         </KeyboardStickyComposer>
         {auxiliaryControls}

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -5,7 +5,6 @@ import {
   FlatList,
   Keyboard,
   KeyboardAvoidingView,
-  InputAccessoryView,
   Platform,
   ListRenderItem,
   ActivityIndicator,
@@ -432,7 +431,6 @@ export function ChatInterface({
 
   // Track the ID of the chat item currently being animated.
   const [animatingItemId, setAnimatingItemId] = useState<string | null>(null);
-  const [bottomContainerHeight, setBottomContainerHeight] = useState(0);
 
   // Speech functionality
   const { isSpeaking, currentId, toggle: toggleSpeech } = useSpeech();
@@ -1052,42 +1050,12 @@ export function ChatInterface({
   // New Activity Pill: floating indicator for off-screen new items
   // ---------------------------------------------------------------------------
 
-  const bottomControls = (
-    <View
-      style={styles.bottomContainer}
-      onLayout={(event) => {
-        if (Platform.OS === 'ios') {
-          setBottomContainerHeight(event.nativeEvent.layout.height);
-        }
-      }}
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={keyboardVerticalOffset}
     >
-      {showEmotionSlider && onEmotionChange && (
-        <EmotionSlider
-          value={emotionValue}
-          onChange={onEmotionChange}
-          onHighEmotion={onHighEmotion}
-          compact={compactEmotionSlider}
-          testID="chat-emotion-slider"
-        />
-      )}
-      {!hideInput && (
-        <ChatInput
-          onSend={onSendMessage}
-          disabled={disabled || isInputDisabled || isLoading}
-          inputDisabled={disabled || isLoading}
-          onVoicePress={onVoicePress}
-          failedMessage={failedMessage}
-          prefillText={prefillText}
-          onPrefillConsumed={onPrefillConsumed}
-        />
-      )}
-      {!isKeyboardVisible && renderAboveInput?.()}
-      {!isKeyboardVisible && renderBelowInput?.()}
-    </View>
-  );
-
-  const chatContent = (
-    <>
       <FlatList
         ref={flatListRef}
         data={listItems}
@@ -1097,7 +1065,6 @@ export function ChatInterface({
         stickyHeaderIndices={stickyHeaderIndices}
         contentContainerStyle={[
           styles.messageList,
-          Platform.OS === 'ios' && bottomContainerHeight > 0 && { paddingBottom: bottomContainerHeight },
           listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
         ]}
         ListHeaderComponent={renderLoadingHeader}
@@ -1119,29 +1086,30 @@ export function ChatInterface({
         scrollEventThrottle={16}
         onContentSizeChange={handleContentSizeChange}
       />
-      {Platform.OS === 'ios' ? (
-        <InputAccessoryView>
-          {bottomControls}
-        </InputAccessoryView>
-      ) : bottomControls}
-    </>
-  );
-
-  if (Platform.OS === 'ios') {
-    return (
-      <View style={styles.container}>
-        {chatContent}
+      <View style={styles.bottomContainer}>
+        {showEmotionSlider && onEmotionChange && (
+          <EmotionSlider
+            value={emotionValue}
+            onChange={onEmotionChange}
+            onHighEmotion={onHighEmotion}
+            compact={compactEmotionSlider}
+            testID="chat-emotion-slider"
+          />
+        )}
+        {!hideInput && (
+          <ChatInput
+            onSend={onSendMessage}
+            disabled={disabled || isInputDisabled || isLoading}
+            inputDisabled={disabled || isLoading}
+            onVoicePress={onVoicePress}
+            failedMessage={failedMessage}
+            prefillText={prefillText}
+            onPrefillConsumed={onPrefillConsumed}
+          />
+        )}
+        {!isKeyboardVisible && renderAboveInput?.()}
+        {!isKeyboardVisible && renderBelowInput?.()}
       </View>
-    );
-  }
-
-  return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={undefined}
-      keyboardVerticalOffset={keyboardVerticalOffset}
-    >
-      {chatContent}
     </KeyboardAvoidingView>
   );
 }

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -950,6 +950,10 @@ export function ChatInterface({
     shouldStickToBottomRef.current = isNearBottom;
   }, []);
 
+  const handleScrollBeginDrag = useCallback(() => {
+    Keyboard.dismiss();
+  }, []);
+
   const handleContentSizeChange = useCallback((_width: number, height: number) => {
     const snapshot = historyLoadSnapshotRef.current;
 
@@ -1068,6 +1072,7 @@ export function ChatInterface({
         onStartReached={handleEndReached}
         onStartReachedThreshold={0.2}
         onLayout={handleListLayout}
+        onScrollBeginDrag={handleScrollBeginDrag}
         onScroll={handleScroll}
         scrollEventThrottle={16}
         onContentSizeChange={handleContentSizeChange}

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -339,17 +339,31 @@ export function ChatInterface({
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
 
-    const showSub = Keyboard.addListener(showEvent, () => {
+    const scheduleKeyboardLayout = (event: Parameters<typeof Keyboard.scheduleLayoutAnimation>[0]) => {
+      if (Platform.OS === 'ios') {
+        Keyboard.scheduleLayoutAnimation(event);
+      }
+    };
+
+    const showSub = Keyboard.addListener(showEvent, (event) => {
+      scheduleKeyboardLayout(event);
       setIsKeyboardVisible(true);
       if (isNearBottomRef.current || shouldStickToBottomRef.current) {
         scrollToBottom(false);
       }
     });
-    const hideSub = Keyboard.addListener(hideEvent, () => setIsKeyboardVisible(false));
+    const hideSub = Keyboard.addListener(hideEvent, (event) => {
+      scheduleKeyboardLayout(event);
+      setIsKeyboardVisible(false);
+    });
+    const changeFrameSub = Platform.OS === 'ios'
+      ? Keyboard.addListener('keyboardWillChangeFrame', scheduleKeyboardLayout)
+      : null;
 
     return () => {
       showSub.remove();
       hideSub.remove();
+      changeFrameSub?.remove();
     };
   }, [scrollToBottom]);
 

--- a/mobile/src/components/SessionChatHeader.tsx
+++ b/mobile/src/components/SessionChatHeader.tsx
@@ -49,8 +49,8 @@ export interface SessionChatHeaderProps {
   hasNewActivity?: boolean;
   /** Callback when the activity menu icon is pressed */
   onMenuPress?: () => void;
-  /** Current stage friendly name to display below partner name */
-  stageName?: string;
+  /** Conversation topic to display below partner name */
+  conversationTopic?: string | null;
   /** Custom container style */
   style?: ViewStyle;
   /** Test ID for testing */
@@ -102,7 +102,7 @@ export function SessionChatHeader({
   onBriefStatusPress,
   hasNewActivity = false,
   onMenuPress,
-  stageName,
+  conversationTopic,
   style,
   testID = 'session-chat-header',
 }: SessionChatHeaderProps) {
@@ -125,12 +125,13 @@ export function SessionChatHeader({
 
   const displayName = partnerName || 'Meet Without Fear';
   const leftActionLabel = leftActionIcon === 'menu' ? 'Open session drawer' : 'Go back';
+  const headerTopic = conversationTopic?.trim();
 
   // Center content - always partner name + status (whether tabs or not)
   const centerContent = (
     <View style={styles.centerSection}>
       <View style={styles.nameRow}>
-        {!hideOnlineStatus && stageName && <StatusDot isOnline={isOnline} />}
+        {!hideOnlineStatus && headerTopic && <StatusDot isOnline={isOnline} />}
         <Text
           style={styles.partnerName}
           numberOfLines={1}
@@ -139,13 +140,14 @@ export function SessionChatHeader({
           {displayName}
         </Text>
       </View>
-      {stageName ? (
+      {headerTopic ? (
         <Text
-          style={styles.stageNameText}
+          style={styles.topicText}
           numberOfLines={1}
-          testID={`${testID}-stage-name`}
+          ellipsizeMode="tail"
+          testID={`${testID}-conversation-topic`}
         >
-          {stageName}
+          {headerTopic}
         </Text>
       ) : !hideOnlineStatus ? (
         <View style={styles.statusRow}>
@@ -352,12 +354,13 @@ const useStyles = () => {
     onlineTextActive: {
       color: palette.success,
     },
-    stageNameText: {
+    topicText: {
       fontSize: 10.5,
       color: palette.textMuted,
       textAlign: 'center' as const,
       marginTop: 1,
       fontFamily: designFonts.sans,
+      maxWidth: '100%' as const,
     },
     briefStatus: {
       fontSize: t.typography.fontSize.sm,

--- a/mobile/src/components/TypewriterText.tsx
+++ b/mobile/src/components/TypewriterText.tsx
@@ -1,204 +1,148 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
-import { Text, Animated, StyleProp, TextStyle } from 'react-native';
-
-// ============================================================================
-// Types
-// ============================================================================
+import { useEffect, useRef, useState } from 'react';
+import { Text, StyleProp, TextStyle } from 'react-native';
 
 interface TypewriterTextProps {
-  /** The text content to animate (can grow over time for streaming) */
+  /** The text content to animate. It may grow while streaming. */
   text: string;
-  /** Text style to apply */
   style?: StyleProp<TextStyle>;
-  /** Delay between each word appearing (ms) */
+  /** Approximate delay between word starts. */
   wordDelay?: number;
-  /** Duration of the fade-in animation for each word (ms) */
+  /** Kept for API compatibility; character reveal does not fade tokens. */
   fadeDuration?: number;
-  /** Skip animation and show full text immediately */
   skipAnimation?: boolean;
-  /** Callback when all current text has been animated */
   onComplete?: () => void;
-  /** Callback during animation progress (for scrolling) */
+  /** Whether catching up to the current text should finish the whole animation. */
+  completeWhenCaughtUp?: boolean;
   onProgress?: () => void;
 }
 
-// ============================================================================
-// Helpers
-// ============================================================================
+const MIN_CHARACTER_DELAY_MS = 10;
 
-// Special token to represent newlines
-const NEWLINE_TOKEN = '\n';
+function getNextChunk(text: string, startIndex: number): string {
+  const remaining = text.slice(startIndex);
+  if (!remaining) return '';
 
-/**
- * Tokenize text into words and newlines
- */
-function tokenize(text: string): string[] {
-  const result: string[] = [];
-  const lines = text.split('\n');
-  lines.forEach((line, lineIndex) => {
-    const words = line.split(/\s+/).filter(word => word.length > 0);
-    result.push(...words);
-    if (lineIndex < lines.length - 1) {
-      result.push(NEWLINE_TOKEN);
-    }
-  });
-  return result;
+  const match = remaining.match(/^(\s+|\S+\s*)/);
+  return match?.[0] || remaining[0];
 }
 
-// ============================================================================
-// Component
-// ============================================================================
+function getCommonPrefixLength(a: string, b: string): number {
+  const max = Math.min(a.length, b.length);
+  let index = 0;
 
-/**
- * Renders text with a word-by-word fade-in typewriter effect.
- * Supports streaming: as text grows, new words are animated in sequence.
- * If text arrives faster than animation, words queue up and animate at wordDelay pace.
- */
+  while (index < max && a[index] === b[index]) {
+    index += 1;
+  }
+
+  return index;
+}
+
 export function TypewriterText({
   text,
   style,
   wordDelay = 50,
-  fadeDuration = 150,
   skipAnimation = false,
   onComplete,
+  completeWhenCaughtUp = true,
   onProgress,
 }: TypewriterTextProps) {
-  // Current tokens from text
-  const tokens = tokenize(text);
-
-  // Animation state stored in refs to persist across renders
-  const animatedValuesRef = useRef<Animated.Value[]>([]);
-  const animationIndexRef = useRef(0); // Next token to animate
-  const isAnimatingRef = useRef(false);
+  const [displayedText, setDisplayedText] = useState(skipAnimation ? text : '');
+  const displayedTextRef = useRef(skipAnimation ? text : '');
+  const targetTextRef = useRef(text);
   const isMountedRef = useRef(true);
+  const isAnimatingRef = useRef(false);
+  const completionNotifiedRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Store callbacks in refs
   const onCompleteRef = useRef(onComplete);
   const onProgressRef = useRef(onProgress);
+  const completeWhenCaughtUpRef = useRef(completeWhenCaughtUp);
+
   onCompleteRef.current = onComplete;
   onProgressRef.current = onProgress;
+  completeWhenCaughtUpRef.current = completeWhenCaughtUp;
 
-  // Force re-render when we need to show more tokens
-  const [, forceUpdate] = useState(0);
+  useEffect(() => {
+    targetTextRef.current = text;
+    completionNotifiedRef.current = false;
 
-  // Animate the next token in queue
-  const animateNext = useCallback(() => {
-    if (!isMountedRef.current) return;
-
-    const idx = animationIndexRef.current;
-    const values = animatedValuesRef.current;
-
-    // Check if we've caught up to all available tokens
-    if (idx >= values.length) {
-      isAnimatingRef.current = false;
-      // Check if we've animated all tokens and text is complete
-      // (onComplete is called when animation catches up)
-      onCompleteRef.current?.();
+    if (skipAnimation) {
+      displayedTextRef.current = text;
+      setDisplayedText(text);
+      if (completeWhenCaughtUp) onCompleteRef.current?.();
       return;
     }
 
-    // Animate this token
-    const animValue = values[idx];
-    if (animValue) {
-      Animated.timing(animValue, {
-        toValue: 1,
-        duration: fadeDuration,
-        useNativeDriver: true,
-      }).start();
+    if (!isAnimatingRef.current) {
+      isAnimatingRef.current = true;
+      scheduleNextTick(0);
     }
+    // scheduleNextTick is intentionally a local function below; its refs are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, skipAnimation, completeWhenCaughtUp]);
 
-    // Update visible count
-    animationIndexRef.current = idx + 1;
-    forceUpdate(n => n + 1);
-
-    // Call progress callback periodically
-    if (idx % 3 === 0) {
-      onProgressRef.current?.();
-    }
-
-    // Determine delay for next token
-    const currentToken = tokens[idx];
-    const nextDelay = currentToken === NEWLINE_TOKEN ? 0 : wordDelay;
-
-    // Schedule next animation
-    timerRef.current = setTimeout(animateNext, nextDelay);
-  }, [wordDelay, fadeDuration, tokens]);
-
-  // Start animation loop if not already running
-  const startAnimation = useCallback(() => {
-    if (isAnimatingRef.current || skipAnimation) return;
-    isAnimatingRef.current = true;
-    animateNext();
-  }, [animateNext, skipAnimation]);
-
-  // Handle new tokens arriving
   useEffect(() => {
-    const currentCount = animatedValuesRef.current.length;
-    const newCount = tokens.length;
-
-    if (newCount > currentCount) {
-      // Add animated values for new tokens
-      for (let i = currentCount; i < newCount; i++) {
-        animatedValuesRef.current.push(new Animated.Value(skipAnimation ? 1 : 0));
-      }
-
-      // If skipping animation, update animation index to match
-      if (skipAnimation) {
-        animationIndexRef.current = newCount;
-        forceUpdate(n => n + 1);
-      } else {
-        // Start animation if not already running
-        startAnimation();
-      }
+    if (
+      completeWhenCaughtUp &&
+      !isAnimatingRef.current &&
+      displayedTextRef.current === targetTextRef.current &&
+      targetTextRef.current.length > 0 &&
+      !completionNotifiedRef.current
+    ) {
+      completionNotifiedRef.current = true;
+      onCompleteRef.current?.();
     }
-  }, [tokens.length, skipAnimation, startAnimation]);
+  }, [completeWhenCaughtUp, text]);
 
-  // Cleanup on unmount
   useEffect(() => {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
+      if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, []);
 
-  // If skipping animation, render plain text
-  if (skipAnimation) {
-    return <Text style={style}>{text}</Text>;
-  }
+  const scheduleNextTick = (delay: number) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      if (!isMountedRef.current) return;
 
-  // Render animated tokens
-  const visibleCount = animationIndexRef.current;
+      const target = targetTextRef.current;
+      const current = displayedTextRef.current;
 
-  return (
-    <Text style={style}>
-      {tokens.slice(0, visibleCount).map((token, index) => {
-        const animValue = animatedValuesRef.current[index];
-        const isNewline = token === NEWLINE_TOKEN;
-        const isLastToken = index === visibleCount - 1;
-        const nextToken = tokens[index + 1];
-        const nextIsNewline = nextToken === NEWLINE_TOKEN;
-
-        // Render newlines directly
-        if (isNewline) {
-          return '\n';
+      if (current === target) {
+        isAnimatingRef.current = false;
+        if (completeWhenCaughtUpRef.current && target.length > 0 && !completionNotifiedRef.current) {
+          completionNotifiedRef.current = true;
+          onCompleteRef.current?.();
         }
+        return;
+      }
 
-        // Add space after word unless it's the last visible or next is newline
-        const suffix = isLastToken || nextIsNewline ? '' : ' ';
+      if (!target.startsWith(current)) {
+        const commonPrefixLength = getCommonPrefixLength(current, target);
+        const stableText = current.slice(0, commonPrefixLength);
 
-        return (
-          <Animated.Text
-            key={index}
-            style={{ opacity: animValue }}
-          >
-            {token}{suffix}
-          </Animated.Text>
-        );
-      })}
-    </Text>
-  );
+        displayedTextRef.current = stableText;
+        setDisplayedText(stableText);
+        onProgressRef.current?.();
+
+        scheduleNextTick(0);
+        return;
+      }
+
+      const chunk = getNextChunk(target, current.length);
+      const nextText = target.slice(0, current.length + chunk.length);
+      displayedTextRef.current = nextText;
+      setDisplayedText(nextText);
+      onProgressRef.current?.();
+
+      const characterDelay = Math.max(
+        MIN_CHARACTER_DELAY_MS,
+        Math.floor(wordDelay / Math.max(1, chunk.trim().length)),
+      );
+      scheduleNextTick(characterDelay * Math.max(1, chunk.length));
+    }, delay);
+  };
+
+  return <Text style={style}>{skipAnimation ? text : displayedText}</Text>;
 }

--- a/mobile/src/components/TypingIndicator.tsx
+++ b/mobile/src/components/TypingIndicator.tsx
@@ -12,8 +12,16 @@ export function TypingIndicator() {
   const dot1 = useRef(new Animated.Value(0.3)).current;
   const dot2 = useRef(new Animated.Value(0.3)).current;
   const dot3 = useRef(new Animated.Value(0.3)).current;
+  const entrance = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
+    Animated.timing(entrance, {
+      toValue: 1,
+      duration: 220,
+      delay: 120,
+      useNativeDriver: true,
+    }).start();
+
     const animateDot = (dot: Animated.Value, delay: number) => {
       return Animated.loop(
         Animated.sequence([
@@ -45,14 +53,22 @@ export function TypingIndicator() {
       animation2.stop();
       animation3.stop();
     };
-  }, [dot1, dot2, dot3]);
+  }, [dot1, dot2, dot3, entrance]);
+
+  const translateY = entrance.interpolate({
+    inputRange: [0, 1],
+    outputRange: [12, 0],
+  });
 
   return (
-    <View testID="typing-indicator" style={styles.container}>
+    <Animated.View
+      testID="typing-indicator"
+      style={[styles.container, { opacity: entrance, transform: [{ translateY }] }]}
+    >
       <Animated.View style={[styles.dot, { opacity: dot1 }]} />
       <Animated.View style={[styles.dot, { opacity: dot2 }]} />
       <Animated.View style={[styles.dot, { opacity: dot3 }]} />
-    </View>
+    </Animated.View>
   );
 }
 

--- a/mobile/src/components/__tests__/SessionChatHeader.test.tsx
+++ b/mobile/src/components/__tests__/SessionChatHeader.test.tsx
@@ -110,6 +110,33 @@ describe('SessionChatHeader', () => {
     });
   });
 
+  describe('conversation topic', () => {
+    it('shows the conversation topic below the partner name when provided', () => {
+      const { getByTestId, queryByTestId } = render(
+        <SessionChatHeader
+          partnerName="Alex"
+          conversationTopic="Feeling stuck about household responsibilities"
+        />
+      );
+
+      expect(getByTestId('session-chat-header-conversation-topic')).toHaveTextContent(
+        'Feeling stuck about household responsibilities'
+      );
+      expect(queryByTestId('session-chat-header-online-status')).toBeNull();
+    });
+
+    it('falls back to online status when the conversation topic is blank', () => {
+      const { getByTestId, queryByTestId } = render(
+        <SessionChatHeader partnerName="Alex" conversationTopic="   " />
+      );
+
+      expect(queryByTestId('session-chat-header-conversation-topic')).toBeNull();
+      expect(getByTestId('session-chat-header-online-status')).toHaveTextContent(
+        'offline'
+      );
+    });
+  });
+
   describe('interactions', () => {
     it('calls onPress when header center is pressed', () => {
       const onPress = jest.fn();

--- a/mobile/src/hooks/__tests__/useStreamingMessage.test.ts
+++ b/mobile/src/hooks/__tests__/useStreamingMessage.test.ts
@@ -1,9 +1,10 @@
 import React from 'react';
 import { act, renderHook } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Stage } from '@meet-without-fear/shared';
+import { MessageRole, Stage } from '@meet-without-fear/shared';
 import { useStreamingMessage } from '../useStreamingMessage';
 import { messageKeys, sessionKeys, stageKeys, timelineKeys } from '../queryKeys';
+import { getAnimationIdentity } from '../../utils/animationBridge';
 
 jest.mock('../../lib/api', () => ({
   getAuthToken: jest.fn().mockResolvedValue('test-token'),
@@ -11,11 +12,17 @@ jest.mock('../../lib/api', () => ({
   getE2EAuthHeaders: jest.fn().mockReturnValue(null),
 }));
 
-const mockEventSourceInstances: Array<{ close: jest.Mock }> = [];
+type MockSseEvent = { data?: string; message?: string };
+type MockEventSourceInstance = {
+  listeners: Record<string, Array<(event: MockSseEvent) => void>>;
+  close: jest.Mock;
+};
+
+const mockEventSourceInstances: MockEventSourceInstance[] = [];
 
 jest.mock('react-native-sse', () => {
   class MockEventSource {
-    listeners: Record<string, Array<(event: { data?: string; message?: string }) => void>> = {};
+    listeners: Record<string, Array<(event: MockSseEvent) => void>> = {};
     close = jest.fn();
 
     constructor() {
@@ -24,7 +31,7 @@ jest.mock('react-native-sse', () => {
 
     addEventListener(
       eventName: string,
-      listener: (event: { data?: string; message?: string }) => void
+      listener: (event: MockSseEvent) => void
     ) {
       this.listeners[eventName] = this.listeners[eventName] || [];
       this.listeners[eventName].push(listener);
@@ -100,5 +107,68 @@ describe('useStreamingMessage', () => {
     unmount();
     queryClient.clear();
     warnSpy.mockRestore();
+  });
+
+  it('keeps cached AI messages marked streaming until text_complete', async () => {
+    const queryClient = createQueryClient();
+
+    const { result, unmount } = renderHook(() => useStreamingMessage(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.sendMessage({
+        sessionId: 'session-123',
+        content: 'Tell me more',
+        currentStage: Stage.WITNESS,
+      });
+    });
+
+    const eventSource = mockEventSourceInstances[0];
+
+    act(() => {
+      eventSource.listeners.chunk[0]({ data: JSON.stringify({ text: 'Hello' }) });
+    });
+
+    let cachedMessages = queryClient.getQueryData<{ messages: Array<{ role: MessageRole; status?: string; content: string }> }>(
+      messageKeys.list('session-123')
+    )?.messages;
+    let cachedAIMessage = cachedMessages?.find((message) => message.role === MessageRole.AI);
+
+    expect(cachedAIMessage).toMatchObject({
+      content: 'Hello',
+      status: 'streaming',
+    });
+
+    act(() => {
+      eventSource.listeners.text_complete[0]({ data: JSON.stringify({ metadata: {} }) });
+    });
+
+    cachedMessages = queryClient.getQueryData<{ messages: Array<{ role: MessageRole; status?: string; content: string }> }>(
+      messageKeys.list('session-123')
+    )?.messages;
+    cachedAIMessage = cachedMessages?.find((message) => message.role === MessageRole.AI);
+
+    expect(cachedAIMessage).toMatchObject({
+      content: 'Hello',
+      status: 'sent',
+    });
+
+    act(() => {
+      eventSource.listeners.complete[0]({
+        data: JSON.stringify({ messageId: 'server-ai-message-1', metadata: {} }),
+      });
+    });
+
+    cachedMessages = queryClient.getQueryData<{ messages: Array<{ id: string; role: MessageRole; status?: string; content: string }> }>(
+      messageKeys.list('session-123')
+    )?.messages;
+    cachedAIMessage = cachedMessages?.find((message) => message.role === MessageRole.AI);
+
+    expect(cachedAIMessage?.id).toBe('server-ai-message-1');
+    expect(getAnimationIdentity('server-ai-message-1')).toMatch(/^streaming-/);
+
+    unmount();
+    queryClient.clear();
   });
 });

--- a/mobile/src/hooks/useMessages.ts
+++ b/mobile/src/hooks/useMessages.ts
@@ -103,6 +103,7 @@ export interface UseInfiniteMessagesOptions {
 export interface UseInfiniteMessagesResult {
   data: InfiniteData<GetMessagesResponse> | undefined;
   isLoading: boolean;
+  isFetching: boolean;
   isError: boolean;
   error: Error | null;
   fetchNextPage: () => void;
@@ -154,6 +155,7 @@ export function useInfiniteMessages(
   return {
     data: result.data,
     isLoading: result.isLoading,
+    isFetching: result.isFetching,
     isError: result.isError,
     error: result.error,
     fetchNextPage: result.fetchNextPage,

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -593,7 +593,7 @@ export function useStreamingMessage(
       textCompleteReceivedRef.current = false;
 
       // Create optimistic user message
-      const optimisticUserMessage: MessageDTO = {
+      const optimisticUserMessage: CachedStreamingMessage = {
         id: optimisticUserIdRef.current,
         sessionId,
         senderId: null,
@@ -601,6 +601,7 @@ export function useStreamingMessage(
         content,
         stage: currentStage ?? Stage.ONBOARDING,
         timestamp: new Date().toISOString(),
+        status: 'sending',
       };
 
       // Add optimistic user message to cache
@@ -869,7 +870,9 @@ export function useStreamingMessage(
                 aiMessageIdRef.current = data.messageId;
               }
               if (realUserIdRef.current && activeUserMessageIdRef.current.startsWith('optimistic-user-')) {
+                bridgeAnimatedId(activeUserMessageIdRef.current, realUserIdRef.current);
                 replaceMessageIdInCache(sessionId, activeUserMessageIdRef.current, realUserIdRef.current, currentStage);
+                updateMessageInCache(sessionId, realUserIdRef.current, { status: 'sent' } as Partial<CachedStreamingMessage>, currentStage);
                 activeUserMessageIdRef.current = realUserIdRef.current;
               }
 

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -19,7 +19,7 @@ import {
 } from '@meet-without-fear/shared';
 import { messageKeys, sessionKeys, stageKeys, timelineKeys } from './queryKeys';
 import { getPersistedMessageRefreshQueryKeys } from '../utils/realtimeInvalidation';
-import { preRegisterAnimatedId } from '../utils/animationBridge';
+import { bridgeAnimatedId } from '../utils/animationBridge';
 
 // ============================================================================
 // Types
@@ -63,6 +63,10 @@ export interface StreamMetadata {
 
 /** Status of a streaming message */
 export type StreamStatus = 'idle' | 'sending' | 'streaming' | 'complete' | 'error';
+
+type CachedStreamingMessage = MessageDTO & {
+  status?: 'sending' | 'streaming' | 'sent' | 'error';
+};
 
 /** Parameters for sending a streaming message */
 export interface SendStreamingMessageParams {
@@ -167,7 +171,7 @@ export function useStreamingMessage(
    * Add a message to the cache
    */
   const addMessageToCache = useCallback(
-    (sessionId: string, message: MessageDTO, stage?: Stage) => {
+    (sessionId: string, message: CachedStreamingMessage, stage?: Stage) => {
       const updateCache = (old: GetMessagesResponse | undefined) => {
         if (!old) {
           return { messages: [message], hasMore: false };
@@ -660,7 +664,7 @@ export function useStreamingMessage(
           if (placeholderCreated) return;
           placeholderCreated = true;
           setStatus('streaming');
-          const placeholderAIMessage: MessageDTO = {
+          const placeholderAIMessage: CachedStreamingMessage = {
             id: aiMessageIdRef.current,
             sessionId,
             senderId: null,
@@ -668,6 +672,7 @@ export function useStreamingMessage(
             content: '',
             stage: currentStage ?? Stage.ONBOARDING,
             timestamp: new Date().toISOString(),
+            status: 'streaming',
           };
           addMessageToCache(sessionId, placeholderAIMessage, currentStage);
         };
@@ -724,7 +729,7 @@ export function useStreamingMessage(
             }
 
             const updateCache = () => {
-              const updatedAIMessage: MessageDTO = {
+              const updatedAIMessage: CachedStreamingMessage = {
                 id: aiMessageIdRef.current,
                 sessionId,
                 senderId: null,
@@ -732,6 +737,7 @@ export function useStreamingMessage(
                 content: accumulatedTextRef.current,
                 stage: currentStage ?? Stage.ONBOARDING,
                 timestamp: new Date().toISOString(),
+                status: 'streaming',
               };
               addMessageToCache(sessionId, updatedAIMessage, currentStage);
               lastCacheUpdateRef.current = Date.now();
@@ -794,7 +800,7 @@ export function useStreamingMessage(
             console.log(`[useStreamingMessage] [TIMING] text_complete parsed`);
 
             // Update cache with final content
-            const finalAIMessage: MessageDTO = {
+            const finalAIMessage: CachedStreamingMessage = {
               id: aiMessageIdRef.current,
               sessionId,
               senderId: null,
@@ -802,6 +808,7 @@ export function useStreamingMessage(
               content: accumulatedTextRef.current,
               stage: currentStage ?? Stage.ONBOARDING,
               timestamp: new Date().toISOString(),
+              status: 'sent',
             };
             addMessageToCache(sessionId, finalAIMessage, currentStage);
 
@@ -857,8 +864,8 @@ export function useStreamingMessage(
               // This prevents ChatInterface from re-animating messages whose IDs
               // change from streaming placeholders to real UUIDs during refetch.
               if (data.messageId && aiMessageIdRef.current.startsWith('streaming-')) {
+                bridgeAnimatedId(aiMessageIdRef.current, data.messageId);
                 replaceMessageIdInCache(sessionId, aiMessageIdRef.current, data.messageId, currentStage);
-                preRegisterAnimatedId(data.messageId);
                 aiMessageIdRef.current = data.messageId;
               }
               if (realUserIdRef.current && activeUserMessageIdRef.current.startsWith('optimistic-user-')) {
@@ -870,7 +877,7 @@ export function useStreamingMessage(
 
               // If text_complete wasn't received (fallback), handle completion here
               if (!textCompleteReceivedRef.current) {
-                const finalAIMessage: MessageDTO = {
+                const finalAIMessage: CachedStreamingMessage = {
                   id: aiMessageIdRef.current,
                   sessionId,
                   senderId: null,
@@ -878,6 +885,7 @@ export function useStreamingMessage(
                   content: accumulatedTextRef.current,
                   stage: currentStage ?? Stage.ONBOARDING,
                   timestamp: new Date().toISOString(),
+                  status: 'sent',
                 };
                 addMessageToCache(sessionId, finalAIMessage, currentStage);
 

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -266,6 +266,7 @@ export function useUnifiedSession(
   const {
     data: messagesData,
     isLoading: loadingMessages,
+    isFetching: fetchingMessages,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -1199,6 +1200,7 @@ export function useUnifiedSession(
   return {
     // Loading state
     isLoading: loadingSession || loadingProgress || loadingMessages,
+    isFetchingMessages: fetchingMessages && !isFetchingNextPage,
     loadError: accessDenied ? null : stateError,
     refetchSession: refetchState,
     accessDenied,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -215,9 +215,21 @@ const SUPPRESSED_CHAPTER_STAGES = new Set([Stage.ONBOARDING, Stage.INFORMED_EMPA
  */
 function deriveChapterMarkers(
   messages: ChatMessage[],
+  anchors?: Partial<Record<Stage, string | null | undefined>>,
 ): ChatIndicatorItem[] {
   const markers: ChatIndicatorItem[] = [];
   const seenStages = new Set<number>();
+  const markerTimestampForStage = (stage: Stage, fallbackTimestamp: string): string | undefined => {
+    const anchorTimestamp = anchors?.[stage];
+
+    switch (stage) {
+      case Stage.WITNESS:
+      case Stage.PERSPECTIVE_STRETCH:
+        return anchorTimestamp || undefined;
+      default:
+        return anchorTimestamp || fallbackTimestamp;
+    }
+  };
 
   for (const msg of messages) {
     const stage = msg.stage as number | undefined;
@@ -227,11 +239,14 @@ function deriveChapterMarkers(
 
       const friendlyName = STAGE_FRIENDLY_NAMES[stage];
       if (friendlyName) {
+        const markerTimestamp = markerTimestampForStage(stage as Stage, msg.timestamp);
+        if (!markerTimestamp) continue;
+
         markers.push({
           type: 'indicator',
           indicatorType: 'stage-chapter',
           id: `stage-chapter-${stage}`,
-          timestamp: msg.timestamp,
+          timestamp: markerTimestamp,
           metadata: { stageName: friendlyName, stageColor: STAGE_COLORS[stage as Stage] },
         });
       }
@@ -2186,6 +2201,9 @@ export function UnifiedSessionScreen({
 
   // Build indicators array using centralized deriveIndicators function
   // This moves indicator logic to the utils layer, making it testable and reusable
+  const invitationMessageConfirmedAt = invitation?.messageConfirmedAt;
+  const invitationAcceptedAt = invitation?.acceptedAt;
+
   const indicators = useMemo((): ChatIndicatorItem[] => {
     // Prepare session data for the selector
     const sessionData: SessionIndicatorData = {
@@ -2193,9 +2211,9 @@ export function UnifiedSessionScreen({
       sessionStatus: session?.status,
       currentUserId: user?.id,
       partnerName: partnerName || 'Partner',
-      invitation: invitation ? {
-        messageConfirmedAt: invitation.messageConfirmedAt,
-        acceptedAt: invitation.acceptedAt,
+      invitation: invitationMessageConfirmedAt || invitationAcceptedAt ? {
+        messageConfirmedAt: invitationMessageConfirmedAt,
+        acceptedAt: invitationAcceptedAt,
       } : undefined,
       milestones: {
         // Use ref as backup to prevent flickering during mutation
@@ -2265,11 +2283,18 @@ export function UnifiedSessionScreen({
     }
 
     // --- Stage chapter markers ---
-    const chapterIndicators = deriveChapterMarkers(messages);
+    // Chapter bars should appear at the milestone that opens the chapter, not
+    // wherever the first message in that stage happens to sort.
+    const chapterIndicators = deriveChapterMarkers(messages, {
+      [Stage.WITNESS]: isInviter
+        ? invitationMessageConfirmedAt
+        : invitationAcceptedAt,
+      [Stage.PERSPECTIVE_STRETCH]: milestones?.feelHeardConfirmedAt,
+    });
     allIndicators.push(...chapterIndicators);
 
     return allIndicators;
-  }, [isInviter, session?.status, invitation?.messageConfirmedAt, invitation?.acceptedAt, milestones?.feelHeardConfirmedAt, isConfirmingFeelHeard, messages, user?.id, partnerName, empathyStatusData?.mySharedAt, empathyStatusData?.myAttempt?.status, empathyStatusData?.myAttempt?.revealedAt, shareOfferData?.hasSuggestion, shareOfferData?.suggestion, myProgress?.stage]);
+  }, [isInviter, session?.status, invitationMessageConfirmedAt, invitationAcceptedAt, milestones?.feelHeardConfirmedAt, isConfirmingFeelHeard, messages, user?.id, partnerName, empathyStatusData?.mySharedAt, empathyStatusData?.myAttempt?.status, empathyStatusData?.myAttempt?.revealedAt, shareOfferData?.hasSuggestion, shareOfferData?.suggestion, myProgress?.stage]);
 
 
 
@@ -3457,7 +3482,7 @@ export function UnifiedSessionScreen({
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
             onBackPress={onNavigateBack}
             onPress={() => setShowPartnerInfo(true)}
-            stageName="Closed"
+            conversationTopic={topicFrame}
             testID="session-chat-header"
           />
           {partnerInfoDrawer}
@@ -3502,7 +3527,7 @@ export function UnifiedSessionScreen({
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
           onBackPress={onNavigateBack}
           onPress={() => setShowPartnerInfo(true)}
-          stageName="Closed"
+          conversationTopic={topicFrame}
           testID="session-chat-header"
         />
         {partnerInfoDrawer}
@@ -3552,7 +3577,7 @@ export function UnifiedSessionScreen({
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
             onBackPress={onNavigateBack}
             onPress={() => setShowPartnerInfo(true)}
-            stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
+            conversationTopic={topicFrame}
             testID="session-chat-header"
           />
           {partnerInfoDrawer}
@@ -3589,7 +3614,7 @@ export function UnifiedSessionScreen({
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
             onBackPress={onNavigateBack}
             onPress={() => setShowPartnerInfo(true)}
-            stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
+            conversationTopic={topicFrame}
             testID="session-chat-header"
           />
           {partnerInfoDrawer}
@@ -3638,7 +3663,7 @@ export function UnifiedSessionScreen({
             : undefined
         }
         onPress={() => setShowPartnerInfo(true)}
-        stageName={myProgress?.stage !== undefined ? STAGE_FRIENDLY_NAMES[myProgress.stage] : undefined}
+        conversationTopic={topicFrame}
         testID="session-chat-header"
       />
       {partnerInfoDrawer}
@@ -4476,7 +4501,7 @@ const useStyles = () => {
       top: 49,
       right: 12,
       maxWidth: 240,
-      backgroundColor: t.colors.bgSecondary,
+      backgroundColor: palette.bgElev,
       borderRadius: t.radius.md,
       paddingHorizontal: t.spacing.md,
       paddingVertical: t.spacing.sm,
@@ -4486,7 +4511,7 @@ const useStyles = () => {
       shadowOffset: { width: 0, height: 4 },
       elevation: 8,
       borderWidth: 1,
-      borderColor: t.colors.border,
+      borderColor: palette.borderStrong,
     },
     shareLaterTooltipTail: {
       position: 'absolute' as const,
@@ -4499,11 +4524,11 @@ const useStyles = () => {
       borderBottomWidth: 8,
       borderLeftColor: 'transparent' as const,
       borderRightColor: 'transparent' as const,
-      borderBottomColor: t.colors.bgSecondary,
+      borderBottomColor: palette.bgElev,
     },
     shareLaterTooltipText: {
       fontSize: t.typography.fontSize.sm,
-      color: t.colors.textPrimary,
+      color: palette.text,
       lineHeight: 20,
       marginBottom: t.spacing.sm,
     },
@@ -4512,7 +4537,7 @@ const useStyles = () => {
       paddingHorizontal: t.spacing.md,
       paddingVertical: t.spacing.xs,
       borderRadius: t.radius.sm,
-      backgroundColor: t.colors.accent,
+      backgroundColor: palette.accent,
     },
     shareLaterTooltipButtonText: {
       color: t.colors.textOnAccent,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -557,6 +557,7 @@ export function UnifiedSessionScreen({
   const {
     // Loading
     isLoading,
+    isFetchingMessages,
     loadError,
     refetchSession,
     accessDenied,
@@ -1867,6 +1868,15 @@ export function UnifiedSessionScreen({
       setMoodCheckLoading(false);
     });
   }, [sessionId]);
+  const [hasReleasedInitialSessionRender, setHasReleasedInitialSessionRender] = useState(false);
+  const isInitialSessionRenderReady = !isLoading && !isFetchingMessages && !moodCheckLoading;
+
+  useEffect(() => {
+    if (isInitialSessionRenderReady) {
+      setHasReleasedInitialSessionRender(true);
+    }
+  }, [isInitialSessionRenderReady]);
+
   // When viewing a resolved session, allow toggling to chat history
   const [viewingResolvedHistory, setViewingResolvedHistory] = useState(false);
 
@@ -3366,7 +3376,7 @@ export function UnifiedSessionScreen({
   // -------------------------------------------------------------------------
   // Loading State
   // -------------------------------------------------------------------------
-  if (isLoading) {
+  if (isLoading || !hasReleasedInitialSessionRender) {
     return (
       <View style={styles.centerContainer}>
         <ActivityIndicator size="large" color={styles.accentColor.color} />

--- a/mobile/src/utils/animationBridge.ts
+++ b/mobile/src/utils/animationBridge.ts
@@ -8,6 +8,7 @@
  */
 
 const preRegisteredIds = new Set<string>();
+const animationIdentityById = new Map<string, string>();
 
 export function preRegisterAnimatedId(id: string): void {
   preRegisteredIds.add(id);
@@ -15,4 +16,12 @@ export function preRegisterAnimatedId(id: string): void {
 
 export function isPreRegisteredAnimatedId(id: string): boolean {
   return preRegisteredIds.has(id);
+}
+
+export function bridgeAnimatedId(oldId: string, newId: string): void {
+  animationIdentityById.set(newId, getAnimationIdentity(oldId));
+}
+
+export function getAnimationIdentity(id: string): string {
+  return animationIdentityById.get(id) || id;
 }

--- a/mobile/src/utils/keyboardController.tsx
+++ b/mobile/src/utils/keyboardController.tsx
@@ -8,10 +8,18 @@ import {
 import type { KeyboardAvoidingViewProps as RNKeyboardAvoidingViewProps } from 'react-native';
 import type { ViewProps } from 'react-native';
 
+type KeyboardStickyComposerProps = ViewProps & {
+  offset?: {
+    closed?: number;
+    opened?: number;
+  };
+  enabled?: boolean;
+};
+
 type KeyboardControllerModule = {
   KeyboardProvider?: React.ComponentType<React.PropsWithChildren>;
   KeyboardAvoidingView?: React.ComponentType<React.PropsWithChildren<RNKeyboardAvoidingViewProps>>;
-  KeyboardStickyView?: React.ComponentType<React.PropsWithChildren<ViewProps>>;
+  KeyboardStickyView?: React.ComponentType<React.PropsWithChildren<KeyboardStickyComposerProps>>;
 };
 
 let keyboardControllerModule: KeyboardControllerModule | null | undefined;
@@ -28,7 +36,7 @@ export function hasLinkedKeyboardController(): boolean {
   }
 }
 
-export function KeyboardStickyComposer({ children, ...props }: React.PropsWithChildren<ViewProps>) {
+export function KeyboardStickyComposer({ children, ...props }: React.PropsWithChildren<KeyboardStickyComposerProps>) {
   const ControllerStickyView = getKeyboardControllerModule()?.KeyboardStickyView;
 
   if (ControllerStickyView) {

--- a/mobile/src/utils/keyboardController.tsx
+++ b/mobile/src/utils/keyboardController.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  KeyboardAvoidingView as RNKeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import type { KeyboardAvoidingViewProps as RNKeyboardAvoidingViewProps } from 'react-native';
+
+type KeyboardControllerModule = {
+  KeyboardProvider?: React.ComponentType<React.PropsWithChildren>;
+  KeyboardAvoidingView?: React.ComponentType<React.PropsWithChildren<RNKeyboardAvoidingViewProps>>;
+};
+
+let keyboardControllerModule: KeyboardControllerModule | null | undefined;
+
+function getKeyboardControllerModule(): KeyboardControllerModule | null {
+  if (Platform.OS === 'web') {
+    return null;
+  }
+
+  if (keyboardControllerModule !== undefined) {
+    return keyboardControllerModule;
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    keyboardControllerModule = require('react-native-keyboard-controller');
+  } catch {
+    keyboardControllerModule = null;
+  }
+
+  return keyboardControllerModule ?? null;
+}
+
+export function KeyboardControllerProvider({ children }: React.PropsWithChildren) {
+  const Provider = getKeyboardControllerModule()?.KeyboardProvider;
+  return Provider ? <Provider>{children}</Provider> : <>{children}</>;
+}
+
+export function KeyboardAwareAvoidingView({ children, ...props }: React.PropsWithChildren<RNKeyboardAvoidingViewProps>) {
+  const ControllerAvoidingView = getKeyboardControllerModule()?.KeyboardAvoidingView;
+
+  if (ControllerAvoidingView) {
+    return (
+      <ControllerAvoidingView {...props}>
+        {children}
+      </ControllerAvoidingView>
+    );
+  }
+
+  return (
+    <RNKeyboardAvoidingView {...props}>
+      {children}
+    </RNKeyboardAvoidingView>
+  );
+}

--- a/mobile/src/utils/keyboardController.tsx
+++ b/mobile/src/utils/keyboardController.tsx
@@ -14,7 +14,7 @@ type KeyboardControllerModule = {
 
 let keyboardControllerModule: KeyboardControllerModule | null | undefined;
 
-function hasLinkedKeyboardController(): boolean {
+export function hasLinkedKeyboardController(): boolean {
   if (NativeModules.KeyboardController) {
     return true;
   }

--- a/mobile/src/utils/keyboardController.tsx
+++ b/mobile/src/utils/keyboardController.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {
   KeyboardAvoidingView as RNKeyboardAvoidingView,
+  NativeModules,
   Platform,
+  TurboModuleRegistry,
 } from 'react-native';
 import type { KeyboardAvoidingViewProps as RNKeyboardAvoidingViewProps } from 'react-native';
 
@@ -12,6 +14,18 @@ type KeyboardControllerModule = {
 
 let keyboardControllerModule: KeyboardControllerModule | null | undefined;
 
+function hasLinkedKeyboardController(): boolean {
+  if (NativeModules.KeyboardController) {
+    return true;
+  }
+
+  try {
+    return Boolean(TurboModuleRegistry.get('KeyboardController'));
+  } catch {
+    return false;
+  }
+}
+
 function getKeyboardControllerModule(): KeyboardControllerModule | null {
   if (Platform.OS === 'web') {
     return null;
@@ -19,6 +33,11 @@ function getKeyboardControllerModule(): KeyboardControllerModule | null {
 
   if (keyboardControllerModule !== undefined) {
     return keyboardControllerModule;
+  }
+
+  if (!hasLinkedKeyboardController()) {
+    keyboardControllerModule = null;
+    return null;
   }
 
   try {

--- a/mobile/src/utils/keyboardController.tsx
+++ b/mobile/src/utils/keyboardController.tsx
@@ -6,15 +6,17 @@ import {
   TurboModuleRegistry,
 } from 'react-native';
 import type { KeyboardAvoidingViewProps as RNKeyboardAvoidingViewProps } from 'react-native';
+import type { ViewProps } from 'react-native';
 
 type KeyboardControllerModule = {
   KeyboardProvider?: React.ComponentType<React.PropsWithChildren>;
   KeyboardAvoidingView?: React.ComponentType<React.PropsWithChildren<RNKeyboardAvoidingViewProps>>;
+  KeyboardStickyView?: React.ComponentType<React.PropsWithChildren<ViewProps>>;
 };
 
 let keyboardControllerModule: KeyboardControllerModule | null | undefined;
 
-function hasLinkedKeyboardController(): boolean {
+export function hasLinkedKeyboardController(): boolean {
   if (NativeModules.KeyboardController) {
     return true;
   }
@@ -24,6 +26,20 @@ function hasLinkedKeyboardController(): boolean {
   } catch {
     return false;
   }
+}
+
+export function KeyboardStickyComposer({ children, ...props }: React.PropsWithChildren<ViewProps>) {
+  const ControllerStickyView = getKeyboardControllerModule()?.KeyboardStickyView;
+
+  if (ControllerStickyView) {
+    return (
+      <ControllerStickyView {...props}>
+        {children}
+      </ControllerStickyView>
+    );
+  }
+
+  return <>{children}</>;
 }
 
 function getKeyboardControllerModule(): KeyboardControllerModule | null {

--- a/mobile/src/utils/keyboardController.tsx
+++ b/mobile/src/utils/keyboardController.tsx
@@ -14,7 +14,7 @@ type KeyboardControllerModule = {
 
 let keyboardControllerModule: KeyboardControllerModule | null | undefined;
 
-export function hasLinkedKeyboardController(): boolean {
+function hasLinkedKeyboardController(): boolean {
   if (NativeModules.KeyboardController) {
     return true;
   }

--- a/mobile/src/utils/keyboardController.tsx
+++ b/mobile/src/utils/keyboardController.tsx
@@ -5,6 +5,7 @@ import {
   Platform,
   TurboModuleRegistry,
 } from 'react-native';
+import Reanimated, { useAnimatedStyle } from 'react-native-reanimated';
 import type { KeyboardAvoidingViewProps as RNKeyboardAvoidingViewProps } from 'react-native';
 import type { ViewProps } from 'react-native';
 
@@ -20,6 +21,10 @@ type KeyboardControllerModule = {
   KeyboardProvider?: React.ComponentType<React.PropsWithChildren>;
   KeyboardAvoidingView?: React.ComponentType<React.PropsWithChildren<RNKeyboardAvoidingViewProps>>;
   KeyboardStickyView?: React.ComponentType<React.PropsWithChildren<KeyboardStickyComposerProps>>;
+  useReanimatedKeyboardAnimation?: () => {
+    height: { value: number };
+    progress: { value: number };
+  };
 };
 
 let keyboardControllerModule: KeyboardControllerModule | null | undefined;
@@ -37,17 +42,45 @@ export function hasLinkedKeyboardController(): boolean {
 }
 
 export function KeyboardStickyComposer({ children, ...props }: React.PropsWithChildren<KeyboardStickyComposerProps>) {
-  const ControllerStickyView = getKeyboardControllerModule()?.KeyboardStickyView;
+  const module = getKeyboardControllerModule();
 
-  if (ControllerStickyView) {
+  if (module?.useReanimatedKeyboardAnimation) {
     return (
-      <ControllerStickyView {...props}>
+      <LinkedKeyboardStickyComposer
+        {...props}
+        useReanimatedKeyboardAnimation={module.useReanimatedKeyboardAnimation}
+      >
         {children}
-      </ControllerStickyView>
+      </LinkedKeyboardStickyComposer>
     );
   }
 
   return <>{children}</>;
+}
+
+function LinkedKeyboardStickyComposer({
+  children,
+  offset: { closed = 0, opened = 0 } = {},
+  style,
+  enabled = true,
+  useReanimatedKeyboardAnimation,
+  ...props
+}: React.PropsWithChildren<KeyboardStickyComposerProps> & {
+  useReanimatedKeyboardAnimation: NonNullable<KeyboardControllerModule['useReanimatedKeyboardAnimation']>;
+}) {
+  const { height, progress } = useReanimatedKeyboardAnimation();
+  const animatedStyle = useAnimatedStyle(() => {
+    const insetOffset = progress.value > 0.001 ? opened : closed;
+    return {
+      transform: [{ translateY: enabled ? height.value + insetOffset : closed }],
+    };
+  }, [closed, opened, enabled]);
+
+  return (
+    <Reanimated.View style={[style, animatedStyle]} {...props}>
+      {children}
+    </Reanimated.View>
+  );
 }
 
 function getKeyboardControllerModule(): KeyboardControllerModule | null {

--- a/package-lock.json
+++ b/package-lock.json
@@ -201,6 +201,7 @@
         "react-native-audio-record": "^0.2.2",
         "react-native-drawer-layout": "^4.2.1",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-keyboard-controller": "^1.21.7",
         "react-native-reanimated": "4.1.6",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -247,6 +248,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "mobile/node_modules/react-native-keyboard-controller": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.21.7.tgz",
+      "integrity": "sha512-gs+8nI8HYnRdDt4NWbk1iVuS6kDLf2taJvp+h/TjM1FBdtnQmlYLJ6buNiUqSnkIH4OFEAxdNr3/GOOYdLfkUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.0.0"
       }
     },
     "mobile/node_modules/react-native-reanimated": {


### PR DESCRIPTION
## Summary
- converts chat sticky stage headers to work with the normal list flow
- fixes chat auto-scroll, keyboard handling, typing indicator placement, and streaming/typewriter animation behavior
- adds a rebuilt-iOS keyboard controller path so the input and emotion slider follow interactive keyboard drags smoothly
- keeps a safe fallback for older dev-client builds where the keyboard controller native module is not linked

## Validation
- `npm --workspace mobile run check`
- `NODE_PATH=/Users/shantam/Software/meet-without-fear/node_modules/jest-expo/node_modules npm --workspace mobile test -- ChatInterface --runInBand`
