### PR TITLE
fix(stream): fall back to pre-scrub text when scrubbing empties AI response (#672)

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -2061,6 +2061,7 @@ export async function sendMessageStream(req: Request, res: Response): Promise<vo
     // Stream AI response (with analysis block trap)
     // =========================================================================
     let accumulatedText = '';
+    let rawAccumulatedText = ''; // tag-stripped but NOT planner-scrubbed; used as fallback
     let metadata: SessionStateToolInput = {};
     let streamError: Error | null = null;
 
@@ -2195,6 +2196,11 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
         // This removes newlines at the start without breaking word spacing in subsequent chunks
         if (!firstChunkTime && cleanText.length > 0) {
           cleanText = cleanText.trimStart();
+        }
+
+        // Track tag-stripped text before planner scrubbing (fallback if scrubbing empties everything)
+        if (cleanText.length > 0) {
+          rawAccumulatedText += cleanText;
         }
 
         const scrubbed = scrubVisibleAIText(cleanText, { preserveBoundaryWhitespace: true });
@@ -2609,14 +2615,22 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
 
       // Guard: empty AI response after parsing + dispatch means the model emitted
       // no usable user-facing text, or the upstream stream failed without
-      // producing text. Treat this as a failed turn so the frontend can show its
-      // retry/error state instead of saving a misleading canned response.
+      // producing text.
       if (!accumulatedText.trim()) {
-        logger.error(`[sendMessageStream:${requestId}] Empty AI response after tag stripping`, {
-          dispatchTag: dispatchTag ?? null,
-          scrubbedPlannerText: scrubbedResponse.scrubbed,
-        });
-        throw new Error('AI response was empty after tag stripping');
+        if (rawAccumulatedText.trim()) {
+          // Scrubbing removed all visible content (e.g. only planner lines survived
+          // tag stripping). Fall back to the pre-scrub text — showing slightly raw
+          // text is far better than throwing and deleting the user message.
+          logger.warn(`[sendMessageStream:${requestId}] Scrubbing produced empty response; falling back to pre-scrub text (${rawAccumulatedText.trim().length} chars)`);
+          accumulatedText = rawAccumulatedText.trim();
+          sendSSE(res, { event: 'chunk', data: { text: accumulatedText } });
+        } else {
+          logger.error(`[sendMessageStream:${requestId}] Empty AI response after tag stripping`, {
+            dispatchTag: dispatchTag ?? null,
+            scrubbedPlannerText: scrubbedResponse.scrubbed,
+          });
+          throw new Error('AI response was empty after tag stripping');
+        }
       }
 
       finalizeTurnMetrics(turnId);

--- a/backend/src/routes/__tests__/messages.test.ts
+++ b/backend/src/routes/__tests__/messages.test.ts
@@ -899,6 +899,91 @@ describe('Messages API (Fire-and-Forget)', () => {
         })
       );
     });
+
+    it('falls back to pre-scrub text when scrubbing empties the response', async () => {
+      // Regression #672: if the visible portion after </thinking> consists entirely
+      // of planner lines that scrubVisibleAIText removes, the guard throws and
+      // deletes the user message. The fix falls back to the pre-scrub text.
+      const stage1Progress = {
+        id: 'progress-1',
+        sessionId: mockSessionId,
+        userId: mockUser.id,
+        stage: 1,
+        status: 'IN_PROGRESS',
+        gatesSatisfied: {},
+      };
+      const session = {
+        id: mockSessionId,
+        status: 'ACTIVE',
+        relationship: {
+          members: [{ userId: mockUser.id }, { userId: 'partner-1' }],
+        },
+      };
+      const userMessage = {
+        id: 'msg-user-scrub-empty',
+        sessionId: mockSessionId,
+        senderId: mockUser.id,
+        role: 'USER',
+        content: 'Tell me more.',
+        stage: 1,
+        timestamp: new Date('2026-05-25T18:00:00Z'),
+      };
+
+      (prisma.session.findFirst as jest.Mock).mockResolvedValue(session);
+      (prisma.session.findUnique as jest.Mock).mockResolvedValue(session);
+      (prisma.stageProgress.findFirst as jest.Mock).mockResolvedValue(stage1Progress);
+      (prisma.stageProgress.findUnique as jest.Mock).mockResolvedValue(stage1Progress);
+      (prisma.message.create as jest.Mock).mockImplementation(async ({ data }) => (
+        data.role === 'USER'
+          ? { ...userMessage, content: data.content }
+          : {
+              id: 'msg-ai-scrub-empty',
+              sessionId: mockSessionId,
+              senderId: null,
+              forUserId: mockUser.id,
+              role: 'AI',
+              content: data.content,
+              stage: data.stage,
+              timestamp: new Date('2026-05-25T18:00:02Z'),
+            }
+      ));
+      (prisma.message.findMany as jest.Mock).mockResolvedValue([userMessage]);
+      (prisma.message.count as jest.Mock).mockResolvedValue(1);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ name: 'Partner' });
+      (prisma.userVessel.findUnique as jest.Mock).mockResolvedValue(null);
+
+      // Model responds with <thinking> then ONLY planner lines that get scrubbed
+      async function* llmStream() {
+        yield { type: 'text', text: '<thinking>\nI need to respond carefully.\n</thinking>\n' };
+        yield { type: 'text', text: 'I should acknowledge what they said.\n' };
+        yield { type: 'text', text: "Here's my plan to address their concern." };
+        yield { type: 'done' };
+      }
+      (getSonnetStreamingResponse as jest.Mock).mockReturnValue(llmStream());
+
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: mockSessionId },
+        body: { content: userMessage.content },
+      });
+      const { res, writeMock } = createMockResponse();
+
+      await sendMessageStream(req as Request, res as Response);
+
+      const sseOutput = writeMock.mock.calls.map(([chunk]) => String(chunk)).join('');
+      // Should NOT throw or delete user message
+      expect(prisma.message.delete).not.toHaveBeenCalled();
+      // Should contain fallback text (the pre-scrub planner lines)
+      expect(sseOutput).toContain('acknowledge what they said');
+      // AI reply persisted
+      expect(prisma.message.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            role: 'AI',
+          }),
+        })
+      );
+    });
   });
 
   describe('POST /sessions/:id/feel-heard (confirmFeelHeard)', () => {


### PR DESCRIPTION
## Changes
- Fix: when planner scrubbing removes all visible text, fall back to the tag-stripped (pre-scrub) text instead of throwing and deleting the user message
- Add: `rawAccumulatedText` accumulator that tracks text after tag stripping but before planner scrubbing
- Add: regression test simulating a model response consisting entirely of planner lines

## Root Cause
PR #663 fixed the case where the model omits `<thinking>`, but a residual path remained: when the visible portion after `</thinking>` consists entirely of planner-line text that `scrubVisibleAIText` removes (e.g. "I should...", "Here's my plan..."), `accumulatedText` ends up empty. The empty-response guard then throws, deleting the user message — 7 occurrences in prod across one session since #663 merged.

The fix tracks text after tag stripping but before planner scrubbing. When scrubbing empties the result, it falls back to the raw text and sends it as an SSE chunk. Showing slightly raw text is far better than a failed submit.

Related to #672

## Provenance
- **Source:** GitHub Issue #672
- **Prompt(s) used:** fix-bugs workspace (stages 02-06)

## Docs updated
- No doc changes needed