### PR TITLE
Fix duplicate needs capture in Stage 3

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1783,7 +1783,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
 
     // Assemble full context including notable facts from UserVessel
     // Also fetch latest emotional reading for intensity-dependent prompt behavior
-    const [contextBundle, sharedContentHistory, milestoneContext, emotionalIntensity] = await Promise.all([
+    const [contextBundle, sharedContentHistory, milestoneContext, emotionalIntensity, capturedNeeds] = await Promise.all([
       assembleContextBundle(
         sessionId,
         user.id,
@@ -1817,6 +1817,22 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
         }
         return 5; // Default if no reading
       })(),
+      // Stage 3: fetch already-captured needs so the AI avoids duplicates
+      currentStage === 3
+        ? (async () => {
+            const vessel = await prisma.userVessel.findUnique({
+              where: { userId_sessionId: { userId: user.id, sessionId } },
+              select: { id: true },
+            });
+            if (!vessel) return null;
+            const needs = await prisma.identifiedNeed.findMany({
+              where: { vesselId: vessel.id },
+              orderBy: { createdAt: 'asc' },
+              select: { id: true, need: true, confirmed: true },
+            });
+            return needs.length > 0 ? needs : null;
+          })()
+        : Promise.resolve(null),
     ]);
 
     logger.info(`[sendMessageStream:${requestId}] Context assembled: notableFacts=${contextBundle.notableFacts?.length ?? 0}, emotionalIntensity=${emotionalIntensity}`);
@@ -1948,6 +1964,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
       empathyDraft: empathyDraftContent || undefined,
       isRefiningEmpathy: isRefiningEmpathy || undefined,
       refiningNeed: refiningNeedContext,
+      capturedNeeds,
       stage4InventoryContext,
       stage4WalkthroughContext,
       stage4OpenNeeds,

--- a/backend/src/services/needs.ts
+++ b/backend/src/services/needs.ts
@@ -223,6 +223,12 @@ export async function captureSingleNeedForUser(
     : [];
 
   const created = await prisma.$transaction(async (tx) => {
+    // Prevent duplicate unconfirmed needs from accumulating across turns.
+    // The AI cannot see already-captured needs and may re-propose.
+    await tx.identifiedNeed.deleteMany({
+      where: { vesselId: vessel.id, confirmed: false },
+    });
+
     const need = await tx.identifiedNeed.create({
       data: {
         vesselId: vessel.id,

--- a/backend/src/services/stage-prompts.ts
+++ b/backend/src/services/stage-prompts.ts
@@ -445,6 +445,8 @@ export interface PromptContext {
     need: string;
     category?: string;
   } | null;
+  /** Stage 3: already-captured needs so the AI avoids duplicates */
+  capturedNeeds?: Array<{ id: string; need: string; confirmed: boolean }> | null;
   /** Whether user is actively refining their empathy draft */
   isRefiningEmpathy?: boolean;
   /** Shared context from partner (when guesser is in REFINING status from reconciler flow) */
@@ -938,6 +940,14 @@ ${buildResponseProtocol(3)}`;
     dynamicParts.push(`REFINING NEED CONTEXT:
 The user is refining need ${context.refiningNeed.id} currently reading: "${context.refiningNeed.need}".
 Focus on this need only this turn. If the user's update is clear, call update_session_state with needAction.type=refine and supersedes="${context.refiningNeed.id}" for the revised version. If they dismiss or say never mind, respond conversationally and do not update state.`);
+  }
+
+  // Inject already-captured needs so the AI avoids proposing duplicates
+  if (context.capturedNeeds?.length) {
+    const needsList = context.capturedNeeds
+      .map((n, i) => `${i + 1}. "${n.need}" (${n.confirmed ? 'confirmed' : 'draft'})`)
+      .join('\n');
+    dynamicParts.push(`ALREADY CAPTURED NEEDS:\n${needsList}\nDo NOT propose a need that duplicates an existing one. If ${context.userName} says this is enough, stop proposing new needs.`);
   }
 
   // Content-aware pacing (every turn): let what the user said drive the mode,


### PR DESCRIPTION
## Summary

- **Bug 1 fix**: `captureSingleNeedForUser` now deletes existing unconfirmed needs before creating a new one, preventing duplicates from accumulating when the AI proposes on consecutive turns
- **Bug 2 fix**: Stage 3 dynamic prompt now injects the current captured needs list so the AI knows what's already been captured and avoids re-proposing
- Adds `capturedNeeds` field to `PromptContext` and fetches it in parallel during message streaming

## Provenance

- Channel: DM (Shantam)
- Requester: Shantam (U0AD3TF2U7L)
- Context: Duplicate needs appeared in session `cmpc3ra1g0097nw1yu40bb1q6` — three needs captured across three consecutive turns despite user confirming first was enough

## Test plan

- [ ] Verify type-checking passes (`npm run check`)
- [ ] Verify existing needs tests pass
- [ ] Manual test: in Stage 3, confirm a single need → verify AI doesn't re-propose on the next turn
- [ ] Manual test: confirm that confirmed needs are preserved (only unconfirmed are replaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)