### PR TITLE
fix: confirm needs button triggers transition immediately

### DIFF
--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -97,6 +97,10 @@ export function NeedsDrawer({
   position3QRef.current = position3Q;
   positionFullRef.current = insets.top;
 
+  // Stable ref for onClose so closeDrawer identity doesn't change on every render
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   // -------------------------------------------------------------------------
   // Animation refs
   // -------------------------------------------------------------------------
@@ -170,9 +174,9 @@ export function NeedsDrawer({
       wasOpened.current = false;
       isClosing.current = false;
       setIsMounted(false);
-      onClose();
+      onCloseRef.current();
     });
-  }, [drawerTranslate, backdropOpacity, onClose]);
+  }, [drawerTranslate, backdropOpacity]);
 
   useEffect(() => {
     if (visible) {

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -1527,7 +1527,8 @@ export function useConfirmNeeds(
     UseMutationOptions<
       ConfirmNeedsResponse,
       ApiClientError,
-      { sessionId: string; needIds: string[]; adjustments?: NeedAdjustment[] }
+      { sessionId: string; needIds: string[]; adjustments?: NeedAdjustment[] },
+      { previousNeeds: GetNeedsResponse | undefined }
     >,
     'mutationFn'
   >
@@ -1540,6 +1541,30 @@ export function useConfirmNeeds(
         needIds,
         adjustments,
       });
+    },
+    onMutate: async ({ sessionId, needIds }) => {
+      await queryClient.cancelQueries({ queryKey: stageKeys.needs(sessionId) });
+      const previousNeeds = queryClient.getQueryData<GetNeedsResponse>(
+        stageKeys.needs(sessionId),
+      );
+      queryClient.setQueryData<GetNeedsResponse>(
+        stageKeys.needs(sessionId),
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            needs: old.needs.map((n) =>
+              needIds.includes(n.id) ? { ...n, confirmed: true } : n,
+            ),
+          };
+        },
+      );
+      return { previousNeeds };
+    },
+    onError: (_err, { sessionId }, context) => {
+      if (context?.previousNeeds) {
+        queryClient.setQueryData(stageKeys.needs(sessionId), context.previousNeeds);
+      }
     },
     onSuccess: (_, { sessionId }) => {
       patchStage3Gates(queryClient, sessionId, {

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -4025,6 +4025,7 @@ export function UnifiedSessionScreen({
             });
           } else {
             handleConfirmAllNeeds(() => {
+              markCompleted('confirmed-needs');
               setShowNeedsDrawer(false);
             });
           }

--- a/mobile/src/utils/__tests__/chatUIState.test.ts
+++ b/mobile/src/utils/__tests__/chatUIState.test.ts
@@ -964,7 +964,7 @@ describe('Needs Review Panel Visibility', () => {
     expect(result.panels.showNeedsReviewPanel).toBe(false);
   });
 
-  it('still shows when only the confirm latch is set and needs are not shared', () => {
+  it('hides review and shows share when local confirm latch is set before server catches up', () => {
     const inputs = createInputs({
       myStage: Stage.NEED_MAPPING,
       compactMySigned: true,
@@ -976,7 +976,9 @@ describe('Needs Review Panel Visibility', () => {
     });
 
     const result = computeChatUIState(inputs);
-    expect(result.panels.showNeedsReviewPanel).toBe(true);
+    expect(result.panels.showNeedsReviewPanel).toBe(false);
+    expect(result.panels.showNeedsSharePanel).toBe(true);
+    expect(result.aboveInputPanel).toBe('needs-share');
   });
 
   it('does not show when no needs available', () => {

--- a/mobile/src/utils/chatUIState.ts
+++ b/mobile/src/utils/chatUIState.ts
@@ -383,6 +383,7 @@ function computeShowNeedsReviewPanel(inputs: ChatUIStateInputs): boolean {
     needsAvailable,
     allNeedsConfirmed,
     needsShared,
+    hasConfirmedNeedsLocal,
     sessionStatus,
   } = inputs;
 
@@ -395,8 +396,8 @@ function computeShowNeedsReviewPanel(inputs: ChatUIStateInputs): boolean {
     return false;
   }
 
-  // Already shared - reveal/waiting state owns the next step.
-  if (needsShared || allNeedsConfirmed) {
+  // Already shared or confirmed - reveal/waiting state owns the next step.
+  if (needsShared || allNeedsConfirmed || hasConfirmedNeedsLocal) {
     return false;
   }
 
@@ -419,7 +420,7 @@ function computeShowNeedsSharePanel(inputs: ChatUIStateInputs): boolean {
 
   const currentStage = myStage ?? Stage.ONBOARDING;
   if (currentStage !== Stage.NEED_MAPPING) return false;
-  if (!needsAvailable || !allNeedsConfirmed) return false;
+  if (!needsAvailable || (!allNeedsConfirmed && !hasConfirmedNeedsLocal)) return false;
   if (needsShared || needsRevealReady) return false;
   return true;
 }


### PR DESCRIPTION
## Changes
- Fix: Stabilize NeedsDrawer close animation by using a ref for onClose, preventing drawer flicker during re-renders
- Fix: Add optimistic cache update in useConfirmNeeds so allNeedsConfirmed flips to true immediately (with rollback on error)
- Fix: Wire up hasConfirmedNeedsLocal latch — markCompleted('confirmed-needs') now fires on confirm, and both computeShowNeedsReviewPanel and computeShowNeedsSharePanel respect the latch to bridge the gap before server refetch
- Test: Update chatUIState test to verify review panel hides and share panel shows when local latch is set

Related to #609

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** After tapping the button to confirm my needs, the drawer hid and showed a couple of times before finally closing. But more importantly, it then did not do anything. I still see the CTA and no new message or transition. I can even open up the same drawer again. Can you check if it even submitted?

## Docs updated
No doc changes needed — pure behavior fixes (optimistic cache, ref stabilization, latch wiring) with no UI layout or architecture changes.