### PR TITLE
Shorten CTA subtitle and show input in Stage 4

### DIFF
--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1724,7 +1724,9 @@ export function UnifiedSessionScreen({
   const redesignedStage4ShouldHideInput =
     hasRedesignedStage4 &&
     !!stage4State &&
-    !redesignedStage4AllowsInput;
+    !redesignedStage4AllowsInput &&
+    // Don't hide input before walkthrough begins — user should be able to chat
+    (redesignedStage4ProposalCount > 0 || !!stage4State.walkthrough?.currentNeed);
 
   const submitStage4Selection = useSubmitStage4ProposalSelection({
     onError: () => {
@@ -3648,7 +3650,7 @@ export function UnifiedSessionScreen({
                 tone="needs"
                 eyebrow="What matters"
                 title="Start with the first need"
-                subtitle="Open this to work through what might honor it, one need at a time."
+                subtitle="Tap to explore what might honor each need."
                 compact
                 pressable
                 primaryAction={{


### PR DESCRIPTION
## Summary

- Shorten "Start with the first need" subtitle from "Open this to work through what might honor it, one need at a time." to "Tap to explore what might honor each need." — the long text was being truncated on one line
- Show the chat input before the Stage 4 walkthrough begins — previously hidden for all Stage 4 states unless actively walking needs, now visible when proposalCount is 0 and no walkthrough is in progress

Follow-up to #646 (CTA bottom cut-off fix).

## Test plan

- [ ] Open a session at Stage 4 with no proposals yet
- [ ] Verify CTA subtitle fits cleanly without truncation
- [ ] Verify chat input is visible below the emotion slider
- [ ] Start walking needs — verify input shows during walkthrough
- [ ] After proposals exist — verify input hides appropriately

## Provenance

- **Channel:** #bugs-and-requests
- **Requester:** Shantam

🤖 Generated with [Claude Code](https://claude.com/claude-code)