### PR TITLE
[codex] Add Stage 4 walkthrough reset recovery

### DIFF
--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -243,7 +243,7 @@ const submitStage4SelectionsRequestSchema = z.object({
 });
 
 const stage4NeedWalkthroughActionSchema = z.object({
-  action: z.enum(['covered', 'skip']),
+  action: z.enum(['covered', 'skip', 'reset']),
 });
 
 const requestSuggestionsRequestSchema = z.object({
@@ -303,6 +303,13 @@ class Stage4ClosedConflictError extends Error {
   constructor() {
     super('Stage 4 is already closed');
     this.name = 'Stage4ClosedConflictError';
+  }
+}
+
+class Stage4WalkthroughNeedNotFoundError extends Error {
+  constructor() {
+    super('Stage 4 walkthrough need not found');
+    this.name = 'Stage4WalkthroughNeedNotFoundError';
   }
 }
 
@@ -413,9 +420,15 @@ async function updateStage4WalkthroughNeed(
   sessionId: string,
   userId: string,
   needId: string,
-  action: 'covered' | 'skip'
+  action: 'covered' | 'skip' | 'reset',
 ): Promise<GetStage4StateResponse> {
   const before = await buildStage4State(sessionId, userId);
+  const targetOwnNeed = before.walkthrough.ownNeeds.find(need => need.id === needId);
+  const targetPartnerNeed = before.walkthrough.partnerNeeds.find(need => need.id === needId);
+  if (!targetOwnNeed && !targetPartnerNeed) {
+    throw new Stage4WalkthroughNeedNotFoundError();
+  }
+
   const progress = await prisma.stageProgress.findUnique({
     where: { sessionId_userId_stage: { sessionId, userId, stage: 4 } },
     select: { gatesSatisfied: true },
@@ -430,46 +443,56 @@ async function updateStage4WalkthroughNeed(
   const covered = new Set(
     Array.isArray(existing.coveredNeedIds)
       ? existing.coveredNeedIds.filter((id): id is string => typeof id === 'string')
-      : []
+      : [],
   );
   const skipped = new Set(
     Array.isArray(existing.skippedNeedIds)
       ? existing.skippedNeedIds.filter((id): id is string => typeof id === 'string')
-      : []
+      : [],
   );
 
   if (action === 'covered') {
     covered.add(needId);
     skipped.delete(needId);
-  } else {
+  } else if (action === 'skip') {
     skipped.add(needId);
     covered.delete(needId);
+  } else {
+    covered.delete(needId);
+    skipped.delete(needId);
   }
 
   const remainingOwn = before.walkthrough.ownNeeds.find(
-    (need) => !covered.has(need.id) && !skipped.has(need.id)
+    need => !covered.has(need.id) && !skipped.has(need.id),
   );
   const remainingPartner = before.walkthrough.partnerNeeds.find(
-    (need) => !covered.has(need.id) && !skipped.has(need.id)
+    need => !covered.has(need.id) && !skipped.has(need.id),
   );
-  const phase =
-    before.walkthrough.phase === 'MY_NEEDS' && remainingOwn
-      ? 'MY_NEEDS'
-      : before.walkthrough.phase === 'MY_NEEDS' && remainingPartner
-        ? 'PARTNER_NEEDS'
-        : before.walkthrough.phase === 'PARTNER_NEEDS' && remainingPartner
-          ? 'PARTNER_NEEDS'
-          : remainingOwn
-            ? 'MY_NEEDS'
-            : remainingPartner
-              ? 'PARTNER_NEEDS'
-              : 'QUALITY_REVIEW';
-  const currentNeedId =
-    phase === 'MY_NEEDS'
-      ? remainingOwn?.id ?? null
-      : phase === 'PARTNER_NEEDS'
-        ? remainingPartner?.id ?? null
-        : null;
+
+  let phase: 'MY_NEEDS' | 'PARTNER_NEEDS' | 'QUALITY_REVIEW';
+  let currentNeedId: string | null;
+  if (action === 'reset') {
+    phase = targetOwnNeed ? 'MY_NEEDS' : 'PARTNER_NEEDS';
+    currentNeedId = needId;
+  } else if (before.walkthrough.phase === 'MY_NEEDS' && remainingOwn) {
+    phase = 'MY_NEEDS';
+    currentNeedId = remainingOwn.id;
+  } else if (before.walkthrough.phase === 'MY_NEEDS' && remainingPartner) {
+    phase = 'PARTNER_NEEDS';
+    currentNeedId = remainingPartner.id;
+  } else if (before.walkthrough.phase === 'PARTNER_NEEDS' && remainingPartner) {
+    phase = 'PARTNER_NEEDS';
+    currentNeedId = remainingPartner.id;
+  } else if (remainingOwn) {
+    phase = 'MY_NEEDS';
+    currentNeedId = remainingOwn.id;
+  } else if (remainingPartner) {
+    phase = 'PARTNER_NEEDS';
+    currentNeedId = remainingPartner.id;
+  } else {
+    phase = 'QUALITY_REVIEW';
+    currentNeedId = null;
+  }
 
   await prisma.stageProgress.update({
     where: { sessionId_userId_stage: { sessionId, userId, stage: 4 } },
@@ -684,6 +707,15 @@ export async function updateStage4WalkthroughNeedStatus(req: Request, res: Respo
       errorResponse(res, 'SESSION_NOT_ACTIVE', 'Session is not active', 400);
       return;
     }
+    if (mutable.progress?.stage !== 4) {
+      errorResponse(
+        res,
+        'VALIDATION_ERROR',
+        `Cannot update Stage 4 walkthrough: you are in stage ${mutable.progress?.stage ?? 0}, but stage 4 is required`,
+        400,
+      );
+      return;
+    }
     if (await prisma.stage4Closure.findUnique({ where: { sessionId } })) {
       errorResponse(res, 'CONFLICT', 'Stage 4 is already closed', 409);
       return;
@@ -699,6 +731,10 @@ export async function updateStage4WalkthroughNeedStatus(req: Request, res: Respo
   } catch (error) {
     if (error instanceof Stage4StateNotFoundError) {
       errorResponse(res, 'NOT_FOUND', 'Session not found', 404);
+      return;
+    }
+    if (error instanceof Stage4WalkthroughNeedNotFoundError) {
+      errorResponse(res, 'NOT_FOUND', 'Need not found', 404);
       return;
     }
     logger.error('[updateStage4WalkthroughNeedStatus] Error:', error);

--- a/backend/src/routes/__tests__/stage4.test.ts
+++ b/backend/src/routes/__tests__/stage4.test.ts
@@ -1006,6 +1006,98 @@ describe('Stage 4 API', () => {
         })
       );
     });
+
+    it('resets a skipped partner need from quality review back to walkthrough without removing proposals', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId, needId: 'need-partner' },
+        body: { action: 'reset' },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(mockSession());
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue({
+        stage: 4,
+        gatesSatisfied: {},
+      });
+      (prisma.stageProgress.findUnique as jest.Mock).mockResolvedValue({
+        gatesSatisfied: {
+          stage4Walkthrough: {
+            phase: 'QUALITY_REVIEW',
+            currentNeedId: null,
+            coveredNeedIds: ['need-own'],
+            skippedNeedIds: ['need-partner'],
+          },
+        },
+      });
+      (prisma.strategyProposal.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: mockStrategyIds[0],
+          description: 'Weekly check-in',
+          needsAddressed: ['need-own'],
+          duration: null,
+          measureOfSuccess: null,
+          kind: Stage4ProposalKind.SHARED_PROPOSAL,
+          status: Stage4ProposalStatus.ACTIVE,
+          createdByUserId: mockUser.id,
+          updatedAt: new Date('2026-05-06T10:00:00.000Z'),
+        },
+      ]);
+      (prisma.stage4ProposalSelection.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.stage4NeedCoverage.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'coverage-own',
+          needId: 'need-own',
+          needLabel: 'reliability around chores',
+          sourceUserId: mockUser.id,
+          coverageStatus: 'OPEN',
+          coveringProposalIds: [mockStrategyIds[0]],
+          note: null,
+          updatedAt: new Date('2026-05-06T10:03:00.000Z'),
+        },
+        {
+          id: 'coverage-partner',
+          needId: 'need-partner',
+          needLabel: 'more appreciation',
+          sourceUserId: mockPartnerId,
+          coverageStatus: 'OPEN',
+          coveringProposalIds: [],
+          note: null,
+          updatedAt: new Date('2026-05-06T10:04:00.000Z'),
+        },
+      ]);
+      (prisma.stage4Closure.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.agreement.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.tendingEntry.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.strategyProposalNeed.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.stageProgress.update as jest.Mock).mockResolvedValue({});
+
+      await updateStage4WalkthroughNeedStatus(req as Request, res as Response);
+
+      expect(prisma.stageProgress.update).toHaveBeenCalledWith({
+        where: { sessionId_userId_stage: { sessionId: mockSessionId, userId: mockUser.id, stage: 4 } },
+        data: {
+          gatesSatisfied: expect.objectContaining({
+            stage4Walkthrough: expect.objectContaining({
+              phase: 'PARTNER_NEEDS',
+              currentNeedId: 'need-partner',
+              coveredNeedIds: ['need-own'],
+              skippedNeedIds: [],
+            }),
+          }),
+        },
+      });
+      expect(prisma.strategyProposal.findMany).toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            state: expect.any(Object),
+          }),
+        })
+      );
+    });
   });
 
   describe('POST /sessions/:id/stage4 selections and close', () => {

--- a/mobile/src/components/Stage4RedesignPanel.tsx
+++ b/mobile/src/components/Stage4RedesignPanel.tsx
@@ -33,6 +33,7 @@ interface Stage4RedesignPanelProps {
   onUndeclineNeed?: (needId: string) => void;
   onMarkNeedCovered?: (needId: string) => void;
   onSkipNeed?: (needId: string) => void;
+  onResetNeed?: (needId: string) => void;
   onBackToChat?: () => void;
   onCloseStage4: (kind: Stage4ClosureKind, reason: Stage4ClosureReason, checkInDate: string) => void;
 }
@@ -699,6 +700,7 @@ export function Stage4RedesignPanel({
   onUndeclineNeed,
   onMarkNeedCovered,
   onSkipNeed,
+  onResetNeed,
   onBackToChat,
   onCloseStage4,
 }: Stage4RedesignPanelProps) {
@@ -843,6 +845,10 @@ export function Stage4RedesignPanel({
 
   if (!state.outcome && walkthrough.phase === 'QUALITY_REVIEW') {
     if (allProposals.length === 0) {
+      const reviewedNeeds = [...walkthrough.ownNeeds, ...walkthrough.partnerNeeds].filter(
+        (need) => need.status === 'covered' || need.status === 'skipped'
+      );
+
       return (
         <View style={styles.container} testID="stage4-redesign-panel">
           <View style={styles.walkthroughHeader}>
@@ -857,6 +863,23 @@ export function Stage4RedesignPanel({
               Close this and keep talking in the chat. When something feels workable, it will appear here for review.
             </Text>
           </View>
+          {reviewedNeeds.length > 0 && onResetNeed && (
+            <View style={styles.card} testID="stage4-empty-review-needs">
+              <Text style={styles.sectionTitle}>Go back to a need</Text>
+              {reviewedNeeds.map((need) => (
+                <TouchableOpacity
+                  key={need.id}
+                  style={styles.secondaryButton}
+                  onPress={() => onResetNeed(need.id)}
+                  accessibilityRole="button"
+                  testID={`stage4-reset-need-${need.id}`}
+                >
+                  <RotateCcw color={palette.text} size={17} />
+                  <Text style={styles.secondaryButtonText}>{need.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          )}
           {!hideFooter && (
             <Stage4RedesignFooter
               state={state}

--- a/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
+++ b/mobile/src/components/__tests__/Stage4RedesignPanel.test.tsx
@@ -259,6 +259,7 @@ describe('Stage4RedesignPanel', () => {
 
   it('does not show agreement review when quality review has no proposals', () => {
     const onBackToChat = jest.fn();
+    const onResetNeed = jest.fn();
     const reviewState: GetStage4StateResponse = {
       ...walkthroughNeedsState,
       inventory: {
@@ -279,13 +280,18 @@ describe('Stage4RedesignPanel', () => {
         {...defaultProps}
         state={reviewState}
         onBackToChat={onBackToChat}
+        onResetNeed={onResetNeed}
       />
     );
 
     expect(screen.getByText('Keep brainstorming')).toBeTruthy();
     expect(screen.getByText('No options have been captured yet.')).toBeTruthy();
+    expect(screen.getByText('Go back to a need')).toBeTruthy();
     expect(screen.queryByText('Review agreements')).toBeNull();
     expect(screen.queryByText('Options to consider')).toBeNull();
+
+    fireEvent.press(screen.getByTestId('stage4-reset-need-coverage-0'));
+    expect(onResetNeed).toHaveBeenCalledWith('coverage-0');
 
     fireEvent.press(screen.getByTestId('stage4-back-to-chat'));
 

--- a/mobile/src/hooks/useStages.ts
+++ b/mobile/src/hooks/useStages.ts
@@ -2280,11 +2280,11 @@ export function useUpdateStage4WalkthroughNeed() {
   return useMutation<
     { state: GetStage4StateResponse },
     ApiClientError,
-    { sessionId: string; needId: string; action: 'covered' | 'skip' },
+    { sessionId: string; needId: string; action: 'covered' | 'skip' | 'reset' },
     { previous: GetStage4StateResponse | undefined }
   >({
     mutationFn: async ({ sessionId, needId, action }) =>
-      post<{ state: GetStage4StateResponse }, { action: 'covered' | 'skip' }>(
+      post<{ state: GetStage4StateResponse }, { action: 'covered' | 'skip' | 'reset' }>(
         `/sessions/${sessionId}/stage4/walkthrough/needs/${needId}`,
         { action }
       ),

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1995,6 +1995,19 @@ export function UnifiedSessionScreen({
     },
     [sessionId, showError, updateStage4WalkthroughNeed]
   );
+  const handleResetStage4Need = useCallback(
+    (needId: string) => {
+      updateStage4WalkthroughNeed.mutate(
+        { sessionId, needId, action: 'reset' },
+        {
+          onError: () => {
+            showError('Could not go back to that need. Please try again.');
+          },
+        }
+      );
+    },
+    [sessionId, showError, updateStage4WalkthroughNeed]
+  );
   const handleReviseStage4Selections = useCallback(() => {
     unshareStage4Selections.mutate(
       { sessionId },
@@ -3930,6 +3943,7 @@ export function UnifiedSessionScreen({
               onUndeclineNeed={handleUndeclineStage4Need}
               onMarkNeedCovered={handleMarkStage4NeedCovered}
               onSkipNeed={handleSkipStage4Need}
+              onResetNeed={handleResetStage4Need}
               onCloseStage4={handleCloseRedesignedStage4}
             />
             {tendingPanel}
@@ -4730,6 +4744,7 @@ export function UnifiedSessionScreen({
                 onUndeclineNeed={handleUndeclineStage4Need}
                 onMarkNeedCovered={handleMarkStage4NeedCovered}
                 onSkipNeed={handleSkipStage4Need}
+                onResetNeed={handleResetStage4Need}
                 onBackToChat={() => setShowStage4Drawer(false)}
                 onCloseStage4={(kind, reason, checkInDate) => {
                   handleCloseRedesignedStage4(kind, reason, checkInDate);


### PR DESCRIPTION
## Summary

- Add a backend-supported `reset` action to the Stage 4 walkthrough need endpoint.
- Clear covered/skipped walkthrough markers for the selected need and restore the correct own/partner walkthrough phase from server state.
- Add an empty-review recovery UI so users can go back to a reviewed need instead of only returning to chat.

## Why

Issue #654 identified a recoverable but awkward state: Stage 4 can reach `QUALITY_REVIEW` with no proposals and no `currentNeed`, leaving the client without a structured backend action to unskip/reset a need.

Closes #654.

## Validation

- `cd backend && npm test -- --runTestsByPath src/routes/__tests__/stage4.test.ts --runInBand`
- `cd backend && npm run check`
- `cd mobile && npm test -- --runTestsByPath src/components/__tests__/Stage4RedesignPanel.test.tsx --runInBand`
- `cd mobile && npm run check`