### PR TITLE
fix(security): strip therapy content from application logs

### DIFF
--- a/backend/src/controllers/messages.ts
+++ b/backend/src/controllers/messages.ts
@@ -7,6 +7,7 @@
  * - GET /sessions/:id/messages - Get conversation history
  */
 
+import crypto from 'crypto';
 import { Request, Response } from 'express';
 import { Prisma } from '@prisma/client';
 import { logger } from '../lib/logger';
@@ -1158,7 +1159,8 @@ export async function getConversationHistory(
     // Check for duplicate content (same content, same role, within 1 second)
     const contentMap = new Map<string, typeof messages>();
     messages.forEach(m => {
-      const key = `${m.role}:${m.content.substring(0, 100)}`;
+      const contentHash = crypto.createHash('sha256').update(m.content).digest('hex').substring(0, 12);
+      const key = `${m.role}:${contentHash}`;
       if (!contentMap.has(key)) {
         contentMap.set(key, []);
       }
@@ -2222,13 +2224,13 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
         const needMatch = buffer.match(/<need>([\s\S]*?)<\/need>/i);
         if (needMatch) {
           needTagContent = needMatch[1].trim();
-          logger.info(`[sendMessageStream:${requestId}] [HIDDEN NEED]:`, needTagContent.substring(0, 160) + (needTagContent.length > 160 ? '...' : ''));
+          logger.info(`[sendMessageStream:${requestId}] [HIDDEN NEED]: {length: ${needTagContent.length}}`);
         }
 
         const needActionMatch = buffer.match(/<need-action\b[^>]*>[\s\S]*?<\/need-action>|<need-action\b[^>]*\/>/i);
         if (needActionMatch) {
           needActionTagContent = needActionMatch[0].trim();
-          logger.info(`[sendMessageStream:${requestId}] [HIDDEN NEED ACTION]:`, needActionTagContent.substring(0, 160) + (needActionTagContent.length > 160 ? '...' : ''));
+          logger.info(`[sendMessageStream:${requestId}] [HIDDEN NEED ACTION]: {length: ${needActionTagContent.length}}`);
         }
 
         const needsMatch = buffer.match(/<needs>([\s\S]*?)<\/needs>/i);
@@ -2246,7 +2248,7 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
         const stage4WalkthroughMatch = buffer.match(/<stage4_walkthrough>([\s\S]*?)<\/stage4_walkthrough>/i);
         if (stage4WalkthroughMatch) {
           stage4WalkthroughTagContent = stage4WalkthroughMatch[1].trim();
-          logger.info(`[sendMessageStream:${requestId}] [HIDDEN STAGE 4 WALKTHROUGH]:`, stage4WalkthroughTagContent.substring(0, 160) + (stage4WalkthroughTagContent.length > 160 ? '...' : ''));
+          logger.info(`[sendMessageStream:${requestId}] [HIDDEN STAGE 4 WALKTHROUGH]: {length: ${stage4WalkthroughTagContent.length}}`);
         }
 
         // Extract dispatch tag if present - store for handling after streaming
@@ -2573,7 +2575,7 @@ Write only the user-facing conversational response. Do not include tool JSON, XM
       // =========================================================================
       const dispatchTag = dispatchTagContent || parsed.dispatchTag;
       if (dispatchTag) {
-        logger.info(`[sendMessageStream:${requestId}] Dispatch detected: ${dispatchTag}`);
+        logger.info(`[sendMessageStream:${requestId}] Dispatch detected: {length: ${dispatchTag.length}}`);
         isDispatchMessage = true;
 
         // Build dispatch context with conversation history and session state

--- a/backend/src/services/reconciler/sharing.ts
+++ b/backend/src/services/reconciler/sharing.ts
@@ -264,7 +264,7 @@ export async function generatePostShareContinuation(
   try {
     const parsed = extractJsonFromResponse(response) as { response?: string };
     if (parsed && typeof parsed.response === 'string') {
-      logger.debug('Generated continuation', { stage: currentStage, preview: parsed.response.substring(0, 50) });
+      logger.debug('Generated continuation', { stage: currentStage, contentLength: parsed.response.length });
       return parsed.response;
     }
   } catch (error) {
@@ -276,7 +276,7 @@ export async function generatePostShareContinuation(
   const responseMatch = stripped.match(/"response"\s*:\s*"((?:[^"\\]|\\.)*)"/);
   if (responseMatch) {
     const extracted = responseMatch[1].replace(/\\"/g, '"').replace(/\\n/g, '\n').replace(/\\\\/g, '\\');
-    logger.debug('Extracted response via regex', { preview: extracted.substring(0, 50) });
+    logger.debug('Extracted response via regex', { contentLength: extracted.length });
     return extracted;
   }
 


### PR DESCRIPTION
## Changes
- Fix: Replace `[HIDDEN NEED]` content substring preview with `{length: N}` metadata
- Fix: Replace `[HIDDEN NEED ACTION]` content substring preview with `{length: N}` metadata
- Fix: Replace `[HIDDEN STAGE 4 WALKTHROUGH]` content substring preview with `{length: N}` metadata
- Fix: Replace duplicate detection content prefix (`content.substring(0, 100)`) with SHA-256 content hash
- Fix: Replace dispatch tag full content log with `{length: N}` metadata
- Fix: Replace `preview` field in reconciler sharing logs with `contentLength`

Related to #619

## Provenance
- **Channel:** #security-audit
- **Requested by:** automated security audit (weekly)
- **Original message:** Weekly security audit 2026-05-18
- **Prompt(s) used:** 7-domain parallel scan — logging & monitoring agent

## Docs updated
No doc changes needed — logging-only security fix with no API or behavior changes