### PR TITLE
fix: close rate limiting gaps on LLM, reconciler, and WebSocket routes

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import routes from './routes';
 import { requestContextMiddleware } from './middleware/request-context';
 import { errorHandler, notFoundHandler } from './middleware/errors';
 import { scannerFilter } from './middleware/scanner-filter';
+import { globalRateLimit } from './middleware/rate-limit';
 import { logger } from './lib/logger';
 
 const app = express();
@@ -87,6 +88,9 @@ app.use((req, res, next) => {
 app.get('/health', (_, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
+
+// Global rate limit — 100 req/min per user safety net (before route-specific limits)
+app.use('/api', globalRateLimit);
 
 // API routes - support both /api and /api/v1 for compatibility
 app.use('/api/v1', routes);

--- a/backend/src/routes/messages.ts
+++ b/backend/src/routes/messages.ts
@@ -11,6 +11,7 @@
 import { Router } from 'express';
 import { requireAuth, requireSessionAccess } from '../middleware/auth';
 import { asyncHandler } from '../middleware/errors';
+import { streamingRateLimit } from '../middleware/rate-limit';
 import {
   sendMessage,
   sendMessageStream,
@@ -26,6 +27,7 @@ router.post(
   '/sessions/:id/messages',
   requireAuth,
   requireSessionAccess,
+  streamingRateLimit,
   asyncHandler(sendMessage)
 );
 
@@ -34,6 +36,7 @@ router.post(
   '/sessions/:id/messages/stream',
   requireAuth,
   requireSessionAccess,
+  streamingRateLimit,
   asyncHandler(sendMessageStream)
 );
 
@@ -58,6 +61,7 @@ router.post(
   '/sessions/:id/messages/initial',
   requireAuth,
   requireSessionAccess,
+  streamingRateLimit,
   asyncHandler(getInitialMessage)
 );
 

--- a/backend/src/routes/reconciler.ts
+++ b/backend/src/routes/reconciler.ts
@@ -9,6 +9,7 @@
 
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth';
+import { empathyRateLimit } from '../middleware/rate-limit';
 import {
   runReconcilerHandler,
   getReconcilerStatusHandler,
@@ -33,7 +34,7 @@ router.use(requireAuth);
  * Analyzes empathy gaps in both directions (A→B and B→A).
  * Should be called after both users have shared their empathy statements.
  */
-router.post('/sessions/:id/reconciler/run', runReconcilerHandler);
+router.post('/sessions/:id/reconciler/run', empathyRateLimit, runReconcilerHandler);
 
 /**
  * Get reconciler status for a session
@@ -58,7 +59,7 @@ router.get('/sessions/:id/reconciler/share-offer', getShareOfferHandler);
  *
  * Accept (with selected quote or custom content) or decline the share offer.
  */
-router.post('/sessions/:id/reconciler/share-offer/respond', respondToShareOfferHandler);
+router.post('/sessions/:id/reconciler/share-offer/respond', empathyRateLimit, respondToShareOfferHandler);
 
 /**
  * Skip share offer without explicit response
@@ -66,7 +67,7 @@ router.post('/sessions/:id/reconciler/share-offer/respond', respondToShareOfferH
  *
  * Marks the share offer as skipped, allowing progression without sharing.
  */
-router.post('/sessions/:id/reconciler/share-offer/skip', skipShareOfferHandler);
+router.post('/sessions/:id/reconciler/share-offer/skip', empathyRateLimit, skipShareOfferHandler);
 
 /**
  * Generate a share draft for the user
@@ -75,7 +76,7 @@ router.post('/sessions/:id/reconciler/share-offer/skip', skipShareOfferHandler);
  * Called when user taps "Yes, help me share" in the ShareTopicDrawer.
  * Generates a draft based on suggestedShareFocus and saves as AI message.
  */
-router.post('/sessions/:id/reconciler/share-offer/generate-draft', generateShareDraftHandler);
+router.post('/sessions/:id/reconciler/share-offer/generate-draft', empathyRateLimit, generateShareDraftHandler);
 
 /**
  * Get reconciler summary after completion
@@ -93,7 +94,7 @@ router.get('/sessions/:id/reconciler/summary', getReconcilerSummaryHandler);
  * Client sends full conversation history each time. No DB writes.
  * Returns AI coaching response and optional proposed content.
  */
-router.post('/sessions/:id/reconciler/refinement/message', refinementChatMessageHandler);
+router.post('/sessions/:id/reconciler/refinement/message', empathyRateLimit, refinementChatMessageHandler);
 
 /**
  * Finalize refinement — share refined content with partner
@@ -101,6 +102,6 @@ router.post('/sessions/:id/reconciler/refinement/message', refinementChatMessage
  *
  * Creates SHARED_CONTEXT message and notifies partner via Ably.
  */
-router.post('/sessions/:id/reconciler/refinement/finalize', refinementFinalizeHandler);
+router.post('/sessions/:id/reconciler/refinement/finalize', empathyRateLimit, refinementFinalizeHandler);
 
 export default router;

--- a/backend/src/services/realtime-transcription.ts
+++ b/backend/src/services/realtime-transcription.ts
@@ -31,6 +31,24 @@ const ASSEMBLYAI_WS_BASE = 'wss://streaming.assemblyai.com/v3/ws';
 // At 16kHz, 16-bit mono PCM: 50ms = 1600 bytes
 const MIN_CHUNK_SIZE = 1600;
 
+// WebSocket connection rate limit: 5 upgrades per 60s per user
+const WS_RATE_WINDOW_MS = 60_000;
+const WS_RATE_MAX = 5;
+const wsConnectionTimestamps = new Map<string, number[]>();
+
+function isWsRateLimited(userId: string): boolean {
+  const now = Date.now();
+  const timestamps = wsConnectionTimestamps.get(userId) || [];
+  const recent = timestamps.filter((t) => now - t < WS_RATE_WINDOW_MS);
+  if (recent.length >= WS_RATE_MAX) {
+    wsConnectionTimestamps.set(userId, recent);
+    return true;
+  }
+  recent.push(now);
+  wsConnectionTimestamps.set(userId, recent);
+  return false;
+}
+
 /**
  * Attach a /realtime WebSocket endpoint to an existing HTTP server.
  * Call this from server.ts after creating the HTTP server.
@@ -55,15 +73,25 @@ export function attachRealtimeWebSocket(server: Server): void {
       return;
     }
 
+    let userId: string;
     try {
       const { verifyToken } = await import('@clerk/express');
       const session = await verifyToken(token, {
         secretKey: CLERK_SECRET_KEY!,
       });
-      logger.info('[Realtime] Authenticated WebSocket upgrade for user:', session.sub);
+      userId = session.sub;
+      logger.info('[Realtime] Authenticated WebSocket upgrade for user:', userId);
     } catch (error) {
       logger.warn('[Realtime] WebSocket upgrade rejected: invalid token', error);
       (socket as Socket).write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+      (socket as Socket).destroy();
+      return;
+    }
+
+    // Rate limit: max 5 WebSocket connections per minute per user
+    if (isWsRateLimited(userId)) {
+      logger.warn('[Realtime] WebSocket upgrade rejected: rate limited for user:', userId);
+      (socket as Socket).write('HTTP/1.1 429 Too Many Requests\r\n\r\n');
       (socket as Socket).destroy();
       return;
     }


### PR DESCRIPTION
## Changes
- Mount `globalRateLimit` (100 req/min per user) in `app.ts` before API routes as a safety net
- Apply `streamingRateLimit` (10 req/min) to all LLM-triggering message POST routes (`/messages`, `/messages/stream`, `/messages/initial`)
- Apply `empathyRateLimit` (20 req/min) to all 6 reconciler POST routes
- Add in-memory per-user connection-rate limit (5 connections/min) to `/realtime` WebSocket upgrade handler

Related to #618

## Provenance
- **Channel:** #security-audit
- **Requested by:** automated security audit (weekly)
- **Original message:** Weekly security audit 2026-05-18
- **Prompt(s) used:** 7-domain parallel scan — network/app security + asset inventory agents

## Docs updated
No doc changes needed — additive middleware insertion only, no API contract changes