### PR TITLE
[codex] Polish chat chapter and composer UI

### DIFF
--- a/mobile/src/components/ChatIndicator.tsx
+++ b/mobile/src/components/ChatIndicator.tsx
@@ -5,22 +5,14 @@
  * Used for things like "Invitation Sent" markers.
  */
 
-import { View, Text, TouchableOpacity } from 'react-native';
+import { useEffect, useRef } from 'react';
+import { View, Text, TouchableOpacity, Animated, Easing } from 'react-native';
 import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
 
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/** Pick white or dark text based on background luminance. */
-function getContrastTextColor(hex: string): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance > 0.55 ? '#1a1815' : '#ffffff';
-}
 
 // ============================================================================
 // Semantic Color System
@@ -81,15 +73,49 @@ interface ChatIndicatorProps {
     /** Stage accent color for stage-chapter bar background */
     stageColor?: string;
   };
+  /** Slide stage chapter markers in when they first appear live. */
+  animateEntrance?: boolean;
+  onEntranceComplete?: () => void;
 }
+
+const STAGE_CHAPTER_ENTRANCE_DURATION_MS = 260;
+const STAGE_CHAPTER_ENTRANCE_OFFSET = 36;
 
 // ============================================================================
 // Component
 // ============================================================================
 
-export function ChatIndicator({ type, timestamp, testID, onPress, metadata }: ChatIndicatorProps) {
+export function ChatIndicator({
+  type,
+  timestamp,
+  testID,
+  onPress,
+  metadata,
+  animateEntrance = false,
+  onEntranceComplete,
+}: ChatIndicatorProps) {
   const styles = useStyles();
   const { palette } = useAppAppearance();
+  const entranceAnim = useRef(new Animated.Value(animateEntrance ? 0 : 1)).current;
+
+  useEffect(() => {
+    if (!animateEntrance) {
+      entranceAnim.setValue(1);
+      return;
+    }
+
+    entranceAnim.setValue(0);
+    Animated.timing(entranceAnim, {
+      toValue: 1,
+      duration: STAGE_CHAPTER_ENTRANCE_DURATION_MS,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      if (finished) {
+        onEntranceComplete?.();
+      }
+    });
+  }, [animateEntrance, entranceAnim, onEntranceComplete]);
 
   const semanticColors = {
     informational: { text: palette.accentText, line: palette.borderStrong },
@@ -250,20 +276,32 @@ export function ChatIndicator({ type, timestamp, testID, onPress, metadata }: Ch
     }
   };
 
-  // Special rendering for stage-chapter indicators — full-width colored bar
+  // Special rendering for stage-chapter indicators — full-width sticky section header
   if (type === 'stage-chapter') {
     const stageColor = metadata?.stageColor || semanticColors.informational.text;
-    const barTextColor = getContrastTextColor(stageColor);
 
     return (
-      <View
-        style={[styles.stageChapterBar, { backgroundColor: stageColor }]}
+      <Animated.View
+        style={[
+          styles.stageChapterBar,
+          {
+            borderTopColor: stageColor,
+            borderBottomColor: stageColor,
+            opacity: entranceAnim,
+            transform: [{
+              translateX: entranceAnim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [-STAGE_CHAPTER_ENTRANCE_OFFSET, 0],
+              }),
+            }],
+          },
+        ]}
         testID={testID || 'chat-indicator-stage-chapter'}
       >
-        <Text style={[styles.stageChapterText, { color: barTextColor }]}>
+        <Text style={[styles.stageChapterText, { color: stageColor }]}>
           {getIndicatorText()}
         </Text>
-      </View>
+      </Animated.View>
     );
   }
 
@@ -342,9 +380,12 @@ const useStyles = () => {
       fontSize: 16,
       fontWeight: '600',
     },
