### PR TITLE
docs: document application logging security measures (#619)

### DIFF
--- a/docs/backend/api/stage-1.md
+++ b/docs/backend/api/stage-1.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 description: Endpoints for the witness stage - being heard by the AI.
 slug: /backend/api/stage-1
 created: 2026-03-11
-updated: 2026-05-02
+updated: 2026-06-12
 status: living
 ---
 # Stage 1 API: The Witness

--- a/docs/backend/security/index.md
+++ b/docs/backend/security/index.md
@@ -3,6 +3,7 @@ title: Security Architecture
 sidebar_position: 1
 description: Security implementation for Meet Without Fear, focusing on privacy isolation and consent enforcement.
 slug: /backend/security
+updated: 2026-06-12
 ---
 # Security Architecture
 
@@ -18,6 +19,12 @@ API-level authorization and role-based access (user vs admin vs AI acting-on-beh
 
 ### Encryption
 Data encryption at rest and in transit (Render Postgres + TLS everywhere). Field-level AES-256-GCM encryption for sensitive PII fields (message content, conversation summaries, notable facts, etc.) via Prisma client extension — see `backend/src/lib/prisma-encryption-middleware.ts`.
+
+### Application Logging
+Therapy content is stripped from application logs to prevent session fragments from leaking to Render logs and Sentry breadcrumbs. Instead of logging content substrings, we log metadata-only: character counts, SHA-256 content hashes, or tag lengths. Applied in:
+- Message handling: hidden needs, need-actions, stage 4 walkthroughs, and dispatch tags logged as `{length: N}`
+- Duplicate detection: using content hash instead of substring
+- Reconciler sharing: post-share continuation logged with content length only
 
 ### Audit Logging
 Consent decisions and retrieval attempts recorded for review


### PR DESCRIPTION
## Changes
- Add Application Logging section to security/index.md
- Explain content sanitization to prevent therapy leaks to logs/Sentry
- Note metadata-only logging approach (hashes, lengths)
- Update docs for Stage 1 API and security (audit review)

Fixes #619

## Provenance
- **Channel:** docs-audit (incremental mode)
- **Requested by:** Automated bot (scheduled audit)
- **Original message:** Incremental docs audit (24h lookback)
- **Prompt(s) used:** Incremental audit with code-to-docs mapping

## Docs updated
- `docs/backend/security/index.md` — Added Application Logging section
- `docs/backend/api/stage-1.md` — Updated audit date