### PR TITLE
fix: stream reply when model omits the leading <thinking> tag

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -2064,9 +2064,14 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     let metadata: SessionStateToolInput = {};
     let streamError: Error | null = null;
 
-    // Tag trap state - Claude outputs <thinking>...</thinking> first, which we hide
-    // After thinking, there may be <draft>, <dispatch>, or <needs> tags that we also hide
+    // Tag trap state - Claude USUALLY outputs <thinking>...</thinking> first, which we hide.
+    // After thinking, there may be <draft>, <dispatch>, or <needs> tags that we also hide.
+    // The model occasionally skips the leading <thinking> and goes straight to visible prose
+    // (more often on deep, long-context turns). We start in the thinking trap optimistically,
+    // but the first chunk decides: if the output does not actually begin with <thinking>, we
+    // bail out of the trap immediately so the reply is not swallowed and hidden.
     let isInsideThinking = true;
+    let sawThinkingOpener = false; // Becomes true only once we confirm a real <thinking> opener
     let isTrappingTags = false; // After thinking, buffer to check for hidden semantic tags
     let thinkingBuffer = '';
     let tagTrapBuffer = ''; // Buffer for checking semantic tags after thinking
@@ -2272,6 +2277,30 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
           if (isInsideThinking) {
             thinkingBuffer += event.text;
 
+            // The model is supposed to open with <thinking>, but it sometimes skips
+            // straight to the visible reply (more often on deep, long-context turns).
+            // Decide as soon as we have a non-whitespace prefix: if it cannot become a
+            // "<thinking>" opener, bail out of the trap so the reply is streamed instead
+            // of being swallowed and hidden (which would surface as an empty-response error).
+            if (!sawThinkingOpener) {
+              const trimmedStart = thinkingBuffer.replace(/^\s+/, '');
+              const opener = '<thinking';
+              if (trimmedStart.length > 0) {
+                if (trimmedStart.startsWith(opener)) {
+                  sawThinkingOpener = true;
+                } else if (!opener.startsWith(trimmedStart.slice(0, opener.length))) {
+                  // Definitely not a <thinking> opener — treat everything as visible output.
+                  logger.warn(`[sendMessageStream:${requestId}] Response did not open with <thinking>; routing ${thinkingBuffer.length} buffered chars as visible response.`);
+                  isInsideThinking = false;
+                  isTrappingTags = true; // Run it through the tag trap so any hidden tags are still caught
+                  tagTrapBuffer = thinkingBuffer;
+                  thinkingBuffer = '';
+                  continue;
+                }
+                // else: still ambiguous (e.g. "<th") — keep buffering.
+              }
+            }
+
             // Check for closing tag
             const closingTagIndex = thinkingBuffer.indexOf('</thinking>');
             if (closingTagIndex !== -1) {
@@ -2420,9 +2449,20 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
       // internal reasoning/tool planning than to salvage malformed output.
       // =========================================================================
       if (isInsideThinking && thinkingBuffer.length > 0) {
-        logger.warn(`[sendMessageStream:${requestId}] Stream ended while still in thinking trap. Buffer has ${thinkingBuffer.length} chars. Keeping it hidden.`);
-        processTagTrapBuffer(thinkingBuffer);
-        thinkingContent = thinkingBuffer;
+        if (sawThinkingOpener) {
+          // A genuine <thinking> block was opened but never closed. Keep it hidden:
+          // avoiding leaked chain-of-thought matters more than salvaging malformed output.
+          logger.warn(`[sendMessageStream:${requestId}] Stream ended while still in thinking trap. Buffer has ${thinkingBuffer.length} chars. Keeping it hidden.`);
+          processTagTrapBuffer(thinkingBuffer);
+          thinkingContent = thinkingBuffer;
+        } else {
+          // We never confirmed a <thinking> opener, so the buffered text is the visible
+          // reply — flush it rather than throwing an empty-response error. (Belt-and-suspenders:
+          // PHASE 1 normally bails out of the trap before we reach here.)
+          logger.warn(`[sendMessageStream:${requestId}] Stream ended with no <thinking> opener; flushing ${thinkingBuffer.length} buffered chars as visible response.`);
+          const cleanText = processTagTrapBuffer(thinkingBuffer);
+          sendCleanText(cleanText);
+        }
         thinkingBuffer = '';
         isInsideThinking = false;
       }

--- a/backend/src/routes/__tests__/messages.test.ts
+++ b/backend/src/routes/__tests__/messages.test.ts
@@ -349,7 +349,7 @@ describe('Messages API (Fire-and-Forget)', () => {
       (prisma.tendingCheckin.findMany as jest.Mock).mockResolvedValue([]);
 
       async function* llmStream() {
-        yield { type: 'text', text: 'Mode: STAGE4\n</thinking>\n' };
+        yield { type: 'text', text: '<thinking>\nMode: STAGE4\n</thinking>\n' };
         yield { type: 'text', text: aiMessage.content };
         yield { type: 'done' };
       }
@@ -479,7 +479,7 @@ describe('Messages API (Fire-and-Forget)', () => {
       });
 
       async function* llmStream() {
-        yield { type: 'text', text: 'Mode: WHAT_MATTERS\nNeedsReady:N\n</thinking>\n' };
+        yield { type: 'text', text: '<thinking>\nMode: WHAT_MATTERS\nNeedsReady:N\n</thinking>\n' };
         yield { type: 'text', text: aiMessage.content };
         yield { type: 'done' };
       }
@@ -575,7 +575,7 @@ describe('Messages API (Fire-and-Forget)', () => {
       async function* llmStream() {
         yield {
           type: 'text',
-          text: 'Mode: WITNESS\nUserIntensity: 4\nFeelHeardCheck:Y\nFeelHeardConfirmed:Y\nStrategy: transition\n</thinking>\n',
+          text: '<thinking>\nMode: WITNESS\nUserIntensity: 4\nFeelHeardCheck:Y\nFeelHeardConfirmed:Y\nStrategy: transition\n</thinking>\n',
         };
         yield {
           type: 'text',
@@ -683,7 +683,7 @@ describe('Messages API (Fire-and-Forget)', () => {
       (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue(null);
 
       async function* llmStream() {
-        yield { type: 'text', text: leakedReasoning };
+        yield { type: 'text', text: `<thinking>\n${leakedReasoning}` };
         yield { type: 'text', text: '</thinking>\n' };
         yield { type: 'text', text: visibleResponse };
         yield { type: 'done' };
@@ -779,7 +779,7 @@ describe('Messages API (Fire-and-Forget)', () => {
       (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue(null);
 
       async function* llmStream() {
-        yield { type: 'text', text: 'Mode: STRATEGIC_REPAIR\n</thinking>\n' };
+        yield { type: 'text', text: '<thinking>\nMode: STRATEGIC_REPAIR\n</thinking>\n' };
         yield { type: 'text', text: aiContent };
         yield { type: 'done' };
       }
@@ -806,6 +806,95 @@ describe('Messages API (Fire-and-Forget)', () => {
             gatesSatisfied: expect.objectContaining({
               stage4Walkthrough: expect.anything(),
             }),
+          }),
+        })
+      );
+    });
+
+    it('streams the reply when the model omits the leading <thinking> tag', async () => {
+      // Regression: the model occasionally skips <thinking> and goes straight to the
+      // visible reply. The thinking trap used to swallow the whole reply as hidden
+      // reasoning, throw "AI response was empty after tag stripping", and delete the
+      // user message — surfacing as a failed submit. The reply must stream instead.
+      const stage1Progress = {
+        id: 'progress-1',
+        sessionId: mockSessionId,
+        userId: mockUser.id,
+        stage: 1,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: {},
+      };
+      const session = {
+        id: mockSessionId,
+        status: 'ACTIVE',
+        relationship: {
+          members: [{ userId: mockUser.id }, { userId: 'partner-1' }],
+        },
+      };
+      const userMessage = {
+        id: 'msg-user-no-thinking',
+        sessionId: mockSessionId,
+        senderId: mockUser.id,
+        role: 'USER',
+        content: 'It has been a hard week.',
+        stage: 1,
+        timestamp: new Date('2026-05-25T16:00:00Z'),
+      };
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(session);
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue(session);
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue(stage1Progress);
+      (prisma.stageProgress.findUnique as jest.Mock).mockResolvedValue(stage1Progress);
+      (prisma.message.create as jest.Mock).mockImplementation(async ({ data }) => (
+        data.role === 'USER'
+          ? { ...userMessage, content: data.content }
+          : {
+              id: 'msg-ai-no-thinking',
+              sessionId: mockSessionId,
+              senderId: null,
+              forUserId: mockUser.id,
+              role: 'AI',
+              content: data.content,
+              stage: data.stage,
+              timestamp: new Date('2026-05-25T16:00:02Z'),
+            }
+      ));
+      (prisma.message.findMany as jest.Mock).mockResolvedValue([userMessage]);
+      (prisma.message.count as jest.Mock).mockResolvedValue(1);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ name: 'Partner' });
+      (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue(null);
+
+      // No <thinking> opener at all — visible prose streamed directly, split across chunks.
+      async function* llmStream() {
+        yield { type: 'text', text: 'I hear you - a hard week can weigh on everything. ' };
+        yield { type: 'text', text: "What's been the heaviest part for you?" };
+        yield { type: 'done' };
+      }
+      (getSonnetStreamingResponse as jest.Mock).mockReturnValue(llmStream());
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+        body: { content: userMessage.content },
+      });
+      const { res, writeMock } = createMockResponse();
+
+      await sendMessageStream(req as Request, res as Response);
+
+      const sseOutput = writeMock.mock.calls.map(([chunk]) => String(chunk)).join('');
+      // Reply streamed to the client, not swallowed.
+      expect(sseOutput).toContain('a hard week can weigh on everything');
+      expect(sseOutput).toContain('the heaviest part for you');
+      // No empty-response failure.
+      expect(sseOutput).not.toContain('AI response was empty');
+      // User message kept (not cleaned up as a failed turn).
+      expect(prisma.message.delete).not.toHaveBeenCalled();
+      // AI reply persisted with the visible content.
+      expect(prisma.message.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            role: 'AI',
+            content: expect.stringContaining('a hard week can weigh on everything'),
           }),
         })
       );


### PR DESCRIPTION
## Problem

Repeated failed chat submits in production. Sentry showed a cluster of `sendMessageStream` errors (~10 in 5 minutes) on a real session:

```
warn :: Stream ended while still in thinking trap. Buffer has 297 chars. Keeping it hidden.
error :: Empty AI response after tag stripping
error :: Stream failed, cleaning up user message
```

## Root cause

The streaming handler hard-coded `isInsideThinking = true` and buffered all output until it saw `</thinking>`, assuming every response opens with `<thinking>`. When the model skipped the opener and went straight to the visible reply (more often on deep, long-context turns), the entire reply landed in the thinking buffer, the stream-end flush kept it hidden, and the empty-response guard threw — deleting the user message and surfacing as a failed submit.

The 297-char buffer (~75 tokens) vs. the 1536 `maxTokens` cap confirms the stream ended **naturally**, not by truncation — i.e. those chars were the actual reply, hidden by the trap.

## Fix

- **Detect the opener** on the first non-whitespace chunk. If the output can't become a `<thinking>` opener, bail out of the trap and stream the text normally. Ambiguous partial prefixes (`<th`) keep buffering so a genuine opener split across chunks still works.
- **Safer end-of-stream flush**: only hide the buffer when a real `<thinking>` opener was confirmed; otherwise flush it as the visible reply instead of erroring.

## Tests

- New regression test: a no-`<thinking>` stream now streams the reply, emits no empty-response error, keeps the user message, and persists the AI reply.
- Updated existing streaming mocks to include the literal `<thinking>` opener — matching real output shape (all 63 fixtures open with `<thinking>`; `bedrock.ts` does no assistant prefill).

`npm run check` clean; full `messages.test.ts` suite (22 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)