### PR TITLE
[codex] Guard Stage 4 streaming leftovers

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -585,6 +585,13 @@ export function isReadyForStage3RevealText(content: string): boolean {
     /(list|lists|needs|side by side|reveal|see them|see it|show)/.test(normalized);
 }
 
+function isClarifyingStage4Response(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed.endsWith('?')) return false;
+
+  return /\b(?:do you mean|what do you mean|which|or something else|clarify|more specific|can you say more|are you saying)\b/i.test(trimmed);
+}
+
 async function getStage3GateResponse(sessionId: string, userId: string): Promise<string | null> {
   const partnerId = await getPartnerUserId(sessionId, userId);
   const progress = await prisma.stageProgress.findUnique({
@@ -2230,12 +2237,11 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
               tagTrapBuffer = thinkingBuffer.substring(closingTagIndex + 11); // 11 = '</thinking>'.length
               thinkingBuffer = '';
             }
-            // Safety: If buffer grows without a closing tag, drop it rather
-            // than risk streaming hidden reasoning to the client.
+            // Safety: if the hidden preamble is long, keep waiting for the
+            // closing tag. Flushing here can expose chain-of-thought or tool
+            // planning to the user and persist it as a real AI message.
             else if (thinkingBuffer.length > 2000) {
-              logger.warn(`[sendMessageStream:${requestId}] Thinking buffer exceeded 2000 chars without closing tag; discarding hidden buffer`);
-              isInsideThinking = false;
-              thinkingBuffer = '';
+              logger.warn(`[sendMessageStream:${requestId}] Thinking buffer exceeded 2000 chars without closing tag; continuing to trap hidden text`);
             }
           }
           // PHASE 2: TAG TRAP - Buffer to catch hidden semantic tags before streaming
@@ -2357,15 +2363,13 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
       }
 
       // =========================================================================
