### PR TITLE
Improve review agreements screen readability (#650)

### DIFF
--- a/mobile/src/components/Stage4RedesignPanel.tsx
+++ b/mobile/src/components/Stage4RedesignPanel.tsx
@@ -405,7 +405,7 @@ function ProposalCard({
       ))}
 
       {showStance && (
-        <>
+        <View style={styles.stanceDivider}>
           <Text style={styles.stanceLabel}>Your stance</Text>
           <View style={styles.segmentedControl}>
             {[
@@ -444,7 +444,7 @@ function ProposalCard({
           <Text style={styles.partnerState}>
             {partnerStateLabel(partnerName, proposal.partnerDecisionVisible)}
           </Text>
-        </>
+        </View>
       )}
     </View>
   );
@@ -1192,8 +1192,10 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
   proposalCard: {
     backgroundColor: palette.bgPane,
     borderRadius: 10,
-    padding: 12,
-    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 14,
+    marginBottom: 16,
   },
   proposalHeader: {
     flexDirection: 'row',
@@ -1203,10 +1205,15 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
   },
   proposalKind: {
     color: palette.accentText,
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '700',
     textTransform: 'uppercase',
-    letterSpacing: 0.4,
+    letterSpacing: 0.5,
+    backgroundColor: palette.accentSoft,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+    borderRadius: 4,
+    overflow: 'hidden',
   },
   ownerLabel: {
     color: palette.textMuted,
@@ -1217,21 +1224,27 @@ const makeStyles = (palette: Palette) => StyleSheet.create({
     color: palette.text,
     fontSize: 15,
     lineHeight: 21,
+    marginBottom: 2,
   },
   proposalMeta: {
-    color: palette.textMuted,
-    fontSize: 13,
-    lineHeight: 18,
-    marginTop: 6,
+    color: palette.textFaint,
+    fontSize: 12,
+    lineHeight: 17,
+    marginTop: 4,
+  },
+  stanceDivider: {
+    borderTopWidth: 1,
+    borderTopColor: palette.border,
+    marginTop: 14,
+    paddingTop: 12,
   },
   stanceLabel: {
     color: palette.textMuted,
     fontSize: 12,
-    fontWeight: '600',
-    marginTop: 14,
-    marginBottom: 6,
+    fontWeight: '700',
+    marginBottom: 8,
     textTransform: 'uppercase',
-    letterSpacing: 0.4,
+    letterSpacing: 0.5,
   },
   segmentedControl: {
     flexDirection: 'row',


### PR DESCRIPTION
## Changes
- Add border and increased spacing to proposal cards for clearer visual separation between items
- Badge/pill treatment on proposal kind labels (SHARED PROPOSAL / INDIVIDUAL COMMITMENT) using accent background color
- Add a thin divider line before the "Your stance" section to separate it from metadata
- De-emphasize secondary metadata (Addresses, Timing, Success) with smaller font and lighter color
- Bump stance label font weight for better heading hierarchy

Related to #650

## Provenance
- **Channel:** #bugs-and-requests
- **Requested by:** Shantam (U0AD3TF2U7L)
- **Original message:** The design of this is hard to read because it's a lot of info packed in with headings that are not obvious.

## Docs updated
No doc changes needed — UI styling only, no API/behavior changes.

## Test plan
- [ ] Open a Stage 4 session with shared proposals and verify the improved card layout
- [ ] Confirm proposal kind labels render as colored badges
- [ ] Verify divider line appears between metadata and stance section
- [ ] Check metadata text (Addresses, Timing, Success) is visually de-emphasized
- [ ] Test in both light and dark mode