### PR TITLE
Fix duplicate empathy display: suppress Delivered bubble

### DIFF
--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -2350,27 +2350,34 @@ export function UnifiedSessionScreen({
     }
 
     if (partnerAttempt?.content && (partnerAttempt.revealedAt || partnerAttempt.sharedAt)) {
-      const partnerTimestamp = partnerAttempt.revealedAt || partnerAttempt.sharedAt;
-      const hasPartnerAttemptMessage = baseMessages.some(
-        (message) =>
-          isSameEmpathyAttemptMessage(message, partnerAttempt.sourceUserId, {
-            content: partnerAttempt.content,
-            sharedAt: partnerTimestamp,
-          }),
-      );
+      // When the partner's empathy has been revealed and we're in Stage 2,
+      // the validation card handles this content — skip the "Delivered" bubble.
+      const validationCardWillShow =
+        !!partnerAttempt.revealedAt && myProgress?.stage === Stage.PERSPECTIVE_STRETCH;
 
-      if (!hasPartnerAttemptMessage) {
-        baseMessages.push({
-          id: `partner-empathy-${partnerAttempt.id}`,
-          sessionId,
-          senderId: partnerAttempt.sourceUserId,
-          role: MessageRole.EMPATHY_STATEMENT,
-          content: partnerAttempt.content,
-          stage: Stage.PERSPECTIVE_STRETCH,
-          timestamp: partnerTimestamp,
-          sharedContentDeliveryStatus: 'delivered',
-          sharedContentDirection: 'received',
-        });
+      if (!validationCardWillShow) {
+        const partnerTimestamp = partnerAttempt.revealedAt || partnerAttempt.sharedAt;
+        const hasPartnerAttemptMessage = baseMessages.some(
+          (message) =>
+            isSameEmpathyAttemptMessage(message, partnerAttempt.sourceUserId, {
+              content: partnerAttempt.content,
+              sharedAt: partnerTimestamp,
+            }),
+        );
+
+        if (!hasPartnerAttemptMessage) {
+          baseMessages.push({
+            id: `partner-empathy-${partnerAttempt.id}`,
+            sessionId,
+            senderId: partnerAttempt.sourceUserId,
+            role: MessageRole.EMPATHY_STATEMENT,
+            content: partnerAttempt.content,
+            stage: Stage.PERSPECTIVE_STRETCH,
+            timestamp: partnerTimestamp,
+            sharedContentDeliveryStatus: 'delivered',
+            sharedContentDirection: 'received',
+          });
+        }
       }
     }
 
@@ -2488,6 +2495,7 @@ export function UnifiedSessionScreen({
     empathyStatusData?.myAttempt,
     empathyStatusData?.mySharedContext,
     empathyStatusData?.partnerAttempt,
+    myProgress?.stage,
     sessionId,
     user?.id,
   ]);


### PR DESCRIPTION
## Changes
- Fix: Skip synthesizing the partner empathy "Delivered" message bubble in `displayMessages` when the validation card will be shown (same content, same timestamp)
- The validation card (`partnerName's understanding`) is the intended UI for revealed partner empathy — the message bubble was redundant
- Condition: suppress bubble when `partnerAttempt.revealedAt` exists AND user is in `Stage.PERSPECTIVE_STRETCH` (exactly matching validation card conditions)

Related to #606

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** "This should not show twice. I think we don't need the one that says delivered. Just the one that says I confirmed."

## Docs updated
No doc changes needed — bug fix only, no new behavior or API changes. The mapped doc (`docs/mobile/wireframes/chat-interface.md`) does not describe the Delivered bubble / validation card dedup logic.