-      // SAFETY FLUSH: Handle AI responses that don't follow expected format
-      // If stream ends while still waiting for </thinking>, discard the buffer
-      // rather than risk leaking hidden reasoning. Still parse semantic tags so
-      // dispatch-only responses can be handled without streaming raw content.
+      // SAFETY FLUSH: If the stream ends while still waiting for </thinking>,
+      // keep that content hidden. It is more important to avoid leaking
+      // internal reasoning/tool planning than to salvage malformed output.
       // =========================================================================
       if (isInsideThinking && thinkingBuffer.length > 0) {
-        logger.warn(`[sendMessageStream:${requestId}] Stream ended while still in thinking trap. Buffer has ${thinkingBuffer.length} chars. Discarding hidden buffer.`);
+        logger.warn(`[sendMessageStream:${requestId}] Stream ended while still in thinking trap. Buffer has ${thinkingBuffer.length} chars. Keeping it hidden.`);
         processTagTrapBuffer(thinkingBuffer);
-        // Store the raw buffer as "thinking" for downstream parsing to find dispatch tags
         thinkingContent = thinkingBuffer;
         thinkingBuffer = '';
         isInsideThinking = false;
@@ -2451,6 +2455,24 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
       // Clean accumulated text (strip <draft> and <dispatch> tags if they leaked through)
       const scrubbedResponse = scrubVisibleAIText(parsed.response);
       accumulatedText = scrubbedResponse.text;
+      if (
+        currentStage === 4 &&
+        metadata.stage4WalkthroughAction &&
+        metadata.stage4WalkthroughAction.action !== 'NONE' &&
+        isClarifyingStage4Response(accumulatedText)
+      ) {
+        logger.warn(`[sendMessageStream:${requestId}] Ignoring Stage 4 state capture because visible response asks for clarification`, {
+          action: metadata.stage4WalkthroughAction.action,
+          needId: metadata.stage4WalkthroughAction.needId ?? null,
+          stage4ProposalCount: metadata.stage4Proposals?.length ?? 0,
+        });
+        metadata.stage4WalkthroughAction = {
+          ...metadata.stage4WalkthroughAction,
+          action: 'NONE',
+          reason: 'visible_response_requested_clarification',
+        };
+        metadata.stage4Proposals = undefined;
+      }
 
       // =========================================================================
       // DISPATCH HANDLING: If dispatch tag detected, get and stream dispatched response

--- a/backend/src/routes/__tests__/messages.test.ts
+++ b/backend/src/routes/__tests__/messages.test.ts
@@ -9,7 +9,7 @@ import {
   isReadyForStage3RevealText,
 } from '../../controllers/messages';
 import { prisma } from '../../lib/prisma';
-import { getSonnetStreamingResponse } from '../../lib/bedrock';
+import { getModelCompletionWithTools, getSonnetStreamingResponse } from '../../lib/bedrock';
 import { buildStagePrompt } from '../../services/stage-prompts';
 import { interpretNeedEditRequest } from '../../services/needs-edit-interpreter.service';
 import { applyNeedEdits } from '../../services/needs-edit-applier.service';
@@ -24,6 +24,7 @@ jest.mock('../../services/realtime', () => ({
   notifySessionMembers: jest.fn().mockResolvedValue(undefined),
   publishMessageAIResponse: jest.fn().mockResolvedValue(undefined),
   publishMessageError: jest.fn().mockResolvedValue(undefined),
+  publishTopicFrameUpdated: jest.fn().mockResolvedValue(undefined),
 }));
 
 // Mock partner session classifier (fire-and-forget memory detection)
@@ -106,6 +107,20 @@ jest.mock('../../services/needs-edit-interpreter.service', () => ({
 jest.mock('../../services/needs-edit-applier.service', () => ({
   applyNeedAction: jest.fn(),
   applyNeedEdits: jest.fn(),
+}));
+
+jest.mock('../../services/stage4-capture.service', () => ({
+  captureStage4Turn: jest.fn().mockResolvedValue({
+    appliedOperationCount: 0,
+    skippedOperationCount: 0,
+    selection: null,
+    closureSignal: null,
+    confidence: 0,
+  }),
+}));
+
+jest.mock('../../services/stage4-auto-closure.service', () => ({
+  applyStage4AutoClosureFromSignal: jest.fn().mockResolvedValue({ closed: false }),
 }));
 
 // Mock request context
@@ -605,6 +620,195 @@ describe('Messages API (Fire-and-Forget)', () => {
       const sseOutput = writeMock.mock.calls.map(([chunk]) => String(chunk)).join('');
       expect(sseOutput).not.toContain('"advancedToStage":2');
       expect(endMock).toHaveBeenCalled();
+    });
+
+    it('does not stream or persist long hidden reasoning before the closing thinking tag', async () => {
+      const stage4Progress = {
+        id: 'progress-4',
+        sessionId: mockSessionId,
+        userId: mockUser.id,
+        stage: 4,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: {},
+      };
+      const session = {
+        id: mockSessionId,
+        status: 'ACTIVE',
+        relationship: {
+          members: [{ userId: mockUser.id }, { userId: 'partner-1' }],
+        },
+      };
+      const userMessage = {
+        id: 'msg-user-stage4',
+        sessionId: mockSessionId,
+        senderId: mockUser.id,
+        role: 'USER',
+        content: 'no thanks',
+        stage: 4,
+        timestamp: new Date('2026-05-22T03:35:16Z'),
+      };
+      const visibleResponse = 'Okay, we can leave that need aside and keep going.';
+      const leakedReasoning = [
+        "at the walkthrough state, we're already supposed to be in PARTNER_NEEDS phase working on Shantam's need.",
+        '',
+        'Let me check the ownNeeds in the walkthrough state:',
+        '- cmperm4sf000mpxlkkexdlcze: "To feel connected to Shantam through shared lightness and laughter" - status=covered',
+        '',
+        'So both of Jason\'s needs are already marked as covered in the walkthrough state.',
+        'The need ID for "To feel connected to Shantam through shared lightness and laughter" is cmperm4sf000mpxlkkexdlcze.',
+        'update_session_state with stage4WalkthroughAction SKIP.',
+      ].join('\n').padEnd(2400, ' hidden reasoning.');
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(session);
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue(session);
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue(stage4Progress);
+      (prisma.stageProgress.findUnique as jest.Mock).mockResolvedValue(stage4Progress);
+      (prisma.message.create as jest.Mock).mockImplementation(async ({ data }) => (
+        data.role === 'USER'
+          ? { ...userMessage, content: data.content }
+          : {
+              id: 'msg-ai-stage4',
+              sessionId: mockSessionId,
+              senderId: null,
+              forUserId: mockUser.id,
+              role: 'AI',
+              content: data.content,
+              stage: data.stage,
+              timestamp: new Date('2026-05-22T03:35:46Z'),
+            }
+      ));
+      (prisma.message.findMany as jest.Mock).mockResolvedValue([userMessage]);
+      (prisma.message.count as jest.Mock).mockResolvedValue(1);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ name: 'Partner' });
+      (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue(null);
+
+      async function* llmStream() {
+        yield { type: 'text', text: leakedReasoning };
+        yield { type: 'text', text: '</thinking>\n' };
+        yield { type: 'text', text: visibleResponse };
+        yield { type: 'done' };
+      }
+      (getSonnetStreamingResponse as jest.Mock).mockReturnValue(llmStream());
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+        body: { content: userMessage.content },
+      });
+      const { res, writeMock } = createMockResponse();
+
+      await sendMessageStream(req as Request, res as Response);
+
+      const aiCreateCall = (prisma.message.create as jest.Mock).mock.calls.find(([arg]) => arg.data.role === 'AI');
+      expect(aiCreateCall[0].data.content).toBe(visibleResponse);
+      const sseOutput = writeMock.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(sseOutput).toContain(visibleResponse);
+      expect(sseOutput).not.toContain('PARTNER_NEEDS');
+      expect(sseOutput).not.toContain('update_session_state');
+    });
+
+    it('does not mark a Stage 4 need covered when the visible response asks for clarification', async () => {
+      const stage4Progress = {
+        id: 'progress-4',
+        sessionId: mockSessionId,
+        userId: mockUser.id,
+        stage: 4,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: {},
+      };
+      const session = {
+        id: mockSessionId,
+        status: 'ACTIVE',
+        relationship: {
+          members: [{ userId: mockUser.id }, { userId: 'partner-1' }],
+        },
+      };
+      const userMessage = {
+        id: 'msg-user-stage4-clarify',
+        sessionId: mockSessionId,
+        senderId: mockUser.id,
+        role: 'USER',
+        content: 'I will promise to let him speak and not talk back',
+        stage: 4,
+        timestamp: new Date('2026-05-22T04:10:00Z'),
+      };
+      const aiContent = 'When you say "not talk back" - do you mean you will not interrupt him, or that you will not dismiss what he is saying, or something else?';
+
+      (getModelCompletionWithTools as jest.Mock).mockResolvedValueOnce({
+        text: null,
+        toolInvocations: [{
+          name: 'update_session_state',
+          input: {
+            stage4Proposals: [{
+              action: 'ADD',
+              classification: 'PROPOSAL',
+              description: 'Promise to let him speak without talking back',
+              kind: 'INDIVIDUAL_COMMITMENT',
+              ownerUserId: mockUser.id,
+              needsAddressed: ['need-current'],
+            }],
+            stage4WalkthroughAction: {
+              action: 'COVERED',
+              needId: 'need-current',
+              reason: 'User named a possible commitment.',
+            },
+          },
+        }],
+      });
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(session);
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue(session);
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue(stage4Progress);
+      (prisma.stageProgress.findUnique as jest.Mock).mockResolvedValue(stage4Progress);
+      (prisma.message.create as jest.Mock).mockImplementation(async ({ data }) => (
+        data.role === 'USER'
+          ? { ...userMessage, content: data.content }
+          : {
+              id: 'msg-ai-stage4-clarify',
+              sessionId: mockSessionId,
+              senderId: null,
+              forUserId: mockUser.id,
+              role: 'AI',
+              content: data.content,
+              stage: data.stage,
+              timestamp: new Date('2026-05-22T04:10:20Z'),
+            }
+      ));
+      (prisma.message.findMany as jest.Mock).mockResolvedValue([userMessage]);
+      (prisma.message.count as jest.Mock).mockResolvedValue(1);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ name: 'Partner' });
+      (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue(null);
+
+      async function* llmStream() {
+        yield { type: 'text', text: 'Mode: STRATEGIC_REPAIR\n</thinking>\n' };
+        yield { type: 'text', text: aiContent };
+        yield { type: 'done' };
+      }
+      (getSonnetStreamingResponse as jest.Mock).mockReturnValue(llmStream());
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+        body: { content: userMessage.content },
+      });
+      const { res, writeMock } = createMockResponse();
+
+      await sendMessageStream(req as Request, res as Response);
+
+      const sseOutput = writeMock.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(sseOutput).toContain('When you say');
+      expect(sseOutput).toContain('not talk back');
+      expect(sseOutput).toContain('"stage4WalkthroughAction":{"action":"NONE"');
+      expect(sseOutput).toContain('visible_response_requested_clarification');
+      expect(sseOutput).not.toContain('stage4Proposals');
+      expect(prisma.stageProgress.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            gatesSatisfied: expect.objectContaining({
+              stage4Walkthrough: expect.anything(),
+            }),
+          }),
+        })
+      );
     });
   });
 

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -1062,8 +1062,12 @@ ${context.stage4WalkthroughContext}
 
 Use this as the source of truth for which need is being explored right now. Stay on currentNeed until it is marked covered/skipped in this state or the walkthrough phase is QUALITY_REVIEW.
 Do not choose a different open need from the broader coverage list while currentNeed is present.
