### PR TITLE
fix: sanitize therapy content from application logs

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -871,7 +871,7 @@ export async function getConversationHistory(
     if (duplicateContent.length > 0) {
       logger.warn(`[getConversationHistory:${requestId}] ⚠️  WARNING: Found ${duplicateContent.length} message(s) with duplicate content!`);
       duplicateContent.forEach(([key, msgs]) => {
-        logger.warn(`[getConversationHistory:${requestId}]   Content "${key.substring(0, 50)}...": appears ${msgs.length} times`);
+        logger.warn(`[getConversationHistory:${requestId}]   Duplicate group (role=${key.split(':')[0]}): appears ${msgs.length} times`);
         msgs.forEach((msg, idx) => {
           logger.warn(`[getConversationHistory:${requestId}]     ${idx + 1}. ID=${msg.id}, timestamp=${msg.timestamp.toISOString()}`);
         });
@@ -1747,27 +1747,27 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
         const draftMatch = buffer.match(/<draft>([\s\S]*?)<\/draft>/i);
         if (draftMatch) {
           draftContent = draftMatch[1].trim();
-          logger.info(`[sendMessageStream:${requestId}] [HIDDEN DRAFT]:`, draftContent.substring(0, 100) + (draftContent.length > 100 ? '...' : ''));
+          logger.info(`[sendMessageStream:${requestId}] [HIDDEN DRAFT]: {length: ${draftContent.length}}`);
         }
 
         // Extract structured Stage 3 needs if present.
         const needsMatch = buffer.match(/<needs>([\s\S]*?)<\/needs>/i);
         if (needsMatch) {
           needsTagContent = needsMatch[1].trim();
-          logger.info(`[sendMessageStream:${requestId}] [HIDDEN NEEDS]:`, needsTagContent.substring(0, 160) + (needsTagContent.length > 160 ? '...' : ''));
+          logger.info(`[sendMessageStream:${requestId}] [HIDDEN NEEDS]: {length: ${needsTagContent.length}}`);
         }
 
         const stage4ProposalsMatch = buffer.match(/<stage4_proposals>([\s\S]*?)<\/stage4_proposals>/i);
         if (stage4ProposalsMatch) {
           stage4ProposalsTagContent = stage4ProposalsMatch[1].trim();
-          logger.info(`[sendMessageStream:${requestId}] [HIDDEN STAGE 4 PROPOSALS]:`, stage4ProposalsTagContent.substring(0, 160) + (stage4ProposalsTagContent.length > 160 ? '...' : ''));
+          logger.info(`[sendMessageStream:${requestId}] [HIDDEN STAGE 4 PROPOSALS]: {length: ${stage4ProposalsTagContent.length}}`);
         }
 
         // Extract dispatch tag if present - store for handling after streaming
         const dispatchMatch = buffer.match(/<dispatch>([\s\S]*?)<\/dispatch>/i);
         if (dispatchMatch) {
           dispatchTagContent = dispatchMatch[1].trim();
-          logger.info(`[sendMessageStream:${requestId}] [DISPATCH TAG]:`, dispatchTagContent);
+          logger.info(`[sendMessageStream:${requestId}] [DISPATCH TAG]: {length: ${dispatchTagContent.length}}`);
         }
 
         // Return text with all tags stripped
@@ -1798,7 +1798,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
               // Extract and log the hidden thinking
               thinkingContent = thinkingBuffer.substring(0, closingTagIndex);
               logger.info(`[sendMessageStream:${requestId}] [TIMING] Thinking phase complete at ${thinkingEndTime - streamStartTime}ms`);
-              logger.info(`[sendMessageStream:${requestId}] [HIDDEN THINKING]:`, thinkingContent.substring(0, 200) + (thinkingContent.length > 200 ? '...' : ''));
+              logger.info(`[sendMessageStream:${requestId}] [HIDDEN THINKING]: {length: ${thinkingContent.length}}`);
 
               // Put remaining text into tag trap buffer
               tagTrapBuffer = thinkingBuffer.substring(closingTagIndex + 11); // 11 = '</thinking>'.length

--- a/backend/src/services/ai-orchestrator.ts
+++ b/backend/src/services/ai-orchestrator.ts
@@ -405,7 +405,7 @@ export async function orchestrateResponse(
   });
 
   // Debug: Log formatted context length and snippet
-  logger.info(`[AI Orchestrator] Formatted context: ${formattedContextBundle.length} chars, starts with: "${formattedContextBundle.slice(0, 100).replace(/\n/g, '\\n')}..."`);
+  logger.info(`[AI Orchestrator] Formatted context: ${formattedContextBundle.length} chars`);
 
   // Merge retrieved context with context bundle
   let fullContext = formattedContextBundle;

--- a/backend/src/services/reconciler/analysis.ts
+++ b/backend/src/services/reconciler/analysis.ts
@@ -102,7 +102,7 @@ export async function getSonnetJson<T>(options: {
     logger.debug('Parsed AI JSON response', { operation: effectiveOperation });
     return json;
   } catch (error) {
-    logger.warn('Failed to parse AI JSON response', { operation: effectiveOperation, error: (error as Error).message, rawResponse: response });
+    logger.warn('Failed to parse AI JSON response', { operation: effectiveOperation, error: (error as Error).message, responseLength: response.length });
     return null;
   }
 }

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -544,7 +544,7 @@ Respond in JSON:
   }
   response.suggestedContent = cleanVisibleAIText(response.suggestedContent);
   response.reason = cleanVisibleAIText(response.reason);
-  logger.info('Share suggestion generated', { preview: response.suggestedContent.substring(0, 50), reason: response.reason });
+  logger.info('Share suggestion generated', { contentLength: response.suggestedContent.length, reasonLength: response.reason.length });
 
   // Use provided DB record or fall back to retry loop
   const dbResult = dbReconcilerResult || await findReconcilerResultWithRetry(sessionId, guesser.id, subject.id);
@@ -655,7 +655,7 @@ Respond in JSON:
     return null;
   }
 
-  logger.debug('Refined suggestion generated', { preview: response.refinedContent.substring(0, 50) });
+  logger.debug('Refined suggestion generated', { contentLength: response.refinedContent.length });
   return response.refinedContent;
 }
 
