### PR TITLE
fix: needs validation loading state, AI guidance, and stale CTA

### DIFF
--- a/backend/src/controllers/stage3.ts
+++ b/backend/src/controllers/stage3.ts
@@ -15,7 +15,7 @@ import { Request, Response } from 'express';
 import { Prisma } from '@prisma/client';
 import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
-import { confirmNeedsRequestSchema, ConsentContentType, NeedCategory } from '@meet-without-fear/shared';
+import { confirmNeedsRequestSchema, ConsentContentType, MessageRole, NeedCategory } from '@meet-without-fear/shared';
 import { notifyPartner, publishSessionEvent } from '../services/realtime';
 import { successResponse, errorResponse } from '../utils/response';
 import { getPartnerUserId } from '../utils/session';
@@ -623,6 +623,33 @@ export async function consentToShareNeeds(
       });
     }
 
+    // Generate AI guidance message after sharing
+    const guidanceContent = partnerShared
+      ? 'Both of you have shared your needs. You can now review them side by side and validate whether they feel accurate.'
+      : 'Your needs have been shared. Once your partner shares theirs, you\'ll be able to review them side by side.';
+
+    const guidanceMessage = await prisma.message.create({
+      data: {
+        sessionId,
+        senderId: null,
+        forUserId: user.id,
+        role: 'AI',
+        content: guidanceContent,
+        stage: 3,
+      },
+    });
+
+    const { publishMessageAIResponse } = await import('../services/realtime');
+    await publishMessageAIResponse(sessionId, user.id, {
+      id: guidanceMessage.id,
+      sessionId,
+      senderId: null,
+      content: guidanceMessage.content,
+      timestamp: guidanceMessage.timestamp.toISOString(),
+      role: MessageRole.AI,
+      stage: guidanceMessage.stage,
+    });
+
     successResponse(res, {
       consented: true,
       sharedAt: now.toISOString(),
@@ -812,6 +839,34 @@ export async function validateNeeds(req: Request, res: Response): Promise<void> 
           },
         });
       }
+    }
+
+    // Send AI guidance for the "not reviewed yet" path
+    if (!validated) {
+      const guidanceContent =
+        'No problem — take your time reviewing. You can chat about anything that doesn\'t feel right, and review the needs again when you\'re ready.';
+
+      const guidanceMessage = await prisma.message.create({
+        data: {
+          sessionId,
+          senderId: null,
+          forUserId: user.id,
+          role: 'AI',
+          content: guidanceContent,
+          stage: 3,
+        },
+      });
+
+      const { publishMessageAIResponse } = await import('../services/realtime');
+      await publishMessageAIResponse(sessionId, user.id, {
+        id: guidanceMessage.id,
+        sessionId,
+        senderId: null,
+        content: guidanceMessage.content,
+        timestamp: guidanceMessage.timestamp.toISOString(),
+        role: MessageRole.AI,
+        stage: guidanceMessage.stage,
+      });
     }
 
     successResponse(res, {

--- a/backend/src/controllers/stage3.ts
+++ b/backend/src/controllers/stage3.ts
@@ -16,7 +16,7 @@ import { Prisma } from '@prisma/client';
 import { logger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
 import { confirmNeedsRequestSchema, ConsentContentType, MessageRole, NeedCategory } from '@meet-without-fear/shared';
-import { notifyPartner, publishSessionEvent } from '../services/realtime';
+import { notifyPartner, publishMessageAIResponse, publishSessionEvent } from '../services/realtime';
 import { successResponse, errorResponse } from '../utils/response';
 import { getPartnerUserId } from '../utils/session';
 import { captureProposedNeedsForUser } from '../services/needs';
@@ -639,7 +639,6 @@ export async function consentToShareNeeds(
       },
     });
 
-    const { publishMessageAIResponse } = await import('../services/realtime');
     await publishMessageAIResponse(sessionId, user.id, {
       id: guidanceMessage.id,
       sessionId,
@@ -857,7 +856,6 @@ export async function validateNeeds(req: Request, res: Response): Promise<void> 
         },
       });
 
