### PR TITLE
Fix internal ID shown in proposal Addresses field

### DIFF
--- a/backend/src/services/stage-tools.ts
+++ b/backend/src/services/stage-tools.ts
@@ -97,7 +97,7 @@ Call this tool before your visible conversational response whenever the latest t
             description: { type: 'string' },
             kind: { type: ['string', 'null'], enum: ['SHARED_PROPOSAL', 'INDIVIDUAL_COMMITMENT', null] },
             ownerUserId: { type: ['string', 'null'] },
-            needsAddressed: { type: 'array', items: { type: 'string' } },
+            needsAddressed: { type: 'array', items: { type: 'string' }, description: 'Human-readable need labels (e.g. "Partnership", "Understanding"). Never use internal IDs.' },
             duration: { type: ['string', 'null'] },
             measureOfSuccess: { type: ['string', 'null'] },
           },

--- a/backend/src/services/stage4-capture.service.ts
+++ b/backend/src/services/stage4-capture.service.ts
@@ -84,7 +84,7 @@ export async function linkProposalToIdentifiedNeeds(
   const matchedNeedIds = new Set<string>();
   for (const label of needLabels) {
     for (const candidate of candidates) {
-      if (needLabelMatches(label, candidate.need)) {
+      if (label === candidate.id || needLabelMatches(label, candidate.need)) {
         matchedNeedIds.add(candidate.id);
       }
     }

--- a/backend/src/services/stage4-state.ts
+++ b/backend/src/services/stage4-state.ts
@@ -227,7 +227,8 @@ function buildProposalCard(
   selections: Stage4SelectionRow[],
   coverageRows: Stage4NeedCoverageRow[],
   revealPartnerSelections: boolean,
-  needLinks: Array<{ needId: string; needText: string }> = []
+  needLinks: Array<{ needId: string; needText: string }> = [],
+  needIdToLabel: Map<string, string> = new Map()
 ): ProposalCardDTO {
   const mySelection = selections.find(
     (selection) => selection.proposalId === proposal.id && selection.userId === userId
@@ -273,8 +274,8 @@ function buildProposalCard(
           })
         : linkedCoverage.length > 0
           ? linkedCoverage
-          : proposal.needsAddressed.map((label) => ({
-              label,
+          : proposal.needsAddressed.map((raw) => ({
+              label: needIdToLabel.get(raw) ?? raw,
               coverage: 'COVERED',
             })),
     duration: proposal.duration,
@@ -679,6 +680,10 @@ export async function getStage4State(
     arr.push({ needId: link.needId, needText: text });
     linksByProposal.set(link.proposalId, arr);
   }
+  const needIdToLabel = new Map<string, string>();
+  for (const row of coverageRows) {
+    if (row.needId) needIdToLabel.set(row.needId, row.needLabel);
+  }
   const proposalCards = activeProposals.map((proposal) =>
     buildProposalCard(
       proposal,
@@ -687,7 +692,8 @@ export async function getStage4State(
       selections,
       coverageRows,
       revealPartnerSelections,
-      linksByProposal.get(proposal.id) ?? []
+      linksByProposal.get(proposal.id) ?? [],
+      needIdToLabel
     )
   );
   const unaddressedNeeds = buildUnaddressedNeeds(coverageRows, userId, partnerUserId);


### PR DESCRIPTION
## Changes
- Fix: Add description to AI tool schema for `needsAddressed` instructing use of human-readable labels, not IDs
- Fix: `linkProposalToIdentifiedNeeds` now matches by need ID in addition to fuzzy label matching, so junction records are created even when AI passes IDs
- Fix: `buildProposalCard` fallback resolves ID-like strings to labels via coverage row lookup, fixing display for existing data

Related to #648

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam
- **Original message:** It looks like there's an id or something being shown to the user.

## Docs updated
No doc changes needed — backend-only bug fix with no doc mappings for affected files.