### PR TITLE
docs(mobile, integrations): document Mixpanel opt-out and typing recovery

### DIFF
--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -3,7 +3,7 @@ title: External Integrations
 sidebar_position: 6
 description: "Analysis Date: 2026-03-11"
 created: 2026-03-11
-updated: 2026-05-05
+updated: 2026-05-31
 status: living
 ---
 # External Integrations
@@ -95,6 +95,10 @@ status: living
     - Mobile (native): `mobile/src/services/mixpanel.ts`, `mobile/src/services/analytics.ts`, `mobile/src/components/MixpanelInitializer.tsx`
     - Mobile (Expo web build): `mobile/src/services/mixpanel.web.ts` (platform override using `mixpanel-browser`)
     - Website: Google Analytics via Next.js
+  - Analytics Opt-Out:
+    - Function: `setAnalyticsOptOut(optedOut: boolean)` (exported from `mixpanel.web.ts` for Expo web)
+    - Behavior: When opted out (`true`), all analytics operations are suppressed: `track()`, `identify()`, `alias()`, `setUserProperties()`, and `setUserPropertiesOnce()` become no-ops
+    - Integration point: Called from user privacy settings when user opts out of analytics collection
 
 ## Data Storage
 

--- a/docs/mobile/wireframes/chat-interface.md
+++ b/docs/mobile/wireframes/chat-interface.md
@@ -2,7 +2,7 @@
 title: Chat Interface
 sidebar_position: 3
 description: The primary conversation interface where users interact with the AI.
-updated: 2026-05-15
+updated: 2026-05-31
 status: living
 ---
 # Chat Interface
@@ -60,6 +60,7 @@ Characteristics:
 - Subtle background color
 - AI avatar/icon
 - A typing indicator ("ghost dots") appears while the user is waiting for the AI's reply — it's derived from cache state (the last message role is `USER`, meaning the AI hasn't answered yet) and from pending mutations like `isFetchingInitialMessage` / `isConfirmingFeelHeard` / `isSharingEmpathy` / `isConfirmingInvitation`. Dots hide as soon as the first AI chunk arrives via SSE / Ably.
+  - **Recovery mechanism**: If the typing indicator appears to be stuck (e.g., due to a fire-and-forget Ably message drop during an invitation modal dismiss), a 10-second recovery timer automatically refetches messages. This clears the stuck state without user intervention. The recovery timer is triggered when awaiting invitation or empathy validation follow-ups.
 - **AI error feedback**: when an Ably `onAIError` event arrives (e.g. the backend failed to process the user's message), the optimistic message is rolled back (dots hide automatically) and a toast is shown: *"Something went wrong — Your message could not be processed. Please try again."* This is triggered via `useToast().showError` in `UnifiedSessionScreen`.
 
 ### User Message


### PR DESCRIPTION
## Summary

Documents two undocumented features found in last 24h code changes:

- **Mixpanel opt-out** (`setAnalyticsOptOut()` export): privacy-critical feature added to web analytics but not documented
- **Typing indicator recovery timer**: defensive pattern (10s refetch) for Ably fire-and-forget message drops during modal dismissals

## Changes
- Add: Analytics Opt-Out subsection to integrations.md with function behavior and integration point
- Add: Typing indicator recovery mechanism explanation to chat-interface.md
- Update: Frontmatter dates (updated: 2026-05-31)

## Provenance
- **Channel:** #agentic-devs (cron: audit-docs)
- **Requested by:** Slam Paws (scheduled job)
- **Original message:** Run incremental docs audit (24h lookback)
- **Prompt(s) used:** Incremental audit with git-history-aware analysis; fixed identified drift

## Docs updated
- `docs/architecture/integrations.md` — Added Mixpanel opt-out documentation
- `docs/mobile/wireframes/chat-interface.md` — Added typing indicator recovery timer explanation