@@ -898,7 +898,7 @@ export async function respondToShareSuggestion(
     throw new Error('Share suggestion content is empty - cannot share');
   }
 
-  logger.info('User responded to share offer', { userId, action: response.action, preview: sharedContent.substring(0, 50) });
+  logger.info('User responded to share offer', { userId, action: response.action, contentLength: sharedContent.length });
 
   const subjectName = shareOffer.result.subjectName;
   const guesserName = shareOffer.result.guesserName;
@@ -1328,7 +1328,7 @@ Respond in JSON:
   const suggestedContent = cleanVisibleAIText(suggestionResult.suggestedContent);
   const suggestedReason = cleanVisibleAIText(suggestionResult.reason);
 
-  logger.debug('Generated feelings-focused suggestion', { preview: suggestedContent.substring(0, 50) });
+  logger.debug('Generated feelings-focused suggestion', { contentLength: suggestedContent.length });
 
   // Create or update share offer record with the crafted suggestion
   await prisma.reconcilerShareOffer.upsert({


### PR DESCRIPTION
## Changes
- Fix: Replace AI draft content preview (100 chars) with `{length: N}` in log output
- Fix: Replace needs analysis preview (160 chars) with `{length: N}` in log output
- Fix: Replace stage 4 proposals preview (160 chars) with `{length: N}` in log output
- Fix: Replace full dispatch tag content dump with `{length: N}` in log output
- Fix: Replace extended thinking preview (200 chars) with `{length: N}` in log output
- Fix: Replace duplicate message content preview with role-only metadata
- Fix: Remove context bundle snippet from AI orchestrator log, keep char count
- Fix: Replace raw AI response in reconciler parse failure log with `responseLength`
- Fix: Replace empathy statement previews (4 locations) with `contentLength` metadata

Related to #619

## Provenance
- **Channel:** #security-audit
- **Requested by:** automated security audit (weekly)
- **Original message:** Weekly security audit 2026-05-18
- **Prompt(s) used:** 7-domain parallel scan — logging & monitoring agent

## Docs updated
No doc changes needed — log-only change with no behavioral or API impact.