### PR TITLE
fix(bot): port slam-paws diagnostics from peter-app lineage to MWF

### DIFF
--- a/bot-workspaces/bug-fix/CONTEXT.md
+++ b/bot-workspaces/bug-fix/CONTEXT.md
@@ -16,7 +16,7 @@ End-to-end bug fixing: from issue selection through investigation, implementatio
 ## Workspace References
 
 - `references/branch-naming.md` -- Branch and PR title conventions by issue label
-- `references/test-patterns.md` -- Backend (vitest) and mobile (jest-expo) test patterns
+- `references/test-patterns.md` -- Backend (jest) and mobile (jest-expo) test patterns
 - `references/pr-conventions.md` -- PR body format, reviewer requirements, issue linking
 
 ## Shared Resources Used

--- a/bot-workspaces/bug-fix/references/branch-naming.md
+++ b/bot-workspaces/bug-fix/references/branch-naming.md
@@ -4,41 +4,39 @@
 
 | Issue Label | Branch Pattern | Example |
 |---|---|---|
-| `bug` | `fix/<short-description>-<issue-number>` | `fix/health-score-null-crash-423` |
-| `security` | `fix/security-<short-description>-<issue-number>` | `fix/security-auth-bypass-401` |
-| `bot-pr` | `feat/<short-description>-<issue-number>` | `feat/add-export-button-445` |
+| `bug` | `fix/<short-description>-<issue-number>` | `fix/stage4-transition-copy-633` |
+| `security` | `fix/security-<short-description>-<issue-number>` | `fix/security-ws-token-in-url-620` |
+| `bot-pr` | `feat/<short-description>-<issue-number>` | `feat/analytics-opt-out-toggle-617` |
 
 ## PR Title Format
 
 | Issue Label | Title Pattern | Example |
 |---|---|---|
-| `bug` | `fix(<area>): <description> (#<issue-number>)` | `fix(health): handle null scores in dashboard (#423)` |
-| `security` | `fix(security): <description> (#<issue-number>)` | `fix(security): validate auth tokens on WebSocket (#401)` |
-| `bot-pr` | `feat(<area>): <description> (#<issue-number>)` | `feat(workbench): add CSV export to health page (#445)` |
+| `bug` | `fix(<area>): <description> (#<issue-number>)` | `fix(stage4): warmer transition copy + single CTA (#633)` |
+| `security` | `fix(security): <description> (#<issue-number>)` | `fix(security): move WebSocket auth token out of URL (#620)` |
+| `bot-pr` | `feat(<area>): <description> (#<issue-number>)` | `feat(mobile): make analytics opt-out toggle functional (#617)` |
 
 ## Area Names
 
-Use the service or app name as the area:
+MWF is an **npm-workspaces monorepo** (`backend/`, `mobile/`, `shared/`, `website/`).
+Use the workspace, or the controller/service area within the backend:
 
 | Code Location | Area |
 |---|---|
-| `apps/gateway/src/services/identity/` | `identity` |
-| `apps/gateway/src/services/recording/` | `recording` |
-| `apps/gateway/src/services/insights/` | `insights` |
-| `apps/gateway/src/services/coaching/` | `coaching` |
-| `apps/gateway/src/services/orchestrator/` | `orchestrator` |
-| `apps/gateway/src/services/social/` | `social` |
-| `apps/gateway/src/services/analytics/` | `analytics` |
-| `apps/gateway/src/services/device/` | `device` |
-| `apps/gateway/src/services/push/` | `push` |
-| `apps/mobile/` | `mobile` |
-| `apps/workbench/` | `workbench` |
-| `packages/shared/` | `shared` |
-| `packages/prisma/` | `data` |
+| `backend/src/controllers/` | controller name, e.g. `auth`, `sessions` |
+| `backend/src/services/empathy-*`, `reconciler*` | `empathy` / `reconciler` |
+| `backend/src/services/ai*`, `chat-router/` | `ai` / `chat` |
+| `backend/src/services/push.ts`, `notifications*` | `push` |
+| `backend/src/services/context-*` | `context` |
+| `backend/src/routes/` | `api` (or the route area) |
+| `backend/prisma/` | `data` (schema / migrations) |
+| `mobile/` | `mobile` |
+| `shared/` | `shared` |
+| `website/` | `website` |
 | Cross-cutting | `core` |
 
 ## Short Description Rules
 
-- Use lowercase kebab-case: `fix-null-score`, not `Fix_Null_Score`
-- Max 4-5 words: `health-score-null-crash`, not `fix-the-issue-where-health-scores-crash-when-null`
-- Describe the fix, not the symptom: `handle-null-scores` not `dashboard-broken`
+- Use lowercase kebab-case: `stage4-transition-copy`, not `Stage4_Transition_Copy`
+- Max 4-5 words: `ws-token-in-url`, not `fix-the-issue-where-the-websocket-token-leaks-in-the-url`
+- Describe the fix, not the symptom: `move-token-to-header` not `websocket-broken`

--- a/bot-workspaces/bug-fix/references/test-patterns.md
+++ b/bot-workspaces/bug-fix/references/test-patterns.md
@@ -1,52 +1,48 @@
 # Test Patterns
 
-## Backend Tests (vitest)
+MWF is an **npm-workspaces monorepo**. Both backend and mobile use **Jest**
+(backend: ts-jest; mobile: jest-expo). There is no vitest and no pnpm.
 
-Backend services use vitest. Tests live alongside source files or in `__tests__/` directories.
+## Backend Tests (Jest + ts-jest)
 
-### Mock Pattern
+Tests live in `__tests__/` directories alongside source (e.g.
+`backend/src/middleware/__tests__/auth.test.ts`). `describe/it/expect/jest` are
+global; the mock helper imports `jest` from `@jest/globals`.
 
