### PR TITLE
fix: remove evening daily strategy briefing

### DIFF
--- a/scripts/ec2-bot/crontab.txt
+++ b/scripts/ec2-bot/crontab.txt
@@ -24,7 +24,6 @@
 0 9 * * 1-5 /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled stale-sweeper "Sweep for stale items" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
 */10 * * * * /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled pr-reviewer "Scan and review open bot PRs" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
 0 14 * * *  /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled daily-strategy "Morning strategy briefing" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
-0 2 * * *   /opt/slam-bot/scripts/workspace-dispatcher.sh --scheduled daily-strategy "Evening strategy briefing" >> /var/log/slam-bot/workspace-dispatcher.log 2>&1
 
 # ── Staging branch sync (keeps bot/staging in sync with main, PRs accumulated work) ──
 0 8,20 * * * /opt/slam-bot/scripts/sync-staging.sh >> /var/log/slam-bot/cron.log 2>&1


### PR DESCRIPTION
## Summary

- Removes the evening daily strategy cron entry (`0 2 * * *` / 7pm PT) from `crontab.txt`
- Keeps only the morning briefing (`0 14 * * *` / 7am PT) to `#most-important-thing`

## Provenance

- **Channel:** #bugs-and-requests
- **Requester:** Shantam (<@U0AD3TF2U7L>)
- **Original message:** "We only need the most important thing once a day in the morning. Can you put up a PR to take out the evening one?"

## Test plan

- [ ] Verify crontab only has one `daily-strategy` entry (morning)
- [ ] After merge + git-pull sync, confirm no evening run at 7pm PT

🤖 Generated with [Claude Code](https://claude.com/claude-code)