### PR TITLE
fix: show brainstorm/decline actions for partial needs in Stage 4

### DIFF
--- a/mobile/src/components/Stage4RedesignPanel.tsx
+++ b/mobile/src/components/Stage4RedesignPanel.tsx
@@ -392,7 +392,7 @@ function NeedRows({
 
   if (rows.length === 0) return null;
 
-  const showActions = tone === 'open';
+  const showActions = tone === 'open' || tone === 'partial';
 
   return (
     <View style={styles.coverageGroup}>
@@ -668,7 +668,14 @@ export function Stage4RedesignPanel({
         {coverageHasRows ? (
           <>
             <NeedRows title="Covered" rows={state.coverageAudit.covered} tone="covered" />
-            <NeedRows title="Partly addressed" rows={state.coverageAudit.partial} tone="partial" />
+            <NeedRows
+              title="Partly addressed"
+              rows={state.coverageAudit.partial}
+              tone="partial"
+              onBrainstormNeed={onBrainstormNeed}
+              onDeclineNeed={onDeclineNeed}
+              onUndeclineNeed={onUndeclineNeed}
+            />
             <NeedRows
               title="Not yet addressed"
               rows={state.coverageAudit.open}


### PR DESCRIPTION
## Changes
- Fix: partial needs now show "Brainstorm in chat" and "Leave for now" action buttons (previously only open needs had them)
- Fix: `showActions` in `NeedRows` now includes `tone === 'partial'` alongside `tone === 'open'`
- Fix: pass `onBrainstormNeed`, `onDeclineNeed`, `onUndeclineNeed` callbacks to the partial `NeedRows` component

## Root Cause
The `allOpenNeedsAddressedOrDeclined()` gate checks both `open` AND `partial` needs before enabling "Share my stances". But the UI only rendered action buttons for open needs — partial needs had no escape hatch, permanently blocking users.

Related to #631

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr
- **Original message:** "We got stuck here again"

## Docs updated
No doc changes needed — UI-only bug fix with no architectural or API changes.