### PR TITLE
docs: incremental audit 2026-05-23 — Stage 3/4 rework + Tending flow follow-up

### DIFF
--- a/docs/backend/api/gate-mapping.md
+++ b/docs/backend/api/gate-mapping.md
@@ -35,13 +35,23 @@ Canonical mapping from gate keys to the endpoints/payloads that set them. Used b
 | `needsValidated` | Set automatically after both users share needs; legacy `POST /sessions/:id/needs/validate` remains for compatibility | Side-by-side reveal has been reviewed / Stage 4 can start |
 
 ## Stage 4
+
+**Redesigned flow (primary — willingness-selection model):**
+
+| Gate | Endpoint | Payload trigger |
+|------|----------|-----------------|
+| `selectionSubmitted` | `POST /sessions/:id/stage4/proposals/:proposalId/selection` or `POST /sessions/:id/stage4/selections` or `POST /sessions/:id/stage4/share-selections` | Caller submits or shares willingness decisions |
+| `agreementCreated` | `POST /sessions/:id/stage4/close` | Stage 4 closed with SHARED_AGREEMENT outcome |
+
+**Legacy flow (vestigial — kept for backward compatibility):**
+
 | Gate | Endpoint | Payload trigger |
 |------|----------|-----------------|
 | `strategiesSubmitted` | `POST /sessions/:id/strategies/ready` | Caller marks ready |
 | `rankingsSubmitted` | `POST /sessions/:id/strategies/rank` | Caller submits ranking |
 | `overlapIdentified` | `GET /sessions/:id/strategies/overlap` | Overlap computed (even empty) |
-| `agreementCreated` | `POST /sessions/:id/agreements` | Agreement saved |
 
 ## Notes
 - WAITING state is derived: if one user’s gates for the current stage are all true and the partner’s are not, session shows waiting.
 - Stage advance occurs when all gates for the user’s current stage are true and prerequisites met (e.g., Stage 4 requires both users completed Stage 3).
+- Tending endpoints (`/sessions/:id/tending/*`) operate post-resolution and do not set stage gates.

--- a/docs/backend/api/index.md
+++ b/docs/backend/api/index.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 description: REST API endpoints for the Meet Without Fear backend. All endpoints use JSON request/response bodies.
 slug: /backend/api
 created: 2026-03-11
-updated: 2026-05-18
+updated: 2026-05-23
 status: living
 ---
 # API Specification
