### PR TITLE
Add Process category to notable facts (#535)

### DIFF
--- a/backend/src/services/background-classifier.ts
+++ b/backend/src/services/background-classifier.ts
@@ -85,7 +85,7 @@ const VALID_CATEGORIES: MemoryCategory[] = [
 // ============================================================================
 
 /** Valid categories for notable facts */
-const VALID_FACT_CATEGORIES = ['People', 'Logistics', 'Conflict', 'Emotional', 'History'];
+const VALID_FACT_CATEGORIES = ['People', 'Logistics', 'Conflict', 'Emotional', 'History', 'Process'];
 
 /**
  * Build the unified classification prompt.
@@ -137,6 +137,7 @@ CATEGORIES (use these exact names):
 - Conflict: specific disagreements, triggers, patterns
 - Emotional: feelings, frustrations, fears, hopes
 - History: past events, relationship timeline, backstory
+- Process: conversation dynamics — engagement patterns, repeated behaviors, frame shifts, resistance or openness signals
 
 RULES:
 - Each fact MUST have a category and fact text

--- a/backend/src/services/global-memory.ts
+++ b/backend/src/services/global-memory.ts
@@ -68,9 +68,9 @@ CONSOLIDATION RULES:
 1. Keep the most important, lasting facts about the user
 2. Merge similar or duplicate facts into single entries
 3. Update outdated facts with newer information (newer takes precedence)
-4. Prioritize facts about: People (names, relationships), Emotional patterns, Conflict patterns, Key events
+4. Prioritize facts about: People (names, relationships), Emotional patterns, Conflict patterns, Process dynamics, Key events
 5. Remove session-specific details that won't be relevant in future sessions
-6. Use these categories: People, Logistics, Conflict, Emotional, History
+6. Use these categories: People, Logistics, Conflict, Emotional, History, Process
 7. Keep each fact concise (1 sentence max)
 
 OUTPUT JSON only:

--- a/backend/src/services/partner-session-classifier.ts
+++ b/backend/src/services/partner-session-classifier.ts
@@ -330,12 +330,13 @@ CATEGORIES (use these exact names):
 - Conflict: specific disagreements, triggers, patterns
 - Emotional: feelings, frustrations, fears, hopes
 - History: past events, relationship timeline, backstory
+- Process: conversation dynamics — engagement patterns, repeated behaviors, frame shifts, resistance or openness signals (e.g., "User has deflected the same question 3 times", "User shifted from short answers to detailed sharing", "User expressed frustration with the process itself")
 
 WHAT TO EXCLUDE:
-- Meta-commentary about the session/process
 - Questions to the AI
 - Session style preferences
 - Requests to "remember" things (ignore these)
+- Trivial single-turn behaviors (only note Process patterns spanning 3+ turns or representing a significant shift)
 
 CRITICAL - NEVER ASSUME:
 - Do NOT assume the relationship type between the user and the person discussed
@@ -387,12 +388,13 @@ CATEGORIES (use these exact names):
 - Conflict: specific disagreements, triggers, patterns
 - Emotional: feelings, frustrations, fears, hopes
 - History: past events, relationship timeline, backstory
+- Process: conversation dynamics — engagement patterns, repeated behaviors, frame shifts, resistance or openness signals (e.g., "User has deflected the same question 3 times", "User shifted from short answers to detailed sharing", "User expressed frustration with the process itself")
 
 WHAT TO EXCLUDE:
-- Meta-commentary about the session/process
 - Questions to the AI
 - Session style preferences
 - Requests to "remember" things (ignore these)
+- Trivial single-turn behaviors (only note Process patterns spanning 3+ turns or representing a significant shift)
 
 CRITICAL - NEVER ASSUME:
 - Do NOT assume the relationship type between the user and the person discussed
@@ -420,7 +422,7 @@ OUTPUT JSON only:
 }
 
 /** Valid categories for notable facts */
-const VALID_FACT_CATEGORIES = ['People', 'Logistics', 'Conflict', 'Emotional', 'History'];
+const VALID_FACT_CATEGORIES = ['People', 'Logistics', 'Conflict', 'Emotional', 'History', 'Process'];
 
 /**
  * Normalize a fact's category to title case if it's a known category

--- a/docs/backend/prompting-architecture.md
+++ b/docs/backend/prompting-architecture.md
@@ -3,7 +3,7 @@ title: Backend Prompting Architecture Audit
 sidebar_position: 5
 description: "Last Updated: 2026-03-11"
 created: 2026-03-11
-updated: 2026-05-10
+updated: 2026-05-26
 status: living
 ---
 # Backend Prompting Architecture Audit
@@ -475,7 +475,7 @@ graph TD
    - Session summary (for long sessions)
    - Inner Thoughts reflections (if linked)
    - User memories (preferences, names, communication style)
-   - **Categorized session facts** (People, Logistics, Conflict, Emotional, History)
+   - **Categorized session facts** (People, Logistics, Conflict, Emotional, History, Process)
    - Retrieved context (cross-session, relevant history)
 
 4. **Surface-Specific Formatting (Slack):**
@@ -579,7 +579,7 @@ graph TD
 **Categorized Fact Format:**
 ```typescript
 interface CategorizedFact {
-  category: string;  // People, Logistics, Conflict, Emotional, History
+  category: string;  // People, Logistics, Conflict, Emotional, History, Process
   fact: string;      // 1 sentence max
 }
 ```


### PR DESCRIPTION
## Changes
- Add: `Process` category to `VALID_FACT_CATEGORIES` in both `partner-session-classifier.ts` and `background-classifier.ts`
- Add: Process category definition and examples to diff-based and legacy notable facts prompts
- Add: Process category to `global-memory.ts` consolidation prompt
- Update: "WHAT TO EXCLUDE" rules — removed blanket "meta-commentary about session/process" exclusion, replaced with targeted "trivial single-turn behaviors" exclusion with 3+ turn threshold guidance
- Update: `docs/backend/prompting-architecture.md` to reflect the new category

Related to #535

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Darryl Finkton Jr + Shantam
- **Original message:** 1778456730.964889
- **Prompt(s) used:** partner-session-classifier (diff-based + legacy), background-classifier (inner thoughts), global-memory (consolidation)

## Docs updated
- `docs/backend/prompting-architecture.md` — added Process to category lists (2 occurrences)

🤖 Generated with [Claude Code](https://claude.com/claude-code)