### PR TITLE
[codex] Stabilize session chat loading

### DIFF
--- a/backend/src/controllers/session-state.ts
+++ b/backend/src/controllers/session-state.ts
@@ -24,6 +24,8 @@ import { DEFAULT_PRIVACY_PREFERENCES, ErrorCode, PrivacyPreferencesDTO } from '@
 import { successResponse, errorResponse } from '../utils/response';
 import { getPartnerUserId } from '../utils/session';
 
+const INITIAL_SESSION_MESSAGE_LIMIT = 500;
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -191,7 +193,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
         },
       }),
 
-      // 2. Messages (initial page - 25 most recent for this user)
+      // 2. Messages (initial page - full practical transcript for this user)
       // Uses data isolation: messages with forUserId only show to that specific user
       prisma.message.findMany({
         where: {
@@ -206,7 +208,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
           ],
         },
         orderBy: { timestamp: 'desc' },
-        take: 26, // Take 26 to check if there are more
+        take: INITIAL_SESSION_MESSAGE_LIMIT + 1, // Take one extra to check if there are more
       }),
 
       // 3. User's vessel for this session (for lastSeenChatItemId)
@@ -346,8 +348,8 @@ export async function getSessionState(req: Request, res: Response): Promise<void
     ) : null;
 
     // Build messages response (reverse to chronological order)