-    // Stage chapter bar — full-width colored bar at stage transitions
+    // Stage chapter bar — full-width sticky section header at stage transitions
     stageChapterBar: {
-      paddingVertical: 10,
+      backgroundColor: palette.bg,
+      borderTopWidth: 0.5,
+      borderBottomWidth: 0.5,
+      paddingVertical: 6,
       paddingHorizontal: 18,
     },
     stageChapterText: {

--- a/mobile/src/components/ChatInput.tsx
+++ b/mobile/src/components/ChatInput.tsx
@@ -25,6 +25,8 @@ interface ChatInputProps {
   prefillText?: string | null;
   /** Callback invoked once a prefill has been applied (so caller can clear). */
   onPrefillConsumed?: () => void;
+  /** Whether the software keyboard is currently visible. */
+  keyboardVisible?: boolean;
 }
 
 // ============================================================================
@@ -49,8 +51,9 @@ export function ChatInput({
   failedMessage,
   prefillText,
   onPrefillConsumed,
+  keyboardVisible = false,
 }: ChatInputProps) {
-  const styles = useStyles();
+  const styles = useStyles(keyboardVisible);
   const { palette } = useAppAppearance();
   const [input, setInput] = useState('');
   const inputRef = useRef<TextInputType>(null);
@@ -164,15 +167,15 @@ export function ChatInput({
 // Styles
 // ============================================================================
 
-const useStyles = () => {
+const useStyles = (keyboardVisible: boolean) => {
   const { palette } = useAppAppearance();
   return createStyles((t) => ({
     container: {
       flexDirection: 'row',
       alignItems: 'flex-end',
-      paddingHorizontal: 14,
-      paddingTop: 12,
-      paddingBottom: 18,
+      paddingHorizontal: t.spacing.lg,
+      paddingTop: t.spacing.md,
+      paddingBottom: keyboardVisible ? t.spacing.sm : t.spacing.xl,
       borderTopWidth: 1,
       borderTopColor: palette.border,
       backgroundColor: palette.bg,
@@ -187,8 +190,8 @@ const useStyles = () => {
     },
     input: {
       paddingHorizontal: t.spacing.lg,
-      paddingTop: 12,
-      paddingBottom: 12,
+      paddingTop: t.spacing.md,
+      paddingBottom: t.spacing.md,
       fontSize: 14,
       maxHeight: 140,
       color: palette.text,

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -7,6 +7,7 @@ import {
   Platform,
   ListRenderItem,
   ActivityIndicator,
+  LayoutAnimation,
   NativeSyntheticEvent,
   NativeScrollEvent,
   LayoutChangeEvent,
@@ -86,6 +87,23 @@ export interface ChatCustomCardItem {
 }
 
 export type ChatListItem = ChatMessage | ChatIndicatorItem | ChatValidationCardItem | ChatCustomCardItem | CustomEmptyStateItem;
+
+const AUXILIARY_CONTROLS_LAYOUT_ANIMATION_MS = 110;
+
+const auxiliaryControlsLayoutAnimation = {
+  duration: AUXILIARY_CONTROLS_LAYOUT_ANIMATION_MS,
+  create: {
+    type: LayoutAnimation.Types.easeInEaseOut,
+    property: LayoutAnimation.Properties.opacity,
+  },
+  update: {
+    type: LayoutAnimation.Types.easeInEaseOut,
+  },
+  delete: {
+    type: LayoutAnimation.Types.easeInEaseOut,
+    property: LayoutAnimation.Properties.opacity,
+  },
+};
 
 function isIndicator(item: ChatListItem): item is ChatIndicatorItem {
   return 'type' in item && item.type === 'indicator';
@@ -279,6 +297,8 @@ export function ChatInterface({
   const styles = useStyles();
   const safeAreaInsets = useSafeAreaInsets();
   const flatListRef = useRef<FlatList<ChatListItem>>(null);
+  const flatListContainerRef = useRef<View>(null);
+  const composerContainerRef = useRef<View>(null);
   const scrollMetricsRef = useRef({
     offset: 0,
     contentHeight: 0,
@@ -299,6 +319,9 @@ export function ChatInterface({
   const animationScopeRef = useRef(animationScope);
   const seenAnimatedItemIdsRef = useRef(getSeenAnimatedItemIds(animationScope));
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+  const [composerHeight, setComposerHeight] = useState(0);
+  const [messageListBottomInset, setMessageListBottomInset] = useState(0);
+  const [auxiliaryControlsVisible, setAuxiliaryControlsVisible] = useState(true);
 
   if (animationScopeRef.current !== animationScope) {
     animationScopeRef.current = animationScope;
@@ -368,20 +391,32 @@ export function ChatInterface({
   useEffect(() => {
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    const shownEvent = 'keyboardDidShow';
+    const hiddenEvent = 'keyboardDidHide';
 
     const showSub = Keyboard.addListener(showEvent, () => {
+      LayoutAnimation.configureNext(auxiliaryControlsLayoutAnimation);
+      setAuxiliaryControlsVisible(false);
       setIsKeyboardVisible(true);
       if (isNearBottomRef.current || shouldStickToBottomRef.current) {
         scrollToBottom(false);
       }
     });
     const hideSub = Keyboard.addListener(hideEvent, () => {
+      setMessageListBottomInset(0);
       setIsKeyboardVisible(false);
+    });
+    const shownSub = Keyboard.addListener(shownEvent, () => {});
+    const hiddenSub = Keyboard.addListener(hiddenEvent, () => {
+      LayoutAnimation.configureNext(auxiliaryControlsLayoutAnimation);
+      setAuxiliaryControlsVisible(true);
     });
 
     return () => {
       showSub.remove();
       hideSub.remove();
+      shownSub.remove();
+      hiddenSub.remove();
     };
   }, [scrollToBottom]);
 
@@ -587,9 +622,9 @@ export function ChatInterface({
   if (isInitialLoadRef.current && messages.length > 0) {
     const shouldSkip = skipInitialHistory && messages.length === 1;
     if (!shouldSkip) {
-      messages.forEach((m) => {
-        mountSnapshotIdsRef.current.add(m.id);
-        seenAnimatedItemIdsRef.current.add(m.id);
+      listItems.forEach((item) => {
+        mountSnapshotIdsRef.current.add(item.id);
+        seenAnimatedItemIdsRef.current.add(item.id);
       });
     }
     isInitialLoadRef.current = false;
@@ -797,10 +832,21 @@ export function ChatInterface({
     }
   }, [animatingItemId, onTypewriterStateChange, scrollToBottom]);
 
-  const renderItem: ListRenderItem<ChatListItem> = useCallback(({ item }) => {
+  const renderItem: ListRenderItem<ChatListItem> = useCallback(({ item, index }) => {
+    const nextItem = listItems[index + 1];
+    const shouldPadBeforeChapter =
+      nextItem !== undefined &&
+      isIndicator(nextItem) &&
+      nextItem.indicatorType === 'stage-chapter';
+    const withChapterLeadIn = (content: React.ReactElement) => (
+      shouldPadBeforeChapter
+        ? <View style={styles.beforeChapterLeadIn}>{content}</View>
+        : content
+    );
+
     // 1. Render Custom Empty State (Compact)
     if (isCustomEmptyState(item)) {
-      return (
+      return withChapterLeadIn(
         <View style={styles.customEmptyStateItem} testID="chat-custom-empty-state-item">
           {customEmptyState}
         </View>
@@ -809,25 +855,38 @@ export function ChatInterface({
 
     // 2. Render Indicators
     if (isIndicator(item)) {
+      const itemIndex = listItems.findIndex((listItem) => listItem.id === item.id);
+      const animationIdentity = getAnimationIdentity(item.id);
+      const shouldAnimateStageChapter =
+        item.indicatorType === 'stage-chapter' &&
+        itemIndex >= 0 &&
+        !isAtOrBeforeSeenBoundary(item, itemIndex) &&
+        !animatedItemIdsRef.current.has(item.id) &&
+        !animatedItemIdsRef.current.has(animationIdentity) &&
+        !seenAnimatedItemIdsRef.current.has(item.id) &&
+        !seenAnimatedItemIdsRef.current.has(animationIdentity);
+
       // Shared content and share suggestion indicators are tappable to open the Activity Drawer
       const isTappableIndicator = item.indicatorType === 'context-shared'
         || item.indicatorType === 'empathy-shared';
       const onPress = isTappableIndicator && onContextSharedPress
         ? () => onContextSharedPress(item.timestamp, item.metadata?.isFromMe, item.indicatorType)
         : undefined;
-      return (
+      return withChapterLeadIn(
         <ChatIndicator
           type={item.indicatorType}
           timestamp={item.timestamp}
           onPress={onPress}
           metadata={item.metadata}
+          animateEntrance={shouldAnimateStageChapter}
+          onEntranceComplete={shouldAnimateStageChapter ? () => markItemAnimationSeen(item.id) : undefined}
         />
       );
     }
 
     // 3. Render Validation Cards
     if (isValidationCard(item)) {
-      return (
+      return withChapterLeadIn(
         <EmpathyValidationCard
           partnerName={item.partnerName}
           empathyContent={item.empathyContent}
@@ -847,7 +906,7 @@ export function ChatInterface({
       const animationIdentity = getAnimationIdentity(item.id);
       const isNextAnimatable = animationIdentity === nextAnimatableMessageId;
 
-      return (
+      return withChapterLeadIn(
         <>
           {item.render({
             skipAnimation: !shouldAnimate || !isNextAnimatable,
@@ -887,7 +946,7 @@ export function ChatInterface({
       sharedContentDirection: message.sharedContentDirection,
     };
 
-    return (
+    return withChapterLeadIn(
       <>
         <ChatBubble
           message={bubbleMessage}
@@ -1026,6 +1085,60 @@ export function ChatInterface({
     }
   }, [scrollToBottom]);
 
+  const updateMessageListBottomInset = useCallback(() => {
+    if (!isKeyboardVisible) {
+      setMessageListBottomInset(0);
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      flatListContainerRef.current?.measureInWindow((_listX, listY, _listWidth, listHeight) => {
+        composerContainerRef.current?.measureInWindow((_composerX, composerY) => {
+          const listBottom = listY + listHeight;
+          const nextInset = Math.max(0, Math.ceil(listBottom - composerY));
+
+          setMessageListBottomInset((currentInset) => (
+            Math.abs(currentInset - nextInset) > 1 ? nextInset : currentInset
+          ));
+        });
+      });
+    });
+  }, [isKeyboardVisible]);
+
+  const handleComposerLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = event.nativeEvent.layout.height;
+    setComposerHeight((currentHeight) => (
+      Math.abs(currentHeight - nextHeight) > 1 ? nextHeight : currentHeight
+    ));
+  }, []);
+
+  useEffect(() => {
+    updateMessageListBottomInset();
+
+    if (!isKeyboardVisible) {
+      return;
+    }
+
+    const timeoutIds = [
+      setTimeout(updateMessageListBottomInset, 80),
+      setTimeout(updateMessageListBottomInset, 180),
+      setTimeout(updateMessageListBottomInset, 320),
+    ];
+
+    return () => timeoutIds.forEach(clearTimeout);
+  }, [
+    auxiliaryControlsVisible,
+    composerHeight,
+    isKeyboardVisible,
+    updateMessageListBottomInset,
+  ]);
+
+  useEffect(() => {
+    if (isKeyboardVisible) return;
+
+    setAuxiliaryControlsVisible(Boolean(renderAboveInput || renderBelowInput));
+  }, [isKeyboardVisible, renderAboveInput, renderBelowInput]);
+
   const handleEndReached = useCallback(() => {
     if (!initialBottomScrollCompleteRef.current || !userHasDraggedTranscriptRef.current) {
       return;
@@ -1085,15 +1198,24 @@ export function ChatInterface({
   // New Activity Pill: floating indicator for off-screen new items
   // ---------------------------------------------------------------------------
 
-  const auxiliaryControls = !isKeyboardVisible ? (
-    <>
-      {renderAboveInput?.()}
-      {renderBelowInput?.()}
-    </>
+  const hasAuxiliaryControls = Boolean(renderAboveInput || renderBelowInput);
+  const auxiliaryControls = hasAuxiliaryControls && auxiliaryControlsVisible ? (
+    <View style={styles.auxiliaryControls}>
+        {renderAboveInput?.()}
+        {renderBelowInput?.()}
+    </View>
   ) : null;
 
+  const keyboardOpenMessageListInset = isKeyboardVisible && messageListBottomInset > 0
+    ? { paddingBottom: messageListBottomInset }
+    : null;
+
   const composerControls = (
-    <View style={styles.bottomContainer}>
+    <View
+      ref={composerContainerRef}
+      style={[styles.bottomContainer, isKeyboardVisible && styles.bottomContainerKeyboardOpen]}
+      onLayout={handleComposerLayout}
+    >
       {showEmotionSlider && onEmotionChange && (
         <EmotionSlider
           value={emotionValue}
@@ -1108,12 +1230,14 @@ export function ChatInterface({
           onSend={onSendMessage}
           disabled={disabled || isInputDisabled || isLoading}
           inputDisabled={disabled || isLoading}
+          keyboardVisible={isKeyboardVisible}
           onVoicePress={onVoicePress}
           failedMessage={failedMessage}
           prefillText={prefillText}
           onPrefillConsumed={onPrefillConsumed}
         />
       )}
+      {auxiliaryControls}
     </View>
   );
 
@@ -1127,6 +1251,7 @@ export function ChatInterface({
       stickyHeaderIndices={stickyHeaderIndices}
       contentContainerStyle={[
         styles.messageList,
+        keyboardOpenMessageListInset,
         listItems.length === 0 && (customEmptyState ? styles.customMessageListEmpty : styles.messageListEmpty),
       ]}
       ListHeaderComponent={renderLoadingHeader}
@@ -1158,13 +1283,12 @@ export function ChatInterface({
   if (Platform.OS === 'ios' && hasLinkedKeyboardController()) {
     return (
       <View style={styles.container}>
-        <View style={styles.flatListContainer}>
+        <View ref={flatListContainerRef} style={styles.flatListContainer}>
           {messageList}
         </View>
         <KeyboardStickyComposer offset={{ opened: safeAreaInsets.bottom }}>
           {composerControls}
         </KeyboardStickyComposer>
-        {auxiliaryControls}
       </View>
     );
   }
@@ -1175,9 +1299,10 @@ export function ChatInterface({
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       keyboardVerticalOffset={keyboardVerticalOffset}
     >
-      {messageList}
+      <View ref={flatListContainerRef} style={styles.flatListContainer}>
+        {messageList}
+      </View>
       {composerControls}
-      {auxiliaryControls}
     </KeyboardAwareAvoidingView>
   );
 }
@@ -1228,6 +1353,9 @@ const useStyles = () => {
       paddingTop: t.spacing.md,
       paddingBottom: t.spacing.md,
     },
+    beforeChapterLeadIn: {
+      paddingBottom: t.spacing.xl,
+    },
     loadingSpinner: {
       color: palette.textMuted,
     },
@@ -1258,10 +1386,16 @@ const useStyles = () => {
       fontFamily: designFonts.sans,
     },
     bottomContainer: {
-      // Container for emotion slider, panels above input, and input
+      // Container for the keyboard-sticky composer stack.
       // This ensures KeyboardAvoidingView adjusts relative to this container's bottom
       // rather than just the input field itself
       paddingBottom: t.spacing.sm,
+    },
+    bottomContainerKeyboardOpen: {
+      paddingBottom: 0,
+    },
+    auxiliaryControls: {
+      overflow: 'hidden',
     },
   }));
 };

--- a/mobile/src/components/GuidedActionPanel.tsx
+++ b/mobile/src/components/GuidedActionPanel.tsx
@@ -13,9 +13,16 @@ import {
   Pencil,
   Target,
 } from 'lucide-react-native';
-import { colors, designFonts, useAppAppearance } from '@/theme';
+import { colors, designFonts, radius, spacing, typography, useAppAppearance } from '@/theme';
 
 type GuidedActionTone = 'topic' | 'review' | 'share' | 'success' | 'needs';
+
+const PANEL_BORDER_ACCENT_WIDTH = 3;
+const PANEL_ICON_SIZE = 17;
+const PANEL_ICON_STROKE_WIDTH = 2.4;
+const PANEL_BUTTON_MIN_HEIGHT = spacing['3xl'] + spacing.sm;
+const PANEL_ICON_TOP_ALIGNMENT_OFFSET = 1;
+const PANEL_EYEBROW_LETTER_SPACING = 0.8;
 
 interface GuidedActionButton {
   label: string;
@@ -37,7 +44,7 @@ export interface GuidedActionPanelProps {
 }
 
 function ToneIcon({ tone, color }: { tone: GuidedActionTone; color: string }) {
-  const iconProps = { color, size: 17, strokeWidth: 2.4 };
+  const iconProps = { color, size: PANEL_ICON_SIZE, strokeWidth: PANEL_ICON_STROKE_WIDTH };
   switch (tone) {
     case 'topic':
       return <Target {...iconProps} />;
@@ -130,24 +137,24 @@ export function GuidedActionPanel({
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    gap: 10,
-    paddingHorizontal: 14,
-    paddingVertical: 13,
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
     backgroundColor: colors.bgPrimary,
     borderTopWidth: 1,
     borderTopColor: colors.border,
-    borderLeftWidth: 3,
+    borderLeftWidth: PANEL_BORDER_ACCENT_WIDTH,
   },
   containerCompact: {
-    paddingVertical: 10,
+    paddingVertical: spacing.sm,
   },
   iconWrap: {
-    paddingTop: 1,
+    paddingTop: PANEL_ICON_TOP_ALIGNMENT_OFFSET,
   },
   icon: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
+    width: spacing['3xl'],
+    height: spacing['3xl'],
+    borderRadius: radius.full,
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: colors.userBg,
@@ -157,43 +164,43 @@ const styles = StyleSheet.create({
     minWidth: 0,
   },
   eyebrow: {
-    fontSize: 11,
+    fontSize: typography.fontSize.xs,
     fontWeight: '800',
     textTransform: 'uppercase',
-    letterSpacing: 0.8,
-    marginBottom: 3,
+    letterSpacing: PANEL_EYEBROW_LETTER_SPACING,
+    marginBottom: spacing.xs,
     fontFamily: designFonts.mono,
   },
   title: {
-    fontSize: 15,
+    fontSize: typography.fontSize.md,
     fontWeight: '700',
-    lineHeight: 20,
+    lineHeight: spacing.xl,
     color: colors.textPrimary,
     fontFamily: designFonts.sans,
   },
   subtitle: {
-    marginTop: 4,
-    fontSize: 13,
-    lineHeight: 18,
+    marginTop: spacing.xs,
+    fontSize: typography.fontSize.base,
+    lineHeight: spacing.xl,
     color: colors.textSecondary,
     fontFamily: designFonts.sans,
   },
   actions: {
     flexDirection: 'row',
-    gap: 8,
-    marginTop: 10,
+    gap: spacing.sm,
+    marginTop: spacing.md,
   },
   actionsSingle: {
     justifyContent: 'flex-end',
   },
   button: {
     flex: 1,
-    minHeight: 38,
-    borderRadius: 10,
+    minHeight: PANEL_BUTTON_MIN_HEIGHT,
+    borderRadius: radius.md,
     borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingHorizontal: 12,
+    paddingHorizontal: spacing.md,
   },
   primaryButton: {},
   secondaryButton: {
@@ -204,7 +211,7 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   buttonText: {
-    fontSize: 14,
+    fontSize: typography.fontSize.base,
     fontWeight: '700',
     fontFamily: designFonts.sans,
   },

--- a/mobile/src/components/WaitingBanner.tsx
+++ b/mobile/src/components/WaitingBanner.tsx
@@ -11,6 +11,12 @@ import type { WaitingStatusState } from '../utils/getWaitingStatus';
 import { getWaitingStatusConfig } from '../config/waitingStatusConfig';
 import { designFonts, useAppAppearance } from '../theme';
 
+const WAITING_BANNER_EXPANDED_MAX_HEIGHT = 150;
+const WAITING_BANNER_ENTER_OFFSET = 20;
+const WAITING_BANNER_TEXT_LINE_HEIGHT = 22;
+const WAITING_BANNER_SUBTEXT_LINE_HEIGHT = 18;
+const WAITING_BANNER_ACTION_MIN_HEIGHT = 44;
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -62,12 +68,12 @@ export function WaitingBanner({
           opacity: animationValue,
           maxHeight: animationValue.interpolate({
             inputRange: [0, 1],
-            outputRange: [0, 150],
+            outputRange: [0, WAITING_BANNER_EXPANDED_MAX_HEIGHT],
           }),
           transform: [{
             translateY: animationValue.interpolate({
               inputRange: [0, 1],
-              outputRange: [20, 0],
+              outputRange: [WAITING_BANNER_ENTER_OFFSET, 0],
             }),
           }],
           overflow: 'hidden' as const,
@@ -159,22 +165,22 @@ const useStyles = () =>
     },
     text: {
       fontSize: t.typography.fontSize.md,
-      lineHeight: 22,
+      lineHeight: WAITING_BANNER_TEXT_LINE_HEIGHT,
       color: palette.textMuted,
       textAlign: 'center',
       fontFamily: designFonts.sans,
     },
     subtext: {
-      fontSize: 12,
-      lineHeight: 18,
+      fontSize: t.typography.fontSize.sm,
+      lineHeight: WAITING_BANNER_SUBTEXT_LINE_HEIGHT,
       color: palette.textFaint,
       textAlign: 'center',
-      marginTop: 2,
+      marginTop: t.spacing.xs,
       fontFamily: designFonts.sans,
     },
     exerciseLink: {
       marginTop: t.spacing.sm,
-      minHeight: 44,
+      minHeight: WAITING_BANNER_ACTION_MIN_HEIGHT,
       justifyContent: 'center',
     },
     exerciseLinkText: {
@@ -185,9 +191,9 @@ const useStyles = () =>
     },
     actionButton: {
       marginTop: t.spacing.sm,
-      minHeight: 44,
+      minHeight: WAITING_BANNER_ACTION_MIN_HEIGHT,
       paddingHorizontal: t.spacing.lg,
-      borderRadius: 12,
+      borderRadius: t.radius.md,
       backgroundColor: palette.accent,
       alignItems: 'center',
       justifyContent: 'center',

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -130,6 +130,9 @@ interface UnifiedSessionScreenProps {
   onStageComplete?: (stage: Stage) => void;
 }
 
+const NEEDS_REVIEW_PANEL_EXPANDED_MAX_HEIGHT = 420;
+const NEEDS_REVIEW_PANEL_ENTER_OFFSET = 20;
+
 /**
  * Get brief status text for the header based on session status
  * @param status - The session status
@@ -224,6 +227,7 @@ function deriveChapterMarkers(
 
     switch (stage) {
       case Stage.WITNESS:
+        return fallbackTimestamp;
       case Stage.PERSPECTIVE_STRETCH:
         return anchorTimestamp || undefined;
       default:
@@ -2299,12 +2303,10 @@ export function UnifiedSessionScreen({
     }
 
     // --- Stage chapter markers ---
-    // Chapter bars should appear at the milestone that opens the chapter, not
-    // wherever the first message in that stage happens to sort.
+    // Chapter bars usually appear at the milestone that opens the chapter.
+    // Witness is the exception: invitees first see the topic intro card, so
+    // its chapter marker is anchored to the first Witness prompt instead.
     const chapterIndicators = deriveChapterMarkers(messages, {
-      [Stage.WITNESS]: isInviter
-        ? invitationMessageConfirmedAt
-        : invitationAcceptedAt,
       [Stage.PERSPECTIVE_STRETCH]: milestones?.feelHeardConfirmedAt,
     });
     allIndicators.push(...chapterIndicators);
@@ -3260,9 +3262,8 @@ export function UnifiedSessionScreen({
           return (
             <GuidedActionPanel
               tone="review"
-              eyebrow="What comes next"
               title={title}
-              subtitle={subtitle}
+              compact
               primaryAction={{
                 label,
                 onPress: () => setShowStage4Drawer(true),
@@ -3337,12 +3338,12 @@ export function UnifiedSessionScreen({
             opacity: needsReviewAnim,
             maxHeight: needsReviewAnim.interpolate({
               inputRange: [0, 1],
-              outputRange: [0, 420],
+              outputRange: [0, NEEDS_REVIEW_PANEL_EXPANDED_MAX_HEIGHT],
             }),
             transform: [{
               translateY: needsReviewAnim.interpolate({
                 inputRange: [0, 1],
-                outputRange: [20, 0],
+                outputRange: [NEEDS_REVIEW_PANEL_ENTER_OFFSET, 0],
               }),
             }],
             overflow: 'hidden',


### PR DESCRIPTION
## Summary
- Restyle sticky stage chapter headers with chat-background strips, thin stage-colored borders, and one-time slide-in entrance for new chapter markers.
- Re-anchor the invitee "Your Story" chapter marker to the first Witness prompt and add pre-chapter spacing without affecting sticky positioning.
- Consolidate chat bottom chrome so CTA panels, emotion slider, input, and scroll inset use the same measured composer stack.
- Compact the Stage 4 proposals CTA and convert shared CTA/waiting panel spacing to theme tokens or named constants.

## Validation
- npm run check (mobile)
