### PR TITLE
[codex] Gate status dashboard with Clerk

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -63,13 +63,17 @@ ENABLE_AUDIT_STREAM=false
 # =============================================================================
 # Neural Monitor Dashboard (Optional)
 # =============================================================================
-# Secret for dashboard API auth via X-Dashboard-Secret header
+# Secret for dashboard API auth via X-Dashboard-Secret header.
+# Local/dev only; do not set this in production because browser bundles can leak it.
 # Generate a strong random string: openssl rand -hex 32
 # DASHBOARD_API_SECRET=
 # Comma-separated list of emails allowed to access the dashboard (optional)
 # If set, Clerk-authenticated users must have a matching email
 # DASHBOARD_ALLOWED_EMAILS=admin@example.com,dev@example.com
+# Comma-separated list of Clerk user IDs allowed to access the dashboard (optional)
+# Prefer this in production so access does not depend on custom Clerk token claims.
+# DASHBOARD_ALLOWED_USER_IDS=user_...
 # URL of the deployed dashboard (used for CORS)
-# DASHBOARD_URL=https://your-dashboard.example.com
+# DASHBOARD_URL=https://monitor.meetwithoutfear.com
 
 ASSEMBLYAI_API_KEY=

--- a/backend/src/routes/__tests__/brain-auth.test.ts
+++ b/backend/src/routes/__tests__/brain-auth.test.ts
@@ -70,7 +70,19 @@ describe('brain dashboard auth', () => {
       .set('Authorization', 'Bearer valid-token');
 
     expect(res.status).toBe(403);
-    expect(res.body.error).toMatchObject({ code: 'FORBIDDEN', message: 'Email not authorized for dashboard access' });
+    expect(res.body.error).toMatchObject({ code: 'FORBIDDEN', message: 'Not authorized for dashboard access' });
+  });
+
+  it('rejects Clerk tokens whose sub is not in DASHBOARD_ALLOWED_USER_IDS when only user ids are configured', async () => {
+    process.env.DASHBOARD_ALLOWED_USER_IDS = 'user_allowed';
+    verifyTokenMock.mockResolvedValue({ sub: 'user_blocked' } as any);
+
+    const res = await request(createApp())
+      .get('/brain/ably-token')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatchObject({ code: 'FORBIDDEN', message: 'Not authorized for dashboard access' });
   });
 
   it('rejects requests without a token when Clerk auth is configured', async () => {

--- a/backend/src/routes/__tests__/brain-auth.test.ts
+++ b/backend/src/routes/__tests__/brain-auth.test.ts
@@ -1,0 +1,85 @@
+import express from 'express';
+import request from 'supertest';
+import brainRoutes from '../brain';
+import { verifyToken } from '@clerk/express';
+
+jest.mock('../../lib/prisma');
+jest.mock('@clerk/express', () => ({
+  verifyToken: jest.fn(),
+}));
+
+const verifyTokenMock = verifyToken as jest.MockedFunction<typeof verifyToken>;
+
+function createApp() {
+  const app = express();
+  app.use('/brain', brainRoutes);
+  return app;
+}
+
+describe('brain dashboard auth', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'production',
+      CLERK_SECRET_KEY: 'sk_test_mock',
+      DASHBOARD_API_SECRET: '',
+      DASHBOARD_ALLOWED_EMAILS: '',
+      DASHBOARD_ALLOWED_USER_IDS: '',
+      ABLY_API_KEY: '',
+    };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('allows Clerk tokens whose sub is in DASHBOARD_ALLOWED_USER_IDS', async () => {
+    process.env.DASHBOARD_ALLOWED_USER_IDS = 'user_allowed,user_other';
+    verifyTokenMock.mockResolvedValue({ sub: 'user_allowed' } as any);
+
+    const res = await request(createApp())
+      .get('/brain/ably-token')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatchObject({ code: 'NOT_CONFIGURED', message: 'Ably not configured' });
+  });
+
+  it('allows Clerk tokens whose email is in DASHBOARD_ALLOWED_EMAILS', async () => {
+    process.env.DASHBOARD_ALLOWED_EMAILS = 'admin@example.com';
+    verifyTokenMock.mockResolvedValue({ sub: 'user_any', email: 'Admin@Example.com' } as any);
+
+    const res = await request(createApp())
+      .get('/brain/ably-token')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatchObject({ code: 'NOT_CONFIGURED', message: 'Ably not configured' });
+  });
+
+  it('rejects Clerk tokens that match neither allowlist', async () => {
+    process.env.DASHBOARD_ALLOWED_USER_IDS = 'user_allowed';
+    process.env.DASHBOARD_ALLOWED_EMAILS = 'admin@example.com';
+    verifyTokenMock.mockResolvedValue({ sub: 'user_blocked', email: 'blocked@example.com' } as any);
+
+    const res = await request(createApp())
+      .get('/brain/ably-token')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatchObject({ code: 'FORBIDDEN', message: 'Email not authorized for dashboard access' });
+  });
+
+  it('rejects requests without a token when Clerk auth is configured', async () => {
+    process.env.DASHBOARD_ALLOWED_USER_IDS = 'user_allowed';
+
+    const res = await request(createApp()).get('/brain/ably-token');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatchObject({ code: 'UNAUTHORIZED', message: 'Dashboard authentication required' });
+    expect(verifyTokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/brain.ts
+++ b/backend/src/routes/brain.ts
@@ -21,7 +21,8 @@ const router = Router();
  *   - X-Dashboard-Secret header matching DASHBOARD_API_SECRET env var
  *   - Clerk JWT Bearer token (verified via @clerk/express) with an allowed
  *     email or Clerk user id when allowlists are configured
- * If neither DASHBOARD_API_SECRET nor CLERK_SECRET_KEY is configured, skips auth (dev mode).
+ * If neither DASHBOARD_API_SECRET nor CLERK_SECRET_KEY is configured, allows
+ * local development and rejects production requests.
  */
 async function requireDashboardAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
   const dashboardSecret = process.env.DASHBOARD_API_SECRET;
@@ -59,22 +60,19 @@ async function requireDashboardAuth(req: Request, res: Response, next: NextFunct
         const payload = await verifyToken(token, { secretKey: clerkSecretKey });
 
         const allowedUserIds = process.env.DASHBOARD_ALLOWED_USER_IDS;
-        if (allowedUserIds) {
-          const userIdAllowList = allowedUserIds.split(',').map(id => id.trim()).filter(Boolean);
-          const userId = payload.sub;
-          if (userId && userIdAllowList.includes(userId)) {
-            next();
-            return;
-          }
-        }
-
-        // Role-based auth: check email allowlist if configured
         const allowedEmails = process.env.DASHBOARD_ALLOWED_EMAILS;
-        if (allowedEmails) {
-          const allowList = allowedEmails.split(',').map(e => e.trim().toLowerCase());
+
+        if (allowedUserIds || allowedEmails) {
+          const userIdAllowList = allowedUserIds?.split(',').map(id => id.trim()).filter(Boolean) ?? [];
+          const emailAllowList = allowedEmails?.split(',').map(e => e.trim().toLowerCase()).filter(Boolean) ?? [];
+          const userId = payload.sub;
           const email = (payload as any)?.email || (payload as any)?.sub_email;
-          if (!email || !allowList.includes(email.toLowerCase())) {
-            errorResponse(res, 'FORBIDDEN', 'Email not authorized for dashboard access', 403);
+
+          const userIdAllowed = Boolean(userId && userIdAllowList.includes(userId));
+          const emailAllowed = Boolean(email && emailAllowList.includes(email.toLowerCase()));
+
+          if (!userIdAllowed && !emailAllowed) {
+            errorResponse(res, 'FORBIDDEN', 'Not authorized for dashboard access', 403);
             return;
           }
         }

--- a/backend/src/routes/brain.ts
+++ b/backend/src/routes/brain.ts
@@ -19,7 +19,8 @@ const router = Router();
  * Authentication middleware for the Neural Monitor dashboard.
  * Accepts either:
  *   - X-Dashboard-Secret header matching DASHBOARD_API_SECRET env var
- *   - Clerk JWT Bearer token (verified via @clerk/express)
+ *   - Clerk JWT Bearer token (verified via @clerk/express) with an allowed
+ *     email or Clerk user id when allowlists are configured
  * If neither DASHBOARD_API_SECRET nor CLERK_SECRET_KEY is configured, skips auth (dev mode).
  */
 async function requireDashboardAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -56,6 +57,16 @@ async function requireDashboardAuth(req: Request, res: Response, next: NextFunct
       try {
         const token = authHeader.slice(7);
         const payload = await verifyToken(token, { secretKey: clerkSecretKey });
+
+        const allowedUserIds = process.env.DASHBOARD_ALLOWED_USER_IDS;
+        if (allowedUserIds) {
+          const userIdAllowList = allowedUserIds.split(',').map(id => id.trim()).filter(Boolean);
+          const userId = payload.sub;
+          if (userId && userIdAllowList.includes(userId)) {
+            next();
+            return;
+          }
+        }
 
         // Role-based auth: check email allowlist if configured
         const allowedEmails = process.env.DASHBOARD_ALLOWED_EMAILS;

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -62,6 +62,8 @@ Build profiles are defined in `mobile/eas.json`. Most profiles set `EXPO_PUBLIC_
 | Docs site | `docs-site/` | `npm run docs:deploy` (runs Vercel deploy in docs-site workspace) |
 | Status dashboard | `tools/status-dashboard/` | `npm run deploy:status` (runs `cd tools/status-dashboard && vercel --prod`) |
 
+The internal Neural Monitor dashboard is a standalone Vercel project served at `monitor.meetwithoutfear.com`. It is protected by Clerk in the browser and by backend API allowlists on `/api/brain/*`; production should set `DASHBOARD_ALLOWED_USER_IDS` and `DASHBOARD_ALLOWED_EMAILS`, and should not set `DASHBOARD_API_SECRET`.
+
 ### Web App: Vercel (Expo Web)
 
 The Expo mobile codebase also bundles for web and is served at `app.meetwithoutfear.com`.
@@ -125,7 +127,7 @@ The backend requires the following environment variables (see `backend/.env.exam
 | `APP_URL` | Public-facing app URL (e.g., `https://meetwithoutfear.com`) |
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` | AI services (AWS Bedrock) |
 
-Optional variables include Twilio SMS credentials, Neural Monitor dashboard settings (`DASHBOARD_API_SECRET`, `DASHBOARD_ALLOWED_EMAILS`, `DASHBOARD_URL`), model ID overrides (`BEDROCK_MODEL_ID`), and `FIELD_ENCRYPTION_KEY` (AES-256 key for application-level field encryption — gracefully degrades if not set).
+Optional variables include Twilio SMS credentials, Neural Monitor dashboard settings (`DASHBOARD_ALLOWED_USER_IDS`, `DASHBOARD_ALLOWED_EMAILS`, `DASHBOARD_URL`, local-only `DASHBOARD_API_SECRET`), model ID overrides (`BEDROCK_MODEL_ID`), and `FIELD_ENCRYPTION_KEY` (AES-256 key for application-level field encryption — gracefully degrades if not set).
 
 ### Testing & Development
 

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -146,6 +146,7 @@ Set `CHANNEL=<channel>` in the env so the emoji reaction handlers work.
 - **Docs site (this one)**: Vercel
 - **Marketing site**: Vercel (`website/`)
 - **Web app** (`app.meetwithoutfear.com`): Vercel — Expo Web build of `mobile/`, Vercel project `mwf-app`. Deployed via `.github/workflows/vercel-deploy-app.yml` on pushes to `main` that touch `mobile/**` or `shared/**`.
+- **Neural Monitor** (`monitor.meetwithoutfear.com`): Vercel (`tools/status-dashboard/`) — internal Clerk-gated dashboard for `/api/brain/*` activity, restricted in production to the Shantam and Darryl Clerk user IDs/email addresses.
 - **Test Dashboard**: Vercel (`mwf-test-dashboard`) — Browsable UI for e2e test runs, screenshots, and snapshots. Vercel Postgres (Neon) for run/snapshot metadata; Vercel Blob for screenshots. Deployed via `.github/workflows/vercel-deploy-test-dashboard.yml` on pushes to `main` that touch `tools/test-dashboard/**`. See [E2E Testing Architecture: Test Run Publishing & Dashboard](../e2e-testing/architecture.md#test-run-publishing--dashboard).
 
 See [deployment](../deployment/index.md) for release procedures and env var reference.

--- a/tools/status-dashboard/.env.production.example
+++ b/tools/status-dashboard/.env.production.example
@@ -3,17 +3,19 @@
 # =============================================================================
 
 # Backend API URL (required)
-# Points to your deployed backend instance
-VITE_API_URL=https://your-backend.example.com
+VITE_API_URL=https://api.meetwithoutfear.com
 
 # Deploy target (required for Vercel)
 # Set to "vercel" to use base: '/' instead of '/monitor/'
 VITE_DEPLOY_TARGET=vercel
 
-# Clerk Authentication (optional)
-# If set, enables Clerk-based auth for the dashboard
+# Clerk Authentication (required in production)
+# Enables Clerk-based auth for the dashboard.
 # Get keys from: https://dashboard.clerk.com → Your App → API Keys
 VITE_CLERK_PUBLISHABLE_KEY=pk_live_...
+
+# Do not set VITE_DASHBOARD_SECRET in production.
+# Secrets with a VITE_ prefix are exposed in the browser bundle.
 
 # Ably Realtime (optional for live monitor)
 # ⚠️  WARNING: NEVER set VITE_ABLY_KEY in production!

--- a/tools/status-dashboard/src/App.tsx
+++ b/tools/status-dashboard/src/App.tsx
@@ -1,10 +1,12 @@
 import React, { Suspense } from 'react';
+import { RedirectToSignIn, SignedIn, SignedOut, useAuth } from '@clerk/clerk-react';
 import { Routes, Route } from 'react-router-dom';
 import { AppLayout } from './components/layout/AppLayout';
 import SessionDetail from './components/session/SessionDetail';
 import { ContextPage } from './components/context';
 import { SessionListPage } from './pages/SessionListPage';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { setAuthTokenProvider } from './services/api';
 
 // Lazy-loaded pages (less frequently visited)
 const DashboardPage = React.lazy(() =>
@@ -39,7 +41,7 @@ function PageErrorFallback() {
   );
 }
 
-function App() {
+function AppRoutes() {
   return (
     <Routes>
       <Route element={<AppLayout />}>
@@ -53,6 +55,39 @@ function App() {
       </Route>
     </Routes>
   );
+}
+
+function ClerkGate() {
+  const { getToken, isLoaded } = useAuth();
+  const [authProviderReady, setAuthProviderReady] = React.useState(false);
+
+  React.useLayoutEffect(() => {
+    setAuthTokenProvider(() => getToken());
+    setAuthProviderReady(true);
+
+    return () => {
+      setAuthTokenProvider(null);
+      setAuthProviderReady(false);
+    };
+  }, [getToken]);
+
+  if (!isLoaded || !authProviderReady) return <LoadingSpinner />;
+
+  return (
+    <>
+      <SignedIn>
+        <AppRoutes />
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
+  );
+}
+
+function App() {
+  if (!import.meta.env.VITE_CLERK_PUBLISHABLE_KEY) return <AppRoutes />;
+  return <ClerkGate />;
 }
 
 export default App;

--- a/tools/status-dashboard/src/main.tsx
+++ b/tools/status-dashboard/src/main.tsx
@@ -1,15 +1,26 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { ClerkProvider } from '@clerk/clerk-react';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './style.css';
 
+const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
 function Root() {
-  return (
+  const router = (
     <BrowserRouter basename={import.meta.env.PROD && !import.meta.env.VITE_CLERK_PUBLISHABLE_KEY ? '/monitor' : '/'}>
       <App />
     </BrowserRouter>
+  );
+
+  if (!clerkPublishableKey) return router;
+
+  return (
+    <ClerkProvider publishableKey={clerkPublishableKey}>
+      {router}
+    </ClerkProvider>
   );
 }
 

--- a/tools/status-dashboard/src/services/api.ts
+++ b/tools/status-dashboard/src/services/api.ts
@@ -7,13 +7,28 @@ import { fetchWithRetry } from '../utils/fetchWithRetry';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
+type AuthTokenProvider = () => Promise<string | null>;
+
+let authTokenProvider: AuthTokenProvider | null = null;
+
+export function setAuthTokenProvider(provider: AuthTokenProvider | null): void {
+  authTokenProvider = provider;
+}
+
 /**
  * Resolves auth headers for API requests.
- * Sends X-Dashboard-Secret when VITE_DASHBOARD_SECRET is configured.
+ * Sends a Clerk Bearer token when Clerk is configured.
+ * Allows X-Dashboard-Secret only for local development.
  */
 export async function getAuthHeaders(): Promise<Record<string, string>> {
+  if (import.meta.env.VITE_CLERK_PUBLISHABLE_KEY && authTokenProvider) {
+    const token = await authTokenProvider();
+    if (token) return { Authorization: `Bearer ${token}` };
+  }
+
   const secret = import.meta.env.VITE_DASHBOARD_SECRET;
-  if (secret) return { 'X-Dashboard-Secret': secret };
+  if (secret && !import.meta.env.PROD) return { 'X-Dashboard-Secret': secret };
+
   return {};
 }
 


### PR DESCRIPTION
## Summary
- gates the status dashboard UI with Clerk when a publishable key is configured
- sends Clerk bearer tokens to the brain dashboard API and keeps browser-exposed dashboard secrets dev-only
- adds backend allowlisting by Clerk user ID, keeps email allowlisting, and documents the production monitor deployment

## Validation
- npm --workspace tools/status-dashboard run check
- npm --workspace tools/status-dashboard run build
- npm --workspace backend run test -- brain-auth.test.ts
- npm --workspace backend run check

## Notes
- Production access is intended to be restricted to Shantam and Darryl via DASHBOARD_ALLOWED_USER_IDS and DASHBOARD_ALLOWED_EMAILS.