-      const { publishMessageAIResponse } = await import('../services/realtime');
       await publishMessageAIResponse(sessionId, user.id, {
         id: guidanceMessage.id,
         sessionId,

--- a/backend/src/lib/__mocks__/prisma.ts
+++ b/backend/src/lib/__mocks__/prisma.ts
@@ -4,7 +4,7 @@ const createMockModel = () => ({
   findUnique: jest.fn(() => Promise.resolve(null)),
   findFirst: jest.fn(() => Promise.resolve(null)),
   findMany: jest.fn(() => Promise.resolve([])),
-  create: jest.fn((args: any) => Promise.resolve({ id: 'mock-id', ...args?.data })),
+  create: jest.fn((args: any) => Promise.resolve({ id: 'mock-id', timestamp: new Date(), createdAt: new Date(), updatedAt: new Date(), ...args?.data })),
   createMany: jest.fn(() => Promise.resolve({ count: 0 })),
   update: jest.fn((args: any) => Promise.resolve({ id: 'mock-id', ...args?.data })),
   updateMany: jest.fn(() => Promise.resolve({ count: 0 })),

--- a/backend/src/routes/__tests__/stage3.test.ts
+++ b/backend/src/routes/__tests__/stage3.test.ts
@@ -13,7 +13,12 @@ import { prisma } from '../../lib/prisma';
 jest.mock('../../lib/prisma');
 
 // Mock realtime service
-jest.mock('../../services/realtime');
+jest.mock('../../services/realtime', () => ({
+  ...jest.requireActual('../../services/realtime'),
+  notifyPartner: jest.fn().mockResolvedValue(undefined),
+  publishSessionEvent: jest.fn().mockResolvedValue(undefined),
+  publishMessageAIResponse: jest.fn().mockResolvedValue(undefined),
+}));
 
 
 // Helper to create mock request
@@ -634,6 +639,16 @@ describe('Stage 3 API', () => {
         gatesSatisfied: { needsConfirmed: true, needsShared: true },
       });
 
+      (prisma.message.create as jest.Mock).mockResolvedValue({
+        id: 'msg-guidance-1',
+        sessionId: mockSessionId,
+        senderId: null,
+        content: 'Your needs have been shared.',
+        timestamp: new Date(),
+        role: 'AI',
+        stage: 3,
+      });
+
       const req = createMockRequest({
         user: mockUser,
         params: { id: mockSessionId },
@@ -703,6 +718,16 @@ describe('Stage 3 API', () => {
       (prisma.stageProgress.update as jest.Mock).mockResolvedValue({
         ...mockStageProgress,
         gatesSatisfied: { needsConfirmed: true, needsShared: true },
+      });
+
+      (prisma.message.create as jest.Mock).mockResolvedValue({
+        id: 'msg-guidance-2',
+        sessionId: mockSessionId,
+        senderId: null,
+        content: 'Both of you have shared your needs.',
+        timestamp: new Date(),
+        role: 'AI',
+        stage: 3,
       });
 
       const req = createMockRequest({

--- a/mobile/src/components/NeedsDrawer.tsx
+++ b/mobile/src/components/NeedsDrawer.tsx
@@ -54,6 +54,7 @@ export interface NeedsDrawerProps {
   partnerName?: string;
   onValidateNeeds?: () => void;
   onNeedsNotValidYet?: () => void;
+  isValidating?: boolean;
   testID?: string;
 }
 
@@ -82,6 +83,7 @@ export function NeedsDrawer({
   partnerName = 'Partner',
   onValidateNeeds,
   onNeedsNotValidYet,
+  isValidating = false,
   testID = 'needs-drawer',
 }: NeedsDrawerProps) {
   const insets = useSafeAreaInsets();
@@ -382,17 +384,25 @@ export function NeedsDrawer({
           )}
           {onValidateNeeds && (
             <TouchableOpacity
-              style={styles.primaryButton}
+              style={[
+                styles.primaryButton,
+                isValidating && styles.primaryButtonDisabled,
+              ]}
               onPress={() => {
-                onValidateNeeds();
-                closeDrawer();
+                if (!isValidating) {
+                  onValidateNeeds();
+                  closeDrawer();
+                }
               }}
               activeOpacity={0.7}
+              disabled={isValidating}
               testID={`${testID}-validate-needs`}
               accessibilityRole="button"
               accessibilityLabel="Validate needs"
             >
-              <Text style={styles.primaryButtonText}>Validate needs</Text>
+              <Text style={styles.primaryButtonText}>
+                {isValidating ? 'Validating...' : 'Validate needs'}
+              </Text>
             </TouchableOpacity>
           )}
         </View>

--- a/mobile/src/hooks/useUnifiedSession.ts
+++ b/mobile/src/hooks/useUnifiedSession.ts
@@ -358,7 +358,7 @@ export function useUnifiedSession(
   const { mutate: skipRefinement } = useSkipRefinement();
   const { mutate: confirmNeeds, isPending: isConfirmingNeeds } = useConfirmNeeds();
   const { mutate: consentShareNeeds } = useConsentShareNeeds();
-  const { mutate: validateNeedsMutation } = useValidateNeeds();
+  const { mutate: validateNeedsMutation, isPending: isValidatingNeeds } = useValidateNeeds();
   const { mutate: proposeStrategy, isPending: isProposing } = useProposeStrategy();
   const { mutate: requestSuggestions, isPending: isGenerating } =
     useRequestStrategySuggestions();
@@ -1298,6 +1298,7 @@ export function useUnifiedSession(
     isRespondingToShareOffer,
     isProposing,
     isConfirmingNeeds,
+    isValidatingNeeds,
 
     // Actions
     sendMessage: handleSendMessage,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -620,6 +620,7 @@ export function UnifiedSessionScreen({
     isResubmittingEmpathy,
     isRespondingToShareOffer,
     isConfirmingNeeds,
+    isValidatingNeeds,
 
     // Memory suggestion
     memorySuggestion,
@@ -4040,21 +4041,32 @@ export function UnifiedSessionScreen({
         confirmNeedsLabel={allNeedsConfirmed ? 'Share my needs' : 'Confirm my needs'}
         confirmingNeedsLabel={allNeedsConfirmed ? 'Sharing...' : 'Confirming...'}
         isConfirming={isConfirmingNeeds}
+        isValidating={isValidatingNeeds}
         partnerNeeds={(needsComparisonData?.partnerNeeds ?? []).map((n) => ({
           id: n.id,
           category: String(n.category) || n.need,
           need: n.need,
           confirmed: n.confirmed,
         }))}
-        onValidateNeeds={() => {
-          markCompleted('validated-needs');
-          handleValidateNeedsReveal(() => onStageComplete?.(Stage.NEED_MAPPING));
-        }}
-        onNeedsNotValidYet={() => {
-          handleNeedsNotValidYet(() => {
-            setShowNeedsDrawer(false);
-          });
-        }}
+        onValidateNeeds={
+          completedActions.has('validated-needs') ||
+          (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsValidated === true
+            ? undefined
+            : () => {
+                markCompleted('validated-needs');
+                handleValidateNeedsReveal(() => onStageComplete?.(Stage.NEED_MAPPING));
+              }
+        }
+        onNeedsNotValidYet={
+          completedActions.has('validated-needs') ||
+          (myProgress?.gatesSatisfied as Record<string, unknown> | undefined)?.needsValidated === true
+            ? undefined
+            : () => {
+                handleNeedsNotValidYet(() => {
+                  setShowNeedsDrawer(false);
+                });
+              }
+        }
         partnerName={partnerName}
         testID="needs-drawer"
       />


### PR DESCRIPTION
## Changes
- Fix: Add loading/disabled state to the "Validate needs" button in NeedsDrawer (matches confirm button pattern)
- Fix: Add AI guidance message after consent-to-share-needs so users know what comes next
- Fix: Add AI guidance message after "not reviewed yet" so users get direction
- Fix: Guard validate/not-reviewed-yet callbacks — hide buttons after user has already validated

Related to #612

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** When I submitted my needs I got no feedback that it was submitting. We should handle this consistently across all submissions so that the button is at least at disabled to show tapped and loading. Then once it was submitted I got no AI message guiding the process.

## Docs updated
No doc changes needed — bug fix addressing missing UX feedback; no new endpoints or behavioral contracts changed.