### PR TITLE
[codex] fix ios push notification configuration

### DIFF
--- a/backend/src/services/push.ts
+++ b/backend/src/services/push.ts
@@ -12,7 +12,9 @@ let expoClient: Expo | null = null;
 
 function getExpo(): Expo {
   if (!expoClient) {
-    expoClient = new Expo();
+    expoClient = new Expo({
+      accessToken: process.env.EXPO_ACCESS_TOKEN,
+    });
   }
   return expoClient;
 }

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -38,7 +38,7 @@ All required environment variables for Meet Without Fear services.
 | `CORS_ORIGIN` | Allowed CORS origins | `*` |
 | `RATE_LIMIT_WINDOW_MS` | Rate limit window | `60000` |
 | `RATE_LIMIT_MAX` | Max requests per window | `100` |
-| `EXPO_ACCESS_TOKEN` | Expo push notification token | (optional) |
+| `EXPO_ACCESS_TOKEN` | Expo access token used by the backend when Expo push security is enabled. | (optional unless Expo push security is enabled) |
 | `OPENAI_API_KEY` | OpenAI key for TTS (`/api/tts` → `tts-1` / `tts-1-hd`). Without it, TTS returns 500 and meditation/gratitude/chat read-aloud features are broken. | (none) |
 | `APP_LATEST_BUILD_NUMBER_IOS` / `APP_LATEST_BUILD_NUMBER_ANDROID` | Latest native mobile build number for optional update prompts. Falls back to `APP_LATEST_BUILD_NUMBER`. | `40` |
 | `APP_MIN_BUILD_NUMBER_IOS` / `APP_MIN_BUILD_NUMBER_ANDROID` | Minimum supported native mobile build number for required update prompts. Falls back to `APP_MIN_BUILD_NUMBER`. | (none) |

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -91,7 +91,8 @@
         {
           "faceIDPermission": "Meet Without Fear uses Face ID to protect your private sessions."
         }
-      ]
+      ],
+      "expo-notifications"
     ],
     "extra": {
       "eas": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "e2e"
   ],
   "scripts": {
-    "deploy:mobile:ios": "node scripts/update-build-number.js && cd mobile && EXPO_NO_CAPABILITY_SYNC=1 eas build --platform ios --profile production --auto-submit",
+    "deploy:mobile:ios": "node scripts/update-build-number.js && cd mobile && eas build --platform ios --profile production --auto-submit",
     "deploy:mobile:android": "node scripts/update-build-number.js && cd mobile && eas build --platform android --profile android-apk",
     "deploy:mobile:ota": "cd mobile && ./scripts/publish-ota.sh",
     "deploy:ios:prepare": "node scripts/deploy-ios-prepare.js",


### PR DESCRIPTION
## What changed

- Pass `EXPO_ACCESS_TOKEN` into `expo-server-sdk` so backend sends work when Expo push security is enabled.
- Add the `expo-notifications` config plugin to the Expo app config so EAS production builds include the native notification setup.
- Remove `EXPO_NO_CAPABILITY_SYNC=1` from the iOS deploy command so EAS can sync capabilities for future production builds.
- Clarify the backend environment variable documentation for `EXPO_ACCESS_TOKEN`.

## Why

iOS push notifications had two drift risks: production backend sends ignored the documented Expo access token, and the iOS build path/config could skip native capability/plugin setup for notifications. Either can make production pushes stop working despite valid app/server code paths.

## Validation

- `npm test --workspace=backend -- --runTestsByPath src/services/__tests__/push.test.ts`
- `npm run check --workspace=backend`
- `npm run check --workspace=mobile`
- `npx expo config --json` confirms `expo-notifications` appears in plugin history.
