### PR TITLE
fix: field encryption passes through plaintext when no key (runtime guard)

### DIFF
--- a/backend/src/utils/__tests__/field-encryption.test.ts
+++ b/backend/src/utils/__tests__/field-encryption.test.ts
@@ -149,7 +149,7 @@ describe('field-encryption', () => {
     });
   });
 
-  describe('production enforcement (no key)', () => {
+  describe('production without key (test-phase passthrough)', () => {
     beforeEach(() => {
       _resetForTesting();
       delete process.env.FIELD_ENCRYPTION_KEY;
@@ -158,14 +158,27 @@ describe('field-encryption', () => {
 
     afterEach(() => {
       process.env.NODE_ENV = 'test';
+      delete process.env.REQUIRE_FIELD_ENCRYPTION;
     });
 
-    it('encrypt throws when no key is set in production', () => {
-      expect(() => encrypt('sensitive data')).toThrow('FIELD_ENCRYPTION_KEY is not set in production');
+    it('encrypt passes through unchanged when no key is set (default)', () => {
+      expect(encrypt('sensitive data')).toBe('sensitive data');
     });
 
-    it('decrypt throws when no key is set in production', () => {
-      expect(() => decrypt('enc:v1:abc:def:ghi')).toThrow('FIELD_ENCRYPTION_KEY is not set in production');
+    it('decrypt passes through unchanged when no key is set (default)', () => {
+      expect(decrypt('enc:v1:abc:def:ghi')).toBe('enc:v1:abc:def:ghi');
+    });
+
+    it('encrypt throws when REQUIRE_FIELD_ENCRYPTION=true and no key', () => {
+      process.env.REQUIRE_FIELD_ENCRYPTION = 'true';
+      _resetForTesting();
+      expect(() => encrypt('sensitive data')).toThrow('REQUIRE_FIELD_ENCRYPTION=true');
+    });
+
+    it('decrypt throws when REQUIRE_FIELD_ENCRYPTION=true and no key', () => {
+      process.env.REQUIRE_FIELD_ENCRYPTION = 'true';
+      _resetForTesting();
+      expect(() => decrypt('enc:v1:abc:def:ghi')).toThrow('REQUIRE_FIELD_ENCRYPTION=true');
     });
   });
 

--- a/backend/src/utils/field-encryption.ts
+++ b/backend/src/utils/field-encryption.ts
@@ -9,7 +9,8 @@
  *
  * Configuration:
  *   FIELD_ENCRYPTION_KEY — 32-byte key, base64-encoded.
- *   Required in production (throws on missing key). In dev/test, passes through unchanged.
+ *   When unset, values pass through unchanged (plaintext). Set
+ *   REQUIRE_FIELD_ENCRYPTION=true to require a key in production (throws if missing).
  */
 
 import crypto from 'crypto';
@@ -31,13 +32,17 @@ function getKey(): Buffer | null {
 
   const raw = process.env.FIELD_ENCRYPTION_KEY;
   if (!raw) {
-    if (process.env.NODE_ENV === 'production') {
+    // During the pre-launch test phase we deliberately run keyless so content
+    // stays plaintext and is directly inspectable for prompt debugging. Only
+    // fail when enforcement is explicitly opted into via REQUIRE_FIELD_ENCRYPTION.
+    if (process.env.NODE_ENV === 'production' && process.env.REQUIRE_FIELD_ENCRYPTION === 'true') {
       throw new Error(
-        '[FieldEncryption] FIELD_ENCRYPTION_KEY is not set in production. ' +
+        '[FieldEncryption] FIELD_ENCRYPTION_KEY is not set but REQUIRE_FIELD_ENCRYPTION=true. ' +
           'Sensitive fields must not be stored as plaintext. ' +
           'Generate a key with: openssl rand -base64 32',
       );
     }
+    // No key configured → encrypt()/decrypt() pass values through unchanged (plaintext).
     return null;
   }
 


### PR DESCRIPTION
## Changes
- Fix: `getKey()` in `field-encryption.ts` no longer throws in production when `FIELD_ENCRYPTION_KEY` is unset — it returns `null`, so `encrypt()`/`decrypt()` pass values through as plaintext (their documented keyless behavior)
- Add: throw is now gated behind the same opt-in `REQUIRE_FIELD_ENCRYPTION=true` introduced in #658
- Update: tests for the new passthrough-vs-enforce behavior

## Why (production was broken)
#658 softened the **startup** fail-fast so the server boots keyless. But #547 added a **second** guard — a runtime throw in `getKey()` — that fires on every sensitive-field read/write. So once #658 let the server boot, every conversation operation 500'd:

```
[getInitialMessage]      -> 500   ← new sessions get NO opener →
                                     UI falls back to "Start the Conversation"
[getSessionState]        -> 500
[getConversationHistory] -> 500
```

This is why a brand-new session showed the empty-state placeholder and the typing dots never resolved. It also broke reading existing sessions.

`encrypt()`/`decrypt()` already short-circuit to plaintext when `getKey()` returns `null`, so returning `null` (instead of throwing) restores the intended keyless/plaintext test-phase behavior.

## Provenance
- **Channel:** local CLI session
- **Requested by:** @galuten (jason@galuten.com)
- **Original message:** New session with Darryl showed "Start the Conversation" empty state after typing dots; traced to 500s from the runtime FIELD_ENCRYPTION_KEY guard missed by #658.
- **Prompt(s) used:** Render runtime log analysis + `/pr`

## Docs updated
- No doc changes needed