-    const hasMoreMessages = messages.length > 25;
-    const messageSlice = hasMoreMessages ? messages.slice(0, 25) : messages;
+    const hasMoreMessages = messages.length > INITIAL_SESSION_MESSAGE_LIMIT;
+    const messageSlice = hasMoreMessages ? messages.slice(0, INITIAL_SESSION_MESSAGE_LIMIT) : messages;
     const messagesResponse = {
       messages: messageSlice.reverse().map(m => ({
         id: m.id,

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -171,6 +171,8 @@ interface ChatInterfaceProps {
   onTypewriterComplete?: () => void;
   /** Callback to report if typewriter is currently animating */
   onTypewriterStateChange?: (isAnimating: boolean) => void;
+  /** Called once the first transcript layout pass has completed. */
+  onInitialRenderReady?: () => void;
   /** Custom element to render when there are no messages (e.g., onboarding compact) */
   customEmptyState?: React.ReactNode;
   /** Keyboard vertical offset for iOS (accounts for header + status bar) */
@@ -258,6 +260,7 @@ export function ChatInterface({
   isLoadingMore = false,
   onTypewriterComplete,
   onTypewriterStateChange,
+  onInitialRenderReady,
   customEmptyState,
   keyboardVerticalOffset = 100,
   skipInitialHistory = false,
@@ -283,6 +286,9 @@ export function ChatInterface({
   });
   const isNearBottomRef = useRef(true);
   const shouldStickToBottomRef = useRef(true);
+  const initialBottomScrollCompleteRef = useRef(false);
+  const hasReportedInitialRenderReadyRef = useRef(false);
+  const userHasDraggedTranscriptRef = useRef(false);
   const scrollRetryTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const scrollRetryAnimationFrameRef = useRef<number | null>(null);
   const localAnimationScopeRef = useRef<string | null>(null);
@@ -299,6 +305,18 @@ export function ChatInterface({
     seenAnimatedItemIdsRef.current = getSeenAnimatedItemIds(animationScope);
   }
 
+  const reportInitialRenderReady = useCallback(() => {
+    if (hasReportedInitialRenderReadyRef.current) return;
+    if (scrollMetricsRef.current.layoutHeight <= 0) return;
+
+    hasReportedInitialRenderReadyRef.current = true;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        onInitialRenderReady?.();
+      });
+    });
+  }, [onInitialRenderReady]);
+
   const scrollToBottom = useCallback((animated: boolean) => {
     scrollRetryTimeoutsRef.current.forEach(clearTimeout);
     scrollRetryTimeoutsRef.current = [];
@@ -312,6 +330,10 @@ export function ChatInterface({
 
       if (contentHeight > 0 && layoutHeight > 0) {
         flatListRef.current?.scrollToOffset({ offset: maxOffset, animated });
+        if (!animated) {
+          initialBottomScrollCompleteRef.current = true;
+          reportInitialRenderReady();
+        }
         return;
       }
 
@@ -326,7 +348,13 @@ export function ChatInterface({
       setTimeout(run, 500),
       setTimeout(run, 800),
     ];
-  }, []);
+  }, [reportInitialRenderReady]);
+
+  useEffect(() => {
+    initialBottomScrollCompleteRef.current = false;
+    hasReportedInitialRenderReadyRef.current = false;
+    userHasDraggedTranscriptRef.current = false;
+  }, [sessionId]);
 
   useEffect(() => {
     return () => {
@@ -625,7 +653,11 @@ export function ChatInterface({
     if (message.role === MessageRole.USER) return false;
     if (message.id.startsWith('optimistic-')) return false;
     const wasPresentAtMount = mountSnapshotIdsRef.current.has(message.id);
-    if (wasPresentAtMount && isAtOrBeforeSeenBoundary(item, index)) return false;
+    // Anything present in the first rendered transcript is history for this
+    // screen open. Keep the unread separator if needed, but do not replay
+    // persisted messages one-by-one on entry; that makes restored sessions
+    // appear to load progressively and shifts the viewport.
+    if (wasPresentAtMount) return false;
 
     // If the user has already replied after this assistant/system message,
     // the message must be visible immediately. It is no longer a live pending
@@ -995,6 +1027,10 @@ export function ChatInterface({
   }, [scrollToBottom]);
 
   const handleEndReached = useCallback(() => {
+    if (!initialBottomScrollCompleteRef.current || !userHasDraggedTranscriptRef.current) {
+      return;
+    }
+
     if (hasMore && !isLoadingMore && onLoadMore) {
       // Set flag BEFORE calling onLoadMore to prevent any scroll effects
       isLoadingHistoryRef.current = true;
@@ -1008,6 +1044,10 @@ export function ChatInterface({
       onLoadMore();
     }
   }, [hasMore, isLoadingMore, onLoadMore]);
+
+  const handleScrollBeginDrag = useCallback(() => {
+    userHasDraggedTranscriptRef.current = true;
+  }, []);
 
   // Cleanup: If loading finishes but no content was added, reset state
   useEffect(() => {
@@ -1035,6 +1075,11 @@ export function ChatInterface({
       return indices;
     }, []);
   }, [listItems]);
+
+  // The backend/query layer controls how many transcript rows are loaded.
+  // Once a page is in memory, render it in one pass so opening a session does
+  // not visibly fill the transcript row-by-row as VirtualizedList batches cells.
+  const loadedTranscriptRowCount = Math.max(1, listItems.length);
 
   // ---------------------------------------------------------------------------
   // New Activity Pill: floating indicator for off-screen new items
@@ -1098,8 +1143,13 @@ export function ChatInterface({
       testID="chat-message-list"
       onStartReached={handleEndReached}
       onStartReachedThreshold={0.2}
+      initialNumToRender={loadedTranscriptRowCount}
+      maxToRenderPerBatch={loadedTranscriptRowCount}
+      updateCellsBatchingPeriod={0}
+      removeClippedSubviews={false}
       onLayout={handleListLayout}
       onScroll={handleScroll}
+      onScrollBeginDrag={handleScrollBeginDrag}
       scrollEventThrottle={16}
       onContentSizeChange={handleContentSizeChange}
     />

--- a/mobile/src/components/__tests__/ChatInterface.test.tsx
+++ b/mobile/src/components/__tests__/ChatInterface.test.tsx
@@ -397,6 +397,35 @@ describe('ChatBubble', () => {
     expect(screen.getByText('Loaded history response')).toBeTruthy();
   });
 
+  it('does not typewriter persisted unread messages on initial session open', () => {
+    const baseTime = new Date('2026-05-14T12:00:00.000Z').getTime();
+
+    render(
+      <ChatInterface
+        messages={[
+          createMockMessage({
+            id: 'seen-user-message',
+            role: MessageRole.USER,
+            content: 'Already seen user message',
+            timestamp: new Date(baseTime).toISOString(),
+          }),
+          createMockMessage({
+            id: 'persisted-unread-ai',
+            role: MessageRole.AI,
+            content: 'Persisted unread response should render immediately',
+            timestamp: new Date(baseTime + 1000).toISOString(),
+          }),
+        ]}
+        onSendMessage={jest.fn()}
+        sessionId="initial-unread-history-test"
+        lastViewedAt={new Date(baseTime).toISOString()}
+      />
+    );
+
+    expect(screen.getByText('Persisted unread response should render immediately')).toBeTruthy();
+    expect(screen.queryByTestId('typewriter-text')).toBeNull();
+  });
+
   it('displays message content correctly', () => {
     const messages = [
       createMockMessage({ id: '1', content: 'This is a test message with special characters: @#$%' }),

--- a/mobile/src/hooks/__tests__/useMessages.test.ts
+++ b/mobile/src/hooks/__tests__/useMessages.test.ts
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import {
   useMessages,
+  useInfiniteMessages,
   useSendMessage,
   useEmotionalHistory,
   useRecordEmotion,
@@ -158,6 +159,52 @@ describe('useMessages', () => {
 
       expect(result.current.fetchStatus).toBe('idle');
       expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useInfiniteMessages hook', () => {
+    it('loads the newest page first, then requests the immediately older page before the oldest visible message', async () => {
+      mockGet
+        .mockResolvedValueOnce({
+          messages: [
+            { ...mockMessage, id: 'msg-older-visible', timestamp: '2024-01-01T00:00:00.000Z' },
+            { ...mockAiMessage, id: 'msg-newest-visible', timestamp: '2024-01-01T00:00:01.000Z' },
+          ],
+          hasMore: true,
+        })
+        .mockResolvedValueOnce({
+          messages: [
+            { ...mockMessage, id: 'msg-older-page', timestamp: '2023-12-31T23:59:58.000Z' },
+            { ...mockAiMessage, id: 'msg-newer-in-older-page', timestamp: '2023-12-31T23:59:59.000Z' },
+          ],
+          hasMore: false,
+        });
+
+      const { result } = renderHook(
+        () => useInfiniteMessages({ sessionId: 'session-123', limit: 2 }),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      act(() => {
+        result.current.fetchNextPage();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isFetchingNextPage).toBe(false);
+      });
+
+      expect(mockGet).toHaveBeenNthCalledWith(
+        1,
+        '/sessions/session-123/messages?limit=2'
+      );
+      expect(mockGet).toHaveBeenNthCalledWith(
+        2,
+        '/sessions/session-123/messages?limit=2&before=2024-01-01T00%3A00%3A00.000Z'
+      );
     });
   });
 

--- a/mobile/src/hooks/useMessages.ts
+++ b/mobile/src/hooks/useMessages.ts
@@ -130,11 +130,12 @@ export function useInfiniteMessages(
       if (stage !== undefined) queryParams.set('stage', stage.toString());
       queryParams.set('limit', limit.toString());
 
-      // First page: get newest messages (default order is 'desc')
-      // Subsequent pages: get older messages using 'before' cursor with 'asc' order
+      // First page: get newest messages (default order is 'desc').
+      // Subsequent pages also use descending order with the `before` cursor so
+      // the backend returns the immediately previous chunk, then reverses that
+      // chunk into chronological display order.
       if (pageParam) {
         queryParams.set('before', pageParam as string);
-        queryParams.set('order', 'asc');
       }
 
       const url = `/sessions/${sessionId}/messages?${queryParams.toString()}`;

--- a/mobile/src/hooks/useSessions.ts
+++ b/mobile/src/hooks/useSessions.ts
@@ -29,6 +29,7 @@ import {
   Stage,
   SessionStateResponse,
   TimelineResponse,
+  GetMessagesResponse,
   ChatItemType,
   IndicatorType,
   IndicatorItem,
@@ -38,6 +39,7 @@ import {
 import {
   sessionKeys,
   stageKeys,
+  messageKeys,
   timelineKeys,
   notificationKeys,
 } from './queryKeys';
@@ -877,8 +879,20 @@ export function useSessionState(
         queryClient.setQueryData(stageKeys.progress(sessionId), data.progress);
       }
 
-      // Don't hydrate messageKeys.list — UI reads from messageKeys.infinite,
-      // and overwriting here can clobber optimistic transition messages.
+      // Hydrate only the infinite cache when empty. The session-state endpoint
+      // already returns the initial message page, and this prevents the chat
+      // from rendering blank while the separate infinite query starts. Do not
+      // overwrite existing data because mutations and realtime events update
+      // this cache optimistically after initial load.
+      if (!queryClient.getQueryData(messageKeys.infinite(sessionId))) {
+        queryClient.setQueryData<InfiniteData<GetMessagesResponse>>(
+          messageKeys.infinite(sessionId),
+          {
+            pages: [data.messages],
+            pageParams: [undefined],
+          }
+        );
+      }
 
       if (data.invitation && !queryClient.getQueryData(sessionKeys.sessionInvitation(sessionId))) {
         queryClient.setQueryData(sessionKeys.sessionInvitation(sessionId), {

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -55,6 +55,8 @@ import {
 } from './useStages';
 import { shouldFetchShareOffer } from '../utils/shareOfferEligibility';
 
+const SESSION_TRANSCRIPT_MESSAGE_LIMIT = 500;
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -271,7 +273,7 @@ export function useUnifiedSession(
     hasNextPage,
     isFetchingNextPage,
   } = useInfiniteMessages(
-    { sessionId: sessionId!, limit: 25 },
+    { sessionId: sessionId!, limit: SESSION_TRANSCRIPT_MESSAGE_LIMIT },
     { enabled: !!sessionId && !accessDenied && stateResolved }
   );
 

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1869,7 +1869,13 @@ export function UnifiedSessionScreen({
     });
   }, [sessionId]);
   const [hasReleasedInitialSessionRender, setHasReleasedInitialSessionRender] = useState(false);
+  const [hasCompletedInitialChatRender, setHasCompletedInitialChatRender] = useState(false);
   const isInitialSessionRenderReady = !isLoading && !isFetchingMessages && !moodCheckLoading;
+
+  useEffect(() => {
+    setHasReleasedInitialSessionRender(false);
+    setHasCompletedInitialChatRender(false);
+  }, [sessionId]);
 
   useEffect(() => {
     if (isInitialSessionRenderReady) {
@@ -3646,45 +3652,53 @@ export function UnifiedSessionScreen({
   // -------------------------------------------------------------------------
   return (
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-      <SessionChatHeader
-        partnerName={partnerName}
-        partnerOnline={partnerOnline}
-        connectionStatus={connectionStatus}
-        briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
-        hideOnlineStatus={isInvitationPhase}
-        onBackPress={onNavigateBack}
-        onBriefStatusPress={
-          session?.status === SessionStatus.INVITED && invitation?.isInviter
-            ? () => {
-                setShowShareLaterTooltip(false);
-                setActivityFocusTarget(null);
-                setShowActivityMenu(true);
-              }
-            : undefined
-        }
-        hasNewActivity={!isInOnboardingUnsigned ? (pendingActionsQuery.data?.actions?.length ?? 0) > 0 : false}
-        onMenuPress={
-          !isInOnboardingUnsigned
-            ? () => {
-                setShowShareLaterTooltip(false);
-                setActivityFocusTarget(null);
-                setShowActivityMenu(true);
-              }
-            : undefined
-        }
-        onPress={() => setShowPartnerInfo(true)}
-        conversationTopic={topicFrame}
-        testID="session-chat-header"
-      />
-      {partnerInfoDrawer}
-      {/* Chat content - Share is now a separate route */}
-      {(
-      <View style={styles.content}>
-        <ChatInterface
+      <View
+        style={[
+          styles.initialSessionSurface,
+          !hasCompletedInitialChatRender && styles.initialSessionSurfaceHidden,
+        ]}
+        pointerEvents={hasCompletedInitialChatRender ? 'auto' : 'none'}
+      >
+        <SessionChatHeader
+          partnerName={partnerName}
+          partnerOnline={partnerOnline}
+          connectionStatus={connectionStatus}
+          briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
+          hideOnlineStatus={isInvitationPhase}
+          onBackPress={onNavigateBack}
+          onBriefStatusPress={
+            session?.status === SessionStatus.INVITED && invitation?.isInviter
+              ? () => {
+                  setShowShareLaterTooltip(false);
+                  setActivityFocusTarget(null);
+                  setShowActivityMenu(true);
+                }
+              : undefined
+          }
+          hasNewActivity={!isInOnboardingUnsigned ? (pendingActionsQuery.data?.actions?.length ?? 0) > 0 : false}
+          onMenuPress={
+            !isInOnboardingUnsigned
+              ? () => {
+                  setShowShareLaterTooltip(false);
+                  setActivityFocusTarget(null);
+                  setShowActivityMenu(true);
+                }
+              : undefined
+          }
+          onPress={() => setShowPartnerInfo(true)}
+          conversationTopic={topicFrame}
+          testID="session-chat-header"
+        />
+        {partnerInfoDrawer}
+        {/* Chat content - Share is now a separate route */}
+        {(
+        <View style={styles.content}>
+          <ChatInterface
           sessionId={sessionId}
           messages={displayMessages}
           indicators={indicators}
           onSendMessage={sendMessageWithTracking}
+          onInitialRenderReady={() => setHasCompletedInitialChatRender(true)}
           failedMessage={failedMessageContent}
           prefillText={stage4BrainstormPrefill}
           onPrefillConsumed={() => setStage4BrainstormPrefill(null)}
@@ -3785,14 +3799,22 @@ export function UnifiedSessionScreen({
           validationCards={validationCards}
           onValidateAccurate={handleValidationAccurate}
           onValidateNotQuite={handleValidationNotQuite}
-        />
+          />
 
-        {/* Waiting banner removed - now handled by the guided input panel renderer */}
+          {/* Waiting banner removed - now handled by the guided input panel renderer */}
 
-        {/* Note: Compact is now rendered via renderCustomEmptyState in ChatInterface */}
+          {/* Note: Compact is now rendered via renderCustomEmptyState in ChatInterface */}
 
-        {/* Inline cards and memory suggestion now rendered via renderBelowChat prop in ChatInterface */}
+          {/* Inline cards and memory suggestion now rendered via renderBelowChat prop in ChatInterface */}
+        </View>
+        )}
       </View>
+
+      {!hasCompletedInitialChatRender && (
+        <View style={styles.loadingOverlay} pointerEvents="auto">
+          <ActivityIndicator size="large" color={styles.accentColor.color} />
+          <Text style={styles.loadingText}>Loading session...</Text>
+        </View>
       )}
 
       {/* Overlays */}
@@ -4286,6 +4308,23 @@ const useStyles = () => {
     },
     content: {
       flex: 1,
+    },
+    initialSessionSurface: {
+      flex: 1,
+    },
+    initialSessionSurfaceHidden: {
+      opacity: 0,
+    },
+    loadingOverlay: {
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: palette.bg,
+      padding: 20,
     },
     centerContainer: {
       flex: 1,

--- a/shared/src/validation/__tests__/messages.test.ts
+++ b/shared/src/validation/__tests__/messages.test.ts
@@ -59,9 +59,16 @@ describe('getMessagesQuerySchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects limit over 100', () => {
+  it('accepts full session transcript limit', () => {
     const result = getMessagesQuerySchema.safeParse({
-      limit: 200,
+      limit: 500,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects limit over 500', () => {
+    const result = getMessagesQuerySchema.safeParse({
+      limit: 501,
     });
     expect(result.success).toBe(false);
   });

--- a/shared/src/validation/messages.ts
+++ b/shared/src/validation/messages.ts
@@ -22,7 +22,7 @@ export {
 // ============================================================================
 
 export const getMessagesQuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).max(100).default(25),
+  limit: z.coerce.number().int().min(1).max(500).default(25),
   before: z.string().optional(),
   after: z.string().optional(),
   /** Order by timestamp: 'asc' (oldest first) or 'desc' (newest first, for initial load) */


### PR DESCRIPTION
## Summary

Stabilizes session chat opening by avoiding progressive transcript assembly and first-load scroll jumps.

## What changed

- Load a practical full transcript page, up to 500 messages, through the consolidated session state and message history endpoints.
- Hydrate the mobile infinite-message cache from `/sessions/:id/state` so the chat does not start blank while a second message query resolves.
- Render already-loaded transcript rows in one initial pass and keep the loading overlay visible until the chat has completed its first layout and bottom-scroll pass.
- Prevent initial persisted messages from replaying as live animations on session open.
- Keep older-message pagination as a fallback, but block accidental top pagination until the user actually drags the transcript.

## Why

The non-inverted chat list could mount at the top, batch rows, trigger pagination, and reveal settled chat content in pieces. For typical MWF sessions, fetching the full practical transcript is simpler and gives a more stable first frame.

## Validation

- `npm run check --workspace @meet-without-fear/mobile`
- `npm run check --workspace @meet-without-fear/backend`
- `npm run check --workspace @meet-without-fear/shared`

Note: targeted Jest tests still do not execute locally because the existing test setup cannot resolve `react-test-renderer` from `@testing-library/react-native`.
