### PR TITLE
[codex] Add pending invitation share action

### DIFF
--- a/mobile/src/components/SessionChatHeader.tsx
+++ b/mobile/src/components/SessionChatHeader.tsx
@@ -14,7 +14,7 @@ import {
   TouchableOpacity,
   ViewStyle,
 } from 'react-native';
-import { Menu } from 'lucide-react-native';
+import { Menu, Share2 } from 'lucide-react-native';
 import { ConnectionStatus } from '@meet-without-fear/shared';
 import { createStyles } from '../theme/styled';
 import { designFonts, useAppAppearance } from '../theme';
@@ -45,6 +45,13 @@ export interface SessionChatHeaderProps {
   onPress?: () => void;
   /** Optional callback when brief status is pressed (e.g., to show invitation options) */
   onBriefStatusPress?: () => void;
+  /** Optional right-side icon action. Takes precedence over briefStatus. */
+  rightAction?: {
+    icon: 'share';
+    accessibilityLabel: string;
+    onPress: () => void;
+    testID?: string;
+  };
   /** Conversation topic to display below partner name */
   conversationTopic?: string | null;
   /** Custom container style */
@@ -96,6 +103,7 @@ export function SessionChatHeader({
   leftActionIcon = 'back',
   onPress,
   onBriefStatusPress,
+  rightAction,
   conversationTopic,
   style,
   testID = 'session-chat-header',
@@ -120,6 +128,7 @@ export function SessionChatHeader({
   const displayName = partnerName || 'Meet Without Fear';
   const leftActionLabel = leftActionIcon === 'menu' ? 'Open session drawer' : 'Go back';
   const headerTopic = conversationTopic?.trim();
+  const rightActionTestID = rightAction?.testID ?? `${testID}-right-action`;
 
   // Center content - always partner name + status (whether tabs or not)
   const centerContent = (
@@ -200,7 +209,18 @@ export function SessionChatHeader({
 
       {/* Right section: Activity menu icon or brief status */}
       <View style={styles.rightSection}>
-        {briefStatus ? (
+        {rightAction ? (
+          <TouchableOpacity
+            style={styles.iconButton}
+            onPress={rightAction.onPress}
+            accessibilityRole="button"
+            accessibilityLabel={rightAction.accessibilityLabel}
+            testID={rightActionTestID}
+            hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+          >
+            {rightAction.icon === 'share' && <Share2 color={palette.textMuted} size={22} />}
+          </TouchableOpacity>
+        ) : briefStatus ? (
           onBriefStatusPress ? (
             <TouchableOpacity
               style={styles.briefStatusPill}
@@ -284,6 +304,13 @@ const useStyles = () => {
     },
     rightSpacer: {
       width: 32,
+    },
+    iconButton: {
+      width: 36,
+      height: 36,
+      borderRadius: 10,
+      alignItems: 'center',
+      justifyContent: 'center',
     },
     partnerName: {
       fontSize: 20,

--- a/mobile/src/components/__tests__/SessionChatHeader.test.tsx
+++ b/mobile/src/components/__tests__/SessionChatHeader.test.tsx
@@ -108,6 +108,26 @@ describe('SessionChatHeader', () => {
 
       expect(queryByTestId('session-chat-header-brief-status')).toBeNull();
     });
+
+    it('renders right action instead of brief status when provided', () => {
+      const onPress = jest.fn();
+      const { getByTestId, queryByTestId } = render(
+        <SessionChatHeader
+          partnerName="Alex"
+          briefStatus="invited"
+          rightAction={{
+            icon: 'share',
+            accessibilityLabel: 'Share invitation',
+            onPress,
+          }}
+        />
+      );
+
+      fireEvent.press(getByTestId('session-chat-header-right-action'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+      expect(queryByTestId('session-chat-header-brief-status')).toBeNull();
+    });
   });
 
   describe('conversation topic', () => {

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1365,12 +1365,25 @@ export function UnifiedSessionScreen({
   // Invitation panel dismissal (allows the user to defer sharing).
   // -------------------------------------------------------------------------
   const [invitationPanelDismissed, setInvitationPanelDismissed] = useState(false);
+  const [showInvitationReadyModal, setShowInvitationReadyModal] = useState(false);
 
-  // Tooltip shown after "Later" — points at the book icon to teach the user
-  // they can share later from the activity drawer. Session-local only.
+  // Tooltip shown after "Later" — points at the header share icon to teach the
+  // user they can share later. Session-local only.
   const [showShareLaterTooltip, setShowShareLaterTooltip] = useState(false);
   const [shareLaterTooltipShownThisSession, setShareLaterTooltipShownThisSession] =
     useState(false);
+
+  const handleDismissInvitationReadyModal = useCallback(() => {
+    setShowInvitationReadyModal(false);
+    setInvitationPanelDismissed(true);
+    if (!invitationConfirmed) {
+      confirmInvitationAndAwaitFollowUp();
+    }
+    if (!shareLaterTooltipShownThisSession) {
+      setShowShareLaterTooltip(true);
+      setShareLaterTooltipShownThisSession(true);
+    }
+  }, [confirmInvitationAndAwaitFollowUp, invitationConfirmed, shareLaterTooltipShownThisSession]);
 
   // Refinement Modal
   const [refinementOfferId, setRefinementOfferId] = useState<string | null>(null);
@@ -2675,6 +2688,22 @@ export function UnifiedSessionScreen({
   }, [invitation?.id]);
 
   const partnerAccepted = !!invitation?.acceptedAt;
+  const canSharePendingInvitation = isInviter &&
+    session?.status === SessionStatus.INVITED &&
+    !!invitationUrl &&
+    !!topicFrame &&
+    !partnerAccepted;
+  const pendingInvitationShareAction = canSharePendingInvitation
+    ? {
+        icon: 'share' as const,
+        accessibilityLabel: 'Share invitation',
+        onPress: () => {
+          setShowShareLaterTooltip(false);
+          setShowInvitationReadyModal(true);
+        },
+        testID: 'session-chat-header-share-invitation',
+      }
+    : undefined;
 
   // Shared share-invitation handler used by the InvitationReadyModal.
   const handleShareInvitation = useCallback(async (): Promise<boolean> => {
@@ -3484,6 +3513,7 @@ export function UnifiedSessionScreen({
             partnerOnline={partnerOnline}
             connectionStatus={connectionStatus}
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
+            rightAction={pendingInvitationShareAction}
             onBackPress={onNavigateBack}
             onPress={() => setShowPartnerInfo(true)}
             conversationTopic={topicFrame}
@@ -3529,6 +3559,7 @@ export function UnifiedSessionScreen({
           partnerOnline={partnerOnline}
           connectionStatus={connectionStatus}
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
+          rightAction={pendingInvitationShareAction}
           onBackPress={onNavigateBack}
           onPress={() => setShowPartnerInfo(true)}
           conversationTopic={topicFrame}
@@ -3579,6 +3610,7 @@ export function UnifiedSessionScreen({
             partnerOnline={partnerOnline}
             connectionStatus={connectionStatus}
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
+            rightAction={pendingInvitationShareAction}
             onBackPress={onNavigateBack}
             onPress={() => setShowPartnerInfo(true)}
             conversationTopic={topicFrame}
@@ -3616,6 +3648,7 @@ export function UnifiedSessionScreen({
             partnerOnline={partnerOnline}
             connectionStatus={connectionStatus}
             briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
+            rightAction={pendingInvitationShareAction}
             onBackPress={onNavigateBack}
             onPress={() => setShowPartnerInfo(true)}
             conversationTopic={topicFrame}
@@ -3652,6 +3685,7 @@ export function UnifiedSessionScreen({
           partnerOnline={partnerOnline}
           connectionStatus={connectionStatus}
           briefStatus={getBriefStatus(session?.status, invitation?.isInviter)}
+          rightAction={pendingInvitationShareAction}
           hideOnlineStatus={isInvitationPhase}
           onBackPress={onNavigateBack}
           onPress={() => setShowPartnerInfo(true)}
@@ -4084,24 +4118,17 @@ export function UnifiedSessionScreen({
       {/* Invitation Ready Modal — replaces the inline 'invitation' panel.
           Opens automatically when the topic is confirmed and the user has not
           yet shared or dismissed; "Later" then surfaces an onboarding tooltip
-          pointing at the book icon. */}
+          pointing at the header share icon. */}
       <Modal
         visible={
-          (shouldShowInvitationPanel || auditFixture === 'invitation-ready') &&
+          (shouldShowInvitationPanel || showInvitationReadyModal || auditFixture === 'invitation-ready') &&
           !!topicFrame &&
           !!invitationUrl &&
           !partnerAccepted
         }
         transparent
         animationType="fade"
-        onRequestClose={() => {
-          setInvitationPanelDismissed(true);
-          confirmInvitationAndAwaitFollowUp();
-          if (!shareLaterTooltipShownThisSession) {
-            setShowShareLaterTooltip(true);
-            setShareLaterTooltipShownThisSession(true);
-          }
-        }}
+        onRequestClose={handleDismissInvitationReadyModal}
       >
         <View style={styles.invitationModalBackdrop}>
           <View
@@ -4110,14 +4137,7 @@ export function UnifiedSessionScreen({
           >
             <TouchableOpacity
               style={styles.invitationModalCloseButton}
-              onPress={() => {
-                setInvitationPanelDismissed(true);
-                confirmInvitationAndAwaitFollowUp();
-                if (!shareLaterTooltipShownThisSession) {
-                  setShowShareLaterTooltip(true);
-                  setShareLaterTooltipShownThisSession(true);
-                }
-              }}
+              onPress={handleDismissInvitationReadyModal}
               accessibilityRole="button"
               accessibilityLabel="Close"
               testID="invitation-modal-close-button"
@@ -4137,8 +4157,11 @@ export function UnifiedSessionScreen({
                 onPress={async () => {
                   const didShare = await handleShareInvitation();
                   if (didShare) {
+                    setShowInvitationReadyModal(false);
                     setInvitationPanelDismissed(true);
-                    confirmInvitationAndAwaitFollowUp();
+                    if (!invitationConfirmed) {
+                      confirmInvitationAndAwaitFollowUp();
+                    }
                   }
                 }}
                 accessibilityRole="button"


### PR DESCRIPTION
## Summary
- Adds a reusable right-side share icon action to the session chat header.
- Shows the share icon for inviters while the partner invitation is still pending.
- Reopens the existing invitation-ready share modal from that icon after the original prompt is dismissed.

## Impact
Inviters can get back to the invitation share flow after closing the original share prompt, without the removed book/drawer affordance.

## Validation
- `npm run check` in `mobile` passed.
- `npx eslint src/components/SessionChatHeader.tsx src/components/__tests__/SessionChatHeader.test.tsx src/screens/UnifiedSessionScreen.tsx` passed with existing warnings only.
- Focused Jest suite was attempted but the local environment failed before loading tests because `@testing-library/react-native` could not resolve `react-test-renderer`.
