### PR TITLE
[codex] Fix web Mixpanel opt-out export

### DIFF
--- a/mobile/src/services/__tests__/mixpanel.web.test.ts
+++ b/mobile/src/services/__tests__/mixpanel.web.test.ts
@@ -1,0 +1,70 @@
+type MixpanelBrowserMock = {
+  init: jest.Mock;
+  track: jest.Mock;
+  identify: jest.Mock;
+  alias: jest.Mock;
+  people: {
+    set: jest.Mock;
+    set_once: jest.Mock;
+  };
+  register: jest.Mock;
+  reset: jest.Mock;
+};
+
+const loadWebMixpanel = () => {
+  jest.resetModules();
+
+  const mixpanel: MixpanelBrowserMock = {
+    init: jest.fn(),
+    track: jest.fn(),
+    identify: jest.fn(),
+    alias: jest.fn(),
+    people: {
+      set: jest.fn(),
+      set_once: jest.fn(),
+    },
+    register: jest.fn(),
+    reset: jest.fn(),
+  };
+
+  jest.doMock('mixpanel-browser', () => ({
+    __esModule: true,
+    default: mixpanel,
+  }));
+
+  process.env.EXPO_PUBLIC_MIXPANEL_TOKEN = 'test-token';
+
+  const service = require('../mixpanel.web') as typeof import('../mixpanel.web');
+  return { service, mixpanel };
+};
+
+describe('mixpanel web service', () => {
+  afterEach(() => {
+    delete process.env.EXPO_PUBLIC_MIXPANEL_TOKEN;
+    jest.dontMock('mixpanel-browser');
+  });
+
+  it('exports setAnalyticsOptOut and suppresses analytics calls when opted out', async () => {
+    const { service, mixpanel } = loadWebMixpanel();
+
+    expect(typeof service.setAnalyticsOptOut).toBe('function');
+
+    await service.initializeMixpanel();
+    service.track('Before Opt Out');
+
+    service.setAnalyticsOptOut(true);
+    service.track('After Opt Out');
+    service.identify('user-1');
+    const didAlias = await service.alias('user-1');
+    service.setUserProperties({ plan: 'test' });
+    service.setUserPropertiesOnce({ first_seen_at: '2026-05-30T00:00:00.000Z' });
+
+    expect(mixpanel.track).toHaveBeenCalledTimes(1);
+    expect(mixpanel.track).toHaveBeenCalledWith('Before Opt Out', undefined);
+    expect(mixpanel.identify).not.toHaveBeenCalled();
+    expect(didAlias).toBe(false);
+    expect(mixpanel.alias).not.toHaveBeenCalled();
+    expect(mixpanel.people.set).not.toHaveBeenCalled();
+    expect(mixpanel.people.set_once).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/services/mixpanel.web.ts
+++ b/mobile/src/services/mixpanel.web.ts
@@ -12,6 +12,7 @@ import mixpanel from 'mixpanel-browser';
 let didInit = false;
 let hasToken = false;
 let identifiedUserId: string | null = null;
+let analyticsOptedOut = false;
 
 const log = (message: string, ...args: unknown[]): void => {
   if (__DEV__) {
@@ -47,6 +48,7 @@ const assertInit = (): void => {
 
 export const track = (eventName: string, properties?: Record<string, unknown>): void => {
   assertInit();
+  if (analyticsOptedOut) return;
   if (__DEV__ && properties) {
     if ('session_id' in properties && !properties.session_id) {
       console.warn(`[Mixpanel DEV] "${eventName}" tracked with falsy session_id`);
@@ -64,6 +66,7 @@ export const track = (eventName: string, properties?: Record<string, unknown>): 
 
 export const identify = (userId: string): void => {
   assertInit();
+  if (analyticsOptedOut) return;
   if (identifiedUserId === userId) return;
   identifiedUserId = userId;
   if (!hasToken) {
@@ -79,6 +82,7 @@ export const identify = (userId: string): void => {
 
 export const alias = async (aliasId: string): Promise<boolean> => {
   assertInit();
+  if (analyticsOptedOut) return false;
   if (typeof aliasId !== 'string' || aliasId.trim().length === 0) {
     console.warn('[Mixpanel Web] alias() skipped: aliasId is not a valid string');
     return false;
@@ -101,6 +105,7 @@ export const alias = async (aliasId: string): Promise<boolean> => {
 
 export const setUserProperties = (properties: Record<string, unknown>): void => {
   assertInit();
+  if (analyticsOptedOut) return;
   if (!hasToken) {
     log('Set User Properties:', properties);
     return;
@@ -114,6 +119,7 @@ export const setUserProperties = (properties: Record<string, unknown>): void => 
 
 export const setUserPropertiesOnce = (properties: Record<string, unknown>): void => {
   assertInit();
+  if (analyticsOptedOut) return;
   if (!hasToken) {
     log('Set User Properties Once:', properties);
     return;
@@ -141,6 +147,10 @@ export const reset = (): void => {
     return;
   }
   mixpanel.reset();
+};
+
+export const setAnalyticsOptOut = (optedOut: boolean): void => {
+  analyticsOptedOut = optedOut;
 };
 
 export const isInitialized = (): boolean => didInit;


### PR DESCRIPTION
## Summary

Fixes #679.

The Expo web build resolves `../services/mixpanel` to `mixpanel.web.ts`, but that platform-specific wrapper did not export `setAnalyticsOptOut`. `MixpanelInitializer` calls that function when privacy preferences load, causing the production web bundle to throw and render a blank page.

This PR adds the missing web export and mirrors the native opt-out guard for tracking, identity, alias, and people-property calls. It also adds a direct regression test for `mixpanel.web.ts` so this platform override stays API-compatible.

## Validation

- `npm test -- --runTestsByPath src/services/__tests__/mixpanel.web.test.ts --runInBand`
- `npm run check`