+When phase=MY_NEEDS, help ${context.userName} find options that could honor their own named need.
+When phase=PARTNER_NEEDS, explicitly signal the handoff if this is the first partner need, then help ${context.userName} consider what might honor ${partnerName}'s named need without treating it as an obligation. Focus on shared options or things ${context.userName} can genuinely choose; do not assign tasks to ${partnerName}.
+Only say the walkthrough is complete, that "both your needs and ${partnerName}'s" are done, or that it is time to review "what's on the table" when walkthrough phase is QUALITY_REVIEW. If currentNeed is present after your state action, keep the visible response on that current need instead.
 If the user clearly agrees to move on from currentNeed, call update_session_state with stage4WalkthroughAction.action=COVERED. If they explicitly want to leave the current need aside, use SKIP. Otherwise use NONE.
-If the user gives a concrete enough option for currentNeed, capture or revise the proposal and then either ask whether they want one more option for that same need or, if their latest turn already indicates completion, mark it COVERED. Do not require every detail before moving on when missing details can be inferred provisionally from context.`);
+If the user gives a concrete enough option for currentNeed, capture or revise the proposal and then either ask whether they want one more option for that same need or, if their latest turn already indicates completion, mark it COVERED. Do not require every detail before moving on when missing details can be inferred provisionally from context.
+They do not have to solve every need. They can cover it, skip it for now, or leave it open as useful information. The walkthrough can only reach QUALITY_REVIEW once each own and partner need has either been covered or skipped.`);
   }
   if (context.stage4InventoryContext) {
     dynamicParts.push(`CURRENT STAGE 4 PROPOSAL INVENTORY:

--- a/mobile/src/hooks/__tests__/useStreamingMessage.test.ts
+++ b/mobile/src/hooks/__tests__/useStreamingMessage.test.ts
@@ -67,7 +67,7 @@ describe('useStreamingMessage', () => {
     jest.useRealTimers();
   });
 
-  it('recovers a stuck stream timeout by refetching persisted messages instead of entering error state', async () => {
+  it('soft-recovers a slow stream by refetching persisted messages without closing the connection', async () => {
     const queryClient = createQueryClient();
     const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
     const refetchSpy = jest.spyOn(queryClient, 'refetchQueries');
@@ -92,8 +92,8 @@ describe('useStreamingMessage', () => {
       jest.advanceTimersByTime(15000);
     });
 
-    expect(mockEventSourceInstances[0].close).toHaveBeenCalled();
-    expect(result.current.status).toBe('idle');
+    expect(mockEventSourceInstances[0].close).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('sending');
     expect(result.current.errorMessage).toBeNull();
     expect(result.current.failedMessageContent).toBeNull();
 
@@ -102,7 +102,14 @@ describe('useStreamingMessage', () => {
     expect(refetchSpy).toHaveBeenCalledWith({ queryKey: timelineKeys.infinite('session-123') });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: sessionKeys.state('session-123') });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: stageKeys.empathyStatus('session-123') });
-    expect(warnSpy).toHaveBeenCalledWith('[useStreamingMessage] 15s timeout - recovering persisted messages');
+    expect(warnSpy).toHaveBeenCalledWith('[useStreamingMessage] 15s soft recovery - refetching persisted messages while stream remains open');
+
+    await act(async () => {
+      jest.advanceTimersByTime(75000);
+    });
+
+    expect(mockEventSourceInstances[0].close).toHaveBeenCalled();
+    expect(result.current.status).toBe('idle');
 
     unmount();
     queryClient.clear();

--- a/mobile/src/hooks/useStreamingMessage.ts
+++ b/mobile/src/hooks/useStreamingMessage.ts
@@ -57,6 +57,7 @@ export interface StreamMetadata {
   offerReadyToShare?: boolean;
   proposedEmpathyStatement?: string | null;
   proposedStrategies?: string[];
+  stage4Proposals?: Array<Record<string, unknown>>;
   proposedNeeds?: CapturedNeedInput[];
   proposedNeed?: CapturedNeedInput;
   needAction?: {
@@ -70,6 +71,14 @@ export interface StreamMetadata {
     action: 'COVERED' | 'SKIP' | 'NONE';
     needId?: string;
     reason?: string;
+  };
+  stage4Capture?: {
+    appliedOperationCount?: number;
+    skippedOperationCount?: number;
+    selectionCaptured?: boolean;
+    closureSignalCaptured?: boolean;
+    confidence?: number;
+    autoClosed?: boolean;
   };
   topicFrame?: string | null;
   analysis?: string;
@@ -179,7 +188,9 @@ export function useStreamingMessage(
 
   // Ref for 15-second fallback timer to handle stuck connections
   const fallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const FALLBACK_TIMEOUT = 15000; // 15 seconds
+  const hardTimeoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const SOFT_RECOVERY_TIMEOUT = 15000; // 15 seconds
+  const HARD_STREAM_TIMEOUT = 90000; // 90 seconds
   const reconciliationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   /**
@@ -449,6 +460,12 @@ export function useStreamingMessage(
         queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
         queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
       }
+      if (stage === Stage.STRATEGIC_REPAIR) {
+        queryClient.invalidateQueries({ queryKey: stageKeys.stage4(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.strategies(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.agreements(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+      }
     },
     [queryClient]
   );
@@ -492,6 +509,12 @@ export function useStreamingMessage(
         queryClient.invalidateQueries({ queryKey: stageKeys.empathyStatus(sessionId) });
       }
       if (stage === Stage.NEED_MAPPING) {
+        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+      }
+      if (stage === Stage.STRATEGIC_REPAIR) {
+        queryClient.invalidateQueries({ queryKey: stageKeys.stage4(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.strategies(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.agreements(sessionId) });
         queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
       }
 
@@ -557,6 +580,17 @@ export function useStreamingMessage(
       if (metadata.proposedNeeds && metadata.proposedNeeds.length > 0) {
         queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
         queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
+      }
+
+      if (
+        metadata.stage4Proposals ||
+        metadata.stage4WalkthroughAction ||
+        metadata.stage4Capture
+      ) {
+        queryClient.invalidateQueries({ queryKey: stageKeys.stage4(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.strategies(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.agreements(sessionId) });
+        queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
       }
 
       // NOTE: We intentionally avoid broad invalidation here.
@@ -652,23 +686,39 @@ export function useStreamingMessage(
 
         eventSourceRef.current = es;
 
-        // Start 15-second fallback timer for stuck connections
-        // If streaming doesn't complete in time, poll for latest state
+        // Start a soft recovery timer for slow streams. Some model calls take
+        // longer than 15s before the first visible token; do not close the SSE
+        // connection here or the final response can be lost after it persists.
         if (fallbackTimerRef.current) {
           clearTimeout(fallbackTimerRef.current);
         }
         fallbackTimerRef.current = setTimeout(() => {
-          // Only trigger if EventSource is still active (connection still open)
-          // The timer is cleared on complete/error, so reaching here means we're stuck
           if (eventSourceRef.current) {
-            console.warn('[useStreamingMessage] 15s timeout - recovering persisted messages');
-            // Close the stuck connection
+            console.warn('[useStreamingMessage] 15s soft recovery - refetching persisted messages while stream remains open');
+            fallbackTimerRef.current = null;
+            reconcilePersistedMessages(sessionId);
+            queryClient.invalidateQueries({ queryKey: sessionKeys.state(sessionId) });
+            if (currentStage === Stage.PERSPECTIVE_STRETCH) {
+              queryClient.invalidateQueries({ queryKey: stageKeys.empathyStatus(sessionId) });
+            }
+            if (currentStage === Stage.NEED_MAPPING) {
+              queryClient.invalidateQueries({ queryKey: stageKeys.progress(sessionId) });
+            }
+          }
+        }, SOFT_RECOVERY_TIMEOUT);
+
+        if (hardTimeoutTimerRef.current) {
+          clearTimeout(hardTimeoutTimerRef.current);
+        }
+        hardTimeoutTimerRef.current = setTimeout(() => {
+          if (eventSourceRef.current) {
+            console.warn('[useStreamingMessage] 90s hard timeout - closing stream and recovering persisted messages');
             eventSourceRef.current.close();
             eventSourceRef.current = null;
-            fallbackTimerRef.current = null;
+            hardTimeoutTimerRef.current = null;
             recoverTimedOutStream(sessionId, currentStage);
           }
-        }, FALLBACK_TIMEOUT);
+        }, HARD_STREAM_TIMEOUT);
 
         // Create placeholder AI message once streaming starts
         let placeholderCreated = false;
@@ -864,6 +914,10 @@ export function useStreamingMessage(
             clearTimeout(fallbackTimerRef.current);
             fallbackTimerRef.current = null;
           }
+          if (hardTimeoutTimerRef.current) {
+            clearTimeout(hardTimeoutTimerRef.current);
+            hardTimeoutTimerRef.current = null;
+          }
           if (pendingUpdateRef.current) {
             clearTimeout(pendingUpdateRef.current);
             pendingUpdateRef.current = null;
@@ -939,6 +993,10 @@ export function useStreamingMessage(
             clearTimeout(fallbackTimerRef.current);
             fallbackTimerRef.current = null;
           }
+          if (hardTimeoutTimerRef.current) {
+            clearTimeout(hardTimeoutTimerRef.current);
+            hardTimeoutTimerRef.current = null;
+          }
           if (reconciliationTimerRef.current) {
             clearTimeout(reconciliationTimerRef.current);
             reconciliationTimerRef.current = null;
@@ -970,6 +1028,10 @@ export function useStreamingMessage(
           clearTimeout(reconciliationTimerRef.current);
           reconciliationTimerRef.current = null;
         }
+        if (hardTimeoutTimerRef.current) {
+          clearTimeout(hardTimeoutTimerRef.current);
+          hardTimeoutTimerRef.current = null;
+        }
         console.error('[useStreamingMessage] Error:', error);
         cleanupFailedStream(sessionId, currentStage);
         setErrorMessage((error as Error).message || 'Failed to send message');
@@ -988,6 +1050,10 @@ export function useStreamingMessage(
     if (fallbackTimerRef.current) {
       clearTimeout(fallbackTimerRef.current);
       fallbackTimerRef.current = null;
+    }
+    if (hardTimeoutTimerRef.current) {
+      clearTimeout(hardTimeoutTimerRef.current);
+      hardTimeoutTimerRef.current = null;
     }
     if (reconciliationTimerRef.current) {
       clearTimeout(reconciliationTimerRef.current);

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1707,19 +1707,24 @@ export function UnifiedSessionScreen({
   const hasRedesignedStage4 =
     !!stage4State &&
     (currentStage === Stage.STRATEGIC_REPAIR || session?.status === SessionStatus.RESOLVED);
+  const isStage4WalkingNeeds =
+    hasRedesignedStage4 &&
+    Boolean(stage4State?.walkthrough?.currentNeed) &&
+    (stage4State?.walkthrough?.phase === 'MY_NEEDS' ||
+      stage4State?.walkthrough?.phase === 'PARTNER_NEEDS');
+
   const redesignedStage4ProposalCount =
     (stage4State?.inventory.sharedProposals.length ?? 0) +
     (stage4State?.inventory.individualCommitments.length ?? 0);
   const redesignedStage4AllowsInput =
     currentStage === Stage.STRATEGIC_REPAIR &&
     !!stage4State &&
-    (
-      stage4State.phase === Stage4Phase.INVENTORY_BUILDING ||
-      (
-        stage4State.phase === Stage4Phase.COVERAGE_REVIEW &&
-        redesignedStage4ProposalCount < 2
-      )
-    );
+    !stage4State.outcome &&
+    isStage4WalkingNeeds;
+  const redesignedStage4ShouldHideInput =
+    hasRedesignedStage4 &&
+    !!stage4State &&
+    !redesignedStage4AllowsInput;
 
   const submitStage4Selection = useSubmitStage4ProposalSelection({
     onError: () => {
@@ -3588,16 +3593,16 @@ export function UnifiedSessionScreen({
           );
         }
 
-        // Fallback: when no other panel is queued and we're in the redesigned
-        // Stage 4, surface the proposal-review entry point above the input so
-        // the user always has a way to open the Stage 4 drawer.
+        // Fallback: always keep the redesigned Stage 4 surface reachable. The
+        // drawer is the only place to review proposals, explicitly skip a need,
+        // or mark the current need covered.
         if (hasRedesignedStage4 && stage4State) {
           const walkthrough = stage4State.walkthrough;
-          const isWalkingNeeds =
+          if (
             !stage4State.outcome &&
             (walkthrough.phase === 'MY_NEEDS' || walkthrough.phase === 'PARTNER_NEEDS') &&
-            Boolean(walkthrough.currentNeed);
-          if (isWalkingNeeds && walkthrough.currentNeed) {
+            walkthrough.currentNeed
+          ) {
             const currentNeedProposalCount = walkthrough.proposalGroups.reduce(
               (count, group) => count + group.proposals.length,
               0
@@ -3607,7 +3612,7 @@ export function UnifiedSessionScreen({
             const totalInPhase = Math.max(1, walkthrough.totalInPhase);
             const subtitle =
               currentNeedProposalCount === 0
-                ? 'Keep working in chat; open this only if you want to skip.'
+                ? 'Open this to review the current need, skip it, or keep working in chat.'
                 : currentNeedProposalCount === 1
                   ? 'Open this to refine the option, mark it covered, or skip it.'
                   : `Open this to refine ${currentNeedProposalCount} options, mark it covered, or skip it.`;
@@ -4301,7 +4306,9 @@ export function UnifiedSessionScreen({
             </>
           ) : undefined}
           hideInput={
-            redesignedStage4AllowsInput ? false : derivedShouldHideInput
+            redesignedStage4AllowsInput
+              ? false
+              : redesignedStage4ShouldHideInput || derivedShouldHideInput
           }
           validationCards={validationCards}
           onValidateAccurate={handleValidationAccurate}


### PR DESCRIPTION
## Summary
- keep hidden Stage 4 thinking trapped until the closing tag, and keep malformed hidden buffers out of visible/persisted AI text
- prevent Stage 4 walkthrough/proposal state capture when the visible response is asking the user for clarification
- refresh Stage 4 caches from streaming metadata and use soft/hard streaming recovery timeouts on mobile
- keep the redesigned Stage 4 drawer reachable while hiding freeform input outside active needs walkthrough states

## Validation
- `npm test -- --runInBand src/routes/__tests__/messages.test.ts` from `backend`
- `npm test -- --runInBand src/hooks/__tests__/useStreamingMessage.test.ts` from `mobile`
- `npm run check` from `backend`
- `npm run check` from `mobile`
