### PR TITLE
Fix invitation follow-up recovery

### DIFF
--- a/mobile/src/hooks/__tests__/useSessions.test.ts
+++ b/mobile/src/hooks/__tests__/useSessions.test.ts
@@ -16,9 +16,10 @@ import {
   useInvitation,
   useAcceptInvitation,
   useDeclineInvitation,
+  useConfirmInvitationMessage,
   sessionKeys,
 } from '../useSessions';
-import { SessionStatus } from '@meet-without-fear/shared';
+import { SessionStatus, StageStatus } from '@meet-without-fear/shared';
 
 // Import mocked functions
 import * as api from '../../lib/api';
@@ -50,6 +51,11 @@ function createWrapper(): React.FC<{ children: React.ReactNode }> {
       },
     },
   });
+  return ({ children }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function createWrapperWithClient(queryClient: QueryClient): React.FC<{ children: React.ReactNode }> {
   return ({ children }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
 }
@@ -390,6 +396,89 @@ describe('useSessions', () => {
       expect(mockPost).toHaveBeenCalledWith('/invitations/inv-123/decline', {
         reason: undefined,
       });
+    });
+  });
+
+  describe('useConfirmInvitationMessage hook', () => {
+    it('updates cached session status to INVITED when invitation confirmation advances to witness', async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+          },
+        },
+      });
+
+      queryClient.setQueryData(sessionKeys.state('session-123'), {
+        session: {
+          id: 'session-123',
+          status: SessionStatus.CREATED,
+          currentStage: 0,
+          stageStatus: StageStatus.IN_PROGRESS,
+          relationshipId: 'relationship-123',
+          partner: { id: 'user-456', name: 'Partner', nickname: null },
+          myProgress: { stage: 0, status: StageStatus.IN_PROGRESS },
+          createdAt: '2024-01-01T00:00:00.000Z',
+          resolvedAt: null,
+          lastViewedAt: null,
+          partnerLastViewedAt: null,
+          partnerLastActiveAt: null,
+          lastSeenChatItemId: null,
+          sourceInnerThoughts: null,
+        },
+        progress: {
+          sessionId: 'session-123',
+          myProgress: {
+            stage: 0,
+            status: StageStatus.IN_PROGRESS,
+            startedAt: null,
+            completedAt: null,
+            gatesSatisfied: {},
+          },
+          partnerProgress: {
+            stage: 0,
+            status: StageStatus.IN_PROGRESS,
+            startedAt: null,
+            completedAt: null,
+          },
+          canAdvance: false,
+          milestones: {
+            witnessStartedAt: null,
+            feelHeardConfirmedAt: null,
+          },
+        },
+        messages: [],
+        invitation: {
+          id: 'inv-123',
+          messageConfirmed: false,
+          messageConfirmedAt: null,
+          topicFrame: 'house chores',
+        },
+        compact: null,
+      });
+
+      mockPost.mockResolvedValueOnce({
+        confirmed: true,
+        invitation: {
+          id: 'inv-123',
+          messageConfirmed: true,
+          messageConfirmedAt: '2024-01-01T00:01:00.000Z',
+          topicFrame: 'house chores',
+        },
+        advancedToStage: 1,
+      });
+
+      const { result } = renderHook(() => useConfirmInvitationMessage(), {
+        wrapper: createWrapperWithClient(queryClient),
+      });
+
+      await act(async () => {
+        await result.current.mutateAsync({ sessionId: 'session-123' });
+      });
+
+      expect(mockPost).toHaveBeenCalledWith('/sessions/session-123/invitation/confirm', {});
+      expect(queryClient.getQueryData<any>(sessionKeys.state('session-123'))?.session.status)
+        .toBe(SessionStatus.INVITED);
     });
   });
 

--- a/mobile/src/hooks/useSessions.ts
+++ b/mobile/src/hooks/useSessions.ts
@@ -690,6 +690,7 @@ export function useConfirmInvitationMessage(
         const newSession = data.advancedToStage !== undefined
           ? {
               ...existingState.session,
+              status: SessionStatus.INVITED,
               currentStage: data.advancedToStage,
               stageStatus: StageStatus.IN_PROGRESS,
               myProgress: {

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -148,6 +148,8 @@ interface UnifiedSessionScreenProps {
 
 const NEEDS_REVIEW_PANEL_EXPANDED_MAX_HEIGHT = 420;
 const NEEDS_REVIEW_PANEL_ENTER_OFFSET = 20;
+const FIRE_AND_FORGET_RECOVERY_INTERVAL_MS = 10_000;
+const FIRE_AND_FORGET_RECOVERY_MAX_ATTEMPTS = 6;
 
 /**
  * Get brief status text for the header based on session status
@@ -1390,6 +1392,30 @@ export function UnifiedSessionScreen({
     setIsAwaitingInvitationFollowUp(true);
     handleConfirmInvitationMessage();
   }, [handleConfirmInvitationMessage]);
+
+  // If a fire-and-forget AI response is missed via Ably, poll persisted messages
+  // for a bounded window. The derived message checks above clear these latches
+  // as soon as the missing AI message lands in the cache.
+  useEffect(() => {
+    if (!isAwaitingInvitationFollowUp && !isAwaitingEmpathyValidationFollowUp) return;
+
+    let attempts = 0;
+    const recoveryTimer = setInterval(() => {
+      attempts += 1;
+      console.log('[UnifiedSessionScreen] Fire-and-forget recovery: refetching persisted messages', {
+        attempts,
+      });
+      refetchPersistedMessages();
+
+      if (attempts >= FIRE_AND_FORGET_RECOVERY_MAX_ATTEMPTS) {
+        setIsAwaitingInvitationFollowUp(false);
+        setIsAwaitingEmpathyValidationFollowUp(false);
+        clearInterval(recoveryTimer);
+      }
+    }, FIRE_AND_FORGET_RECOVERY_INTERVAL_MS);
+
+    return () => clearInterval(recoveryTimer);
+  }, [isAwaitingInvitationFollowUp, isAwaitingEmpathyValidationFollowUp, refetchPersistedMessages]);
 
   const shouldRunInvitationFollowUp =
     currentStage === Stage.ONBOARDING && !hasInvitationTransitionResponse;


### PR DESCRIPTION
## Summary

- Update invitation confirmation cache state so the session status moves from `CREATED` to `INVITED` after the backend advances the inviter to Stage 1
- Add bounded retry recovery for missed fire-and-forget AI responses instead of relying on a single delayed refetch
- Add a regression test proving the cached session status changes to `INVITED` after invitation confirmation

## Why

PR #678 mitigates the stuck typing indicator by doing a one-shot refetch after 10 seconds. That helps only when the AI message has already been persisted by then. The deeper issue is that the mobile cache can keep `session.status` as `CREATED`, which disables realtime subscriptions while the client is waiting for the Ably `message.ai_response` event.

This fix keeps realtime enabled by updating the cached status immediately, and retains a bounded persisted-message recovery path for missed Ably events or slow background generation.

## Validation

- `npm --workspace mobile run check`
- `npm --workspace mobile test -- --runTestsByPath src/hooks/__tests__/useSessions.test.ts --runInBand --forceExit`

Fixes #677