### PR TITLE
Exclude partial needs from Stage 4 sharing gate

### DIFF
--- a/mobile/src/components/Stage4RedesignPanel.tsx
+++ b/mobile/src/components/Stage4RedesignPanel.tsx
@@ -59,7 +59,7 @@ function allOpenNeedsAddressedOrDeclined(state: GetStage4StateResponse): boolean
       .filter((p) => p.myDecision === Stage4SelectionDecision.WILLING)
       .map((p) => p.id),
   );
-  const rows = [...safeState.coverageAudit.open, ...safeState.coverageAudit.partial];
+  const rows = safeState.coverageAudit.open;
   return rows.every((row) => {
     if (row.userDeclinedToAddress) return true;
     return row.coveringProposalIds.some((pid) => willingProposalIds.has(pid));

--- a/mobile/src/components/Stage4RedesignPanel.tsx
+++ b/mobile/src/components/Stage4RedesignPanel.tsx
@@ -49,7 +49,7 @@ interface Stage4RedesignFooterProps {
 }
 
 /**
- * True iff every OPEN or PARTIAL need is either covered by a proposal the user
+ * True iff every OPEN need is either covered by a proposal the user
  * marked WILLING or explicitly declined ("leave for now") by the user.
  */
 function allOpenNeedsAddressedOrDeclined(state: GetStage4StateResponse): boolean {


### PR DESCRIPTION
## Changes
- Fix: Remove PARTIAL coverage rows from the `allOpenNeedsAddressedOrDeclined()` gate check — only OPEN needs now block sharing
- The gate previously included both OPEN and PARTIAL rows, but only OPEN needs have user-actionable controls (brainstorm in chat / leave for now). PARTIAL needs blocked sharing with no escape hatch.
- The CTA subtitle text ("brainstorm or set them aside first") is accurate for OPEN needs, so no text change needed.

Related to #649

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam
- **Original message:** "It says there are needs still unaddressed but that doesn't seem true. I think the brainstorm is not even an option anymore."

## Docs updated
No doc changes needed — one-line logic fix in mobile component.