### PR TITLE
docs: incremental audit 2026-05-26 — stage4 coverage, waiting state, push token, stage2 gate

### DIFF
--- a/docs/backend/api/stage-2.md
+++ b/docs/backend/api/stage-2.md
@@ -3,7 +3,7 @@ title: "Stage 2 API: Perspective Stretch"
 sidebar_position: 7
 description: Endpoints for building and exchanging empathy attempts.
 slug: /backend/api/stage-2
-updated: 2026-05-12
+updated: 2026-05-26
 status: living
 ---
 # Stage 2 API: Perspective Stretch
@@ -211,7 +211,7 @@ Besides the Phase-1 / Phase-2 core above, the routes file exposes these controll
 | `POST` | `/api/v1/sessions/:id/empathy/refine` | Run AI refinement on the caller's current draft (used by the validation feedback / coach loop) |
 | `POST` | `/api/v1/sessions/:id/empathy/resubmit` | After refinement, resubmit an updated `EmpathyAttempt` on top of an existing validation request. **Validation**: returns 400 `VALIDATION_ERROR` if the submitted content is identical to the previous attempt after whitespace normalization and case folding. |
 | `POST` | `/api/v1/sessions/:id/empathy/skip-refinement` | Accept or decline the current gap as a "willing-to-accept" difference and advance without further refinement; updates `skippedRefinement`, `willingToAccept`, `skipReason` on the caller's StageProgress |
-| `GET`  | `/api/v1/sessions/:id/empathy/share-suggestion` | Asymmetric reconciler: fetch a suggestion to help the caller close an empathy gap for the partner. The mobile client only surfaces this panel after the caller has consented to share their own empathy attempt (`alreadyConsented === true` on the `EmpathyDraftDTO`). |
+| `GET`  | `/api/v1/sessions/:id/empathy/share-suggestion` | Asymmetric reconciler: fetch a suggestion to help the caller close an empathy gap for the partner. The mobile client only surfaces this panel after the caller has consented to share their own empathy attempt (`alreadyConsented === true` on the `EmpathyDraftDTO`). The backend returns `{ hasSuggestion: false }` immediately if the caller's current stage progress is not Stage 2 — no reconciler work is performed for out-of-stage requests. |
 | `POST` | `/api/v1/sessions/:id/empathy/share-suggestion/respond` | Accept or decline a share suggestion |
 | `POST` | `/api/v1/sessions/:id/empathy/validation-feedback/draft` | Draft feedback via the "Feedback Coach" AI flow |
 | `POST` | `/api/v1/sessions/:id/empathy/validation-feedback/refine` | Iterate on feedback-coach output |

--- a/docs/backend/api/stage-4.md
+++ b/docs/backend/api/stage-4.md
@@ -22,7 +22,7 @@ Stage 4 is **sequential** (unlike stages 1-3 which are parallel). Both users mus
 ### Data persistence
 - Proposals → `StrategyProposal` with `kind` (SHARED_PROPOSAL | INDIVIDUAL_COMMITMENT), `source` (USER_SUBMITTED | AI_SUGGESTED | CURATED), and `status` (ACTIVE | REVISED | REMOVED | CONVERTED_TO_AGREEMENT). The redesigned walkthrough exposes a source label (current user, partner, AI, or unknown) so users understand where options came from.
 - Willingness selections → `Stage4ProposalSelection` per user per proposal
-- Coverage audit → `Stage4NeedCoverage` tracks which confirmed needs are addressed by proposals
+- Coverage audit → `Stage4NeedCoverage` tracks which confirmed needs are addressed by proposals. The `classifyCoverage` function scores each (need, proposal) pair using the following priority (first hit scores 1.0): (1) need's ID appears in `proposal.needsAddressed` (legacy string-ID match), (2) `proposal.needLinks` contains a `StrategyProposalNeed` join-table row with that `needId` (relational match — set when AI-suggested proposals are created via `POST /stage4/proposals/suggest` with a `needId`), (3) normalized text label match against `needsAddressed` entries, (4) direct mention / lexical / semantic heuristics. DB-relation matching takes precedence over text-label heuristics, ensuring proposals explicitly linked to a need are never missed by fuzzy scoring.
 - Walkthrough state → `StageProgress.gatesSatisfied.stage4Walkthrough` stores the caller's focused phase, current need, covered needs, and skipped needs
 - Closure → `Stage4Closure` records the final outcome kind (SHARED_AGREEMENT | NO_SHARED_AGREEMENT)
 - Agreements → `Agreement` rows linked to proposals via `proposalId`

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -3,7 +3,7 @@ title: Deployment
 sidebar_position: 1
 description: Production deployment targets and distribution options for the Meet Without Fear platform.
 created: 2026-03-11
