### PR TITLE
Refine compact guided CTAs

### DIFF
--- a/mobile/app/(auth)/design-system.tsx
+++ b/mobile/app/(auth)/design-system.tsx
@@ -416,16 +416,25 @@ function CtaSection({
       <View style={styles.ctaStack}>
         <GuidedActionPanel
           tone="review"
+          eyebrow="Empathy draft"
+          title="Ready to review"
+          compact
+          pressable
+          primaryAction={{ label: 'Review what you’ll share', onPress: () => {} }}
+        />
+        <GuidedActionPanel
+          tone="review"
           eyebrow="Revision"
-          title="Revisit what you’ll share"
-          subtitle="Sam shared more context. Check whether your understanding should change."
-          primaryAction={{ label: 'Review', onPress: () => {} }}
+          title="Review the update"
+          compact
+          pressable
+          primaryAction={{ label: 'Review revision', onPress: () => {} }}
         />
         <GuidedActionPanel
           tone="topic"
           eyebrow="Topic frame"
           title="Household chores and feeling unseen"
-          subtitle="This stays above the input until you confirm it."
+          compact
           primaryAction={{ label: 'Use this topic', onPress: () => {} }}
         />
         <ShareTopicPanel
@@ -434,7 +443,7 @@ function CtaSection({
           partnerName="Sam"
           onPress={onOpenShareDrawer}
         />
-        <FeelHeardConfirmation onConfirm={() => {}} onContinue={() => {}} />
+        <FeelHeardConfirmation onConfirm={() => {}} />
         <CompactAgreementBar onSign={() => {}} buttonLabel="Ready" />
         <GuidedActionPanel
           tone="needs"

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -396,7 +396,7 @@ export function ChatInterface({
 
     const showSub = Keyboard.addListener(showEvent, () => {
       LayoutAnimation.configureNext(auxiliaryControlsLayoutAnimation);
-      setAuxiliaryControlsVisible(false);
+      setAuxiliaryControlsVisible(true);
       setIsKeyboardVisible(true);
       if (isNearBottomRef.current || shouldStickToBottomRef.current) {
         scrollToBottom(false);

--- a/mobile/src/components/FeelHeardConfirmation.tsx
+++ b/mobile/src/components/FeelHeardConfirmation.tsx
@@ -13,7 +13,6 @@ import { GuidedActionPanel } from './GuidedActionPanel';
 
 interface FeelHeardConfirmationProps {
   onConfirm: () => void;
-  onContinue?: () => void;
   isPending?: boolean;
 }
 
@@ -23,19 +22,13 @@ interface FeelHeardConfirmationProps {
 
 export function FeelHeardConfirmation({
   onConfirm,
-  onContinue,
   isPending = false,
 }: FeelHeardConfirmationProps) {
   return (
     <GuidedActionPanel
       tone="success"
-      title="Do you feel heard enough to continue?"
-      secondaryAction={onContinue ? {
-        label: 'Not yet',
-        onPress: onContinue,
-        disabled: isPending,
-        testID: 'feel-heard-not-yet',
-      } : undefined}
+      title="Feel heard enough to continue?"
+      compact
       primaryAction={{
         label: 'I feel heard',
         onPress: onConfirm,

--- a/mobile/src/components/GuidedActionPanel.tsx
+++ b/mobile/src/components/GuidedActionPanel.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   ActivityIndicator,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
+  type ViewStyle,
 } from 'react-native';
 import {
   Check,
@@ -40,6 +41,7 @@ export interface GuidedActionPanelProps {
   primaryAction?: GuidedActionButton;
   secondaryAction?: GuidedActionButton;
   compact?: boolean;
+  pressable?: boolean;
   testID?: string;
 }
 
@@ -61,6 +63,10 @@ function ToneIcon({ tone, color }: { tone: GuidedActionTone; color: string }) {
   }
 }
 
+function getCompactButtonWidth(label: string): number {
+  return Math.min(190, Math.max(76, label.length * 7 + 28));
+}
+
 export function GuidedActionPanel({
   tone,
   eyebrow,
@@ -69,34 +75,49 @@ export function GuidedActionPanel({
   primaryAction,
   secondaryAction,
   compact = false,
+  pressable = false,
   testID,
 }: GuidedActionPanelProps) {
   const { palette } = useAppAppearance();
   const accent = tone === 'success' ? palette.success : palette.accent;
   const actions = [secondaryAction, primaryAction].filter(Boolean) as GuidedActionButton[];
+  const [panelWidth, setPanelWidth] = useState(0);
+  const showPressableRow = pressable && !!primaryAction && !secondaryAction;
+  const centerSingleLinePressable = showPressableRow && compact && !eyebrow && !subtitle;
+  const compactInlineActions = !showPressableRow && compact && actions.length > 0 && panelWidth >= 390;
+  const containerStyle: ViewStyle[] = [
+    styles.container,
+    ...(compact ? [styles.containerCompact] : []),
+    { borderLeftColor: accent, backgroundColor: palette.bg, borderTopColor: palette.border },
+  ];
 
-  return (
-    <View
-      style={[
-        styles.container,
-        compact && styles.containerCompact,
-        { borderLeftColor: accent, backgroundColor: palette.bg, borderTopColor: palette.border },
-      ]}
-      testID={testID}
-    >
-      <View style={styles.iconWrap}>
-        <View style={[styles.icon, { backgroundColor: palette.chipBg }]}>
+  const content = (
+    <>
+      <View style={[styles.iconWrap, centerSingleLinePressable && styles.iconWrapCentered]}>
+        <View style={[styles.icon, compact && styles.iconCompact, { backgroundColor: palette.chipBg }]}>
           <ToneIcon tone={tone} color={accent} />
         </View>
       </View>
-      <View style={styles.body}>
-        {eyebrow ? (
-          <Text style={[styles.eyebrow, { color: accent }]}>{eyebrow}</Text>
-        ) : null}
-        <Text style={[styles.title, { color: palette.text }]}>{title}</Text>
-        {subtitle ? <Text style={[styles.subtitle, { color: palette.textMuted }]}>{subtitle}</Text> : null}
-        {actions.length > 0 ? (
-          <View style={[styles.actions, actions.length === 1 && styles.actionsSingle]}>
+      <View style={[
+        styles.body,
+        compactInlineActions && styles.bodyCompactWithAction,
+        centerSingleLinePressable && styles.bodySingleLinePressable,
+      ]}>
+        <View style={styles.textBlock}>
+          {eyebrow ? (
+            <Text style={[styles.eyebrow, compact && styles.eyebrowCompact, { color: accent }]}>{eyebrow}</Text>
+          ) : null}
+          <Text style={[styles.title, compact && styles.titleCompact, { color: palette.text }]}>{title}</Text>
+          {subtitle ? <Text style={[styles.subtitle, compact && styles.subtitleCompact, { color: palette.textMuted }]}>{subtitle}</Text> : null}
+        </View>
+        {!showPressableRow && actions.length > 0 ? (
+          <View style={[
+            styles.actions,
+            compact && styles.actionsCompact,
+            compactInlineActions && styles.actionsCompactInline,
+            compact && !compactInlineActions && styles.actionsCompactStacked,
+            actions.length === 1 && (!compact || compactInlineActions) && styles.actionsSingle,
+          ]}>
             {actions.map((action) => {
               const isPrimary = action === primaryAction;
               return (
@@ -107,6 +128,8 @@ export function GuidedActionPanel({
                     isPrimary
                       ? [styles.primaryButton, { backgroundColor: accent, borderColor: accent }]
                       : [styles.secondaryButton, { backgroundColor: palette.bgElev, borderColor: palette.border }],
+                    compact && styles.buttonCompact,
+                    compact && { minWidth: getCompactButtonWidth(action.label) },
                     action.disabled && styles.buttonDisabled,
                   ]}
                   onPress={action.onPress}
@@ -119,6 +142,7 @@ export function GuidedActionPanel({
                   ) : (
                     <Text style={[
                       styles.buttonText,
+                      compact && styles.buttonTextCompact,
                       isPrimary ? [styles.primaryButtonText, { color: '#fffaf0' }] : [styles.secondaryButtonText, { color: accent }],
                     ]}>
                       {action.label}
@@ -130,6 +154,33 @@ export function GuidedActionPanel({
           </View>
         ) : null}
       </View>
+    </>
+  );
+
+  if (showPressableRow) {
+    return (
+      <TouchableOpacity
+        style={containerStyle}
+        testID={testID}
+        onLayout={(event) => setPanelWidth(event.nativeEvent.layout.width)}
+        onPress={primaryAction.onPress}
+        disabled={primaryAction.disabled || primaryAction.loading}
+        activeOpacity={0.75}
+        accessibilityRole="button"
+        accessibilityLabel={primaryAction.label}
+      >
+        {content}
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <View
+      style={containerStyle}
+      testID={testID}
+      onLayout={(event) => setPanelWidth(event.nativeEvent.layout.width)}
+    >
+      {content}
     </View>
   );
 }
@@ -151,6 +202,10 @@ const styles = StyleSheet.create({
   iconWrap: {
     paddingTop: PANEL_ICON_TOP_ALIGNMENT_OFFSET,
   },
+  iconWrapCentered: {
+    paddingTop: 0,
+    justifyContent: 'center',
+  },
   icon: {
     width: spacing['3xl'],
     height: spacing['3xl'],
@@ -159,9 +214,25 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: colors.userBg,
   },
+  iconCompact: {
+    width: spacing['2xl'],
+    height: spacing['2xl'],
+  },
   body: {
     flex: 1,
     minWidth: 0,
+  },
+  bodyCompactWithAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  textBlock: {
+    flex: 1,
+    minWidth: 0,
+  },
+  bodySingleLinePressable: {
+    justifyContent: 'center',
   },
   eyebrow: {
     fontSize: typography.fontSize.xs,
@@ -171,12 +242,19 @@ const styles = StyleSheet.create({
     marginBottom: spacing.xs,
     fontFamily: designFonts.mono,
   },
+  eyebrowCompact: {
+    marginBottom: 2,
+  },
   title: {
     fontSize: typography.fontSize.md,
     fontWeight: '700',
     lineHeight: spacing.xl,
     color: colors.textPrimary,
     fontFamily: designFonts.sans,
+  },
+  titleCompact: {
+    fontSize: typography.fontSize.base,
+    lineHeight: spacing.lg,
   },
   subtitle: {
     marginTop: spacing.xs,
@@ -185,10 +263,24 @@ const styles = StyleSheet.create({
     color: colors.textSecondary,
     fontFamily: designFonts.sans,
   },
+  subtitleCompact: {
+    fontSize: typography.fontSize.sm,
+    lineHeight: spacing.lg,
+  },
   actions: {
     flexDirection: 'row',
     gap: spacing.sm,
     marginTop: spacing.md,
+  },
+  actionsCompact: {
+    marginTop: spacing.sm,
+  },
+  actionsCompactInline: {
+    marginTop: 0,
+    flexShrink: 0,
+  },
+  actionsCompactStacked: {
+    justifyContent: 'center',
   },
   actionsSingle: {
     justifyContent: 'flex-end',
@@ -202,6 +294,13 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: spacing.md,
   },
+  buttonCompact: {
+    flexGrow: 0,
+    flexShrink: 0,
+    minHeight: spacing['2xl'],
+    minWidth: 72,
+    paddingHorizontal: spacing.lg,
+  },
   primaryButton: {},
   secondaryButton: {
     backgroundColor: colors.bgSecondary,
@@ -214,6 +313,10 @@ const styles = StyleSheet.create({
     fontSize: typography.fontSize.base,
     fontWeight: '700',
     fontFamily: designFonts.sans,
+  },
+  buttonTextCompact: {
+    fontSize: typography.fontSize.sm,
+    flexShrink: 0,
   },
   primaryButtonText: {
     color: colors.textOnAccent,

--- a/mobile/src/components/ShareTopicPanel.tsx
+++ b/mobile/src/components/ShareTopicPanel.tsx
@@ -41,7 +41,9 @@ export function ShareTopicPanel({
   return (
     <GuidedActionPanel
       tone={action === 'OFFER_SHARING' ? 'share' : 'review'}
-      title={`Share this with ${partnerName}?`}
+      title={`Opportunity to share with ${partnerName}`}
+      compact
+      pressable
       primaryAction={{ label: 'Review', onPress }}
       testID="share-topic-panel"
     />

--- a/mobile/src/components/UniversalChat.tsx
+++ b/mobile/src/components/UniversalChat.tsx
@@ -464,7 +464,6 @@ function renderTrigger(
         <FeelHeardConfirmation
           key={trigger.id}
           onConfirm={() => onAction(trigger.id, TriggerAction.FEEL_HEARD_CONFIRMED)}
-          onContinue={() => onAction(trigger.id, TriggerAction.FEEL_HEARD_CONTINUE)}
         />
       );
 

--- a/mobile/src/components/WaitingBanner.tsx
+++ b/mobile/src/components/WaitingBanner.tsx
@@ -6,16 +6,18 @@
  */
 
 import { View, Text, ActivityIndicator, Animated, Pressable } from 'react-native';
+import { Clock3 } from 'lucide-react-native';
 import { createStyles } from '../theme/styled';
 import type { WaitingStatusState } from '../utils/getWaitingStatus';
 import { getWaitingStatusConfig } from '../config/waitingStatusConfig';
-import { designFonts, useAppAppearance } from '../theme';
+import { designFonts, radius, spacing, useAppAppearance } from '../theme';
 
 const WAITING_BANNER_EXPANDED_MAX_HEIGHT = 150;
 const WAITING_BANNER_ENTER_OFFSET = 20;
-const WAITING_BANNER_TEXT_LINE_HEIGHT = 22;
+const WAITING_BANNER_TEXT_LINE_HEIGHT = 20;
 const WAITING_BANNER_SUBTEXT_LINE_HEIGHT = 18;
-const WAITING_BANNER_ACTION_MIN_HEIGHT = 44;
+const WAITING_BANNER_ACTION_MIN_HEIGHT = 36;
+const WAITING_BANNER_BORDER_ACCENT_WIDTH = 3;
 
 // ============================================================================
 // Types
@@ -85,55 +87,60 @@ export function WaitingBanner({
     <Animated.View style={containerStyle} testID={testID}>
       <View style={styles.content}>
         {/* Spinner for analyzing state */}
-        {config.showSpinner && (
-          <ActivityIndicator
-            size="small"
-            color={styles.spinnerColor.color}
-            style={styles.spinner}
-            testID={`${testID}-spinner`}
-          />
-        )}
+        <View style={styles.iconWrap}>
+          {config.showSpinner ? (
+            <ActivityIndicator
+              size="small"
+              color={styles.spinnerColor.color}
+              testID={`${testID}-spinner`}
+            />
+          ) : (
+            <Clock3 color={styles.spinnerColor.color} size={16} strokeWidth={2.4} />
+          )}
+        </View>
 
-        {/* Main text */}
-        <Text style={styles.text} testID={`${testID}-text`}>
-          {bannerText}
-        </Text>
-
-        {/* Subtext if present */}
-        {config.bannerSubtext && (
-          <Text style={styles.subtext} testID={`${testID}-subtext`}>
-            {config.bannerSubtext}
+        <View style={styles.textBlock}>
+          {/* Main text */}
+          <Text style={styles.text} testID={`${testID}-text`}>
+            {bannerText}
           </Text>
-        )}
 
-        {/* Inline action button (e.g. Review). Driven by config.actionLabel. */}
-        {config.actionLabel && onActionPress && (
-          <Pressable
-            onPress={onActionPress}
-            style={styles.actionButton}
-            testID={`${testID}-action`}
-            accessibilityRole="button"
-            accessibilityLabel={config.actionLabel}
-          >
-            <Text style={styles.actionButtonText}>{config.actionLabel}</Text>
-          </Pressable>
-        )}
-
-        {/* Breathing exercise link */}
-        {onExercisePress && (
-          <Pressable
-            onPress={onExercisePress}
-            style={styles.exerciseLink}
-            testID={`${testID}-exercise-link`}
-            accessibilityRole="button"
-            accessibilityLabel="Take a breath while you wait"
-            accessibilityHint="Opens breathing and grounding exercises"
-          >
-            <Text style={styles.exerciseLinkText}>
-              Take a breath while you wait
+          {/* Subtext if present */}
+          {config.bannerSubtext && (
+            <Text style={styles.subtext} testID={`${testID}-subtext`}>
+              {config.bannerSubtext}
             </Text>
-          </Pressable>
-        )}
+          )}
+
+          {/* Inline action button (e.g. Review). Driven by config.actionLabel. */}
+          {config.actionLabel && onActionPress && (
+            <Pressable
+              onPress={onActionPress}
+              style={styles.actionButton}
+              testID={`${testID}-action`}
+              accessibilityRole="button"
+              accessibilityLabel={config.actionLabel}
+            >
+              <Text style={styles.actionButtonText}>{config.actionLabel}</Text>
+            </Pressable>
+          )}
+
+          {/* Breathing exercise link */}
+          {onExercisePress && (
+            <Pressable
+              onPress={onExercisePress}
+              style={styles.exerciseLink}
+              testID={`${testID}-exercise-link`}
+              accessibilityRole="button"
+              accessibilityLabel="Breathe"
+              accessibilityHint="Opens breathing and grounding exercises"
+            >
+              <Text style={styles.exerciseLinkText}>
+                Breathe
+              </Text>
+            </Pressable>
+          )}
+        </View>
       </View>
     </Animated.View>
   );
@@ -151,37 +158,49 @@ const useStyles = () =>
       backgroundColor: palette.bg,
       borderTopWidth: 1,
       borderTopColor: palette.border,
+      borderLeftWidth: WAITING_BANNER_BORDER_ACCENT_WIDTH,
+      borderLeftColor: palette.info,
     },
     content: {
-      alignItems: 'center',
-      paddingVertical: t.spacing.md,
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: t.spacing.sm,
+      paddingVertical: t.spacing.sm,
       paddingHorizontal: t.spacing.lg,
     },
-    spinner: {
-      marginBottom: t.spacing.xs,
+    iconWrap: {
+      width: spacing['2xl'],
+      height: spacing['2xl'],
+      borderRadius: radius.full,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: palette.chipBg,
     },
     spinnerColor: {
       color: palette.info,
     },
+    textBlock: {
+      flex: 1,
+      minWidth: 0,
+    },
     text: {
-      fontSize: t.typography.fontSize.md,
+      fontSize: t.typography.fontSize.base,
       lineHeight: WAITING_BANNER_TEXT_LINE_HEIGHT,
       color: palette.textMuted,
-      textAlign: 'center',
       fontFamily: designFonts.sans,
     },
     subtext: {
       fontSize: t.typography.fontSize.sm,
       lineHeight: WAITING_BANNER_SUBTEXT_LINE_HEIGHT,
       color: palette.textFaint,
-      textAlign: 'center',
       marginTop: t.spacing.xs,
       fontFamily: designFonts.sans,
     },
     exerciseLink: {
-      marginTop: t.spacing.sm,
+      marginTop: t.spacing.xs,
       minHeight: WAITING_BANNER_ACTION_MIN_HEIGHT,
       justifyContent: 'center',
+      alignSelf: 'flex-start',
     },
     exerciseLinkText: {
       fontSize: t.typography.fontSize.sm,
@@ -192,14 +211,15 @@ const useStyles = () =>
     actionButton: {
       marginTop: t.spacing.sm,
       minHeight: WAITING_BANNER_ACTION_MIN_HEIGHT,
-      paddingHorizontal: t.spacing.lg,
+      paddingHorizontal: t.spacing.md,
       borderRadius: t.radius.md,
       backgroundColor: palette.accent,
+      alignSelf: 'flex-start',
       alignItems: 'center',
       justifyContent: 'center',
     },
     actionButtonText: {
-      fontSize: t.typography.fontSize.md,
+      fontSize: t.typography.fontSize.sm,
       color: palette.bg,
       fontWeight: '700',
       fontFamily: designFonts.sans,

--- a/mobile/src/components/__tests__/FeelHeardConfirmation.test.tsx
+++ b/mobile/src/components/__tests__/FeelHeardConfirmation.test.tsx
@@ -11,16 +11,10 @@ import { FeelHeardConfirmation } from '../FeelHeardConfirmation';
 describe('FeelHeardConfirmation', () => {
   const defaultProps = {
     onConfirm: jest.fn(),
-    onContinue: jest.fn(),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('renders continue button', () => {
-    render(<FeelHeardConfirmation {...defaultProps} />);
-    expect(screen.getByText('Not yet')).toBeTruthy();
   });
 
   it('renders confirm button', () => {
@@ -28,16 +22,9 @@ describe('FeelHeardConfirmation', () => {
     expect(screen.getByText('I feel heard')).toBeTruthy();
   });
 
-  it('calls onContinue when continue is pressed', () => {
-    const onContinue = jest.fn();
-    render(<FeelHeardConfirmation onConfirm={jest.fn()} onContinue={onContinue} />);
-    fireEvent.press(screen.getByText('Not yet'));
-    expect(onContinue).toHaveBeenCalled();
-  });
-
   it('calls onConfirm when confirm is pressed', () => {
     const onConfirm = jest.fn();
-    render(<FeelHeardConfirmation onConfirm={onConfirm} onContinue={jest.fn()} />);
+    render(<FeelHeardConfirmation onConfirm={onConfirm} />);
     fireEvent.press(screen.getByText('I feel heard'));
     expect(onConfirm).toHaveBeenCalled();
   });

--- a/mobile/src/components/__tests__/ShareTopicPanel.test.tsx
+++ b/mobile/src/components/__tests__/ShareTopicPanel.test.tsx
@@ -36,12 +36,12 @@ describe('ShareTopicPanel', () => {
   describe('content', () => {
     it('displays the suggestion text with partner name', () => {
       render(<ShareTopicPanel {...defaultProps} />);
-      expect(screen.getByText('Share this with Partner?')).toBeTruthy();
+      expect(screen.getByText('Opportunity to share with Partner')).toBeTruthy();
     });
 
     it('displays correct name when partnerName changes', () => {
       render(<ShareTopicPanel {...defaultProps} partnerName="Alex" />);
-      expect(screen.getByText('Share this with Alex?')).toBeTruthy();
+      expect(screen.getByText('Opportunity to share with Alex')).toBeTruthy();
     });
   });
 

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -3094,7 +3094,7 @@ export function UnifiedSessionScreen({
             tone="topic"
             eyebrow="Topic frame"
             title={topicFrame}
-            subtitle="This stays above the input at the end of Stage 0. To change it, tell me below."
+            compact
             primaryAction={{
               label: 'Use this topic',
               onPress: handleConfirmTopicFrame,
@@ -3128,12 +3128,11 @@ export function UnifiedSessionScreen({
               <GuidedActionPanel
                 tone="review"
                 eyebrow={isRefiningEmpathy ? 'Revision' : 'Empathy draft'}
-                title={isRefiningEmpathy ? 'Revisit what you’ll share' : 'Review what you’ll share'}
-                subtitle={isRefiningEmpathy
-                  ? `${partnerName} shared more context. Check whether your understanding should change.`
-                  : `Open your draft before sending it to ${partnerName}.`}
+                title={isRefiningEmpathy ? 'Review the update' : 'Ready to review'}
+                compact
+                pressable
                 primaryAction={{
-                  label: 'Review',
+                  label: isRefiningEmpathy ? 'Review revision' : 'Review what you’ll share',
                   onPress: () => setShowEmpathyDrawer(true),
                   testID: 'empathy-review-button',
                 }}
@@ -3266,6 +3265,7 @@ export function UnifiedSessionScreen({
               tone="review"
               title={title}
               compact
+              pressable
               primaryAction={{
                 label,
                 onPress: () => setShowStage4Drawer(true),


### PR DESCRIPTION
## Summary
- keep guided CTAs visible while the keyboard is open
- add compact pressable guided panels for low-profile review/share prompts
- refresh waiting banner styling to match guided panels
- update design-system CTA samples and related tests

## Verification
- npm --workspace mobile run check

Note: targeted Jest tests still require the missing react-test-renderer install in this workspace.