### PR TITLE
Fix session waiting state UI

### DIFF
--- a/backend/src/controllers/notifications.ts
+++ b/backend/src/controllers/notifications.ts
@@ -70,15 +70,25 @@ export async function getPendingActionsHandler(
 
     const actions: PendingAction[] = [];
 
-    // 1. Pending share offers (reconciler suggested sharing)
-    const shareOffers = await prisma.reconcilerShareOffer.findMany({
-      where: {
-        userId: user.id,
-        result: { sessionId },
-        status: { in: ['PENDING', 'OFFERED'] },
-      },
-      include: { result: true },
+    const userStageProgress = await prisma.stageProgress.findFirst({
+      where: { sessionId, userId: user.id },
+      orderBy: { stage: 'desc' },
+      select: { stage: true },
     });
+    const userMaxStage = userStageProgress?.stage ?? 0;
+
+    // 1. Pending share offers (reconciler suggested sharing). These are only
+    // actionable while the user is still in Stage 2.
+    const shareOffers = userMaxStage === 2
+      ? await prisma.reconcilerShareOffer.findMany({
+          where: {
+            userId: user.id,
+            result: { sessionId },
+            status: { in: ['PENDING', 'OFFERED'] },
+          },
+          include: { result: true },
+        })
+      : [];
 
     for (const offer of shareOffers) {
       actions.push({
@@ -124,13 +134,6 @@ export async function getPendingActionsHandler(
     // Only show if user has completed Stage 1 (advanced to stage >= 2).
     // Partner may share context before this user finishes Stage 1, but we
     // suppress the notification until the user is ready to see it.
-    const userStageProgress = await prisma.stageProgress.findFirst({
-      where: { sessionId, userId: user.id },
-      orderBy: { stage: 'desc' },
-      select: { stage: true },
-    });
-    const userMaxStage = userStageProgress?.stage ?? 0;
-
     if (userMaxStage >= 2) {
       const vessel = await prisma.userVessel.findUnique({
         where: { userId_sessionId: { userId: user.id, sessionId } },
@@ -217,14 +220,23 @@ export async function getBadgeCountHandler(
     for (const session of sessions) {
       let count = 0;
 
-      // Share offers
-      const shareOfferCount = await prisma.reconcilerShareOffer.count({
-        where: {
-          userId: user.id,
-          result: { sessionId: session.id },
-          status: { in: ['PENDING', 'OFFERED'] },
-        },
+      const badgeStageProgress = await prisma.stageProgress.findFirst({
+        where: { sessionId: session.id, userId: user.id },
+        orderBy: { stage: 'desc' },
+        select: { stage: true },
       });
+      const userMaxStage = badgeStageProgress?.stage ?? 0;
+
+      // Share offers are only actionable while the user is still in Stage 2.
+      const shareOfferCount = userMaxStage === 2
+        ? await prisma.reconcilerShareOffer.count({
+            where: {
+              userId: user.id,
+              result: { sessionId: session.id },
+              status: { in: ['PENDING', 'OFFERED'] },
+            },
+          })
+        : 0;
       count += shareOfferCount;
 
       // Unvalidated partner empathy
@@ -240,13 +252,7 @@ export async function getBadgeCountHandler(
 
       // Unread shared context messages (from partner, not self-sent)
       // Only count if user has completed Stage 1 (advanced to stage >= 2)
-      const badgeStageProgress = await prisma.stageProgress.findFirst({
-        where: { sessionId: session.id, userId: user.id },
-        orderBy: { stage: 'desc' },
-        select: { stage: true },
-      });
-
-      if ((badgeStageProgress?.stage ?? 0) >= 2) {
+      if (userMaxStage >= 2) {
         const vessel = await prisma.userVessel.findUnique({
           where: { userId_sessionId: { userId: user.id, sessionId: session.id } },
           select: { lastViewedShareTabAt: true },

--- a/backend/src/controllers/stage2.ts
+++ b/backend/src/controllers/stage2.ts
@@ -2283,6 +2283,24 @@ export async function getShareSuggestion(
       return;
     }
 
+    const progress = await prisma.stageProgress.findFirst({
+      where: {
+        sessionId,
+        userId: user.id,
+        status: { in: ['IN_PROGRESS', 'GATE_PENDING'] },
+      },
+      orderBy: { stage: 'desc' },
+      select: { stage: true },
+    });
+
+    if ((progress?.stage ?? 0) !== 2) {
+      successResponse(res, {
+        hasSuggestion: false,
+        suggestion: null,
+      });
+      return;
+    }
+
     // Get share suggestion from reconciler service
     const result = await getShareSuggestionForUser(sessionId, user.id);
 

--- a/mobile/src/components/ChatInterface.tsx
+++ b/mobile/src/components/ChatInterface.tsx
@@ -1250,6 +1250,7 @@ export function ChatInterface({
           testID="chat-emotion-slider"
         />
       )}
+      {auxiliaryControls}
       {!hideInput && (
         <ChatInput
           onSend={onSendMessage}
@@ -1262,7 +1263,6 @@ export function ChatInterface({
           onPrefillConsumed={onPrefillConsumed}
         />
       )}
-      {auxiliaryControls}
     </View>
   );
 

--- a/mobile/src/components/__tests__/ChatInterface.test.tsx
+++ b/mobile/src/components/__tests__/ChatInterface.test.tsx
@@ -203,7 +203,7 @@ describe('ChatInterface', () => {
       expect(input.props.editable).toBe(false);
     });
 
-    it('keeps guided action panels below the chat input', () => {
+    it('keeps guided action panels above the chat input', () => {
       render(
         <ChatInterface
           messages={[]}
@@ -228,7 +228,7 @@ describe('ChatInterface', () => {
       const panelBranch = ancestor?.children.find((child: any) => typeof child !== 'string' && contains(child, panel));
 
       expect(ancestor).toBeTruthy();
-      expect(ancestor.children.indexOf(panelBranch)).toBeGreaterThan(ancestor.children.indexOf(inputBranch));
+      expect(ancestor.children.indexOf(panelBranch)).toBeLessThan(ancestor.children.indexOf(inputBranch));
     });
   });
 

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -1366,6 +1366,26 @@ export function UnifiedSessionScreen({
     }
   }, [invitationConfirmed, hasInvitationTransitionResponse]);
 
+  const hasEmpathyValidationFollowUp = useMemo(() => {
+    if (!partnerEmpathyData?.validatedAt) return false;
+    const validatedAt = new Date(partnerEmpathyData.validatedAt).getTime();
+    if (!Number.isFinite(validatedAt)) return false;
+
+    return messages.some((message) => {
+      if (message.role !== MessageRole.AI || message.stage !== Stage.PERSPECTIVE_STRETCH) {
+        return false;
+      }
+      const timestamp = new Date(message.timestamp).getTime();
+      return Number.isFinite(timestamp) && timestamp >= validatedAt;
+    });
+  }, [messages, partnerEmpathyData?.validatedAt]);
+
+  useEffect(() => {
+    if (!isAwaitingEmpathyValidationFollowUp || hasEmpathyValidationFollowUp) {
+      setIsAwaitingEmpathyValidationFollowUp(false);
+    }
+  }, [hasEmpathyValidationFollowUp, isAwaitingEmpathyValidationFollowUp]);
+
   const confirmInvitationAndAwaitFollowUp = useCallback(() => {
     setIsAwaitingInvitationFollowUp(true);
     handleConfirmInvitationMessage();

--- a/mobile/src/utils/__tests__/getWaitingStatus.test.ts
+++ b/mobile/src/utils/__tests__/getWaitingStatus.test.ts
@@ -306,6 +306,21 @@ describe('Priority 4: Stage 2 (Empathy)', () => {
     expect(computeWaitingStatus(inputs)).toBe('partner-validating-empathy');
   });
 
+  it('returns partner-validating-empathy during optimistic validation before my attempt status refetches', () => {
+    const inputs = createDefaultInputs({
+      myStage: Stage.PERSPECTIVE_STRETCH,
+      partnerStage: Stage.PERSPECTIVE_STRETCH,
+      hasPartnerEmpathy: true,
+      empathyStatus: {
+        myAttemptStatus: 'READY',
+      },
+      myValidation: { validated: true },
+      partnerValidated: false,
+    });
+
+    expect(computeWaitingStatus(inputs)).toBe('partner-validating-empathy');
+  });
+
   it('returns partner-revising-empathy after I send feedback on partner empathy', () => {
     const inputs = createDefaultInputs({
       myStage: Stage.PERSPECTIVE_STRETCH,

--- a/mobile/src/utils/getWaitingStatus.ts
+++ b/mobile/src/utils/getWaitingStatus.ts
@@ -270,10 +270,12 @@ export function computeWaitingStatus(inputs: WaitingStatusInputs): WaitingStatus
 
   // User has validated the partner's empathy attempt, but the partner has not
   // validated the user's revealed attempt yet. There is no useful freeform
-  // user action here; the next gate belongs to the partner.
+  // user action here; the next gate belongs to the partner. This intentionally
+  // does not require a specific myAttempt status because the live cache can lag
+  // behind the partner-empathy optimistic validation result.
   if (
     myStage === Stage.PERSPECTIVE_STRETCH &&
-    empathyStatus?.myAttemptStatus === 'REVEALED' &&
+    hasPartnerEmpathy &&
     inputs.myValidation?.validated &&
     inputs.partnerValidated === false
   ) {


### PR DESCRIPTION
## Summary
- hide Stage 2 chat input while waiting after empathy validation, even during optimistic cache windows
- clear the empathy validation typing indicator once the follow-up AI message is present
- show guided action panels above the composer and suppress stale share offers outside Stage 2

## Verification
- `npm test -- --runTestsByPath src/utils/__tests__/getWaitingStatus.test.ts src/utils/__tests__/chatUIState.test.ts src/components/__tests__/ShareTopicPanel.test.tsx src/components/__tests__/ChatInterface.test.tsx`
- `npm run check` in `mobile`
- `npm test -- --runTestsByPath src/controllers/__tests__/stage2-copy.test.ts`
- `npm run check` in `backend`