### PR TITLE
[codex] fix Stage 4 need-id coverage

### DIFF
--- a/backend/src/services/__tests__/stage4-coverage.service.test.ts
+++ b/backend/src/services/__tests__/stage4-coverage.service.test.ts
@@ -142,6 +142,65 @@ describe('stage4-coverage.service', () => {
     expect(result).toEqual({ covered: 0, partial: 0, open: 2, total: 2 });
   });
 
+  it('covers a need when a proposal stores the need id in needsAddressed', async () => {
+    (prisma.identifiedNeed.findMany as jest.Mock).mockResolvedValue([
+      need({
+        id: 'need-authenticity',
+        need: "I need authenticity in our relating — the knowledge that I'm honoring him and he's honoring me",
+      }),
+    ]);
+    (prisma.strategyProposal.findMany as jest.Mock).mockResolvedValue([
+      proposal({
+        id: 'proposal-honesty',
+        description: 'When we talk, Shantam will commit to being honest about where things stand',
+        needsAddressed: ['need-authenticity'],
+      }),
+    ]);
+
+    const result = await refreshStage4NeedCoverage(sessionId);
+
+    expect(prisma.stage4NeedCoverage.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          needId: 'need-authenticity',
+          coverageStatus: 'COVERED',
+          coveringProposalIds: ['proposal-honesty'],
+        }),
+      ],
+    });
+    expect(result).toEqual({ covered: 1, partial: 0, open: 0, total: 1 });
+  });
+
+  it('covers a need when a proposal has a StrategyProposalNeed link row', async () => {
+    (prisma.identifiedNeed.findMany as jest.Mock).mockResolvedValue([
+      need({
+        id: 'need-clarity',
+        need: "To know whether Shantam's not right now means temporary or permanent",
+      }),
+    ]);
+    (prisma.strategyProposal.findMany as jest.Mock).mockResolvedValue([
+      proposal({
+        id: 'proposal-checkin',
+        description: 'Check in once every 6 months to talk about how things are',
+        needsAddressed: [],
+        needLinks: [{ needId: 'need-clarity' }],
+      }),
+    ]);
+
+    const result = await refreshStage4NeedCoverage(sessionId);
+
+    expect(prisma.stage4NeedCoverage.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          needId: 'need-clarity',
+          coverageStatus: 'COVERED',
+          coveringProposalIds: ['proposal-checkin'],
+        }),
+      ],
+    });
+    expect(result).toEqual({ covered: 1, partial: 0, open: 0, total: 1 });
+  });
+
   it('partly covers Stage 4 needs when proposals use process language instead of repeated need text', async () => {
     (prisma.identifiedNeed.findMany as jest.Mock).mockResolvedValue([
       need({

--- a/backend/src/services/stage4-coverage.service.ts
+++ b/backend/src/services/stage4-coverage.service.ts
@@ -16,6 +16,7 @@ type ProposalRow = {
   description: string;
   needsAddressed: string[];
   status: Stage4ProposalStatus;
+  needLinks?: Array<{ needId: string }>;
 };
 
 export type Stage4NeedCoverageRefreshResult = {
@@ -151,9 +152,13 @@ function classifyCoverage(
   const normalizedNeed = normalizeText(need.need);
   const scored = proposals
     .map((proposal) => {
+      const linkedByNeedId =
+        proposal.needsAddressed.includes(need.id) ||
+        (proposal.needLinks ?? []).some((link) => link.needId === need.id);
       const addressed = proposal.needsAddressed.some((label) => {
         const normalizedLabel = normalizeText(label);
-        return normalizedLabel === normalizedNeed ||
+        return label === need.id ||
+          normalizedLabel === normalizedNeed ||
           normalizedLabel.includes(normalizedNeed) ||
           normalizedNeed.includes(normalizedLabel);
       });
@@ -162,7 +167,7 @@ function classifyCoverage(
       const directMention = normalizedProposalText.includes(normalizedNeed);
       const lexicalScore = overlapScore(need.need, text);
       const semanticScore = conceptOverlapScore(need.need, text);
-      const score = addressed || directMention
+      const score = linkedByNeedId || addressed || directMention
         ? 1
         : Math.max(lexicalScore, Math.min(semanticScore, 0.74));
       return { proposal, score };
@@ -217,6 +222,11 @@ export async function refreshStage4NeedCoverage(
       where: {
         sessionId,
         status: { not: Stage4ProposalStatus.REMOVED },
+      },
+      include: {
+        needLinks: {
+          select: { needId: true },
+        },
       },
       orderBy: { updatedAt: 'desc' },
     }) as Promise<ProposalRow[]>,


### PR DESCRIPTION
## Summary
- Treat explicit Stage 4 need IDs in proposal.needsAddressed as full coverage matches.
- Include StrategyProposalNeed link rows when refreshing Stage 4 need coverage.
- Add regression coverage for both need-ID and join-table coverage paths.

## Root cause
The share gate reads Stage4NeedCoverage.coveringProposalIds, but coverage refresh only matched proposal needs by text. A proposal could display as addressing a need because it stored the need ID, while the coverage audit still kept the same need OPEN with no covering proposals.

## Production repair
Refreshed Stage 4 coverage for session cmpc3ra1g0097nw1yu40bb1q6 after applying the fixed classifier locally. Result: covered=2, partial=1, open=0.

## Validation
- npm test -- --runInBand backend/src/services/__tests__/stage4-coverage.service.test.ts
- npm run check