### PR TITLE
docs: incremental audit 2026-05-25 — encryption opt-in, Stage 4 share gate, self-invite guard

### DIFF
--- a/docs/backend/api/sessions.md
+++ b/docs/backend/api/sessions.md
@@ -38,6 +38,7 @@ interface CreateSessionRequest {
 ### Validation Rules
 
 - Must provide `personId` OR `inviteName`
+- `personId` cannot be the caller's own user ID — returns `VALIDATION_ERROR` (400)
 - If `personId` has an existing `ACTIVE`/`CREATED`/`INVITED` session, that session is returned instead of creating a new one
 
 ### Invitation Delivery

--- a/docs/backend/api/stage-4.md
+++ b/docs/backend/api/stage-4.md
@@ -3,7 +3,7 @@ title: "Stage 4 API: Strategic Repair"
 sidebar_position: 11
 description: Endpoints for collaborative strategy proposal, willingness selection, agreement documentation, and Tending check-ins.
 slug: /backend/api/stage-4
-updated: 2026-05-23
+updated: 2026-05-25
 ---
 # Stage 4 API: Strategic Repair
 
@@ -459,6 +459,8 @@ When no typed kind is supplied the heuristic defaults to **INDIVIDUAL_COMMITMENT
 > **Note:** `SHARED_AGREEMENT` closures are not handled by this function. They require the manual `POST /stage4/close` endpoint, which evaluates mutual WILLING selections and creates agreement records.
 
 Both auto-closure and manual `POST /stage4/close` filter needs using **OPEN and PARTIAL** coverage status when computing `openNeedIds` for the closure record.
+
+> **Share gate (POST /stage4/share-selections)**: Before sharing, the server verifies every **OPEN** (not partial) need is either addressed by a willing-active proposal or explicitly declined. Partially-covered needs no longer block sharing.
 
 ---
 

--- a/docs/backend/security/index.md
+++ b/docs/backend/security/index.md
@@ -37,7 +37,7 @@ Consent decisions and retrieval attempts recorded for review
 - **Stage enforcement source of truth**: App-layer retrieval contracts + StageProgress gates.
 - **Consent scope**: All consent records are tied to a session + targetId + targetType; revocation must cascade to SharedVessel content (set `consentActive=false`) and mark dependent outputs stale.
 - **Admin access**: Only for global library curation; no access to user vessels. Admin queries must keep explicit user/session/relationship filters.
-- **Encryption**: TLS to Postgres, Render at-rest encryption, hash push tokens, and avoid storing secrets in user rows. Application-level field encryption (AES-256-GCM) auto-encrypts sensitive fields on write and auto-decrypts on read. `FIELD_ENCRYPTION_KEY` is required in production (server refuses to start without it); in dev/test it passes through unchanged.
+- **Encryption**: TLS to Postgres, Render at-rest encryption, hash push tokens, and avoid storing secrets in user rows. Application-level field encryption (AES-256-GCM) auto-encrypts sensitive fields on write and auto-decrypts on read. `FIELD_ENCRYPTION_KEY` is optional during the pre-launch test phase — when unset, sensitive fields are stored as plaintext and the server logs a warning. Set `REQUIRE_FIELD_ENCRYPTION=true` (alongside the key) to re-enable fail-fast enforcement before public launch. In dev/test the key is always optional and values pass through unchanged.
 - **Audit log**: Log every `/consent/decide`, `/consent/revoke`, and retrieval contract rejection.
 
 ---

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 description: All required environment variables for Meet Without Fear services.
 slug: /deployment/environment-variables
 created: 2026-03-11
-updated: 2026-05-15
+updated: 2026-05-25
 status: living
 ---
 # Environment Variables
@@ -26,12 +26,13 @@ All required environment variables for Meet Without Fear services.
 | `AWS_ACCESS_KEY_ID` | AWS credentials for Bedrock | `AKIA...` |
 | `AWS_SECRET_ACCESS_KEY` | AWS credentials for Bedrock | (secret) |
 | `AWS_REGION` | AWS region for Bedrock | `us-west-2` |
-| `FIELD_ENCRYPTION_KEY` | 32-byte base64 key for AES-256-GCM field encryption. Server refuses to start without it in production. Generate with `openssl rand -base64 32` | (secret) |
+| `FIELD_ENCRYPTION_KEY` | 32-byte base64 key for AES-256-GCM field encryption. When unset, sensitive fields are stored as plaintext and the server logs a warning (intentional during the test phase). Generate with `openssl rand -base64 32` | (optional pre-launch; required before public launch) |
 
 ### Optional
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `REQUIRE_FIELD_ENCRYPTION` | Set to `true` to make a missing `FIELD_ENCRYPTION_KEY` a fatal startup error. Re-enable before public launch. | `false` |
 | `REDIS_URL` | Redis connection string | (none - in-memory fallback) |
 | `LOG_LEVEL` | Logging verbosity | `info` |
 | `CORS_ORIGIN` | Allowed CORS origins | `*` |
@@ -120,7 +121,7 @@ Set via Render dashboard or `render.yaml`:
 - `JWT_REFRESH_SECRET`: Generate with `generateValue: true`
 - `ABLY_API_KEY`: Set manually (secret)
 - `AWS_*`: Set manually (secrets)
-- `FIELD_ENCRYPTION_KEY`: Generate with `openssl rand -base64 32` (secret)
+- `FIELD_ENCRYPTION_KEY`: Generate with `openssl rand -base64 32` (optional during test phase; required before public launch — also set `REQUIRE_FIELD_ENCRYPTION=true`)
 
 ## Secrets Management
 


### PR DESCRIPTION
## Summary

Incremental doc audit for 2026-05-25 (24h lookback). 7 code-change commits since last audit — 4 doc gaps found and fixed.

## Changes

| Doc | Issue | Fix |
|-----|-------|-----|
| `docs/backend/security/index.md` | Stated `FIELD_ENCRYPTION_KEY` is required in production (server refuses to start). PRs #658/#659 made it optional with a warn-only mode. | Updated to reflect opt-in enforcement via `REQUIRE_FIELD_ENCRYPTION=true` |
| `docs/deployment/environment-variables.md` | Same wrong claim + missing `REQUIRE_FIELD_ENCRYPTION` variable entirely | Moved key description to optional/test-phase; added `REQUIRE_FIELD_ENCRYPTION` row; updated Production section note |
| `docs/backend/api/stage-4.md` | Share gate behavior undocumented: PR #656 changed it to block only on OPEN needs (partial coverage no longer blocks sharing) | Added note under Auto-Closure section |
| `docs/backend/api/sessions.md` | New self-invite guard (400 VALIDATION_ERROR when `personId === caller`) from PR #657 was missing from validation rules | Added validation rule |

## Code changes audited (not needing doc updates)

- **PR #660** (`micro-tag-parser.ts`): Strip `<tool_calls>`/`<invoke>` XML from visible AI response — defense-in-depth at display layer, no API surface change
- **PR #657** (`messages.ts`): Partner name recovery from relationship data for older sessions — internal fallback, no API shape change  
- **PR #626** (`realtime-transcription.ts`): WebSocket first-message auth — docs already updated in that PR's commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)