### PR TITLE
fix: resolve partner name on existing-person invitation path

### DIFF
--- a/backend/src/controllers/invitations.ts
+++ b/backend/src/controllers/invitations.ts
@@ -315,6 +315,12 @@ export async function createSession(req: Request, res: Response): Promise<void> 
     }
 
     const { personId, inviteName, innerThoughtsId, linkedAtMessageId, context } = parseResult.data;
+    let inviteeDisplayName = inviteName?.trim() || undefined;
+
+    if (personId === user.id) {
+      errorResponse(res, 'VALIDATION_ERROR', 'Cannot start a session with yourself', 400);
+      return;
+    }
 
     // Create or find relationship
     let relationship;
@@ -329,11 +335,51 @@ export async function createSession(req: Request, res: Response): Promise<void> 
             },
           },
         },
-        include: { relationship: true },
+        include: {
+          user: {
+            select: {
+              firstName: true,
+              name: true,
+            },
+          },
+          relationship: {
+            include: {
+              members: {
+                where: { userId: user.id },
+                select: { nickname: true },
+              },
+            },
+          },
+        },
       });
 
       if (existingMember) {
         relationship = existingMember.relationship;
+        inviteeDisplayName =
+          inviteeDisplayName ||
+          existingMember.relationship.members[0]?.nickname ||
+          existingMember.user.firstName ||
+          existingMember.user.name ||
+          undefined;
+      } else {
+        const existingUser = await prisma.user.findUnique({
+          where: { id: personId },
+          select: {
+            firstName: true,
+            name: true,
+          },
+        });
+
+        if (!existingUser) {
+          errorResponse(res, 'NOT_FOUND', 'Person not found', 404);
+          return;
+        }
+
+        inviteeDisplayName =
+          inviteeDisplayName ||
+          existingUser.firstName ||
+          existingUser.name ||
+          undefined;
       }
     }
 
@@ -342,10 +388,18 @@ export async function createSession(req: Request, res: Response): Promise<void> 
       relationship = await prisma.relationship.create({
         data: {
           members: {
-            create: {
-              userId: user.id,
-              nickname: inviteName || null, // Store what inviter calls the invitee
-            },
+            create: personId
+              ? [
+                  {
+                    userId: user.id,
+                    nickname: inviteName || null, // Store what inviter calls the invitee
+                  },
+                  { userId: personId },
+                ]
+              : {
+                  userId: user.id,
+                  nickname: inviteName || null, // Store what inviter calls the invitee
+                },
           },
         },
       });
@@ -399,7 +453,7 @@ export async function createSession(req: Request, res: Response): Promise<void> 
         data: {
           sessionId: sess.id,
           invitedById: user.id,
-          name: inviteName,
+          name: inviteeDisplayName,
           expiresAt,
         },
       });
@@ -483,8 +537,8 @@ export async function createSession(req: Request, res: Response): Promise<void> 
           createdAt: session.createdAt,
           // Include partner info with nickname for immediate display
           partner: {
-            id: '',
-            name: inviteName || null,
+            id: personId || '',
+            name: inviteeDisplayName || null,
             nickname: inviteName || null,
           },
         },

--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -1301,6 +1301,41 @@ export async function getInitialMessage(
     } else {
       // Inviter: partner name is from the invitation
       partnerName = invitation?.name || undefined;
+
+      // Older sessions created from an existing person may have a blank
+      // invitation name. Recover the display name from the relationship so the
+      // opening prompt does not ask who the user already selected.
+      if (!partnerName) {
+        const inviterMembership = await prisma.relationshipMember.findUnique({
+          where: {
+            relationshipId_userId: {
+              relationshipId: session.relationshipId,
+              userId: user.id,
+            },
+          },
+          select: { nickname: true },
+        });
+        const partnerMember = await prisma.relationshipMember.findFirst({
+          where: {
+            relationshipId: session.relationshipId,
+            userId: { not: user.id },
+          },
+          select: {
+            user: {
+              select: {
+                firstName: true,
+                name: true,
+              },
+            },
+          },
+        });
+
+        partnerName =
+          inviterMembership?.nickname ||
+          partnerMember?.user.firstName ||
+          partnerMember?.user.name ||
+          undefined;
+      }
     }
 
     // Check if this session originated from an Inner Thoughts session

