### PR TITLE
fix: remove PII from notable-facts log line in Context Assembler

### DIFF
--- a/backend/src/services/context-assembler.ts
+++ b/backend/src/services/context-assembler.ts
@@ -943,13 +943,13 @@ async function loadNotableFacts(
 
   // Debug logging to track notable facts loading
   if (!vessel) {
-    logger.info(`[Context Assembler] loadNotableFacts: No UserVessel found for session=${sessionId}, user=${userId}`);
+    logger.debug(`[Context Assembler] loadNotableFacts: No UserVessel found for session=${sessionId}, user=${userId}`);
     return undefined;
   }
 
   const rawFacts = vessel.notableFacts;
   if (!rawFacts) {
-    logger.info(`[Context Assembler] loadNotableFacts: UserVessel exists but no facts for session=${sessionId}, user=${userId}`);
+    logger.debug(`[Context Assembler] loadNotableFacts: UserVessel exists but no facts for session=${sessionId}, user=${userId}`);
     return undefined;
   }
 
@@ -973,7 +973,7 @@ async function loadNotableFacts(
     return undefined;
   }
 
-  logger.info(`[Context Assembler] loadNotableFacts: Loaded ${categorizedFacts.length} facts for session=${sessionId}, user=${userId}:`, categorizedFacts.slice(0, 3));
+  logger.info(`[Context Assembler] loadNotableFacts: Loaded ${categorizedFacts.length} facts for session=${sessionId}, user=${userId}`);
   return categorizedFacts;
 }
 


### PR DESCRIPTION
## Changes
- Fix: Remove notable-facts content (PII) from `loadNotableFacts` info-level log line — now logs only the count
- Fix: Downgrade no-vessel/no-facts debug logs from `info` to `debug` to reduce log noise

Related to #629

## Provenance
- **Channel:** GitHub issue (security/bug)
- **Requested by:** Daily health check (2026-05-18)
- **Original message:** Context Assembler logs notable-facts content (PII) to Render at info level
- **Prompt(s) used:** N/A — direct code fix

## Docs updated
No doc changes needed — log-level-only fix in a single file, no docs mapped to `context-assembler.ts`