### PR TITLE
[codex] Fix empty Stage 4 review state

### DIFF
--- a/mobile/src/components/Stage4RedesignPanel.tsx
+++ b/mobile/src/components/Stage4RedesignPanel.tsx
@@ -33,6 +33,7 @@ interface Stage4RedesignPanelProps {
   onUndeclineNeed?: (needId: string) => void;
   onMarkNeedCovered?: (needId: string) => void;
   onSkipNeed?: (needId: string) => void;
+  onBackToChat?: () => void;
   onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason, checkInDate: string) => void;
 }
 
@@ -45,6 +46,7 @@ interface Stage4RedesignFooterProps {
   onShareSelections?: () => void;
   onReviseSelections?: () => void;
   onKeepRefiningNoOverlap?: () => void;
+  onBackToChat?: () => void;
   onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason, checkInDate: string) => void;
 }
 
@@ -535,6 +537,7 @@ export function Stage4RedesignFooter({
   onReviseSelections,
   onCloseStage4,
   onKeepRefiningNoOverlap,
+  onBackToChat,
 }: Stage4RedesignFooterProps) {
   const { palette } = useAppAppearance();
   const styles = useMemo(() => makeStyles(palette), [palette]);
@@ -576,10 +579,22 @@ export function Stage4RedesignFooter({
   if (allProposals.length === 0) {
     return (
       <View style={styles.footerContainer}>
-        <View style={styles.statusBlock}>
-          <Text style={styles.statusText}>
-            Proposals will appear here as your conversation develops them.
-          </Text>
+        <View style={styles.actions}>
+          <View style={styles.statusBlock}>
+            <Text style={styles.statusText}>
+              Close this and keep brainstorming in the chat. Proposals will appear here once they are captured.
+            </Text>
+          </View>
+          {onBackToChat && (
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={onBackToChat}
+              accessibilityRole="button"
+              testID="stage4-back-to-chat"
+            >
+              <Text style={styles.secondaryButtonText}>Back to chat</Text>
+            </TouchableOpacity>
+          )}
         </View>
       </View>
     );
@@ -684,6 +699,7 @@ export function Stage4RedesignPanel({
   onUndeclineNeed,
   onMarkNeedCovered,
   onSkipNeed,
+  onBackToChat,
   onCloseStage4,
 }: Stage4RedesignPanelProps) {
   const { palette } = useAppAppearance();
@@ -826,6 +842,39 @@ export function Stage4RedesignPanel({
   }
 
   if (!state.outcome && walkthrough.phase === 'QUALITY_REVIEW') {
+    if (allProposals.length === 0) {
+      return (
+        <View style={styles.container} testID="stage4-redesign-panel">
+          <View style={styles.walkthroughHeader}>
+            <View>
+              <Text style={styles.walkthroughTitle}>Keep brainstorming</Text>
+              <Text style={styles.walkthroughProgress}>No options have been captured yet.</Text>
+            </View>
+          </View>
+          <View style={styles.card}>
+            <Text style={styles.sectionTitle}>Next step</Text>
+            <Text style={styles.emptyText}>
+              Close this and keep talking in the chat. When something feels workable, it will appear here for review.
+            </Text>
+          </View>
+          {!hideFooter && (
+            <Stage4RedesignFooter
+              state={state}
+              partnerName={partnerName}
+              isClosing={isClosing}
+              isSharing={isSharing}
+              isRevising={isRevising}
+              onShareSelections={onShareSelections}
+              onReviseSelections={onReviseSelections}
+              onKeepRefiningNoOverlap={onKeepRefiningNoOverlap}
+              onBackToChat={onBackToChat}
+              onCloseStage4={onCloseStage4}
+            />
+          )}
+        </View>
+      );
+    }
+
     return (
       <View style={styles.container} testID="stage4-redesign-panel">
         <View style={styles.walkthroughHeader}>

--- a/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
+++ b/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
@@ -257,6 +257,41 @@ describe('Stage4RedesignPanel', () => {
     expect(screen.getAllByLabelText('Willing for proposal').length).toBeGreaterThan(0);
   });
 
+  it('does not show agreement review when quality review has no proposals', () => {
+    const onBackToChat = jest.fn();
+    const reviewState: GetStage4StateResponse = {
+      ...walkthroughNeedsState,
+      inventory: {
+        ...walkthroughNeedsState.inventory,
+        sharedProposals: [],
+        individualCommitments: [],
+      },
+      walkthrough: {
+        ...walkthroughNeedsState.walkthrough!,
+        phase: 'QUALITY_REVIEW',
+        currentNeed: null,
+        proposalGroups: [],
+      },
+    };
+
+    render(
+      <Stage4RedesignPanel
+        {...defaultProps}
+        state={reviewState}
+        onBackToChat={onBackToChat}
+      />
+    );
+
+    expect(screen.getByText('Keep brainstorming')).toBeTruthy();
+    expect(screen.getByText('No options have been captured yet.')).toBeTruthy();
+    expect(screen.queryByText('Review agreements')).toBeNull();
+    expect(screen.queryByText('Options to consider')).toBeNull();
+
+    fireEvent.press(screen.getByTestId('stage4-back-to-chat'));
+
+    expect(onBackToChat).toHaveBeenCalledTimes(1);
+  });
+
   it('enables shared-agreement closure only when mutual willingness is visible', () => {
     const state: GetStage4StateResponse = {
       ...baseState,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -4725,6 +4725,7 @@ export function UnifiedSessionScreen({
                 onUndeclineNeed={handleUndeclineStage4Need}
                 onMarkNeedCovered={handleMarkStage4NeedCovered}
                 onSkipNeed={handleSkipStage4Need}
+                onBackToChat={() => setShowStage4Drawer(false)}
                 onCloseStage4={(kind, reason, checkInDate) => {
                   handleCloseRedesignedStage4(kind, reason, checkInDate);
                   setShowStage4Drawer(false);
@@ -4742,6 +4743,7 @@ export function UnifiedSessionScreen({
               onShareSelections={handleShareStage4Selections}
               onReviseSelections={handleReviseStage4Selections}
               onKeepRefiningNoOverlap={handleKeepRefiningNoOverlap}
+              onBackToChat={() => setShowStage4Drawer(false)}
               onCloseStage4={(kind, reason, checkInDate) => {
                 handleCloseRedesignedStage4(kind, reason, checkInDate);
                 setShowStage4Drawer(false);

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -3645,16 +3645,21 @@ export function UnifiedSessionScreen({
           ];
           const proposalCount = allProposals.length;
           if (proposalCount === 0) {
+            const isEmptyQualityReview = walkthrough.phase === 'QUALITY_REVIEW';
             return (
               <GuidedActionPanel
                 tone="needs"
-                eyebrow="What matters"
-                title="Start with the first need"
-                subtitle="Tap to explore what might honor each need."
+                eyebrow={isEmptyQualityReview ? 'What comes next' : 'What matters'}
+                title={isEmptyQualityReview ? 'Keep brainstorming' : 'Start with the first need'}
+                subtitle={
+                  isEmptyQualityReview
+                    ? 'No options captured yet. Keep talking in chat.'
+                    : 'Tap to explore what might honor each need.'
+                }
                 compact
                 pressable
                 primaryAction={{
-                  label: 'Open Stage 4',
+                  label: isEmptyQualityReview ? 'Open guidance' : 'Open Stage 4',
                   onPress: () => {
                     Keyboard.dismiss();
                     setShowStage4Drawer(true);


### PR DESCRIPTION
## Summary

- Handle the empty Stage 4 `QUALITY_REVIEW` state as a brainstorming recovery state instead of an agreement review.
- Add a `Back to chat` affordance for the Stage 4 drawer when no proposals have been captured.
- Add regression coverage for the empty review state.

## Why

Stephanie hit a drawer that said `Review agreements` even though there were no proposals and no composer in the drawer. That made the app feel like it wanted input but offered nowhere to type.

## Root Cause

The Stage 4 panel treated `walkthrough.phase === QUALITY_REVIEW` as agreement review unconditionally. When `allProposals.length === 0`, it still rendered `Options to consider` / `No proposals captured yet`, and the drawer footer only said proposals would appear later.

## Validation

- `npm --prefix mobile test -- Stage4RedesignPanel.test.tsx --runInBand`
- `npm --prefix mobile run check`
- `git diff --check`