--- a/backend/src/routes/__tests__/invitations.test.ts
+++ b/backend/src/routes/__tests__/invitations.test.ts
@@ -110,6 +110,63 @@ describe('Invitations API', () => {
       );
     });
 
+    it('uses the selected existing person name when creating an invitation', async () => {
+      const mockUser = { id: 'user-1', email: 'inviter@example.com', name: 'Inviter' };
+      const mockRelationship = {
+        id: 'rel-1',
+        members: [{ nickname: null }],
+      };
+      const mockSession = { id: 'session-1', status: 'CREATED', createdAt: new Date() };
+      const mockInvitation = { id: 'inv-1' };
+
+      (prisma.relationshipMember.findFirst as jest.Mock).mockResolvedValue({
+        relationship: mockRelationship,
+        user: {
+          firstName: 'Darryl',
+          name: 'Darryl Person',
+        },
+      });
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(null);
+      (prisma.session.create as jest.Mock).mockResolvedValue(mockSession);
+      (prisma.invitation.create as jest.Mock).mockResolvedValue(mockInvitation);
+      (prisma.stageProgress.create as jest.Mock).mockResolvedValue({});
+      (prisma.userVessel.create as jest.Mock).mockResolvedValue({});
+      (prisma.sharedVessel.create as jest.Mock).mockResolvedValue({});
+
+      const req = createMockRequest({
+        user: mockUser,
+        body: {
+          personId: 'user-2',
+        },
+      });
+      const { res, statusMock, jsonMock } = createMockResponse();
+
+      await createSession(req as Request, res as Response);
+
+      expect(prisma.relationship.create).not.toHaveBeenCalled();
+      expect(prisma.invitation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            name: 'Darryl',
+          }),
+        })
+      );
+      expect(statusMock).toHaveBeenCalledWith(201);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            session: expect.objectContaining({
+              partner: expect.objectContaining({
+                id: 'user-2',
+                name: 'Darryl',
+              }),
+            }),
+          }),
+        })
+      );
+    });
+
     it('requires authentication', async () => {
       const req = createMockRequest({
         body: { inviteName: 'Partner Name' },

--- a/mobile/app/(auth)/session/new.tsx
+++ b/mobile/app/(auth)/session/new.tsx
@@ -49,7 +49,8 @@ export default function NewSessionScreen() {
   const router = useRouter();
   const { palette } = useAppAppearance();
   const styles = useStyles();
-  const { partnerName, innerThoughtsId, linkedAtMessageId } = useLocalSearchParams<{
+  const { partnerId, partnerName, innerThoughtsId, linkedAtMessageId } = useLocalSearchParams<{
+    partnerId?: string;
     partnerName?: string;
     innerThoughtsId?: string;
     linkedAtMessageId?: string;
@@ -101,6 +102,20 @@ export default function NewSessionScreen() {
       setMode('new'); // Switch to new person mode since we have a name
     }
   }, [partnerName]);
+
+  // Pre-select an existing person when launched from their detail screen.
+  useEffect(() => {
+    if (!partnerId || selectedPerson) {
+      return;
+    }
+
+    const person = people.find((p) => p.id === partnerId);
+    if (person) {
+      setSelectedPerson(person);
+      setMode('pick');
+      setBypassDuplicateCheck(false);
+    }
+  }, [partnerId, people, selectedPerson]);
 
   // Determine if we have people to pick from
   const hasPeople = people.length > 0;


### PR DESCRIPTION
## Changes
- Fix: existing-person invitation path now resolves and stores the selected person's display name on the invitation (`invitations.ts`)
- Fix: recover partner name from relationship data for older sessions where `invitation.name` is blank (`messages.ts`)
- Fix: honor `partnerId` when starting a session from a person detail screen (`new.tsx`)
- Add: backend regression test for the existing-person name resolution (`invitations.test.ts`)

**Root cause:** the existing-person path only sent `personId`, so the backend stored `invitation.name` as `undefined` and the first-message AI prompt saw "someone" instead of the partner's name. The session header still showed the correct name from relationship data, which masked the bug.

## Provenance
- **Channel:** local CLI session
- **Requested by:** @galuten (jason@galuten.com)
- **Original message:** Work performed by Codex at the user's request; user asked Claude to open a PR for the resulting changes.
- **Prompt(s) used:** `/pr` skill

## Docs updated
- No doc changes needed (bug fix; no mapped docs match the changed files)