-Always use `vi.hoisted()` + `vi.mock()` for dependency mocking:
+### Prisma Mock Pattern
+
+The Prisma client lives at `backend/src/lib/prisma` and has a manual mock at
+`backend/src/lib/__mocks__/prisma.ts` (every model pre-stubbed). Activate it with
+a bare `jest.mock` of the prisma module — Jest auto-uses the `__mocks__` version —
+then drive individual calls by casting to `jest.Mock`:
 
 ```typescript
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { prisma } from '../../lib/prisma';
+import { handler } from '../route-handler';
 
-// 1. Hoist mock definitions (runs before imports)
-const mockPrisma = vi.hoisted(() => ({
-  recording: {
-    findUnique: vi.fn(),
-    update: vi.fn(),
-  },
+// Auto-mock — Jest picks up backend/src/lib/__mocks__/prisma.ts
+jest.mock('../../lib/prisma');
+
+// Mock collaborating services as needed
+jest.mock('../../services/empathy-state-machine', () => ({
+  advanceEmpathyState: jest.fn(),
 }));
-
-const mockService = vi.hoisted(() => ({
-  processRecording: vi.fn(),
-}));
-
-// 2. Mock modules
-vi.mock('../../../packages/prisma', () => ({
-  prisma: mockPrisma,
-}));
-
-vi.mock('../services/recordingService', () => ({
-  recordingService: mockService,
-}));
-
-// 3. Import the module under test AFTER mocks
-import { handler } from './route-handler';
 
 describe('handler', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    jest.clearAllMocks();
   });
 
-  it('should handle the happy path', async () => {
-    mockPrisma.recording.findUnique.mockResolvedValue({ id: '123' });
+  it('handles the happy path', async () => {
+    (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+      id: 'abc',
+      status: 'ACTIVE',
+    });
     // ... test logic
   });
 
-  it('should handle the error case (regression test for bug)', async () => {
-    mockPrisma.recording.findUnique.mockResolvedValue(null);
+  it('handles a missing session (regression test for bug)', async () => {
+    (prisma.session.findUnique as jest.Mock).mockResolvedValue(null);
     // ... assert the fix works
   });
 });
@@ -55,14 +51,16 @@ describe('handler', () => {
 ### Running Backend Tests
 
 ```bash
-cd && pnpm test
-# Or target a specific file:
-cd && pnpm vitest run apps/gateway/src/services/insights/__tests__/healthService.test.ts
+npm test --workspace backend
+# Target a specific file:
+cd backend && npx jest src/services/__tests__/empathy-state-machine.test.ts
+# See console output while debugging (backend runs silent by default):
+npm test --workspace backend -- --verbose
 ```
 
 ## Mobile Tests (jest-expo)
 
-Mobile app uses jest-expo with React Native Testing Library.
+Mobile uses jest-expo with React Native Testing Library.
 
 ### Component Test Pattern
 
@@ -93,9 +91,9 @@ describe('MyComponent', () => {
 ### Running Mobile Tests
 
 ```bash
-cd && pnpm test -- --selectProjects mobile
-# Or target a specific file:
-cd repo root apps/mobile && npx jest src/components/__tests__/MyComponent.test.tsx
+npm test --workspace mobile
+# Target a specific file:
+cd mobile && npx jest src/components/__tests__/MyComponent.test.tsx
 ```
 
 ## Bug Fix Test Strategy
@@ -108,7 +106,10 @@ When fixing a bug, write tests that:
 
 Name regression tests clearly:
 ```typescript
