### PR TITLE
fix: make missing FIELD_ENCRYPTION_KEY non-fatal in production

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -61,12 +61,25 @@ if (process.env.E2E_AUTH_BYPASS === 'true' && process.env.NODE_ENV === 'producti
   );
 }
 
-// Fail fast: FIELD_ENCRYPTION_KEY is required in production
+// Field encryption in production.
+// During the pre-launch test phase we deliberately run without a key so that
+// conversation content stays plaintext and can be inspected directly in the DB
+// for prompt debugging. When FIELD_ENCRYPTION_KEY is unset the encryption
+// middleware passes all fields through unchanged (see prisma-encryption-middleware.ts).
+// Set REQUIRE_FIELD_ENCRYPTION=true to re-enable fail-fast enforcement before launch.
 if (!process.env.FIELD_ENCRYPTION_KEY && process.env.NODE_ENV === 'production') {
-  throw new Error(
-    'FATAL: FIELD_ENCRYPTION_KEY is not set in a production environment. ' +
-    'All sensitive fields (messages, empathy drafts, conversation summaries) would be stored as plaintext. ' +
-    'Generate a key with: openssl rand -base64 32'
+  if (process.env.REQUIRE_FIELD_ENCRYPTION === 'true') {
+    throw new Error(
+      'FATAL: FIELD_ENCRYPTION_KEY is not set but REQUIRE_FIELD_ENCRYPTION=true. ' +
+      'All sensitive fields (messages, empathy drafts, conversation summaries) would be stored as plaintext. ' +
+      'Generate a key with: openssl rand -base64 32'
+    );
+  }
+  console.warn(
+    '[WARN] FIELD_ENCRYPTION_KEY is not set in production — sensitive fields ' +
+    '(messages, empathy drafts, conversation summaries) are stored as PLAINTEXT. ' +
+    'This is intentional for the test phase; set FIELD_ENCRYPTION_KEY (and optionally ' +
+    'REQUIRE_FIELD_ENCRYPTION=true) before launch.'
   );
 }
 


### PR DESCRIPTION
## Changes
- Fix: production no longer crashes on boot when `FIELD_ENCRYPTION_KEY` is unset — logs a warning instead
- Add: opt-in `REQUIRE_FIELD_ENCRYPTION=true` to restore fail-fast enforcement before launch

## Why
PR #547 made a missing `FIELD_ENCRYPTION_KEY` a fatal startup error in production. We intentionally run **keyless / plaintext** during the pre-launch test phase so conversation content is directly inspectable in the DB for prompt debugging.

That enforcement has been **crashing every backend deploy since #655** (build succeeds, server exits 1 at startup), so production has been frozen on commit `066c057b` and **five merged PRs never deployed** — including the Stage 3 duplicate-needs fix (#645), Stage 4 share-gate (#656), WebSocket auth (#626), and the partner-name fix (#657).

The encryption middleware already passes all fields through unchanged when no key is set (`prisma-encryption-middleware.ts`), so keyless operation is a supported, deliberate mode — not an accident worth crashing over.

This change self-heals the deploy: the moment it merges, the server boots without a key again and the backlog of merged PRs ships.

## Tradeoff
Plaintext-at-rest for sensitive content. Acceptable for the test phase; set `FIELD_ENCRYPTION_KEY` (and `REQUIRE_FIELD_ENCRYPTION=true`) before real users.

## Provenance
- **Channel:** local CLI session
- **Requested by:** @galuten (jason@galuten.com)
- **Original message:** While debugging why a new session's Stage 0 opener still says "someone" instead of the partner's name, traced it to failed backend deploys; user confirmed they deliberately want plaintext in the test phase for debuggability.
- **Prompt(s) used:** manual investigation (Render API deploy logs) + `/pr`

## Docs updated
- No doc changes needed