### PR TITLE
[codex] Fix Your Story chapter marker anchor

### DIFF
--- a/backend/src/controllers/session-state.ts
+++ b/backend/src/controllers/session-state.ts
@@ -289,6 +289,7 @@ export async function getSessionState(req: Request, res: Response): Promise<void
       feelHeardConfirmedAt?: string;
     } | null;
     const milestones = {
+      witnessStartedAt: myStage1Record?.startedAt?.toISOString() ?? null,
       feelHeardConfirmedAt: stage1Gates?.feelHeardConfirmedAt ?? null,
     };
 

--- a/backend/src/controllers/sessions.ts
+++ b/backend/src/controllers/sessions.ts
@@ -377,6 +377,7 @@ export async function getProgress(req: Request, res: Response): Promise<void> {
     } | null;
 
     const milestones = {
+      witnessStartedAt: myStage1Record?.startedAt?.toISOString() ?? null,
       feelHeardConfirmedAt: stage1Gates?.feelHeardConfirmedAt ?? null,
       needsIdentifiedAt: stage3Gates?.needsIdentifiedAt ?? null,
       commonGroundFoundAt: stage3Gates?.commonGroundFoundAt ?? null,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -216,7 +216,7 @@ const SUPPRESSED_CHAPTER_STAGES = new Set([Stage.ONBOARDING, Stage.INFORMED_EMPA
  * Derive chapter marker indicators from message stage transitions.
  * Inserts a chapter indicator at the first message of each new stage.
  */
-function deriveChapterMarkers(
+export function deriveChapterMarkers(
   messages: ChatMessage[],
   anchors?: Partial<Record<Stage, string | null | undefined>>,
 ): ChatIndicatorItem[] {
@@ -227,7 +227,7 @@ function deriveChapterMarkers(
 
     switch (stage) {
       case Stage.WITNESS:
-        return fallbackTimestamp;
+        return anchorTimestamp || fallbackTimestamp;
       case Stage.PERSPECTIVE_STRETCH:
         return anchorTimestamp || undefined;
       default:
@@ -2236,6 +2236,7 @@ export function UnifiedSessionScreen({
         acceptedAt: invitationAcceptedAt,
       } : undefined,
       milestones: {
+        witnessStartedAt: milestones?.witnessStartedAt ?? null,
         // Use ref as backup to prevent flickering during mutation
         feelHeardConfirmedAt: milestones?.feelHeardConfirmedAt ??
           (hasEverConfirmedFeelHeard.current || isConfirmingFeelHeard ? new Date().toISOString() : null),
@@ -2305,14 +2306,15 @@ export function UnifiedSessionScreen({
     // --- Stage chapter markers ---
     // Chapter bars usually appear at the milestone that opens the chapter.
     // Witness is the exception: invitees first see the topic intro card, so
-    // its chapter marker is anchored to the first Witness prompt instead.
+    // its chapter marker is anchored to the canonical Witness stage start.
     const chapterIndicators = deriveChapterMarkers(messages, {
+      [Stage.WITNESS]: milestones?.witnessStartedAt,
       [Stage.PERSPECTIVE_STRETCH]: milestones?.feelHeardConfirmedAt,
     });
     allIndicators.push(...chapterIndicators);
 
     return allIndicators;
-  }, [isInviter, session?.status, invitationMessageConfirmedAt, invitationAcceptedAt, milestones?.feelHeardConfirmedAt, isConfirmingFeelHeard, messages, user?.id, partnerName, empathyStatusData?.mySharedAt, empathyStatusData?.myAttempt?.status, empathyStatusData?.myAttempt?.revealedAt, shareOfferData?.hasSuggestion, shareOfferData?.suggestion, myProgress?.stage]);
+  }, [isInviter, session?.status, invitationMessageConfirmedAt, invitationAcceptedAt, milestones?.witnessStartedAt, milestones?.feelHeardConfirmedAt, isConfirmingFeelHeard, messages, user?.id, partnerName, empathyStatusData?.mySharedAt, empathyStatusData?.myAttempt?.status, empathyStatusData?.myAttempt?.revealedAt, shareOfferData?.hasSuggestion, shareOfferData?.suggestion, myProgress?.stage]);
 
 
 

--- a/mobile/src/screens/__tests__/NeedsIdentifiedChatCard.test.tsx
+++ b/mobile/src/screens/__tests__/NeedsIdentifiedChatCard.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import {
+  deriveChapterMarkers,
   getEmpathyValidationCardStatus,
   getNeedsDrawerModeForNeedsStatus,
   isLocalEmpathyValidationCurrent,
   NeedsIdentifiedChatCard,
 } from '../UnifiedSessionScreen';
+import { Stage } from '@meet-without-fear/shared';
 
 jest.mock('../../lib/api', () => ({
   ApiClientError: class ApiClientError extends Error {},
@@ -69,5 +71,39 @@ describe('NeedsIdentifiedChatCard', () => {
       { attemptId: 'attempt-1', revisionCount: 1, statusVersion: 4 },
       { id: 'attempt-1', revisionCount: 2, statusVersion: 5 }
     )).toBe(false);
+  });
+});
+
+describe('deriveChapterMarkers', () => {
+  it('anchors Your Story to the Witness stage start when the opening prompt is stored as onboarding', () => {
+    const messages: Parameters<typeof deriveChapterMarkers>[0] = [
+      {
+        id: 'opening-prompt',
+        role: 'AI',
+        content: "I'd like to hear your side now.",
+        timestamp: '2026-05-14T04:51:59.395Z',
+        stage: Stage.ONBOARDING,
+      },
+      {
+        id: 'first-witness-response',
+        role: 'USER',
+        content: 'I actually think the work has been going pretty well.',
+        timestamp: '2026-05-14T04:53:43.402Z',
+        stage: Stage.WITNESS,
+      },
+    ];
+
+    const markers = deriveChapterMarkers(
+      messages,
+      { [Stage.WITNESS]: '2026-05-14T04:51:56.139Z' }
+    );
+
+    expect(markers).toEqual([
+      expect.objectContaining({
+        id: 'stage-chapter-1',
+        timestamp: '2026-05-14T04:51:56.139Z',
+        metadata: expect.objectContaining({ stageName: 'Your Story' }),
+      }),
+    ]);
   });
 });

--- a/mobile/src/utils/chatListSelector.ts
+++ b/mobile/src/utils/chatListSelector.ts
@@ -83,6 +83,8 @@ export interface SessionIndicatorData {
 
   /** Milestones data from cache */
   milestones?: {
+    /** When current user started Stage 1 / Witness */
+    witnessStartedAt?: string | null;
     /** When user confirmed they feel heard (Stage 1 completion) */
     feelHeardConfirmedAt?: string | null;
     /** When needs were identified (Stage 3) */

--- a/shared/src/dto/session-state.ts
+++ b/shared/src/dto/session-state.ts
@@ -76,6 +76,7 @@ export interface SessionStateResponse {
     };
     canAdvance: boolean;
     milestones: {
+      witnessStartedAt: string | null;
       feelHeardConfirmedAt: string | null;
     };
   };

--- a/shared/src/dto/stage.ts
+++ b/shared/src/dto/stage.ts
@@ -107,6 +107,7 @@ export enum StageBlockedReason {
 
 /** Milestone timestamps that persist across stage transitions */
 export interface SessionMilestonesDTO {
+  witnessStartedAt: string | null;
   feelHeardConfirmedAt: string | null;
 }
 


### PR DESCRIPTION
## Summary
- expose the user's Witness stage start timestamp in progress/session-state milestones
- anchor the Your Story chapter marker to that canonical Witness start instead of the first stage=1 message
- add a regression case matching the production session where the opening Witness prompt was stored as onboarding

## Production check
- Session cmp4zyw9l000djo1yp1owc8gx has the opening prompt stored as stage=0 at 2026-05-14T04:51:59.395Z and the first user Witness message stored as stage=1 at 2026-05-14T04:53:43.402Z.
- The user's Stage 1 progress startedAt is 2026-05-14T04:51:56.139Z, which is the correct marker anchor before the opening Witness prompt.

## Validation
- npm run check --workspace=backend
- npm run check --workspace=shared
- npm run check --workspace=mobile
- npm run lint --workspace=mobile (warnings only)

## Not run / blocked
- npm test --workspace=mobile -- NeedsIdentifiedChatCard.test.tsx --runInBand is blocked locally because @testing-library/react-native cannot resolve react-test-renderer before tests execute.
- npm run lint --workspace=backend fails on existing repo-wide lint configuration/errors unrelated to this change.