@@ -170,9 +170,14 @@ Post-resolution check-in and re-entry. Surfaces after a session resolves to help
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/sessions/:id/tending` | List tending entries (scheduled check-ins + re-entries) |
+| `GET` | `/sessions/:id/tending` | List tending entries, coordination cycles, and between-period notes |
+| `GET` | `/sessions/:id/tending/history` | Get historical tending check-ins (last 20) |
+| `POST` | `/sessions/:id/tending/checkin` | Submit structured three-orientation check-in |
+| `POST` | `/sessions/:id/tending/notes` | Create a between-period reflection note |
 | `POST` | `/sessions/:id/tending/reentry` | Initiate passive re-entry on a resolved session |
 | `POST` | `/sessions/:id/tending/:entryId/responses` | Submit response to an open tending entry |
+| `POST` | `/sessions/:id/tending/:entryId/share` | Share an individual tending entry with partner |
+| `POST` | `/sessions/:id/tending/:entryId/unshare` | Unshare an individual tending entry |
 
 ### [Consent](./consent.md)
 Consensual Bridge mechanism.

--- a/docs/backend/api/stage-4.md
+++ b/docs/backend/api/stage-4.md
@@ -3,7 +3,7 @@ title: "Stage 4 API: Strategic Repair"
 sidebar_position: 11
 description: Endpoints for collaborative strategy proposal, willingness selection, agreement documentation, and Tending check-ins.
 slug: /backend/api/stage-4
-updated: 2026-05-19
+updated: 2026-05-23
 ---
 # Stage 4 API: Strategic Repair
 
@@ -52,8 +52,8 @@ interface GetStage4StateResponse {
   coverageAudit: Stage4CoverageAuditDTO;
   mySelections: Stage4SelectionDTO[];
   partnerSelections: Stage4SelectionDTO[];  // visible after both users share
-  mySelectionStatus: 'NOT_SUBMITTED' | 'SUBMITTED' | 'SHARED';
-  partnerSelectionStatus: 'NOT_SUBMITTED' | 'SUBMITTED' | 'SHARED';
+  mySelectionStatus: 'NOT_STARTED' | 'SUBMITTED';
+  partnerSelectionStatus: 'NOT_STARTED' | 'SUBMITTED';
   walkthrough: Stage4WalkthroughDTO;
   outcome: Stage4OutcomeDTO | null;
   tendingPreview: TendingPreviewDTO | null;
@@ -218,7 +218,7 @@ POST /api/v1/sessions/:id/stage4/close
 
 ```typescript
 interface CloseStage4Request {
-  checkInDate?: string;              // ISO 8601 date; defaults to 10 days out when omitted
+  checkInDate: string;               // ISO 8601 date; client defaults to 10 days from defaultCheckInDate in WalkthroughDTO
   kind?: Stage4ClosureKind;          // Overrides computed kind if provided
   reason?: Stage4ClosureReason;
   summary?: string;                  // max 2000 chars
@@ -266,7 +266,7 @@ Publishes the caller's willingness decisions to their partner. Before sharing, d
 POST /api/v1/sessions/:id/stage4/share-selections
 ```
 
-Returns the full `GetStage4StateResponse` with updated `mySelectionStatus: 'SHARED'`.
+Returns the full `GetStage4StateResponse`. After sharing, `mySelectionStatus` remains `'SUBMITTED'` (sharing is tracked via a separate visibility flag, not an additional status state).
 
 ---
 
@@ -278,7 +278,7 @@ Withdraws the caller's shared selections (allowed while partner has not yet shar
 POST /api/v1/sessions/:id/stage4/unshare-selections
 ```
 
-Returns the full `GetStage4StateResponse` with updated `mySelectionStatus: 'SUBMITTED'`.
+Returns the full `GetStage4StateResponse`.
 
 ---
 

--- a/docs/backend/data-model/prisma-schema.md
+++ b/docs/backend/data-model/prisma-schema.md
@@ -3,7 +3,7 @@ title: Prisma Schema
 sidebar_position: 1
 description: Core Vessel Architecture tables plus pointers to the rest of the Prisma schema (Inner Work, reconciler, memory, needs/people, telemetry).
 slug: /backend/data-model/prisma-schema
-updated: "2026-05-13"
+updated: "2026-05-23"
 ---
 # Prisma Schema
 
@@ -245,20 +245,31 @@ model EmotionalReading {
 
 ```prisma
 model IdentifiedNeed {
-  id          String     @id @default(cuid())
-  vessel      UserVessel @relation(fields: [vesselId], references: [id])
-  vesselId    String
-  need        String     // From universal needs taxonomy
-  category    NeedCategory
-  evidence    String[]   // Quotes/references supporting this need
-  confirmed   Boolean    @default(false) // User confirmed this need
-  aiConfidence Float     // AI confidence in identification
-  createdAt   DateTime   @default(now())
+  id                 String           @id @default(cuid())
+  vessel             UserVessel       @relation(fields: [vesselId], references: [id], onDelete: Cascade)
+  vesselId           String
+  need               String           // From universal needs taxonomy
+  category           NeedCategory
+  evidence           String[]         // Quotes/references supporting this need
+  confirmed          Boolean          @default(false) // User confirmed this need
+  aiConfidence       Float            // AI confidence in identification
+  supersededByNeed   IdentifiedNeed?  @relation("NeedSupersession", fields: [supersededByNeedId], references: [id], onDelete: SetNull)
+  supersededByNeedId String?          // Set when this need is replaced by a refined version in Stage 3
+  supersedes         IdentifiedNeed[] @relation("NeedSupersession")
+  lockedAt           DateTime?        // Set when user confirms needs; prevents further AI modifications
+  deletedAt          DateTime?        // Soft-delete; excluded from active need lists
+  createdAt          DateTime         @default(now())
 
   // Link to shared version if consented
   consentedContent ConsentedContent?
 
+  proposalLinks    StrategyProposalNeed[]
+  refiningMessages Message[]          // Messages associated with refining this need in Stage 3
+
   @@index([vesselId])
+  @@index([supersededByNeedId])
+  @@index([lockedAt])
+  @@index([deletedAt])
 }
 
 enum NeedCategory {
@@ -522,16 +533,18 @@ if (progress.isSynthesisDirty) {
 
 ```prisma
 model Message {
-  id        String      @id @default(cuid())
-  session   Session     @relation(fields: [sessionId], references: [id])
-  sessionId String
-  sender    User?       @relation(fields: [senderId], references: [id])
-  senderId  String?     // null for AI messages
-  forUserId String?     // Which user the AI was responding to (data isolation)
-  role      MessageRole
-  content   String      @db.Text
-  stage     Int
-  timestamp DateTime    @default(now())
+  id             String         @id @default(cuid())
+  session        Session        @relation(fields: [sessionId], references: [id])
+  sessionId      String
+  sender         User?          @relation(fields: [senderId], references: [id])
+  senderId       String?        // null for AI messages
+  forUserId      String?        // Which user the AI was responding to (data isolation)
+  role           MessageRole
+  content        String         @db.Text
+  stage          Int
+  timestamp      DateTime       @default(now())
+  refiningNeed   IdentifiedNeed? @relation(fields: [refiningNeedId], references: [id], onDelete: SetNull)
+  refiningNeedId String?        // Links message to the need it helps refine in Stage 3
 
   // NOTE: Message-level embedding removed per fact-ledger architecture.
   // Session-level contentEmbedding on UserVessel is used instead.
@@ -542,6 +555,7 @@ model Message {
 
   @@index([sessionId, timestamp])
   @@index([sessionId, forUserId, role])
+  @@index([refiningNeedId])
 }
 
 ## Stage 2: Empathy Attempts
@@ -858,8 +872,11 @@ model TendingEntry {
   createdAt      DateTime           @default(now())
   updatedAt      DateTime           @updatedAt
 
-  responses      TendingResponse[]
+  responses       TendingResponse[]
   partialClosures TendingResponsePartialClosure[]
+  entryOutcomes   TendingEntryOutcome[]
+  reminders       TendingReminder[]
+  adjustments     TendingAdjustment[]
 
   @@index([sessionId, scope, ownerUserId])
 }
@@ -891,17 +908,23 @@ One response per entry/user (enforced by upsert in the service).
 
 ```prisma
 model TendingResponse {
-  id             String        @id @default(cuid())
-  tendingEntry   TendingEntry  @relation(fields: [tendingEntryId], references: [id])
+  id             String          @id @default(cuid())
+  tendingEntry   TendingEntry    @relation(fields: [tendingEntryId], references: [id], onDelete: Cascade)
   tendingEntryId String
-  user           User          @relation(fields: [userId], references: [id])
+  user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId         String
-  status         String        // e.g. "WORKED", "PARTLY", "DID_NOT_WORK"
-  reflection     String?       @db.Text
-  continueChoice ContinueChoice?  // Structured forward path enum (see ContinueChoice below)
-  submittedAt    DateTime      @default(now())
+  checkin        TendingCheckin? @relation(fields: [checkinId], references: [id], onDelete: SetNull)
+  checkinId      String?         // Linked when submitted as part of a structured three-orientation check-in
+  status         String          // e.g. "WORKED", "PARTLY", "DID_NOT_WORK"
+  reflection     String?         @db.Text
+  continueChoice ContinueChoice? // Structured forward path enum (see ContinueChoice below)
+  submittedAt    DateTime        @default(now())
 
   partialClosures TendingResponsePartialClosure[]
+  entryOutcomes   TendingEntryOutcome[]
+
+  @@unique([tendingEntryId, userId])
+  @@index([checkinId])
 }
 
 enum ContinueChoice {
@@ -933,6 +956,269 @@ model TendingResponsePartialClosure {
 enum PartialClosureResolution {
   RESOLVED
   CONTINUING
+}
+```
+
+### TendingCheckin
+
+Structured three-orientation check-in submitted by a user at the end of a tending period. Captures how things went across all open entries and needs in one transaction. May be linked to a `TendingCoordinationCycle` when partners co-submit.
+
+```prisma
+model TendingCheckin {
+  id                  String                    @id @default(cuid())
+  session             Session                   @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId           String
+  user                User                      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId              String
+  coordinationCycle   TendingCoordinationCycle? @relation(fields: [coordinationCycleId], references: [id], onDelete: SetNull)
+  coordinationCycleId String?
+  nextAction          TendingNextAction?
+  continueChoice      ContinueChoice?
+  reflectionSummary   String?                   @db.Text
+  submittedAt         DateTime                  @default(now())
+  createdAt           DateTime                  @default(now())
+
+  responses          TendingResponse[]
+  entryOutcomes      TendingEntryOutcome[]
+  needOutcomes       TendingNeedOutcome[]
+  reminders          TendingReminder[]
+  adjustments        TendingAdjustment[]
+  betweenPeriodNotes TendingBetweenPeriodNote[]
+
+  @@index([sessionId, submittedAt])
+  @@index([userId, submittedAt])
+  @@index([coordinationCycleId])
+}
+```
+
+### TendingCoordinationCycle
+
+Coordinates a simultaneous check-in across both partners. Created when a user submits a check-in and the partner has not yet submitted. When both submit (or a deadline passes), the cycle resolves and their outcomes are merged.
+
+```prisma
+model TendingCoordinationCycle {
+  id                 String                    @id @default(cuid())
+  session            Session                   @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId          String
+  createdBy          User                      @relation(fields: [createdByUserId], references: [id], onDelete: Cascade)
+  createdByUserId    String
+  coordinationKey    String?                   // Deduplication key; prevents duplicate cycles for the same set of entries
+  status             TendingCoordinationStatus @default(WAITING_FOR_PARTNER)
+  entryIds           String[]
+  participantUserIds String[]
+  submittedUserIds   String[]
+  responseDeadlineAt DateTime
+  resolvedAt         DateTime?
+  resultSummary      String?                   @db.Text
+  createdAt          DateTime                  @default(now())
+  updatedAt          DateTime                  @updatedAt
+
+  checkins TendingCheckin[]
+
+  @@index([sessionId, status])
+  @@index([coordinationKey])
+  @@index([responseDeadlineAt])
+}
+
+enum TendingCoordinationStatus {
+  WAITING_FOR_PARTNER
+  READY_TO_RESOLVE
+  RESOLVED
+  TIMED_OUT
+}
+```
+
+### TendingEntryOutcome
+
+Per-entry follow-through assessment recorded during a structured check-in. One row per entry per check-in.
+
+```prisma
+model TendingEntryOutcome {
+  id                  String                     @id @default(cuid())
+  checkin             TendingCheckin             @relation(fields: [checkinId], references: [id], onDelete: Cascade)
+  checkinId           String
+  tendingEntry        TendingEntry               @relation(fields: [tendingEntryId], references: [id], onDelete: Cascade)
+  tendingEntryId      String
+  response            TendingResponse?           @relation(fields: [responseId], references: [id], onDelete: SetNull)
+  responseId          String?
+  user                User                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId              String
+  followThroughStatus TendingFollowThroughStatus
+  helpfulnessStatus   TendingHelpfulnessStatus?
+  blockerCategories   TendingBlockerCategory[]
+  whatHappened        String?                    @db.Text
+  helpedNeed          String?                    @db.Text
+  blockerNote         String?                    @db.Text
+  stillWorthTrying    Boolean?
+  createdAt           DateTime                   @default(now())
+
+  @@unique([checkinId, tendingEntryId])
+  @@index([tendingEntryId])
+  @@index([userId, createdAt])
+}
+
+enum TendingFollowThroughStatus {
+  HAPPENED
+  PARTLY_HAPPENED
+  DID_NOT_HAPPEN
+  NOT_SURE
+}
+
+enum TendingHelpfulnessStatus {
+  HELPED
+  PARTLY_HELPED
+  DID_NOT_HELP
+  NOT_SURE
+}
+
+enum TendingBlockerCategory {
+  FORGOT
+  TOO_HARD
+  TOO_FREQUENT
+  UNCLEAR
+  PARTNER_DID_NOT_DO_PART
+  I_DID_NOT_DO_PART
+  CIRCUMSTANCES_CHANGED
+  NO_LONGER_WANTED
+  OTHER
+}
+```
+
+### TendingNeedOutcome
+
+Per-need resolution assessment recorded during a structured check-in.
+
+```prisma
+model TendingNeedOutcome {
+  id               String                      @id @default(cuid())
+  checkin          TendingCheckin              @relation(fields: [checkinId], references: [id], onDelete: Cascade)
+  checkinId        String
+  session          Session                     @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId        String
+  needId           String?
+  needLabel        String
+  sourceUserId     String?
+  resolutionStatus TendingNeedResolutionStatus
+  note             String?                     @db.Text
+  changedNeedLabel String?
+  nextAction       TendingNextAction?
+  createdAt        DateTime                    @default(now())
+
+  @@index([sessionId, createdAt])
+  @@index([checkinId])
+  @@index([needId])
+}
+
+enum TendingNeedResolutionStatus {
+  RESOLVED
+  IMPROVING
+  STILL_OPEN
+  CHANGED
+  NOT_SURE
+}
+```
+
+### TendingReminder
+
+A reminder scheduled for a user about a tending entry. Created during a check-in to follow up on open commitments.
+
+```prisma
+model TendingReminder {
+  id             String               @id @default(cuid())
+  session        Session              @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId      String
+  checkin        TendingCheckin?      @relation(fields: [checkinId], references: [id], onDelete: SetNull)
+  checkinId      String?
+  tendingEntry   TendingEntry?        @relation(fields: [tendingEntryId], references: [id], onDelete: Cascade)
+  tendingEntryId String?
+  user           User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId         String
+  scope          TendingReminderScope
+  remindAt       DateTime
+  cadence        String?              // e.g. "WEEKLY", "MONTHLY", "BIMONTHLY", "ONCE"
+  note           String?              @db.Text
+  status         String               @default("SCHEDULED")
+  createdAt      DateTime             @default(now())
+  updatedAt      DateTime             @updatedAt
+
+  @@index([sessionId, remindAt])
+  @@index([userId, remindAt])
+  @@index([checkinId])
+  @@index([tendingEntryId])
+}
+
+enum TendingReminderScope {
+  PRIVATE  // Visible only to the user who created it
+  SHARED   // Visible to both partners
+}
+```
+
+### TendingAdjustment
+
+Records a modification to a commitment (text, cadence, scope, or success criteria) made during a check-in.
+
+```prisma
+model TendingAdjustment {
+  id                     String               @id @default(cuid())
+  session                Session              @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId              String
+  checkin                TendingCheckin       @relation(fields: [checkinId], references: [id], onDelete: Cascade)
+  checkinId              String
+  tendingEntry           TendingEntry         @relation(fields: [tendingEntryId], references: [id], onDelete: Cascade)
+  tendingEntryId         String
+  user                   User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId                 String
+  privacyScope           TendingReminderScope @default(PRIVATE)
+  revisedCommitmentText  String?              @db.Text
+  revisedCadence         String?
+  revisedScope           String?              @db.Text
+  revisedSuccessCriteria String?              @db.Text
+  reason                 String?              @db.Text
+  blockerAddressed       TendingBlockerCategory[]
+  createdAt              DateTime             @default(now())
+
+  @@index([sessionId, createdAt])
+  @@index([checkinId])
+  @@index([tendingEntryId])
+  @@index([userId, createdAt])
+}
+```
+
+### TendingBetweenPeriodNote
+
+A reflection note written between tending check-ins. Can optionally be carried forward and shared with the partner during the next check-in.
+
+```prisma
+model TendingBetweenPeriodNote {
+  id                        String          @id @default(cuid())
+  session                   Session         @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  sessionId                 String
+  user                      User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId                    String
+  content                   String          @db.Text   // max 4000 chars
+  carryForwardSelected      Boolean         @default(false)
+  consentToShareWithPartner Boolean         @default(false)
+  shareConsentAt            DateTime?
+  selectedForCheckin        TendingCheckin? @relation(fields: [selectedForCheckinId], references: [id], onDelete: SetNull)
+  selectedForCheckinId      String?
+  createdAt                 DateTime        @default(now())
+  updatedAt                 DateTime        @updatedAt
+
+  @@index([sessionId, userId, createdAt])
+  @@index([selectedForCheckinId])
+}
+```
+
+### Tending Enums (new in Phase 5)
+
+```prisma
+enum TendingNextAction {
+  FULL_CLOSURE        // Mark all entries COMPLETED; session → RESOLVED
+  EXTEND              // Reschedule open entries with a new date
+  ADJUST_COMMITMENT   // Modify commitment text/cadence/scope
+  REOPEN_STRATEGY_WORK // Return to Stage 4 inventory building
+  NEW_PROCESS         // Create a fresh linked session
+  PARTIAL_CLOSURE     // Close some entries, continue others
 }
 ```
 


### PR DESCRIPTION
## Changes
- **Fix:** `gate-mapping.md` — replace stale legacy Stage 4 gates with redesigned willingness-selection gates (`selectionSubmitted`, `agreementCreated`); mark old ranking gates as vestigial
- **Fix:** `api/index.md` — add 5 missing Tending endpoints (`GET history`, `POST checkin`, `POST notes`, `POST :entryId/share`, `POST :entryId/unshare`)
- **Fix:** `api/stage-4.md` — correct selection status enum (`NOT_SUBMITTED` → `NOT_STARTED`, remove phantom `SHARED` state); fix `CloseStage4Request.checkInDate` (required, not optional); clarify share-selections status semantics
- **Fix:** `prisma-schema.md` — document 7 new Tending models introduced by Phase 5 migrations (`TendingCheckin`, `TendingCoordinationCycle`, `TendingEntryOutcome`, `TendingNeedOutcome`, `TendingReminder`, `TendingAdjustment`, `TendingBetweenPeriodNote`) plus 7 new enums; update `IdentifiedNeed` with Stage 3 need-refinement fields (`lockedAt`, `deletedAt`, `supersededByNeedId`); update `Message` with `refiningNeedId`; update `TendingEntry` and `TendingResponse` with Phase 5 relations

> ⚠️ **Flagged for manual follow-up (not a doc fix):** `backend/src/services/reconciler/sharing.ts` calls `getSonnetJson()` which is not exported by `bedrock.ts`. This is likely a runtime bug — worth investigating before the next deploy.

## Provenance
- **Channel:** cron / `audit-docs`
- **Requested by:** automated nightly run
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** `/audit-docs` — 6 parallel audit agents across prisma schema, stage 3 API, stage 4 + tending API, state machine, prompting architecture, and tending coverage

## Docs updated
- `docs/backend/api/gate-mapping.md`
- `docs/backend/api/index.md`
- `docs/backend/api/stage-4.md`
- `docs/backend/data-model/prisma-schema.md`