-it('should not crash when health score is null (fixes #423)', () => {
+it('does not fire Felt Heard Response with empty session_id (fixes #NNN)', () => {
   // ...
 });
 ```
+
+> Before considering a fix done, run `npm run check` (types across all workspaces)
+> and `npm run test` (all workspaces), per the repo's verification practice.

--- a/bot-workspaces/bug-fix/stages/02-investigate/CONTEXT.md
+++ b/bot-workspaces/bug-fix/stages/02-investigate/CONTEXT.md
@@ -34,7 +34,7 @@ Launch sub-agents in parallel to gather evidence:
 | B | Mixpanel events (`shared/diagnostics/check-mixpanel.md`) | User-facing issues |
 | C | Database anomalies (`shared/diagnostics/check-db.md`) | Data-related bugs |
 | D | Gateway logs (`shared/diagnostics/render-logs.md`) | Server-side errors |
-| E | Pipeline health (`shared/diagnostics/check-pipeline-health.md`) | Recording/coding pipeline issues |
+| E | Conversation health (`shared/diagnostics/check-pipeline-health.md`) | Stuck turns (AI reply missing) / stage stalls |
 
 For `bot-pr` issues (implementation requests), skip diagnostics -- go straight to code research.
 
@@ -49,7 +49,7 @@ For `bot-pr` issues (implementation requests), skip diagnostics -- go straight t
 
 - Cross-reference Sentry errors with log timestamps
 - Match Mixpanel event drops with deployment times
-- Check pipeline progression if recording-related
+- Check conversation/turn progression if a session seems stuck
 - Look for patterns across diagnostic sources
 
 ### 5. Assess fixability

--- a/bot-workspaces/bug-fix/stages/03-plan/CONTEXT.md
+++ b/bot-workspaces/bug-fix/stages/03-plan/CONTEXT.md
@@ -56,7 +56,7 @@ Fix plan (passed to Stage 04):
 - **New files to create**: Test files, migration files
 - **Branch name**: Following the naming convention above
 - **Complexity**: Simple / moderate / complex
-- **Test strategy**: What to test, which test framework (vitest vs jest-expo)
+- **Test strategy**: What to test, which test framework (jest (backend) vs jest-expo (mobile))
 
 ## Exit Criteria
 

--- a/bot-workspaces/bug-fix/stages/04-implement/CONTEXT.md
+++ b/bot-workspaces/bug-fix/stages/04-implement/CONTEXT.md
@@ -20,13 +20,13 @@ Branch naming comes from Stage 03 plan. See `references/branch-naming.md`.
 Follow `CLAUDE.md` architecture principles. Key rules:
 - **Minimal, focused changes** -- fix the bug, nothing more
 - Keep functions small with clear separation of concerns
-- Use types from `packages/shared/` for type safety
+- Use types from `shared/` for type safety
 - No `StyleSheet.create` in mobile code (use NativeWind `className`)
 - No `db:push` -- always `prisma migrate dev` for schema changes
 
 ### 3. Write tests (TDD when possible)
 
-Write tests **covering the fix** -- not just that it works, but that the original bug is prevented. See `references/test-patterns.md` for vitest mock patterns (backend) and jest-expo patterns (mobile).
+Write tests **covering the fix** -- not just that it works, but that the original bug is prevented. See `references/test-patterns.md` for jest mock patterns (backend) and jest-expo patterns (mobile).
 
 ### 4. Commit changes
 

--- a/bot-workspaces/bug-fix/stages/05-verify/CONTEXT.md
+++ b/bot-workspaces/bug-fix/stages/05-verify/CONTEXT.md
@@ -10,10 +10,10 @@
 ### 1. Run tests
 
 ```bash
-cd && pnpm test
+cd && npm run test
 ```
 
-This runs all tests across the monorepo (vitest for backend, jest-expo for mobile).
+This runs all tests across the monorepo (jest for backend, jest-expo for mobile). Backend tests run silent by default; `-- --verbose` shows console output.
 
 If tests fail:
 - Read the failure output carefully
@@ -24,7 +24,7 @@ If tests fail:
 ### 2. Run type checks
 
 ```bash
-cd && pnpm check
+cd && npm run check
 ```
 
 This runs TypeScript type checking across all packages. Fix any type errors introduced by the change.
@@ -60,8 +60,8 @@ git push -u origin <branch-name>
 
 ## Exit Criteria
 
-- `pnpm test` passes (exit code 0)
-- `pnpm check` passes (exit code 0)
+- `npm run test` passes (exit code 0)
+- `npm run check` passes (exit code 0)
 - Branch pushed to remote
 
 ## Completion

--- a/bot-workspaces/daily-strategy/stages/1-gather/CONTEXT.md
+++ b/bot-workspaces/daily-strategy/stages/1-gather/CONTEXT.md
@@ -87,8 +87,8 @@ Returns structured findings with autonomy tier classification.
 
 ### Sub-agent 7: Mixpanel Friction Scanner
 Load `shared/scanners/mixpanel-friction.md` and execute. Detects:
-- Recording funnel drop-offs
-- Feature abandonment patterns
+- Session funnel drop-offs (Session Created → stages 0–4 → Session Resolved)
+- Feature abandonment patterns (inner-work and share flows)
 - Usage anomalies (significant drops from 7-day average)
 Returns structured findings with user impact ranking.
 

--- a/bot-workspaces/docs-audit/CONTEXT.md
+++ b/bot-workspaces/docs-audit/CONTEXT.md
@@ -16,13 +16,16 @@ Detect documentation drift by comparing docs against code. Two modes: incrementa
 
 ## Code-to-Doc Mapping
 
+Authoritative mapping lives in `docs/code-to-docs-mapping.json` (the `docs-impact`
+GitHub Action uses it) — consult it first. Quick reference:
+
 | Code area | Docs to check |
 |---|---|
-| `apps/identity/`, `apps/recording/`, etc. | `docs/architecture/services.md` |
-| `packages/prisma/` | `docs/architecture/data-model.md` |
-| `apps/insights/`, health scoring | `docs/architecture/health-scoring.md`, `docs/science/` |
-| `apps/mobile/` | `docs/mobile/` |
-| `apps/workbench/` | `docs/workbench/` |
-| `render.yaml`, `vercel.json`, `.github/workflows/` | `docs/infrastructure/` |
-| `packages/shared/` | Any doc referencing shared types |
-| `.claude/commands/`, `CLAUDE.md` | `docs/processes/`, `docs/guides/` |
+| `backend/src/controllers/`, `backend/src/routes/` | `docs/backend/api/index.md`, `docs/architecture/backend-overview.md` |
+| `backend/src/services/` (AI / prompting / reconciler) | `docs/backend/prompting-architecture.md`, `docs/backend/reconciler-flow.md` |
+| `backend/prisma/schema.prisma` | `docs/backend/data-model/prisma-schema.md` |
+| `backend/src/**` (security / RLS) | `docs/backend/security/index.md` |
+| `mobile/` | `docs/architecture/structure.md`, `docs/mobile/wireframes/` |
+| `shared/` | Any doc referencing shared types / DTOs |
+| Ably / Clerk / Bedrock / Mixpanel integration | `docs/architecture/integrations.md` |
+| `render.yaml`, `.github/workflows/`, deploy scripts | `docs/deployment/`, `docs/infrastructure/` |

--- a/bot-workspaces/general-pr/stages/01-implement/CONTEXT.md
+++ b/bot-workspaces/general-pr/stages/01-implement/CONTEXT.md
@@ -29,7 +29,7 @@
    - Do not over-engineer or add unrequested features
 
 5. **Run tests**:
-   - Run relevant test suites (`pnpm test` or targeted test commands)
+   - Run relevant test suites (`npm run test` or targeted test commands)
    - If tests fail, fix until green
    - Add tests for new behavior if the area has existing test coverage
 

--- a/bot-workspaces/health-check/stages/audit/CONTEXT.md
+++ b/bot-workspaces/health-check/stages/audit/CONTEXT.md
@@ -34,7 +34,7 @@ Use `github_state_*` helpers for all open issue/PR metadata lookups. Do NOT call
    - Errors during activity windows = user impact
    - Noisy logs: repetitive lines, debug-level in prod, excessive payloads
    - Silent failures: Mixpanel shows start but no completion
-   - Pipeline health: `recording.started` vs completed ratio
+   - Conversation health: sessions whose latest message is `role=USER` for >~3 min (AI reply stuck) — see `shared/diagnostics/check-pipeline-health.md`
    - Performance: slow responses, Bedrock throttling
 5. **Check if already tracked or fixed** — before creating any issue, check the state file first, then use search as needed:
    ```bash

--- a/bot-workspaces/milestone-planner/stages/02-decompose/CONTEXT.md
+++ b/bot-workspaces/milestone-planner/stages/02-decompose/CONTEXT.md
@@ -18,7 +18,7 @@
    - Independently buildable by a single agent
 
 4. **For each sub-issue, draft**:
-   - **Title**: concise, action-oriented (e.g., "Add retry logic to recording upload")
+   - **Title**: concise, action-oriented (e.g., "Add retry logic to LLM turn requests")
    - **Body**: context, requirements, success criteria, relevant references
    - **Labels**: which `bot:*` workspace label applies
    - **Acceptance criteria**: bullet list of what must be true when done

--- a/bot-workspaces/pr-reviewer/references/rebase-guide.md
+++ b/bot-workspaces/pr-reviewer/references/rebase-guide.md
@@ -15,8 +15,8 @@ Files: `label-registry.json`, `bot-workspaces/CLAUDE.md`, `package.json`
 Strategy: **Accept target branch**, then re-apply bot's additions (new entries only)
 
 ### Lock files
-Files: `pnpm-lock.yaml`, `package-lock.json`
-Strategy: **Accept target branch**, then run `pnpm install` to regenerate
+Files: `package-lock.json`
+Strategy: **Accept target branch**, then run `npm install` to regenerate
 
 ### Workspace files (bot-workspaces/)
 Strategy: **Accept PR branch** — the PR is adding new content

--- a/bot-workspaces/pr-reviewer/stages/02-rebase/CONTEXT.md
+++ b/bot-workspaces/pr-reviewer/stages/02-rebase/CONTEXT.md
@@ -92,7 +92,7 @@ git rebase "origin/$BASE_BRANCH"
 See `references/rebase-guide.md`. Default rules:
 
 - `label-registry.json`, root `CLAUDE.md`: prefer target branch (shared config)
-- `package-lock.json`, `pnpm-lock.yaml`: accept target, then re-install
+- `package-lock.json`: accept target, then re-install
 - All other files: prefer the PR branch changes (the feature)
 
 ### 5. Force push the rebased branch

--- a/bot-workspaces/research/stages/01-gather/CONTEXT.md
+++ b/bot-workspaces/research/stages/01-gather/CONTEXT.md
@@ -26,7 +26,7 @@ Search the repository for code relevant to the issue:
 - Use the docs routing table in `CLAUDE.md` to identify which docs to read first
 - Grep for relevant functions, types, routes, and components
 - Read key files to understand current architecture in the affected area
-- Check `packages/prisma/prisma/schema.prisma` if data model is involved
+- Check `backend/prisma/schema.prisma` if data model is involved
 - Look at recent commits in affected areas (`git log --oneline -20 -- <path>`)
 
 Output: list of relevant files, current architecture summary, existing patterns, and technical constraints.

--- a/bot-workspaces/security-audit/stages/1-scan/CONTEXT.md
+++ b/bot-workspaces/security-audit/stages/1-scan/CONTEXT.md
@@ -15,7 +15,7 @@ Launch specialist agents in batches of 4:
 4. **Network & Application Security** — TLS, CORS, input validation, OWASP Top 10, rate limiting, CSP headers, secrets management.
 
 ### Batch 2
-5. **Vulnerability & Dependencies** — `pnpm audit`, outdated packages, third-party security, supply chain risks.
+5. **Vulnerability & Dependencies** — `npm audit`, outdated packages, third-party security, supply chain risks.
 6. **Logging & Monitoring** — Sentry coverage, audit trails, PII in logs, incident response, alerting.
 7. **Compliance & Documentation** — DPAs with vendors, privacy policy, data retention, deletion capability (GDPR/CCPA).
 

--- a/bot-workspaces/shared/diagnostics/check-db.md
+++ b/bot-workspaces/shared/diagnostics/check-db.md
@@ -16,23 +16,38 @@ Fallback: `cd && DATABASE_URL="$PRODUCTION_DATABASE_URL" npm run db:query 'SELEC
 
 ## Default Health Check
 
-1. Table row counts (User, Circle, Person, Recording, Transcript, Segment, CodedTranscript, HealthScore, DimensionMetric)
-2. Recent recordings (last 24h) with circle name and status
-3. Pipeline status via `check-pipeline-health.md`
+1. Table row counts (User, Relationship, Session, Message, InnerWorkSession, Invitation)
+2. Recent sessions (last 24h) with status, type, and message count
+3. Conversation/turn health via `check-pipeline-health.md`
 4. Migration status (last 5 migrations)
+
+Recent sessions query:
+
+```sql
+SELECT s.id, s.status, s.type, s."createdAt",
+       (SELECT COUNT(*) FROM "Message" m WHERE m."sessionId" = s.id) AS messages
+FROM "Session" s
+WHERE s."createdAt" > now() - interval '24 hours'
+ORDER BY s."createdAt" DESC;
+```
 
 ## Key Tables
 
 | Table | Purpose |
 |---|---|
 | `User` | Auth users (Clerk) |
-| `Circle` | Family circles |
-| `Person` | People in circles (adults/children) |
-| `Recording` | Audio recordings |
-| `Transcript` | Transcriptions (ai, ai_assisted, human) |
-| `CodedTranscript` | DPICS/DECS coded transcripts |
-| `HealthScore` | Per-recording health scores |
-| `DimensionMetric` | Granular dimension scores |
+| `Relationship` / `RelationshipMember` | The two-party relationship and its members |
+| `Session` | A conflict-resolution conversation (`SessionStatus`: CREATED→INVITED→ACTIVE→WAITING/PAUSED→RESOLVED/ABANDONED/ARCHIVED) |
+| `Message` | Conversation messages (`MessageRole`: USER/AI/SYSTEM/empathy variants; `stage` 0–4) |
+| `StageProgress` | Per-user stage status (`StageStatus`: NOT_STARTED/IN_PROGRESS/GATE_PENDING/COMPLETED) |
+| `Invitation` | Partner invitations |
+| `InnerWorkSession` / `InnerWorkMessage` | Solo self-reflection sessions |
+| `UserVessel` / `SharedVessel` | Private vs. shared data (Vessel privacy model) |
+| `EmpathyAttempt` / `EmpathyValidation` | Empathy / reconciler flow |
+| `StrategyProposal` / `Stage4*` | Stage 4 resolution building |
+| `Agreement` | Finalized agreements |
+| `TendingEntry` / `TendingCheckin` | Post-resolution tending / re-engagement |
+| `Person` | People referenced within relationships |
 
 ## Security
 

--- a/bot-workspaces/shared/diagnostics/check-pipeline-health.md
+++ b/bot-workspaces/shared/diagnostics/check-pipeline-health.md
@@ -1,39 +1,69 @@
-# Check Pipeline Health Utility
+# Check Conversation Health Utility
 
-Inspect the recording pipeline to identify stuck, failed, or incomplete recordings.
+Inspect MWF's conversation turn flow to identify sessions stuck waiting on an AI
+response or stalled mid-stage.
 
-## Pipeline Progression
+> MWF is a **text-based, staged conversation app** — there is no audio/recording
+> or media-processing pipeline. The "pipeline" here is the per-turn loop:
+> a user sends a `Message` (`role = USER`) → the backend calls the LLM → an
+> `AI` message is written back. A turn whose latest message is still `role = USER`
+> after a few minutes means the AI reply never landed (stuck turn). This mirrors
+> the mobile typing indicator (`role === USER` ⇒ waiting for AI).
+
+## Turn Progression
 
 ```
-Recording (started) -> Transcript (created) -> CodedTranscript (coded) -> HealthScore (scored)
+User Message (role=USER) -> backend LLM call -> AI Message (role=AI)
 ```
 
-Each stage should complete within minutes. A recording stuck at any stage for >1 hour is likely failed.
+Each turn should complete in seconds. A live session whose latest message is
+`role=USER` and older than ~3 minutes is likely a stuck/failed turn.
 
-## Core Query
+## Core Query — stuck turns
 
 ```sql
-SELECT
-  r.id, r.status as recording_status, r.created_at, c.name as circle,
-  (SELECT COUNT(*) FROM "Transcript" t WHERE t.recording_id = r.id) as transcripts,
-  (SELECT COUNT(*) FROM "CodedTranscript" ct JOIN "Transcript" t ON ct.transcript_id = t.id WHERE t.recording_id = r.id) as coded_transcripts,
-  (SELECT COUNT(*) FROM "HealthScore" hs WHERE hs.recording_id = r.id) as health_scores
-FROM "Recording" r
-JOIN "Circle" c ON r.circle_id = c.id
-ORDER BY r.created_at DESC LIMIT 10;
+SELECT s.id, s.status, s.type,
+       last.role  AS last_role,
+       last.stage AS last_stage,
+       last.timestamp AS last_message_at,
+       now() - last.timestamp AS waiting
+FROM "Session" s
+JOIN LATERAL (
+  SELECT m.role, m.stage, m.timestamp
+  FROM "Message" m
+  WHERE m."sessionId" = s.id
+  ORDER BY m.timestamp DESC
+  LIMIT 1
+) last ON true
+WHERE s.status IN ('ACTIVE', 'WAITING')
+ORDER BY last.timestamp ASC
+LIMIT 20;
 ```
 
 ## Interpretation
 
-| Status | Transcripts | Coded | Scores | Meaning |
-|---|---|---|---|---|
-| `completed` | >=1 | >=1 | >=1 | Healthy |
-| `completed` | >=1 | >=1 | 0 | Stuck at scoring |
-| `completed` | >=1 | 0 | 0 | Stuck at coding |
-| `completed` | 0 | 0 | 0 | Stuck at transcription |
-| `processing` | 0 | 0 | 0 | In progress or stuck (check age) |
-| `failed` | any | any | any | Pipeline error |
+| Session status | last_role | Meaning |
+|---|---|---|
+| `ACTIVE` / `WAITING` | `AI` (or empathy/system variant) | Healthy — ball is in the user's court |
+| `ACTIVE` | `USER`, < ~3 min | Turn in progress (AI generating) |
+| `ACTIVE` | `USER`, > ~3 min | **Stuck turn** — AI reply never written; check Render logs / Sentry |
+| `WAITING` | any | One user ahead, waiting on partner (expected, not stuck) |
+| `PAUSED` | any | Cooling period (expected) |
 
-## Stuck Detection
+## Stage-stall detection
 
-Flag as stuck if `processing` and `created_at` > 1 hour ago, or `completed` with missing downstream counts.
+A session whose `StageProgress` for a user has sat in `IN_PROGRESS` or
+`GATE_PENDING` far longer than peers may be stalled:
+
+```sql
+SELECT sp."sessionId", sp."userId", sp.stage, sp.status, sp."updatedAt"
+FROM "StageProgress" sp
+WHERE sp.status IN ('IN_PROGRESS', 'GATE_PENDING')
+  AND sp."updatedAt" < now() - interval '24 hours'
+ORDER BY sp."updatedAt" ASC
+LIMIT 20;
+```
+
+`GATE_PENDING` for a long time usually means "requirements met, awaiting partner"
+— normal for async sessions, not necessarily a bug. Correlate stuck turns with
+Sentry errors and Render logs before flagging.

--- a/bot-workspaces/shared/diagnostics/check-sentry.md
+++ b/bot-workspaces/shared/diagnostics/check-sentry.md
@@ -36,4 +36,4 @@ curl -s -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
 - High event count in short time = active bug
 - First seen recently = possibly from latest deploy
 - High userCount = prioritize
-- Pipeline errors = broken recording flow
+- LLM / turn errors = stuck conversation (AI reply never written back)

--- a/bot-workspaces/shared/scanners/code-health.md
+++ b/bot-workspaces/shared/scanners/code-health.md
@@ -16,13 +16,13 @@ Compare test file counts and recent test failures:
 ```bash
 # Count test files per package
 cd
-find apps/ packages/ -name "*.test.ts" -o -name "*.spec.ts" | wc -l
+find backend/ mobile/ shared/ website/ -name "*.test.ts" -o -name "*.spec.ts" | wc -l
 
 # Check for recently deleted test files
 git log --diff-filter=D --since="7 days ago" --name-only -- "*.test.ts" "*.spec.ts"
 
 # Check for recently added source files without corresponding tests
-git log --diff-filter=A --since="7 days ago" --name-only -- "apps/*/src/**/*.ts" \
+git log --diff-filter=A --since="7 days ago" --name-only -- "*/src/**/*.ts" \
   | grep -v ".test.ts" | grep -v ".spec.ts" | grep -v "index.ts" | grep -v ".d.ts"
 ```
 
@@ -45,7 +45,7 @@ Classify by age and severity:
 ### 3. Check for dependency vulnerabilities
 
 ```bash
-cd && pnpm audit --json 2>/dev/null | jq '.advisories | to_entries | .[] | {severity: .value.severity, title: .value.title, module: .value.module_name}'
+cd && npm audit --json 2>/dev/null | jq '.advisories | to_entries | .[] | {severity: .value.severity, title: .value.title, module: .value.module_name}'
 ```
 
 If health-check has already run recently, reference its findings instead of re-running.

--- a/bot-workspaces/shared/scanners/mixpanel-friction.md
+++ b/bot-workspaces/shared/scanners/mixpanel-friction.md
@@ -4,8 +4,47 @@ Detect user friction patterns from Mixpanel data that warrant investigation or i
 
 ## Prerequisites
 
-- Load `shared/references/credentials.md` for Mixpanel API access
+- Load `shared/references/credentials.md` for Mixpanel API access (`MIXPANEL_USERNAME`,
+  `MIXPANEL_SECRET`, `MIXPANEL_PROJECT_ID`)
 - Load `shared/diagnostics/check-mixpanel.md` for query patterns
+
+> **Scope guard — read before flagging anything.** This scanner must reason
+> ONLY about events that the MWF app actually emits (see the list below). MWF is
+> a **text-based, staged conversation app — there is no audio/recording/upload
+> flow.** Never infer an "outage" or "funnel break" from the absence of an event
+> name that isn't in the emitted set, and never flag a drop unless the 7-day
+> baseline for that metric is itself non-zero (a zero baseline means we never had
+> that data, not that it disappeared). Events go **client→Mixpanel directly**;
+> there is no MWF backend in the path, so "backend routing" is never a cause.
+
+### Events MWF actually emits
+
+Source of truth: `mobile/src/services/analytics.ts` (typed wrapper) plus a handful
+emitted directly via `track()` in `MixpanelInitializer.tsx` / `useOTAUpdate.ts`.
+
+**Lifecycle / auth (direct track):** `App Launch`, `Sign Up Completed`,
+`Sign In Completed`, `Logout`, `OTA Update Checked` / `Downloaded` / `Applied` /
+`Dismissed`. (`App Launch` fires on every prod launch — broadest usage heartbeat.)
+
+**Session journey:** `Person Selected`, `Session Created`, `Invitation Sent`,
+`Compact Signed`, `Stage Started` / `Stage Completed` (carry `stage_name`),
+`Message Sent`, `Felt Heard Response`, `Session Resolved`.
+
+**Share flow:** `Share Topic Shown` / `Accepted` / `Declined` / `Dismissed`,
+`Share Draft Sent`.
+
+**Inner work / KB:** `Inner Work Hub Opened`, `Inner Thoughts Created` / `Linked`,
+`Meditation Started` / `Completed`, `Gratitude Started` / `Completed`,
+`Needs Assessment Started` / `Completed`.
+
+**Errors:** `Error` (with `error_type`, `error_code`, `context`).
+
+> **Known-dead events — DO NOT flag their absence as an outage.** These are
+> defined in `analytics.ts` but **never called** (verified June 2026):
+> `Common Ground Found`, `Strategic Repair Started`, `Strategic Repair Completed`.
+> Zero volume is expected until they're wired up. Also note `Felt Heard Response`
+> is currently hardcoded to `response = 'yes'` (the `'no'` path is unreachable), so
+> a 100%-yes distribution is a known instrumentation gap, not a signal.
 
 ## Process
 
@@ -13,39 +52,66 @@ Detect user friction patterns from Mixpanel data that warrant investigation or i
 
 ```bash
 # Export last 24h of events
-curl -s --user "$MIXPANEL_USER:$MIXPANEL_SECRET" \
-  "https://data.mixpanel.com/api/2.0/export?project_id=3998202&from_date=$(date -d '1 day ago' +%Y-%m-%d)&to_date=$(date +%Y-%m-%d)"
+curl -s --user "$MIXPANEL_USERNAME:$MIXPANEL_SECRET" \
+  "https://data.mixpanel.com/api/2.0/export?project_id=$MIXPANEL_PROJECT_ID&from_date=$(date -d '1 day ago' +%Y-%m-%d)&to_date=$(date +%Y-%m-%d)"
 ```
 
-### 2. Analyze recording funnel
+Also export the prior 7 days to compute rolling baselines for the anomaly checks.
 
-Track the recording flow: `recording_started` -> `recording_stopped` -> `recording_uploaded` -> `recording_processed`
+### 2. Analyze the core session funnel
 
-- Calculate conversion rates between each step
-- Compare to 7-day rolling average
-- Flag steps with >20% drop from average as friction points
+The canonical healthy-session journey (use the actual event names, in this order):
+
+`App Launch` → `Sign In Completed`/`Sign Up Completed` → `Person Selected` →
+`Session Created` → `Invitation Sent` → `Compact Signed` → `Stage Started` →
+`Message Sent` → `Stage Completed` (progressing through stages 0–4 via the
+`stage_name` prop) → `Session Resolved`
+
+- Calculate conversion rate between each adjacent step.
+- For the staged middle, use the `stage_name` property to track `Stage Started` →
+  `Stage Completed` per stage (0→1→2→3→4) and find the stage where users drop.
+- `Invitation Sent` is the multi-party branch (solo sessions skip it) — report its
+  send→`Compact Signed` acceptance rate, but do NOT treat a low invitation count
+  as a funnel break on its own.
+- Compare each conversion to its 7-day rolling average; flag steps with a
+  >20% drop from average as friction points.
 
 ### 3. Detect feature abandonment
 
-Look for patterns where users:
-- Start a flow but don't complete it (e.g., start recording setup but never record)
-- Visit a screen repeatedly but take no action
-- Trigger errors or retry events (indicates confusion or bugs)
+Started-but-not-completed pairs (only the **emitted** pairs — `Strategic Repair`
+is known-dead, skip it):
+- Inner work: `Meditation`, `Gratitude`, `Needs Assessment` — compare
+  `* Started` vs `* Completed`.
+- Share flow: `Share Topic Shown` → `Share Topic Accepted` → `Share Draft Sent`
+  (high `Declined`/`Dismissed` or low draft-sent rate = friction).
+- Engagement signals within a session: low `Felt Heard Response` relative to
+  active sessions (note: currently yes-only, so treat as a volume signal, not a
+  satisfaction ratio).
+- `Error` events: cluster by `error_type` / `error_code`; a spike indicates a bug
+  or confusing UX.
 
-### 4. Detect usage anomalies
+### 4. Detect usage anomalies (the real "tracking down" / outage check)
 
-Compare today's metrics to 7-day averages:
-- Total events (flag if <50% of average)
-- Active users (flag if <50% of average)
-- Key feature usage (flag if any feature drops >30%)
+Compare today's metrics to the 7-day average (only when the baseline is non-zero):
+- **Total events** (flag if <50% of average)
+- **`App Launch` volume** — broadest usage heartbeat, fires every prod launch
+  (flag if <50% of average)
+- **Active users** — distinct `distinct_id` count (flag if <50% of average)
+- **`Message Sent` volume** — the engagement heartbeat (flag if <50% of average)
+- **`Session Created` volume** (flag if <50% of average)
+- Any individual key event (from the emitted set) dropping >30% vs average
+
+A genuine tracking/SDK outage looks like **all** of `App Launch`, total events,
+`Message Sent`, and `Session Created` collapsing to ~0 together against a healthy
+baseline — not a single funnel step being empty.
 
 ### 5. Rank by user impact
 
 | Impact Level | Criteria | Autonomy Tier |
 |---|---|---|
-| Critical | Recording funnel broken (0 completions) | `proceed` |
-| High | >50% funnel drop-off at a step | `proceed` |
-| Medium | Feature abandonment >30% | `suggestion` |
+| Critical | `App Launch`, `Message Sent`, AND `Session Created` all ~0 in 24h while 7-day avg > 0 (app-wide tracking/usage outage) | `proceed` |
+| High | >50% drop vs avg in `App Launch`, `Message Sent`, active users, or a core funnel step (`Session Created`→`Stage Started`, `Stage Completed(4)`→`Session Resolved`) | `proceed` |
+| Medium | Feature abandonment >30% (inner-work or share flow), or any single event >30% below avg | `suggestion` |
 | Low | Minor usage anomaly | `suggestion` |
 
 ## Output Format
@@ -57,15 +123,24 @@ Compare today's metrics to 7-day averages:
 **Items found:** N
 
 ### Funnel Health
-- recording_started -> recording_stopped: N% conversion (avg: N%)
-- recording_stopped -> recording_uploaded: N% conversion (avg: N%)
-- recording_uploaded -> recording_processed: N% conversion (avg: N%)
+- Person Selected -> Session Created:    N% conversion (avg: N%)
+- Session Created -> Compact Signed:     N% conversion (avg: N%)
+- Compact Signed  -> Stage Started:      N% conversion (avg: N%)
+- Stage Started   -> Stage Completed:    N% conversion (avg: N%)  [per stage 0-4]
+- Stage Completed -> Session Resolved:   N% conversion (avg: N%)
+
+### Usage Heartbeat
+- App Launch: N (7-day avg: N)
+- Total events: N (7-day avg: N)
+- Active users: N (7-day avg: N)
+- Message Sent: N (7-day avg: N)
+- Session Created: N (7-day avg: N)
 
 ### Items
 1. **[Friction point description]** — [severity: critical/high/medium/low]
    - Metric: [specific numbers]
    - Baseline: [7-day average]
    - User impact: [N users affected]
-   - Suggested action: [investigate UX | check backend | create issue]
+   - Suggested action: [investigate UX | check client SDK | create issue]
    - Autonomy tier: [proceed | proceed | suggestion]
 ```

--- a/bot-workspaces/shared/skills/pr.md
+++ b/bot-workspaces/shared/skills/pr.md
@@ -4,7 +4,7 @@ Create a pull request with pre-flight checks, documentation updates, and issue l
 
 ## Stages
 
-1. **Pre-flight** — verify not on main or bot/staging, run `pnpm test` and `pnpm check`
+1. **Pre-flight** — verify not on main or bot/staging, run `npm run test` and `npm run check`
 2. **Docs update** — review diff, update affected docs, archive completed plans
    1. Run `git diff main...HEAD --name-only` to identify all changed files
    2. Check `docs/code-to-docs-mapping.json` — it maps code paths to their corresponding docs. For each changed file, find matching entries and read those docs. Also consult the docs routing table in `CLAUDE.md` for any areas not covered by the mapping.

--- a/bot-workspaces/slack-triage/references/classification-guide.md
+++ b/bot-workspaces/slack-triage/references/classification-guide.md
@@ -11,10 +11,10 @@ Something is broken, producing errors, or behaving unexpectedly.
 **Signal words:** "broken", "error", "crash", "not working", "stuck", "freeze", "blank screen", "won't load", "disappeared", "wrong"
 
 **Examples:**
-- "The recording page just shows a blank screen after I hit record"
-- "I keep getting an error when I try to add a family member"
-- "The session timer shows 0:00 even though we recorded for 5 minutes"
-- "App crashed when I opened the health dashboard"
+- "The chat just spins forever after I send a message"
+- "I keep getting an error when I try to invite my co-parent"
+- "We both finished the stage but it never advanced"
+- "App crashed when I opened my session"
 - Screenshot showing an error message or broken UI
 
 ### FEATURE
@@ -24,10 +24,10 @@ A request for new functionality or enhancement to existing functionality.
 **Signal words:** "it would be nice", "can we add", "I wish", "what if", "could you make", "feature request", "would love to see"
 
 **Examples:**
-- "Can we add a way to export session notes as PDF?"
-- "It would be great if the timer had a pause button"
-- "I wish I could see my scores from last month side by side"
-- "What if we added push notifications for session reminders?"
+- "Can we add a way to export my session takeaways as PDF?"
+- "It would be great if I got a reminder to do my tending check-in"
+- "I wish I could see all my past inner-work entries side by side"
+- "What if we added push notifications when my partner responds?"
 
 ### QUESTION
 
@@ -36,10 +36,10 @@ Asking how something works, where to find something, or seeking clarification.
 **Signal words:** "how do I", "where is", "what does", "is there a way", "?", "wondering if", "does it"
 
 **Examples:**
-- "How do I invite another parent to our family circle?"
-- "Where can I see the breakdown of my DPICS scores?"
-- "What does 'Building Momentum' mean on the health page?"
-- "Is there a way to delete a recording?"
+- "How do I invite the other person to a session?"
+- "Where can I find my inner thoughts / knowledge base?"
+- "What does 'felt heard' mean in the empathy step?"
+- "Is there a way to archive or leave a session?"
 
 ### FEEDBACK
 
@@ -48,10 +48,10 @@ Sharing impressions, opinions, or suggestions about the experience without repor
 **Signal words:** "I like", "I don't like", "it feels", "the experience", "UX", "confusing", "love", "annoying"
 
 **Examples:**
-- "The new health dashboard feels really intuitive, love the colors!"
-- "The recording flow is a bit confusing -- I wasn't sure when to start talking"
+- "The new stage transitions feel really smooth, love it!"
+- "The empathy step was a bit confusing -- I wasn't sure what to write"
 - "The session summary is great but feels too long"
-- "I find myself checking the app every day now"
+- "I find myself checking in every day now"
 
 ### REQUEST
 
@@ -78,8 +78,8 @@ A request to flag an existing issue or PR as high-priority. The requester wants 
 
 **Examples:**
 - "Can you prioritize PR #123?"
-- "That issue about the health dashboard should be high priority"
-- "Please flag the recording bug as urgent"
+- "That issue about the session list should be high priority"
+- "Please flag the Stage 4 bug as urgent"
 - "Make the mobile redesign high-priority"
 - "Can you bump up the auth fix? It's blocking us"
 - ⚡ emoji reaction on a message mentioning an issue or PR
@@ -91,9 +91,9 @@ Personal reflection, status update, or conversational message with no action imp
 **Signal words:** "just tried", "interesting", "update:", status reports, thinking aloud
 
 **Examples:**
-- "Just finished our third session this week!"
-- "The kids really enjoyed the activity today"
-- "Interesting to see how the scores change over time"
+- "Just resolved our first conflict in the app!"
+- "The meditation really helped me settle before our session"
+- "Interesting to see how my needs shifted over time"
 - "Update: we've been using it daily for two weeks now"
 - "Happy Friday everyone!"
 
@@ -119,6 +119,6 @@ Messages with images often indicate:
 - **Screenshots of errors/broken UI** --> BUG
 - **Screenshots of desired behavior** --> FEATURE
 - **Screenshots showing confusing flow** --> FEEDBACK
-- **Photos of family using the product** --> OBSERVATION
+- **Screenshots of the app in everyday use** --> OBSERVATION
 
 Always download and view images before classifying if `has_images` is true.

--- a/bot-workspaces/slack-triage/references/response-templates.md
+++ b/bot-workspaces/slack-triage/references/response-templates.md
@@ -36,7 +36,7 @@ Thanks for flagging this! [Brief acknowledgment of the problem]. Created a track
 
 Example:
 ```
-Thanks for flagging this! Looks like the health dashboard is showing stale data after new recordings. Created a tracking issue so the team can dig in:
+Thanks for flagging this! Looks like the session list is showing stale data after a new message. Created a tracking issue so the team can dig in:
 
 <https://github.com/shantamg/meet-without-fear/issues/87|Issue #87>
 ```
@@ -61,7 +61,7 @@ Great idea! Logged it for the team:
 
 Example:
 ```
-Great idea! A pause button for recordings would be really handy. Logged it for the team:
+Great idea! A reminder for tending check-ins would be really handy. Logged it for the team:
 
 <https://github.com/shantamg/meet-without-fear/issues/95|Issue #95>
 ```
@@ -115,9 +115,9 @@ Template:
 
 Example:
 ```
-You can invite another parent from the Team screen -- tap the "+" button in the top right and enter their email. They'll get an invite to join your family circle.
+You can invite the other person right from your session -- tap Share/Invite and send them the link. Once they open it, they'll be guided into the same session to join you.
 
-If they don't see the invite, have them check their spam folder!
+If they don't see it, double-check the link went through -- you can resend it from the same screen!
 ```
 
 ## QUESTION -- Don't know

--- a/bot-workspaces/systems-architect/stages/01-scan/CONTEXT.md
+++ b/bot-workspaces/systems-architect/stages/01-scan/CONTEXT.md
@@ -15,7 +15,7 @@ Launch specialist agents in parallel batches:
 ### Batch 1
 
 1. **Service Architecture** — verify all Hono services follow thin-controller/service-layer pattern. Check for unauthorized new services, direct cross-service imports (should use events), and business logic in route handlers.
-2. **Shared Types & Interfaces** — verify frontend/backend type sharing via `packages/shared/`. Check for duplicated types, divergent interfaces, or types defined locally that belong in shared.
+2. **Shared Types & Interfaces** — verify frontend/backend type sharing via `shared/`. Check for duplicated types, divergent interfaces, or types defined locally that belong in shared.
 3. **Database & Schema** — verify Prisma schema conventions, migration hygiene (no `db:push` artifacts), and data model alignment with `data-model.md`.
 
 ### Batch 2

--- a/bot-workspaces/verify/stages/01-check/CONTEXT.md
+++ b/bot-workspaces/verify/stages/01-check/CONTEXT.md
@@ -76,23 +76,23 @@ From the diff, determine:
 
 | Question | How to determine |
 |---|---|
-| Which packages are affected? | File paths (`apps/`, `packages/`) |
+| Which packages are affected? | File paths (`backend/`, `mobile/`, `shared/`, `website/`) |
 | Are there tests? | Look for `*.test.ts`, `*.spec.ts` files in the diff |
-| Are there new API endpoints? | Route files in `apps/*/src/routes/` |
-| Are there UI changes? | Files in `apps/workbench/`, `apps/mobile/` |
-| Are there schema changes? | `packages/prisma/prisma/schema.prisma` in the diff |
-| Is there a migration? | Files in `packages/prisma/prisma/migrations/` |
+| Are there new API endpoints? | Route files in `backend/src/routes/` |
+| Are there UI changes? | Files in `website/`, `mobile/` |
+| Are there schema changes? | `backend/prisma/schema.prisma` in the diff |
+| Is there a migration? | Files in `backend/prisma/migrations/` |
 
 ### 4. Build verification strategy
 
 Based on the analysis, build a checklist of what to verify:
 
 **Always run:**
-- `pnpm test` (scoped to affected packages if possible)
-- `pnpm check` (TypeScript type checking)
+- `npm run test` (scoped to affected packages if possible)
+- `npm run check` (TypeScript type checking)
 
 **Conditionally run:**
-- `pnpm build` for affected apps (if build-related changes)
+- `npm run build:mobile` / `npm run website:build` for affected apps (if build-related changes)
 - Staging endpoint checks (if API changes and deployment detected)
 - Sentry error check (if recently deployed)
 

--- a/bot-workspaces/verify/stages/02-verify/CONTEXT.md
+++ b/bot-workspaces/verify/stages/02-verify/CONTEXT.md
@@ -21,7 +21,7 @@ git checkout <branch-name>
 npm install
 ```
 
-If lockfile is out of date, note it as a finding but continue with `pnpm install`.
+If lockfile is out of date, note it as a finding but continue with `npm install`.
 
 ### 3. Run tests
 
@@ -29,7 +29,7 @@ If lockfile is out of date, note it as a finding but continue with `pnpm install
 npm run test
 ```
 
-This runs all tests across the monorepo (vitest for backend, jest-expo for mobile).
+This runs all tests across the monorepo (jest for backend, jest-expo for mobile).
 
 Record:
 - Total test count and suite count


### PR DESCRIPTION
## Why

slam-paws posted a **CRITICAL: Mixpanel event tracking down 90%** alert in bot ops. Investigation showed it's a **false alarm that fires every day**, and it's a symptom of a broader issue: the bot's diagnostic/triage knowledge base was inherited from **peter-app** (an audio-recording / transcript-analysis app) and never fully ported to MWF.

### Root cause of the Mixpanel false alarm
The `daily-strategy` briefing runs a Mixpanel Friction Scanner that audited a recording funnel:
```
recording_started -> recording_stopped -> recording_uploaded -> recording_processed
```
MWF emits **none** of these events (it's a text-based, staged conversation app). The scanner found 0 completions, its rubric says `0 completions = Critical`, and the LLM narrated that as *"tracking down 90% — likely SDK connectivity or backend routing failure"* (architecturally impossible — MWF's Mixpanel is client→Mixpanel directly, no backend in the path).

### The contamination was systemic
The same peter-app lineage left the bot:
- querying DB tables that don't exist in MWF (`Recording`, `Transcript`, `CodedTranscript`, `HealthScore`, `DimensionMetric`, `Circle`, `Segment`),
- running `pnpm` / `vitest` commands (MWF is **npm workspaces + Jest**),
- referencing an `apps/*` + `packages/*` monorepo layout (MWF is `backend/ mobile/ shared/ website/`),
- classifying Slack reports with recording-app examples ("hit record", "family circle", "DPICS scores").

## What changed (27 files, bot-workspaces only — no app code)

- **mixpanel-friction scanner** → real session funnel + `App Launch`/`Message Sent`/`Session Created` heartbeat, a scope guard, known-dead-event guard (so `Common Ground Found` / `Strategic Repair` zero volume isn't flagged), and fixes the `$MIXPANEL_USER`→`$MIXPANEL_USERNAME` and hardcoded `project_id`→`$MIXPANEL_PROJECT_ID` bugs.
- **check-db / check-pipeline-health** → MWF schema (`Session`/`Message`/`StageProgress`) and conversation-turn health (latest message `role=USER` ⇒ stuck turn).
- **check-sentry / health-check** → stuck-turn semantics instead of "broken recording flow".
- **bug-fix / verify / pr-reviewer / general-pr / research / security-audit / systems-architect / shared skills + scanners** → npm + Jest, real workspace paths.
- **slack-triage classification + templates** → MWF product vocabulary.
- **docs-audit mapping** → real `docs/` paths.

## Follow-up (NOT in this PR)
A separate audit of MWF's *client-side* analytics coverage found real instrumentation gaps worth a product-side ticket: the invitee-side `Invitation Accepted` event is missing, `Felt Heard Response` is hardcoded `'yes'`, `Common Ground Found` / `Strategic Repair Started/Completed` are defined-but-never-emitted, and Stage 4 resolution-building + AccuracyFeedbackDrawer validation are uninstrumented. These are app changes, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)