### PR TITLE
fix: strip leaked tool-call XML from visible AI response

### DIFF
--- a/backend/src/utils/__tests__/micro-tag-parser.test.ts
+++ b/backend/src/utils/__tests__/micro-tag-parser.test.ts
@@ -246,6 +246,28 @@ Response without closing tag.`;
       expect(result.response).toBeTruthy();
     });
 
+    it('strips a leaked update_session_state tool-call XML block from the response', () => {
+      const raw = `<tool_calls>
+<invoke name="update_session_state">
+<parameter name="mode">ONBOARDING</parameter>
+<parameter name="ready_share">false</parameter>
+<parameter name="draft_topic"></parameter>
+<parameter name="memory_items">[]</parameter>
+</invoke>
+</tool_calls>
+
+Hey Shantam. First, let's write a short topic for Darryl so they know what this is about. What's going on?`;
+
+      const result = parseMicroTagResponse(raw);
+
+      expect(result.response).toBe(
+        "Hey Shantam. First, let's write a short topic for Darryl so they know what this is about. What's going on?"
+      );
+      expect(result.response).not.toContain('<tool_calls>');
+      expect(result.response).not.toContain('<invoke');
+      expect(result.response).not.toContain('update_session_state');
+    });
+
     it('strips multiple tag types from response', () => {
       const raw = `<thinking>Analysis here</thinking>
 

--- a/backend/src/utils/micro-tag-parser.ts
+++ b/backend/src/utils/micro-tag-parser.ts
@@ -393,6 +393,12 @@ export function parseMicroTagResponse(rawResponse: string): ParsedMicroTagRespon
 
   // 2. Clean response text - remove all tags
   let responseText = rawResponse
+    // Defense-in-depth: the model is supposed to call update_session_state via the
+    // real tool-use API, but it sometimes emits the tool call as literal XML text in
+    // the prose pass. Strip any such block so raw <tool_calls>/<invoke> markup never
+    // reaches the user.
+    .replace(/<tool_calls>[\s\S]*?<\/tool_calls>/gi, '')
+    .replace(/<invoke\b[^>]*>[\s\S]*?<\/invoke>/gi, '')
     .replace(/<thinking>[\s\S]*?<\/thinking>/gi, '')
     .replace(/<draft>[\s\S]*?<\/draft>/gi, '')
     .replace(/<need>[\s\S]*?<\/need>/gi, '')


### PR DESCRIPTION
## Changes
- Fix: `parseMicroTagResponse` now strips `<tool_calls>...</tool_calls>` and stray `<invoke>...</invoke>` blocks from the user-facing response text
- Add: regression test for a leaked `update_session_state` tool-call block

## Why
`update_session_state` is a real tool the model should call via the tool-use API (two-pass: state in one pass, prose in another). But the model sometimes emits the tool call as **literal XML text** in the prose pass. The parser stripped every other control tag (`<thinking>`, `<draft>`, `<needs>`, `<stage4_*>`, `<dispatch>`) but not tool-call blocks — so the raw XML rendered on screen above the Stage 0 greeting.

This is a display-layer, defense-in-depth fix: real state still flows through the proper tool-use pass; we just guarantee tool-call markup never reaches the user.

## Provenance
- **Channel:** local CLI session
- **Requested by:** @galuten (jason@galuten.com)
- **Original message:** New Darryl session rendered a raw `<tool_calls><invoke name="update_session_state">...` block above the opener text.
- **Prompt(s) used:** manual investigation + `/pr`

## Docs updated
- No doc changes needed