### PR TITLE
chore(check-db): guard against silently querying the localhost DB

### DIFF
--- a/.claude/commands/check-db.md
+++ b/.claude/commands/check-db.md
@@ -21,6 +21,23 @@ Default to **production read-only** for investigation. A readonly role should on
 
 **SECURITY**: NEVER print full connection strings. Write operations will be rejected by PostgreSQL even if attempted.
 
+### ⚠️ Guard against silently querying the wrong database
+
+`backend/.env`'s `DATABASE_URL` is usually a **local** dev DB (`localhost`), which holds a stale snapshot — NOT production. If you fall back to it without noticing, every result is misleading (this once produced a false "telemetry stopped" conclusion). Before running any query, resolve the URL and confirm the host. Abort and tell the user if it points at localhost when you intended production:
+
+```bash
+DB_URL="${READONLY_DATABASE_URL:-$(grep '^READONLY_DATABASE_URL=' backend/.env 2>/dev/null | cut -d= -f2-)}"
+[ -z "$DB_URL" ] && DB_URL="$(grep '^DATABASE_URL=' backend/.env 2>/dev/null | cut -d= -f2-)"
+# Print host/db ONLY (never the credentials) so you know which DB you're hitting:
+echo "Target DB: $(echo "$DB_URL" | sed -E 's#.*@([^/]+)/([^?]+).*#\1 / \2#')"
+case "$DB_URL" in
+  *@localhost*|*@127.0.0.1*)
+    echo "⚠️  This is a LOCAL database (stale snapshot), not production. For prod investigation, set READONLY_DATABASE_URL or fetch the prod connection string from Render before continuing." ;;
+esac
+```
+
+**Production DB**: the live Render Postgres is `be-heard-db` (`be_heard_db`, instance `dpg-d58660shg0os73bkkpmg-a`, region oregon). When you need prod and only have a localhost `DATABASE_URL`, fetch the prod connection string from the Render API (`/v1/postgres/dpg-d58660shg0os73bkkpmg-a/connection-info`, using `RENDER_API_KEY`) rather than querying localhost.
+
 ## Running queries
 
 Use `psql` directly (available in Docker and most dev environments):


### PR DESCRIPTION
## Why

During the PR #663 investigation, the `check-db` skill silently fell back to `backend/.env`'s `DATABASE_URL` — which points at a **local** dev DB (a stale snapshot ending ~05-21), not production. That produced a false "telemetry stopped on 05-22" conclusion before I noticed the host was `localhost`. Production is a separate Render Postgres (`be-heard-db`), which had today's data the whole time.

## Change

Adds a pre-query guard to the skill that:
- resolves the DB URL and prints the **host/db only** (credentials redacted) so it's obvious which database is being hit,
- warns loudly when the URL is `localhost`/`127.0.0.1` and the intent was production,
- documents the real prod instance (`be-heard-db`, `dpg-d58660shg0os73bkkpmg-a`) and how to fetch its connection string from the Render API instead of querying localhost.

Skill-only change (`.claude/commands/check-db.md`); no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)