### PR TITLE
fix: Stage 4 transition — warmer copy, single CTA, push notification

### DIFF
--- a/backend/src/controllers/stage3.ts
+++ b/backend/src/controllers/stage3.ts
@@ -1028,10 +1028,11 @@ export async function validateNeeds(req: Request, res: Response): Promise<void> 
       });
 
       for (const transitionMessage of transitionMessages) {
-        await publishSessionEvent(sessionId, 'partner.stage_completed', {
+        const eventData = {
           forUserId: transitionMessage.forUserId,
           previousStage: 3,
           currentStage: 4,
+          stage: 3,
           userId: user.id,
           triggeredByUserId: user.id,
           message: {
@@ -1040,7 +1041,14 @@ export async function validateNeeds(req: Request, res: Response): Promise<void> 
             timestamp: transitionMessage.timestamp,
             forUserId: transitionMessage.forUserId,
           },
-        });
+        };
+
+        if (transitionMessage.forUserId === partnerId) {
+          // Use notifyPartner so the partner gets a push notification if offline
+          await notifyPartner(sessionId, partnerId, 'partner.stage_completed', eventData);
+        } else {
+          await publishSessionEvent(sessionId, 'partner.stage_completed', eventData);
+        }
       }
     }
 


### PR DESCRIPTION
## Changes
- Fix: Replace directive "Now move…" transition copy with warmer language that explains what happens next (strategy proposals arriving for review)
- Fix: Hide chat input when Stage 4 CTA panel is active — only one affordance visible at a time instead of competing CTA + input
- Fix: Send push notification to offline partner when session advances from Stage 3 → 4 (was Ably-only, so offline users never got notified)

Related to #633

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** The language of the most recent AI message is not good. "Now move…" doesn't seem like the right hot thing to say to the user and I'm not sure what I'm being asked to do. And there's a CTA in addition to the chat input so I'm not clear what is supposed to happen. Also, I never got a notification that this was ready for me.

## Docs updated
No doc changes needed — behavioral fixes to copy, input visibility logic, and notification plumbing. No API surface or documented architecture changes.