### PR TITLE
Fix CTA panel cut off at bottom of chat screen

### DIFF
--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -1417,7 +1417,9 @@ const useStyles = () => {
       paddingBottom: 0,
     },
     auxiliaryControls: {
-      overflow: 'hidden',
+      // overflow: 'hidden' removed — it interacted badly with
+      // LayoutAnimation during keyboard transitions, permanently
+      // clipping CTA panels at the bottom of the composer.
     },
   }));
 };


### PR DESCRIPTION
## Summary

- Remove `overflow: 'hidden'` from the `auxiliaryControls` container in `ChatInterface`
- This style interacted poorly with `LayoutAnimation` during keyboard transitions, causing the CTA panel's container height to freeze at an intermediate value and permanently clip content
- Fixes both the "Start with the first need" and needs review CTA panels being cut off at the bottom of the screen

## What was happening

The `auxiliaryControls` wrapper had `overflow: 'hidden'`. When a CTA panel appeared while a stale `LayoutAnimation` (configured during keyboard show/hide) was still pending, the container height got frozen at a smaller intermediate value. `overflow: 'hidden'` then permanently clipped the panel — the subtitle text and bottom padding of the CTA card were hidden.

## Why this is safe

The `LayoutAnimation` uses **opacity** for create/delete transitions, so overflow clipping was never needed for those. The `update` animation (110ms easeInEaseOut) may briefly show content beyond bounds during height transitions, which is an acceptable trade-off vs permanently clipping CTAs.

## Test plan

- [ ] Open a session that shows a CTA panel at the bottom (e.g. "Start with the first need")
- [ ] Verify the full CTA card is visible including subtitle text
- [ ] Open keyboard, dismiss it, verify CTA is still fully visible
- [ ] Check the needs review CTA similarly

## Provenance

- **Channel:** #bugs-and-requests
- **Requester:** Shantam
- **Message:** "This CTA is cut off at the bottom. The previous one for the needs had the same issue."

🤖 Generated with [Claude Code](https://claude.com/claude-code)