### PR TITLE
Fix Stage 4 backend share gate

### DIFF
--- a/backend/src/controllers/stage4.ts
+++ b/backend/src/controllers/stage4.ts
@@ -917,13 +917,13 @@ export async function shareStage4Selections(req: Request, res: Response): Promis
       return;
     }
 
-    // Gate: every open/partial need must be addressed by a willing-active
+    // Gate: every open need must be addressed by a willing-active
     // proposal or explicitly declined ("leave for now") by this user.
-    const [openOrPartialNeeds, willingSelections, declinations] = await Promise.all([
+    const [openNeeds, willingSelections, declinations] = await Promise.all([
       prisma.stage4NeedCoverage.findMany({
         where: {
           sessionId,
-          coverageStatus: { in: ['OPEN', 'PARTIAL'] },
+          coverageStatus: 'OPEN',
         },
         select: {
           id: true,
@@ -957,7 +957,7 @@ export async function shareStage4Selections(req: Request, res: Response): Promis
     );
     const declinedNeedIds = new Set(declinations.map((d) => d.needId));
 
-    const ungated = openOrPartialNeeds.filter((row) => {
+    const ungated = openNeeds.filter((row) => {
       const needIdentifier = row.needId ?? row.id;
       if (declinedNeedIds.has(needIdentifier)) return false;
       const hasWillingCover = row.coveringProposalIds.some(

--- a/backend/src/routes/__tests__/stage4.test.ts
+++ b/backend/src/routes/__tests__/stage4.test.ts
@@ -2964,5 +2964,38 @@ describe('Stage 4 API', () => {
       expect(prisma.stageProgress.update).toHaveBeenCalled();
       expect(statusMock).toHaveBeenCalledWith(200);
     });
+
+    it('allows share when remaining coverage rows are only partial', async () => {
+      arrangeForShare({
+        openCoverage: [
+          {
+            id: 'cov-partial',
+            needId: 'need-partial',
+            coverageStatus: 'PARTIAL',
+            coveringProposalIds: ['prop-a'],
+          },
+        ],
+        willingProposalIds: ['prop-a'],
+        activeProposalIds: ['prop-a'],
+      });
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+      });
+      const { res, statusMock } = createMockResponse();
+
+      await shareStage4Selections(req as Request, res as Response);
+
+      expect(prisma.stage4NeedCoverage.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            coverageStatus: 'OPEN',
+          }),
+        })
+      );
+      expect(prisma.stageProgress.update).toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(200);
+    });
   });
 });


### PR DESCRIPTION
## Changes
- Align backend Stage 4 share validation with the frontend rule from #652: only OPEN needs block sharing.
- Keep PARTIAL coverage rows from creating a second backend-only dead end after the Share button is enabled.
- Add a regression test proving partial-only coverage can share while open needs still block.

## Verification
- npm --workspace backend test -- --runTestsByPath src/routes/__tests__/stage4.test.ts --runInBand
- npm --workspace backend run check

Related to #649