### PR TITLE
[codex] Add native build update prompts

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -24,6 +24,7 @@ import tendingRoutes from './tending';
 import ttsRoutes from './tts';
 import voiceRoutes from './voice';
 import e2eRoutes from './e2e';
+import versionRoutes from './version';
 import { logger } from '../lib/logger';
 
 const router = Router();
@@ -32,6 +33,7 @@ logger.info('[Routes] Loading main router...');
 
 // Mount all route modules
 router.use('/brain', brainRoutes);
+router.use(versionRoutes); // Public mobile app version check
 router.use('/auth', authRoutes);
 router.use('/tts', ttsRoutes);
 router.use(voiceRoutes); // Voice transcription token endpoint

--- a/backend/src/routes/version.ts
+++ b/backend/src/routes/version.ts
@@ -1,0 +1,80 @@
+import { Router } from 'express';
+import { ApiResponse, VersionCheckResponse } from '@meet-without-fear/shared';
+
+const router = Router();
+
+const DEFAULT_DOWNLOAD_URL = 'https://meetwithoutfear.com/download';
+
+function readPositiveInt(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? '0', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function readPlatformBuild(
+  platform: 'ios' | 'android',
+  iosKey: string,
+  androidKey: string,
+  fallbackKey: string
+): number {
+  return readPositiveInt(
+    (platform === 'ios' ? process.env[iosKey] : process.env[androidKey]) ??
+      process.env[fallbackKey]
+  );
+}
+
+router.get('/version/check', (req, res) => {
+  const platform = req.query.platform === 'android' ? 'android' : 'ios';
+  const buildNumber = readPositiveInt(
+    typeof req.query.buildNumber === 'string' ? req.query.buildNumber : undefined
+  );
+
+  const minBuild = readPlatformBuild(
+    platform,
+    'APP_MIN_BUILD_NUMBER_IOS',
+    'APP_MIN_BUILD_NUMBER_ANDROID',
+    'APP_MIN_BUILD_NUMBER'
+  );
+  const latestBuild = readPlatformBuild(
+    platform,
+    'APP_LATEST_BUILD_NUMBER_IOS',
+    'APP_LATEST_BUILD_NUMBER_ANDROID',
+    'APP_LATEST_BUILD_NUMBER'
+  );
+  const latestVersion = process.env.APP_LATEST_VERSION ?? '0.0.1';
+  const downloadUrl =
+    (platform === 'ios'
+      ? process.env.APP_DOWNLOAD_URL_IOS
+      : process.env.APP_DOWNLOAD_URL_ANDROID) ??
+    process.env.APP_DOWNLOAD_URL ??
+    DEFAULT_DOWNLOAD_URL;
+
+  let updateStatus: VersionCheckResponse['updateStatus'] = 'up-to-date';
+  if (minBuild > 0 && buildNumber < minBuild) {
+    updateStatus = 'required-update';
+  } else if (latestBuild > 0 && buildNumber < latestBuild) {
+    updateStatus = 'optional-update';
+  }
+
+  const message =
+    process.env.APP_UPDATE_MESSAGE ??
+    (updateStatus === 'required-update'
+      ? 'This version of Meet Without Fear is no longer supported. Please update to continue.'
+      : updateStatus === 'optional-update'
+        ? 'A new version of Meet Without Fear is available with improvements and bug fixes.'
+        : undefined);
+
+  const response: ApiResponse<VersionCheckResponse> = {
+    success: true,
+    data: {
+      updateStatus,
+      latestVersion,
+      latestBuildNumber: latestBuild,
+      message,
+      downloadUrl,
+    },
+  };
+
+  res.json(response);
+});
+
+export default router;

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -35,6 +35,11 @@ All required environment variables for Meet Without Fear services.
 | `RATE_LIMIT_MAX` | Max requests per window | `100` |
 | `EXPO_ACCESS_TOKEN` | Expo push notification token | (optional) |
 | `OPENAI_API_KEY` | OpenAI key for TTS (`/api/tts` → `tts-1` / `tts-1-hd`). Without it, TTS returns 500 and meditation/gratitude/chat read-aloud features are broken. | (none) |
+| `APP_LATEST_BUILD_NUMBER_IOS` / `APP_LATEST_BUILD_NUMBER_ANDROID` | Latest native mobile build number for optional update prompts. Falls back to `APP_LATEST_BUILD_NUMBER`. | `40` |
+| `APP_MIN_BUILD_NUMBER_IOS` / `APP_MIN_BUILD_NUMBER_ANDROID` | Minimum supported native mobile build number for required update prompts. Falls back to `APP_MIN_BUILD_NUMBER`. | (none) |
+| `APP_DOWNLOAD_URL_IOS` / `APP_DOWNLOAD_URL_ANDROID` | Platform-specific update link opened by the native app. Falls back to `APP_DOWNLOAD_URL`, then `https://meetwithoutfear.com/download`. | `https://meetwithoutfear.com/download` |
+| `APP_LATEST_VERSION` | Human-readable app version returned by `/api/version/check`. | `0.0.1` |
+| `APP_UPDATE_MESSAGE` | Optional override for the update modal body. | Auto-generated |
 
 ## JWT Configuration
 

--- a/mobile/app/(auth)/_layout.tsx
+++ b/mobile/app/(auth)/_layout.tsx
@@ -3,8 +3,6 @@ import { useAuth as useClerkAuth } from '@clerk/clerk-expo';
 import { useAppAppearance } from '@/src/theme';
 import { useUserSessionUpdates } from '@/src/hooks/useRealtime';
 import { isE2EMode } from '@/src/providers/E2EAuthProvider';
-import { useOTAUpdate } from '@/src/hooks/useOTAUpdate';
-import { UpdateBanner } from '@/src/components/UpdateBanner';
 import { useNotifications } from '@/src/hooks/useNotifications';
 import { BiometricLockProvider } from '@/src/contexts/BiometricLockContext';
 import { BiometricLockOverlay } from '@/src/components/BiometricLockOverlay';
@@ -24,9 +22,6 @@ export default function AuthLayout() {
   // Skip in E2E mode to avoid token/capability cache issues with the user notification channel
   useUserSessionUpdates({ enabled: !isE2EMode() });
   useNotifications();
-
-  // OTA update banner
-  const { showUpdateBanner, applyUpdate, dismissUpdate } = useOTAUpdate();
 
   // Wait for Clerk to initialize
   if (!isLoaded) {
@@ -111,9 +106,6 @@ export default function AuthLayout() {
           }}
         />
       </Stack>
-      {showUpdateBanner && (
-        <UpdateBanner onApply={applyUpdate} onDismiss={dismissUpdate} />
-      )}
       <BiometricLockOverlay />
     </BiometricLockProvider>
   );

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -18,6 +18,8 @@ import { MixpanelInitializer } from '@/src/components/MixpanelInitializer';
 import { NativeAppBanner } from '@/src/components/NativeAppBanner';
 import { E2EAuthProvider, isE2EMode } from '@/src/providers/E2EAuthProvider';
 import { useOTAUpdate } from '@/src/hooks/useOTAUpdate';
+import { useVersionCheck } from '@/src/hooks/useVersionCheck';
+import { UpdateBanner } from '@/src/components/UpdateBanner';
 
 /** Keys that may contain user names / PII — strip from Sentry context. */
 const PII_KEYS = new Set([
@@ -131,6 +133,8 @@ function AppShell({ includeMixpanel = true }: { includeMixpanel?: boolean }) {
   // Capture invitation deep links to AsyncStorage (backup for home screen pickup)
   useInvitationLink();
   const { palette, scheme } = useAppAppearance();
+  const { versionInfo, showVersionBanner, dismissVersionBanner } = useVersionCheck();
+  const { showUpdateBanner, applyUpdate, dismissUpdate } = useOTAUpdate();
 
   return (
     <View style={[styles.webBackdrop, { backgroundColor: palette.bg }]}>
@@ -153,6 +157,16 @@ function AppShell({ includeMixpanel = true }: { includeMixpanel?: boolean }) {
                     <Stack.Screen name="(auth)" />
                     <Stack.Screen name="+not-found" options={{ headerShown: true }} />
                   </Stack>
+                  {showUpdateBanner ? (
+                    <UpdateBanner onApply={applyUpdate} onDismiss={dismissUpdate} />
+                  ) : showVersionBanner && versionInfo ? (
+                    <UpdateBanner
+                      updateStatus={versionInfo.updateStatus}
+                      message={versionInfo.message}
+                      downloadUrl={versionInfo.downloadUrl}
+                      onDismiss={dismissVersionBanner}
+                    />
+                  ) : null}
                   <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
                 </ToastProvider>
               </SessionDrawerProvider>
@@ -168,10 +182,6 @@ function AppShell({ includeMixpanel = true }: { includeMixpanel?: boolean }) {
  * Root layout component
  */
 function RootLayout() {
-  // Check for OTA updates at root level so it runs even on the sign-in screen.
-  // Without this, users stuck on a broken sign-in can never receive the fix via OTA.
-  useOTAUpdate();
-
   const [fontsLoaded, fontError] = useFonts({
     InstrumentSerif: require('../assets/fonts/InstrumentSerif-Regular.ttf'),
     InstrumentSerifItalic: require('../assets/fonts/InstrumentSerif-Italic.ttf'),

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -35,6 +35,7 @@
     "ably": "^2.16.0",
     "axios": "^1.16.0",
     "expo": "~54.0.32",
+    "expo-application": "~7.0.8",
     "expo-asset": "^12.0.12",
     "expo-audio": "~1.1.1",
     "expo-auth-session": "^7.0.10",

--- a/mobile/src/components/UpdateBanner.tsx
+++ b/mobile/src/components/UpdateBanner.tsx
@@ -1,12 +1,48 @@
-import { View, Text, Pressable, Modal, Platform, StyleSheet } from 'react-native';
-import { colors } from '@/theme';
+import { View, Text, Pressable, Modal, Platform, StyleSheet, Linking } from 'react-native';
+import { AlertTriangle, Download, RefreshCw } from 'lucide-react-native';
+import { designFonts, useAppAppearance } from '@/theme';
+import type { AppUpdateStatus } from '@meet-without-fear/shared';
 
 interface UpdateBannerProps {
-  onApply: () => void;
-  onDismiss: () => void;
+  onApply?: () => void;
+  onDismiss?: () => void;
+  updateStatus?: AppUpdateStatus;
+  message?: string;
+  downloadUrl?: string;
 }
 
-export function UpdateBanner({ onApply, onDismiss }: UpdateBannerProps) {
+export function UpdateBanner({
+  onApply,
+  onDismiss,
+  updateStatus = 'optional-update',
+  message = 'A new version is ready. Tap to update now.',
+  downloadUrl,
+}: UpdateBannerProps) {
+  const { palette } = useAppAppearance();
+  const styles = makeStyles(palette);
+
+  if (updateStatus === 'up-to-date') return null;
+
+  const isRequired = updateStatus === 'required-update';
+  const isOTA = !!onApply;
+  const Icon = isRequired ? AlertTriangle : isOTA ? RefreshCw : Download;
+
+  const handleUpdate = async () => {
+    if (onApply) {
+      await onApply();
+      return;
+    }
+    if (!downloadUrl) return;
+    try {
+      const canOpen = await Linking.canOpenURL(downloadUrl);
+      if (canOpen) {
+        await Linking.openURL(downloadUrl);
+      }
+    } catch (error) {
+      console.warn('[UpdateBanner] Failed to open download URL:', error);
+    }
+  };
+
   return (
     <Modal visible transparent animationType="fade" statusBarTranslucent>
       <View style={styles.overlay}>
@@ -24,19 +60,22 @@ export function UpdateBanner({ onApply, onDismiss }: UpdateBannerProps) {
             }),
           ]}
         >
-          <Text style={styles.title}>Update Available</Text>
-          <Text style={styles.message}>
-            A new version is ready. Tap to update now.
-          </Text>
+          <View style={styles.iconWrap}>
+            <Icon color={palette.accentText} size={22} />
+          </View>
+          <Text style={styles.title}>{isRequired ? 'Update Required' : 'Update Available'}</Text>
+          <Text style={styles.message}>{message}</Text>
 
           <View style={styles.buttons}>
-            <Pressable onPress={onApply} style={styles.updateButton}>
+            <Pressable onPress={handleUpdate} style={styles.updateButton}>
               <Text style={styles.updateButtonText}>Update Now</Text>
             </Pressable>
 
-            <Pressable onPress={onDismiss} style={styles.laterButton}>
-              <Text style={styles.laterButtonText}>Later</Text>
-            </Pressable>
+            {!isRequired && onDismiss && (
+              <Pressable onPress={onDismiss} style={styles.laterButton}>
+                <Text style={styles.laterButtonText}>Later</Text>
+              </Pressable>
+            )}
           </View>
         </View>
       </View>
@@ -44,65 +83,84 @@ export function UpdateBanner({ onApply, onDismiss }: UpdateBannerProps) {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (palette: ReturnType<typeof useAppAppearance>['palette']) => StyleSheet.create({
   overlay: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: 20,
-    backgroundColor: 'rgba(0, 0, 0, 0.9)',
+    backgroundColor: palette.scrim,
   },
   card: {
-    backgroundColor: colors.bgSecondary,
-    borderRadius: 16,
-    padding: 32,
+    backgroundColor: palette.bgElev,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: palette.borderStrong,
+    padding: 24,
     width: '100%',
     maxWidth: 400,
     alignItems: 'center',
   },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: colors.textPrimary,
+  iconWrap: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: palette.accentSoft,
     marginBottom: 16,
+  },
+  title: {
+    fontSize: 20,
+    lineHeight: 26,
+    fontWeight: '700',
+    color: palette.text,
+    marginBottom: 8,
     textAlign: 'center',
+    fontFamily: designFonts.sans,
   },
   message: {
-    fontSize: 16,
-    color: colors.textSecondary,
-    lineHeight: 24,
-    marginBottom: 32,
+    fontSize: 15,
+    color: palette.textMuted,
+    lineHeight: 22,
+    marginBottom: 24,
     textAlign: 'center',
+    fontFamily: designFonts.sans,
   },
   buttons: {
     width: '100%',
-    gap: 12,
+    gap: 10,
   },
   updateButton: {
-    backgroundColor: '#2563eb',
-    paddingVertical: 16,
-    paddingHorizontal: 48,
-    borderRadius: 12,
+    backgroundColor: palette.accent,
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 8,
     width: '100%',
     alignItems: 'center',
   },
   updateButtonText: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#ffffff',
+    fontSize: 15,
+    lineHeight: 20,
+    fontWeight: '700',
+    color: palette.textOnAccent,
+    fontFamily: designFonts.sans,
   },
   laterButton: {
-    paddingVertical: 16,
-    paddingHorizontal: 48,
-    borderRadius: 12,
+    backgroundColor: palette.bgPane,
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 8,
     width: '100%',
     alignItems: 'center',
     borderWidth: 1,
-    borderColor: '#4b5563',
+    borderColor: palette.border,
   },
   laterButtonText: {
-    fontSize: 18,
+    fontSize: 15,
+    lineHeight: 20,
     fontWeight: '600',
-    color: '#9ca3af',
+    color: palette.textMuted,
+    fontFamily: designFonts.sans,
   },
 });

--- a/mobile/src/hooks/index.ts
+++ b/mobile/src/hooks/index.ts
@@ -9,6 +9,7 @@
 // ============================================================================
 
 export { useAuth, useAuthProvider, AuthContext, useUpdateMood, authKeys } from './useAuth';
+export { useVersionCheck } from './useVersionCheck';
 export type { User, AuthContextValue } from './useAuth';
 
 // ============================================================================

--- a/mobile/src/hooks/useVersionCheck.ts
+++ b/mobile/src/hooks/useVersionCheck.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState, Platform, type AppStateStatus } from 'react-native';
+import * as Application from 'expo-application';
+import type { VersionCheckResponse } from '@meet-without-fear/shared';
+import { get } from '@/src/lib/api';
+
+export function useVersionCheck() {
+  const appState = useRef(AppState.currentState);
+  const isChecking = useRef(false);
+  const [versionInfo, setVersionInfo] = useState<VersionCheckResponse | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  const checkVersion = useCallback(async () => {
+    if (Platform.OS === 'web' || isChecking.current) return;
+
+    const buildNumber = Number.parseInt(Application.nativeBuildVersion ?? '0', 10);
+    if (!Number.isFinite(buildNumber) || buildNumber <= 0) return;
+
+    isChecking.current = true;
+    try {
+      const platform = Platform.OS === 'android' ? 'android' : 'ios';
+      const result = await get<VersionCheckResponse>(
+        `/version/check?platform=${platform}&buildNumber=${buildNumber}`
+      );
+      setVersionInfo(result);
+      if (result.updateStatus === 'up-to-date') {
+        setDismissed(false);
+      }
+    } catch (error) {
+      console.warn('[useVersionCheck] Failed to check native app version:', error);
+    } finally {
+      isChecking.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    checkVersion();
+
+    const subscription = AppState.addEventListener(
+      'change',
+      (nextState: AppStateStatus) => {
+        if (appState.current.match(/background/) && nextState === 'active') {
+          checkVersion();
+        }
+        appState.current = nextState;
+      }
+    );
+
+    return () => subscription.remove();
+  }, [checkVersion]);
+
+  return {
+    versionInfo,
+    showVersionBanner:
+      versionInfo !== null &&
+      versionInfo.updateStatus !== 'up-to-date' &&
+      !dismissed,
+    dismissVersionBanner: () => setDismissed(true),
+  };
+}

--- a/mobile/src/hooks/useVersionCheck.web.ts
+++ b/mobile/src/hooks/useVersionCheck.web.ts
@@ -1,0 +1,7 @@
+export function useVersionCheck() {
+  return {
+    versionInfo: null,
+    showVersionBanner: false,
+    dismissVersionBanner: () => {},
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,6 +170,7 @@
         "ably": "^2.16.0",
         "axios": "^1.16.0",
         "expo": "~54.0.32",
+        "expo-application": "~7.0.8",
         "expo-asset": "^12.0.12",
         "expo-audio": "~1.1.1",
         "expo-auth-session": "^7.0.10",

--- a/shared/src/dto/version.ts
+++ b/shared/src/dto/version.ts
@@ -1,0 +1,9 @@
+export type AppUpdateStatus = 'up-to-date' | 'optional-update' | 'required-update';
+
+export interface VersionCheckResponse {
+  updateStatus: AppUpdateStatus;
+  latestVersion: string;
+  latestBuildNumber: number;
+  message?: string;
+  downloadUrl?: string;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -35,6 +35,7 @@ export * from './dto/meditation';
 export * from './dto/cross-feature';
 export * from './dto/chat-item';
 export * from './dto/voice';
+export * from './dto/version';
 
 // Validation schemas
 export * from './validation';


### PR DESCRIPTION
## Summary
- Added a public native app version-check endpoint with platform-specific latest/minimum build controls.
- Added mobile native build update checks using the installed build number.
- Reworked the shared update modal so OTA updates reload and native build updates open the download link, with OTA taking precedence.
- Restyled the modal against the app light/dark appearance palette.

## Validation
- npm run check --workspace=shared
- npm run check --workspace=backend
- npm run check --workspace=mobile
