### PR TITLE
feat(mobile): instrument invitation-accept and empathy-validation events

### DIFF
--- a/mobile/src/hooks/useSessions.ts
+++ b/mobile/src/hooks/useSessions.ts
@@ -15,6 +15,7 @@ import {
   InfiniteData,
 } from '@tanstack/react-query';
 import { get, post, del, ApiClientError } from '../lib/api';
+import { trackInvitationAccepted, trackInvitationDeclined } from '../services/analytics';
 import {
   SessionSummaryDTO,
   SessionDetailDTO,
@@ -288,6 +289,7 @@ export function useAcceptInvitation(
       return post<AcceptInvitationResponse>(`/invitations/${invitationId}/accept`);
     },
     onSuccess: (data) => {
+      trackInvitationAccepted(data.session.id);
       queryClient.invalidateQueries({ queryKey: sessionKeys.lists() });
       queryClient.invalidateQueries({ queryKey: sessionKeys.invitations() });
 
@@ -321,7 +323,8 @@ export function useDeclineInvitation(
         reason,
       });
     },
-    onSuccess: () => {
+    onSuccess: (_, { invitationId }) => {
+      trackInvitationDeclined(invitationId);
       queryClient.invalidateQueries({ queryKey: sessionKeys.invitations() });
     },
     ...options,

--- a/mobile/src/screens/UnifiedSessionScreen.tsx
+++ b/mobile/src/screens/UnifiedSessionScreen.tsx
@@ -130,6 +130,7 @@ import {
   trackShareTopicDeclined,
   trackShareTopicDismissed,
   trackShareDraftSent,
+  trackEmpathyValidated,
 } from '../services/analytics';
 import { shouldShowSessionEntryMoodCheck } from '../utils/sessionEntryMoodCheck';
 import { hasNewerDistinctEmpathyStatement, isSameEmpathyAttemptMessage } from '../utils/empathyMessageMatching';
@@ -2939,10 +2940,11 @@ export function UnifiedSessionScreen({
   }, [partnerEmpathyData?.attempt]);
 
   const handleValidationAccurate = useCallback(() => {
+    trackEmpathyValidated(sessionId, 'accurate');
     markLocalEmpathyValidation('accepted');
     setIsAwaitingEmpathyValidationFollowUp(true);
     handleValidatePartnerEmpathy(true);
-  }, [markLocalEmpathyValidation, handleValidatePartnerEmpathy]);
+  }, [sessionId, markLocalEmpathyValidation, handleValidatePartnerEmpathy]);
 
   const handleValidationNotQuite = useCallback(() => {
     setShowAccuracyFeedbackDrawer(true);
@@ -4497,18 +4499,21 @@ export function UnifiedSessionScreen({
           partnerName={partnerName}
           initialStep="feedback"
           onAccurate={() => {
+            trackEmpathyValidated(sessionId, 'accurate');
             markLocalEmpathyValidation('accepted');
             setIsAwaitingEmpathyValidationFollowUp(true);
             handleValidatePartnerEmpathy(true);
             setShowAccuracyFeedbackDrawer(false);
           }}
           onPartiallyAccurate={() => {
+            trackEmpathyValidated(sessionId, 'partial');
             markLocalEmpathyValidation('accepted');
             setIsAwaitingEmpathyValidationFollowUp(true);
             handleValidatePartnerEmpathy(true, 'Some parts are accurate');
             setShowAccuracyFeedbackDrawer(false);
           }}
           onInaccurate={(roughFeedback) => {
+            trackEmpathyValidated(sessionId, 'inaccurate');
             setShowAccuracyFeedbackDrawer(false);
             openFeedbackCoachWithRoughFeedback(roughFeedback);
           }}

--- a/mobile/src/services/analytics.ts
+++ b/mobile/src/services/analytics.ts
@@ -38,6 +38,18 @@ export function trackInvitationSent(
   });
 }
 
+export function trackInvitationAccepted(sessionId: string): void {
+  track('Invitation Accepted', {
+    session_id: sessionId,
+  });
+}
+
+export function trackInvitationDeclined(invitationId: string): void {
+  track('Invitation Declined', {
+    invitation_id: invitationId,
+  });
+}
+
 export function trackCompactSigned(sessionId: string, isInviter: boolean): void {
   track('Compact Signed', {
     session_id: sessionId,
@@ -107,6 +119,16 @@ export function trackCommonGroundFound(
   track('Common Ground Found', {
     session_id: sessionId,
     overlapping_needs: overlappingNeeds,
+  });
+}
+
+export function trackEmpathyValidated(
+  sessionId: string,
+  accuracy: 'accurate' | 'partial' | 'inaccurate'
+): void {
+  track('Empathy Validated', {
+    session_id: sessionId,
+    accuracy,
   });
 }
 


### PR DESCRIPTION
Adds the highest-value missing Mixpanel events from the analytics coverage audit. **Client-side only**, **mobile only** — no backend or schema changes.

## New events

| Event | Properties | Where | Why it matters |
|---|---|---|---|
| `Invitation Accepted` | `session_id` | `useAcceptInvitation` onSuccess (`useSessions.ts`) | Closes the previously-blind **sent → accepted** invite funnel — we tracked `Invitation Sent` but never the recipient accepting, the single biggest drop-off blind spot. |
| `Invitation Declined` | `invitation_id` | `useDeclineInvitation` onSuccess | Completes the invite outcome funnel. |
| `Empathy Validated` | `session_id`, `accuracy: accurate \| partial \| inaccurate` | inline "accurate" CTA + `AccuracyFeedbackDrawer` handlers (`UnifiedSessionScreen.tsx`) | Captures the core **"did the partner's empathy land"** signal, which had zero instrumentation. |

## Verification
- `npm run check --workspace mobile` — passes (tsc clean)
- `npm test` (analytics / useSessions / AccuracyFeedbackDrawer suites) — 23 passing

## Deliberately deferred (need a product decision, not just an event)
- **Felt Heard "no"**: `FeelHeardConfirmation` only exposes a confirm action — `trackFeltHeardResponse(_, 'no')` stays unreachable until a "no" affordance exists. (Tracked: `Felt Heard Response` is currently 100% `'yes'`.)
- **Common Ground Found**: needs a reliable overlapping-needs count + precise trigger; the realtime `common_ground_ready` event has no count in scope, and firing a bogus `0` would mislead.
- **Granular Stage 4 / Strategic Repair Started/Completed**: Stage 4 is already captured by `Stage Started/Completed(STRATEGIC_REPAIR)`; proposal-level instrumentation in `Stage4RedesignPanel` is a larger, separate task.

Related: the bot-side scanner that was firing the false "Mixpanel down 90%" alert is fixed in #685.

🤖 Generated with [Claude Code](https://claude.com/claude-code)