-updated: 2026-04-20
+updated: 2026-05-26
 status: living
 ---
 # Deployment
@@ -127,7 +127,7 @@ The backend requires the following environment variables (see `backend/.env.exam
 | `APP_URL` | Public-facing app URL (e.g., `https://meetwithoutfear.com`) |
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` | AI services (AWS Bedrock) |
 
-Optional variables include Twilio SMS credentials, Neural Monitor dashboard settings (`DASHBOARD_ALLOWED_USER_IDS`, `DASHBOARD_ALLOWED_EMAILS`, `DASHBOARD_URL`, local-only `DASHBOARD_API_SECRET`), model ID overrides (`BEDROCK_MODEL_ID`), and `FIELD_ENCRYPTION_KEY` (AES-256 key for application-level field encryption — gracefully degrades if not set).
+Optional variables include Twilio SMS credentials, Neural Monitor dashboard settings (`DASHBOARD_ALLOWED_USER_IDS`, `DASHBOARD_ALLOWED_EMAILS`, `DASHBOARD_URL`, local-only `DASHBOARD_API_SECRET`), model ID overrides (`BEDROCK_MODEL_ID`), `FIELD_ENCRYPTION_KEY` (AES-256 key for application-level field encryption — gracefully degrades if not set), and `EXPO_ACCESS_TOKEN` (Expo push notification access token — required when Expo push security is enabled).
 
 ### Testing & Development
 

--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -2,7 +2,7 @@
 title: Chat Interface
 sidebar_position: 3
 description: The primary conversation interface where users interact with the AI.
-updated: 2026-05-15
+updated: 2026-05-26
 status: living
 ---
 # Chat Interface
@@ -285,6 +285,8 @@ flowchart TB
     end
 ```
 
+**Trigger condition (Stage 2):** This state is shown when `empathyValidated` is true and `hasPartnerEmpathy` is false — i.e., the user validated the partner's empathy attempt but the partner has not yet shared theirs. The condition checks `hasPartnerEmpathy` (whether the partner's `EmpathyAttempt` record exists) rather than the caller's own attempt status, making it resilient to optimistic-update cache lag.
+
 ### Session Not Started
 
 ```mermaid
@@ -301,6 +303,8 @@ flowchart TB
 ```
 
 ## Input Area Details
+
+**`auxiliaryControls` render position:** The `auxiliaryControls` slot in `ChatInterface` renders **above** the `ChatInput` row (between the message list and the text input field). Any controls passed via this prop appear before the input, not after it.
 
 ```mermaid
 flowchart TB


### PR DESCRIPTION
## Changes
- Update: `stage-4.md` — document `classifyCoverage` need matching priority; DB-relational `needLinks` match (added in #666) takes precedence over text-label heuristics
- Update: `stage-2.md` — document backend stage-gate on `GET /share-suggestion`; returns `{ hasSuggestion: false }` when caller not in Stage 2 (added in #668)
- Update: `chat-interface.md` — document `auxiliaryControls` render position (above ChatInput after #668); add Stage 2 waiting state trigger condition (`hasPartnerEmpathy` replaces `myAttemptStatus===REVEALED` for cache-lag resilience)
- Update: `deployment/index.md` — add `EXPO_ACCESS_TOKEN` to optional variables list (added in #667)

## Provenance
- **Channel:** cron / audit-docs
- **Requested by:** scheduled bot
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** `audit-docs` skill — incremental stage, 24h lookback

## Docs updated
- `docs/backend/api/stage-4.md`
- `docs/backend/api/stage-2.md`
- `docs/mobile/wireframes/chat-interface.md`
- `docs/deployment/index.md`